### PR TITLE
Fix #38: prevent new steward from executing previous steward's actions

### DIFF
--- a/contracts/governance/IArmadaGovernance.sol
+++ b/contracts/governance/IArmadaGovernance.sol
@@ -38,6 +38,7 @@ struct StewardAction {
     uint256 timestamp;
     bool executed;
     bool vetoed;
+    address proposedBy;
 }
 
 // ========== Interfaces ==========

--- a/contracts/governance/TreasurySteward.sol
+++ b/contracts/governance/TreasurySteward.sol
@@ -161,7 +161,8 @@ contract TreasurySteward is ReentrancyGuard {
             value: value,
             timestamp: block.timestamp,
             executed: false,
-            vetoed: false
+            vetoed: false,
+            proposedBy: msg.sender
         });
 
         emit ActionProposed(actionId, target, value, block.timestamp + actionDelay);
@@ -174,6 +175,7 @@ contract TreasurySteward is ReentrancyGuard {
         require(action.id != 0, "TreasurySteward: unknown action");
         require(!action.executed, "TreasurySteward: already executed");
         require(!action.vetoed, "TreasurySteward: vetoed");
+        require(action.proposedBy == currentSteward, "TreasurySteward: not proposed by current steward");
         require(allowedTargets[action.target], "TreasurySteward: target not allowed");
         require(
             block.timestamp >= action.timestamp + actionDelay,
@@ -219,9 +221,10 @@ contract TreasurySteward is ReentrancyGuard {
         uint256 timestamp,
         bool executed,
         bool vetoed,
-        uint256 executeAfter
+        uint256 executeAfter,
+        address proposedBy
     ) {
         StewardAction storage a = actions[actionId];
-        return (a.target, a.value, a.timestamp, a.executed, a.vetoed, a.timestamp + actionDelay);
+        return (a.target, a.value, a.timestamp, a.executed, a.vetoed, a.timestamp + actionDelay, a.proposedBy);
     }
 }

--- a/test-foundry/StewardSecurity.t.sol
+++ b/test-foundry/StewardSecurity.t.sol
@@ -310,6 +310,73 @@ contract StewardSecurityTest is Test {
     }
 
     // ══════════════════════════════════════════════════════════════════════
+    // Issue #38: New steward cannot execute previous steward's actions
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_executeAction_rejectsDifferentStewardProposal() public {
+        // stewardPerson proposes an action
+        vm.prank(stewardPerson);
+        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
+
+        // Elect a new steward (this contract acts as timelock)
+        address newSteward = address(0xCAFE);
+        steward.electSteward(newSteward);
+        assertEq(steward.currentSteward(), newSteward);
+
+        // Warp past the action delay
+        vm.warp(block.timestamp + TEST_ACTION_DELAY + 1);
+
+        // New steward tries to execute old steward's action — should revert
+        vm.prank(newSteward);
+        vm.expectRevert("TreasurySteward: not proposed by current steward");
+        steward.executeAction(actionId);
+    }
+
+    function test_executeAction_allowsReElectedSteward() public {
+        // stewardPerson proposes an action
+        vm.prank(stewardPerson);
+        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
+
+        // Re-elect the same steward (new term, same address)
+        steward.electSteward(stewardPerson);
+
+        // Warp past the action delay
+        vm.warp(block.timestamp + TEST_ACTION_DELAY + 1);
+
+        // Same steward should still be able to execute their own action
+        vm.prank(stewardPerson);
+        // The call may fail for unrelated reasons (empty data to treasury),
+        // but it should NOT fail with "not proposed by current steward"
+        try steward.executeAction(actionId) {
+            // Success — proposedBy check passed
+        } catch (bytes memory reason) {
+            assertTrue(
+                keccak256(reason) != keccak256(abi.encodeWithSignature("Error(string)", "TreasurySteward: not proposed by current steward")),
+                "Should not revert with proposedBy check for re-elected steward"
+            );
+        }
+    }
+
+    function testFuzz_executeAction_rejectsCrossStewardAction(address newStewardAddr) public {
+        vm.assume(newStewardAddr != stewardPerson);
+        vm.assume(newStewardAddr != address(0));
+
+        // Current steward proposes
+        vm.prank(stewardPerson);
+        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
+
+        // Elect different steward
+        steward.electSteward(newStewardAddr);
+
+        vm.warp(block.timestamp + TEST_ACTION_DELAY + 1);
+
+        // New steward tries to execute — should fail
+        vm.prank(newStewardAddr);
+        vm.expectRevert("TreasurySteward: not proposed by current steward");
+        steward.executeAction(actionId);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
     // End-to-end: propose + execute with realistic delay
     // ══════════════════════════════════════════════════════════════════════
 

--- a/test/governance_integration.ts
+++ b/test/governance_integration.ts
@@ -763,6 +763,78 @@ describe("Governance Integration", function () {
       await stewardContract.connect(dave).executeAction(1);
       expect(await usdc.balanceOf(carol.address)).to.equal(spendAmount);
     });
+
+    it("should reject new steward executing previous steward's actions", async function () {
+      // Elect Dave as first steward
+      await electDaveSteward();
+
+      // Dave proposes an action
+      const spendAmount = ethers.parseUnits("100", USDC_DECIMALS);
+      const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
+        await usdc.getAddress(), carol.address, spendAmount
+      ]);
+      await stewardContract.connect(dave).proposeAction(
+        await treasury.getAddress(), spendData, 0
+      );
+      const actionId = await stewardContract.actionCount();
+
+      // Elect Carol as new steward (replaces Dave)
+      const targets = [await stewardContract.getAddress()];
+      const values = [0n];
+      const calldatas = [
+        stewardContract.interface.encodeFunctionData("electSteward", [carol.address]),
+      ];
+      await passProposal(
+        alice,
+        [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
+        ProposalType.StewardElection, targets, values, calldatas,
+        "Elect Carol as steward"
+      );
+      expect(await stewardContract.currentSteward()).to.equal(carol.address);
+
+      // Wait for action delay to elapse
+      await time.increase(STEWARD_ACTION_DELAY + 1);
+
+      // Carol (new steward) tries to execute Dave's action — should fail
+      await expect(
+        stewardContract.connect(carol).executeAction(actionId)
+      ).to.be.revertedWith("TreasurySteward: not proposed by current steward");
+    });
+
+    it("should allow steward to execute own actions after re-election", async function () {
+      // Elect Dave as steward
+      await electDaveSteward();
+
+      // Dave proposes an action
+      const spendAmount = ethers.parseUnits("100", USDC_DECIMALS);
+      const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
+        await usdc.getAddress(), carol.address, spendAmount
+      ]);
+      await stewardContract.connect(dave).proposeAction(
+        await treasury.getAddress(), spendData, 0
+      );
+      const actionId = await stewardContract.actionCount();
+
+      // Re-elect Dave (same person, new term)
+      const targets = [await stewardContract.getAddress()];
+      const values = [0n];
+      const calldatas = [
+        stewardContract.interface.encodeFunctionData("electSteward", [dave.address]),
+      ];
+      await passProposal(
+        alice,
+        [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
+        ProposalType.StewardElection, targets, values, calldatas,
+        "Re-elect Dave"
+      );
+
+      // Wait for action delay
+      await time.increase(STEWARD_ACTION_DELAY + 1);
+
+      // Dave can still execute his own action after re-election
+      await stewardContract.connect(dave).executeAction(actionId);
+      expect(await usdc.balanceOf(carol.address)).to.equal(spendAmount);
+    });
   });
 
   // ============================================================


### PR DESCRIPTION
## Summary

Closes #38 and defers/makes non-applicable #21.

- Adds `proposedBy` field to `StewardAction` struct, recorded as `msg.sender` at proposal time
- Adds check in `executeAction()` that `action.proposedBy == currentSteward`, so queued actions are invalidated when governance elects a new steward
- Re-election of the same address preserves action validity (same proposer = same currentSteward)

## Test plan
- [x] Foundry: `test_executeAction_rejectsDifferentStewardProposal` — new steward cannot execute old steward's action
- [x] Foundry: `test_executeAction_allowsReElectedSteward` — re-elected steward can still execute their own action
- [x] Foundry: `testFuzz_executeAction_rejectsCrossStewardAction` — fuzz test with arbitrary new steward addresses
- [x] Hardhat: integration test for rejection after steward election via full governance lifecycle
- [x] Hardhat: integration test for re-election preserving action validity

🤖 Generated with [Claude Code](https://claude.com/claude-code)