### PR TITLE
Fix #26: add emergency pause with auto-expiry to governance contracts

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -5,11 +5,12 @@ import "@openzeppelin/contracts/governance/TimelockController.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./IArmadaGovernance.sol";
+import "./EmergencyPausable.sol";
 
 /// @title ArmadaGovernor — Custom governance with typed proposals and token locking
 /// @notice Implements the Armada governance spec: proposal lifecycle, per-type quorum/timing,
 ///         voting via locked tokens, and timelock execution.
-contract ArmadaGovernor is ReentrancyGuard {
+contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
 
     // ============ Types ============
 
@@ -97,8 +98,10 @@ contract ArmadaGovernor is ReentrancyGuard {
         address _votingLocker,
         address _armToken,
         address payable _timelock,
-        address _treasuryAddress
-    ) {
+        address _treasuryAddress,
+        address _guardian,
+        uint256 _maxPauseDuration
+    ) EmergencyPausable(_guardian, _maxPauseDuration, _timelock) {
         require(_votingLocker != address(0), "ArmadaGovernor: zero votingLocker");
         require(_armToken != address(0), "ArmadaGovernor: zero armToken");
         require(_timelock != address(0), "ArmadaGovernor: zero timelock");
@@ -274,7 +277,7 @@ contract ArmadaGovernor is ReentrancyGuard {
     }
 
     /// @notice Execute a queued proposal after timelock delay
-    function execute(uint256 proposalId) external payable nonReentrant {
+    function execute(uint256 proposalId) external payable nonReentrant whenNotPaused {
         require(state(proposalId) == ProposalState.Queued, "ArmadaGovernor: not queued");
 
         Proposal storage p = _proposals[proposalId];

--- a/contracts/governance/ArmadaTreasuryGov.sol
+++ b/contracts/governance/ArmadaTreasuryGov.sol
@@ -4,11 +4,12 @@ pragma solidity ^0.8.17;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "./EmergencyPausable.sol";
 
 /// @title ArmadaTreasuryGov — Governance-controlled treasury with claims mechanism
 /// @notice Owned by TimelockController (immutable). Supports direct distributions,
 ///         claims (deferred exercise), and steward operational budget.
-contract ArmadaTreasuryGov is ReentrancyGuard {
+contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
     using SafeERC20 for IERC20;
 
     // ============ Types ============
@@ -69,7 +70,11 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
 
     // ============ Constructor ============
 
-    constructor(address _owner) {
+    constructor(
+        address _owner,
+        address _guardian,
+        uint256 _maxPauseDuration
+    ) EmergencyPausable(_guardian, _maxPauseDuration, _owner) {
         require(_owner != address(0), "ArmadaTreasuryGov: zero owner");
         owner = _owner; // Should be the timelock address
     }
@@ -77,7 +82,7 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
     // ============ Governance Functions (owner = timelock) ============
 
     /// @notice Direct distribution: send tokens to recipient immediately
-    function distribute(address token, address recipient, uint256 amount) external onlyOwner {
+    function distribute(address token, address recipient, uint256 amount) external onlyOwner whenNotPaused {
         require(recipient != address(0), "ArmadaTreasuryGov: zero address");
         IERC20(token).safeTransfer(recipient, amount);
         emit DirectDistribution(token, recipient, amount);
@@ -122,7 +127,7 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
     /// @notice Exercise a claim — beneficiary receives tokens at their discretion
     /// @param claimId Claim to exercise
     /// @param amount Amount to exercise (can be partial)
-    function exerciseClaim(uint256 claimId, uint256 amount) external nonReentrant {
+    function exerciseClaim(uint256 claimId, uint256 amount) external nonReentrant whenNotPaused {
         Claim storage c = claims[claimId];
         require(c.beneficiary == msg.sender, "ArmadaTreasuryGov: not beneficiary");
         require(amount > 0, "ArmadaTreasuryGov: zero amount");
@@ -140,7 +145,7 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
     /// @dev The budget is 1% of the treasury balance snapshotted at the start of each 30-day period.
     /// The period starts on the first spend after the previous period expires. Mid-period balance
     /// changes (deposits, governance distributions) do not affect the current period's budget.
-    function stewardSpend(address token, address recipient, uint256 amount) external onlySteward {
+    function stewardSpend(address token, address recipient, uint256 amount) external onlySteward whenNotPaused {
         require(recipient != address(0), "ArmadaTreasuryGov: zero address");
         require(amount > 0, "ArmadaTreasuryGov: zero amount");
 

--- a/contracts/governance/EmergencyPausable.sol
+++ b/contracts/governance/EmergencyPausable.sol
@@ -1,0 +1,105 @@
+// ABOUTME: Base contract providing emergency pause with auto-expiry and guardian role.
+// ABOUTME: Guardian can pause for a limited duration; governance (timelock) can unpause or rotate guardian.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+/// @title EmergencyPausable — Time-limited emergency pause with guardian role
+/// @notice Provides a guardian-triggered pause that auto-expires after a configurable duration.
+///         Governance (the timelock) can always unpause early and rotate the guardian.
+///         The guardian cannot permanently freeze the system — the pause always expires.
+///         Implements pause logic directly (not extending OZ Pausable) because auto-expiry
+///         requires the internal pause flag and paused() to stay in sync, which OZ Pausable's
+///         private _paused flag prevents.
+abstract contract EmergencyPausable {
+
+    // ============ State ============
+
+    /// @notice Whether the contract is currently in a paused state (internal flag)
+    bool private _paused;
+
+    /// @notice Address authorized to trigger emergency pause
+    address public guardian;
+
+    /// @notice Timestamp when the current pause expires (0 if not paused)
+    uint256 public pauseExpiry;
+
+    /// @notice Maximum duration a pause can last
+    uint256 public immutable maxPauseDuration;
+
+    /// @notice Timelock address (governance authority for unpause and guardian rotation)
+    address public immutable pauseTimelock;
+
+    // ============ Events ============
+
+    event EmergencyPaused(address indexed guardian, uint256 expiry);
+    event EmergencyUnpaused(address indexed caller);
+    event GuardianUpdated(address indexed oldGuardian, address indexed newGuardian);
+
+    // ============ Constructor ============
+
+    /// @param _guardian Initial guardian address
+    /// @param _maxPauseDuration Maximum pause duration in seconds
+    /// @param _pauseTimelock Timelock address (governance) that can unpause and set guardian
+    constructor(address _guardian, uint256 _maxPauseDuration, address _pauseTimelock) {
+        require(_guardian != address(0), "EmergencyPausable: zero guardian");
+        require(_maxPauseDuration > 0, "EmergencyPausable: zero duration");
+        require(_pauseTimelock != address(0), "EmergencyPausable: zero timelock");
+
+        guardian = _guardian;
+        maxPauseDuration = _maxPauseDuration;
+        pauseTimelock = _pauseTimelock;
+    }
+
+    // ============ Modifiers ============
+
+    modifier onlyGuardian() {
+        require(msg.sender == guardian, "EmergencyPausable: not guardian");
+        _;
+    }
+
+    modifier onlyPauseTimelock() {
+        require(msg.sender == pauseTimelock, "EmergencyPausable: not timelock");
+        _;
+    }
+
+    /// @dev Reverts if the contract is paused (accounting for auto-expiry).
+    modifier whenNotPaused() {
+        require(!paused(), "Pausable: paused");
+        _;
+    }
+
+    // ============ View Functions ============
+
+    /// @notice Returns true only if paused AND the pause has not expired
+    function paused() public view virtual returns (bool) {
+        return _paused && block.timestamp < pauseExpiry;
+    }
+
+    // ============ Guardian Functions ============
+
+    /// @notice Guardian triggers emergency pause. Auto-expires after maxPauseDuration.
+    function emergencyPause() external onlyGuardian {
+        require(!paused(), "EmergencyPausable: already paused");
+        _paused = true;
+        pauseExpiry = block.timestamp + maxPauseDuration;
+        emit EmergencyPaused(msg.sender, pauseExpiry);
+    }
+
+    // ============ Governance Functions ============
+
+    /// @notice Governance (timelock) can unpause at any time
+    function emergencyUnpause() external onlyPauseTimelock {
+        require(paused(), "EmergencyPausable: not paused");
+        _paused = false;
+        pauseExpiry = 0;
+        emit EmergencyUnpaused(msg.sender);
+    }
+
+    /// @notice Governance (timelock) can rotate the guardian
+    function setGuardian(address _guardian) external onlyPauseTimelock {
+        require(_guardian != address(0), "EmergencyPausable: zero guardian");
+        emit GuardianUpdated(guardian, _guardian);
+        guardian = _guardian;
+    }
+}

--- a/contracts/governance/TreasurySteward.sol
+++ b/contracts/governance/TreasurySteward.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./IArmadaGovernance.sol";
+import "./EmergencyPausable.sol";
 
 /// @title TreasurySteward — Elected steward with action queue and veto mechanism
 /// @notice Steward is elected via governance (StewardElection proposal). Has limited powers:
@@ -13,7 +14,7 @@ import "./IArmadaGovernance.sol";
 ///         can veto actions via governance proposals before they are executed.
 ///         The action delay is enforced to be >= 120% of the fastest governance veto cycle,
 ///         ensuring governance always has time to veto before execution.
-contract TreasurySteward is ReentrancyGuard {
+contract TreasurySteward is ReentrancyGuard, EmergencyPausable {
 
     // ============ Constants ============
 
@@ -72,7 +73,14 @@ contract TreasurySteward is ReentrancyGuard {
     /// @param _treasury ArmadaTreasuryGov address
     /// @param _governor ArmadaGovernor address (used to derive minimum action delay)
     /// @param _actionDelay Delay before steward actions can execute (veto window)
-    constructor(address _timelock, address _treasury, address _governor, uint256 _actionDelay) {
+    constructor(
+        address _timelock,
+        address _treasury,
+        address _governor,
+        uint256 _actionDelay,
+        address _guardian,
+        uint256 _maxPauseDuration
+    ) EmergencyPausable(_guardian, _maxPauseDuration, _timelock) {
         require(_timelock != address(0), "TreasurySteward: zero timelock");
         require(_treasury != address(0), "TreasurySteward: zero treasury");
         require(_governor != address(0), "TreasurySteward: zero governor");
@@ -183,7 +191,7 @@ contract TreasurySteward is ReentrancyGuard {
     }
 
     /// @notice Execute a proposed steward action (after delay, if not vetoed)
-    function executeAction(uint256 actionId) external onlySteward nonReentrant {
+    function executeAction(uint256 actionId) external onlySteward nonReentrant whenNotPaused {
         StewardAction storage action = actions[actionId];
         require(action.id != 0, "TreasurySteward: unknown action");
         require(!action.executed, "TreasurySteward: already executed");

--- a/contracts/governance/VotingLocker.sol
+++ b/contracts/governance/VotingLocker.sol
@@ -6,12 +6,13 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "./IArmadaGovernance.sol";
+import "./EmergencyPausable.sol";
 
 /// @title VotingLocker — Lock ARM tokens to gain voting power
 /// @notice Holds ARM tokens on behalf of voters with per-user checkpointing.
 ///         The ArmadaGovernor reads voting power from this contract via getPastLockedBalance().
 ///         Checkpoint pattern adapted from OpenZeppelin ERC20Votes.
-contract VotingLocker is ReentrancyGuard, IVotingLocker {
+contract VotingLocker is ReentrancyGuard, IVotingLocker, EmergencyPausable {
     using SafeERC20 for IERC20;
     using SafeCast for uint256;
 
@@ -39,7 +40,12 @@ contract VotingLocker is ReentrancyGuard, IVotingLocker {
 
     // ============ Constructor ============
 
-    constructor(address _armToken) {
+    constructor(
+        address _armToken,
+        address _guardian,
+        uint256 _maxPauseDuration,
+        address _pauseTimelock
+    ) EmergencyPausable(_guardian, _maxPauseDuration, _pauseTimelock) {
         armToken = IERC20(_armToken);
     }
 
@@ -68,7 +74,7 @@ contract VotingLocker is ReentrancyGuard, IVotingLocker {
     //   lock tokens, vote on a proposal, then immediately unlock and sell, bearing no
     //   economic exposure to the outcome. Consider adding a time-lock (e.g. tokens stay
     //   locked until the voting period ends for any proposal they voted on).
-    function unlock(uint256 amount) external nonReentrant {
+    function unlock(uint256 amount) external nonReentrant whenNotPaused {
         require(amount > 0, "VotingLocker: zero amount");
 
         uint256 oldBalance = _getLatestLockedBalance(msg.sender);

--- a/scripts/crowdfund_demo.ts
+++ b/scripts/crowdfund_demo.ts
@@ -273,7 +273,9 @@ async function main() {
   console.log("");
 
   const VotingLocker = await ethers.getContractFactory("VotingLocker");
-  const votingLocker = await VotingLocker.deploy(await armToken.getAddress());
+  const votingLocker = await VotingLocker.deploy(
+    await armToken.getAddress(), deployer.address, 14 * 86400, deployer.address
+  );
   await votingLocker.waitForDeployment();
 
   const armBal = await armToken.balanceOf(bigSeeds[0].address);

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -78,16 +78,13 @@ async function main() {
   const armTokenAddress = await armToken.getAddress();
   console.log(`   ArmadaToken: ${armTokenAddress}`);
 
-  // 2. Deploy VotingLocker
-  console.log("2. Deploying VotingLocker...");
-  const VotingLocker = await ethers.getContractFactory("VotingLocker");
-  const votingLocker = await VotingLocker.deploy(armTokenAddress, nm.override());
-  await votingLocker.deploymentTransaction()!.wait();
-  const votingLockerAddress = await votingLocker.getAddress();
-  console.log(`   VotingLocker: ${votingLockerAddress}`);
+  // Emergency pause config: deployer as initial guardian, 14 day max pause
+  // TODO: Transfer guardian to a dedicated multisig after deployment
+  const guardianAddress = deployer.address;
+  const maxPauseDuration = 14 * 24 * 60 * 60; // 14 days
 
-  // 3. Deploy TimelockController
-  console.log("3. Deploying TimelockController...");
+  // 2. Deploy TimelockController (needed before VotingLocker for pauseTimelock)
+  console.log("2. Deploying TimelockController...");
   const TimelockController = await ethers.getContractFactory("TimelockController");
   const timelock = await TimelockController.deploy(
     timelockDelay, [], [], deployer.address, nm.override()
@@ -96,10 +93,22 @@ async function main() {
   const timelockAddress = await timelock.getAddress();
   console.log(`   TimelockController: ${timelockAddress}`);
 
+  // 3. Deploy VotingLocker
+  console.log("3. Deploying VotingLocker...");
+  const VotingLocker = await ethers.getContractFactory("VotingLocker");
+  const votingLocker = await VotingLocker.deploy(
+    armTokenAddress, guardianAddress, maxPauseDuration, timelockAddress, nm.override()
+  );
+  await votingLocker.deploymentTransaction()!.wait();
+  const votingLockerAddress = await votingLocker.getAddress();
+  console.log(`   VotingLocker: ${votingLockerAddress}`);
+
   // 4. Deploy ArmadaTreasuryGov
   console.log("4. Deploying ArmadaTreasuryGov...");
   const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
-  const treasury = await ArmadaTreasuryGov.deploy(timelockAddress, nm.override());
+  const treasury = await ArmadaTreasuryGov.deploy(
+    timelockAddress, guardianAddress, maxPauseDuration, nm.override()
+  );
   await treasury.deploymentTransaction()!.wait();
   const treasuryAddress = await treasury.getAddress();
   console.log(`   ArmadaTreasuryGov: ${treasuryAddress}`);
@@ -108,7 +117,8 @@ async function main() {
   console.log("5. Deploying ArmadaGovernor...");
   const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
   const governor = await ArmadaGovernor.deploy(
-    votingLockerAddress, armTokenAddress, timelockAddress, treasuryAddress, nm.override()
+    votingLockerAddress, armTokenAddress, timelockAddress, treasuryAddress,
+    guardianAddress, maxPauseDuration, nm.override()
   );
   await governor.deploymentTransaction()!.wait();
   const governorAddress = await governor.getAddress();
@@ -117,7 +127,10 @@ async function main() {
   // 6. Deploy TreasurySteward
   console.log("6. Deploying TreasurySteward...");
   const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
-  const steward = await TreasurySteward.deploy(timelockAddress, treasuryAddress, governorAddress, stewardDelay, nm.override());
+  const steward = await TreasurySteward.deploy(
+    timelockAddress, treasuryAddress, governorAddress, stewardDelay,
+    guardianAddress, maxPauseDuration, nm.override()
+  );
   await steward.deploymentTransaction()!.wait();
   const stewardAddress = await steward.getAddress();
   console.log(`   TreasurySteward: ${stewardAddress}`);

--- a/scripts/full_lifecycle_demo.ts
+++ b/scripts/full_lifecycle_demo.ts
@@ -134,21 +134,26 @@ async function main() {
   await armToken.waitForDeployment();
   log("DEPLOY", `ArmadaToken: ${await armToken.getAddress()}`);
 
-  // 1b. VotingLocker
-  const VotingLocker = await ethers.getContractFactory("VotingLocker");
-  const votingLocker = await VotingLocker.deploy(await armToken.getAddress());
-  await votingLocker.waitForDeployment();
-  log("DEPLOY", `VotingLocker: ${await votingLocker.getAddress()}`);
+  const MAX_PAUSE = 14 * ONE_DAY;
 
-  // 1c. TimelockController
+  // 1b. TimelockController (deployed first — needed as pauseTimelock)
   const TimelockController = await ethers.getContractFactory("TimelockController");
   const timelock = await TimelockController.deploy(TIMELOCK_MIN_DELAY, [], [], deployer.address);
   await timelock.waitForDeployment();
-  log("DEPLOY", `TimelockController: ${await timelock.getAddress()}`);
+  const tlAddr = await timelock.getAddress();
+  log("DEPLOY", `TimelockController: ${tlAddr}`);
+
+  // 1c. VotingLocker
+  const VotingLocker = await ethers.getContractFactory("VotingLocker");
+  const votingLocker = await VotingLocker.deploy(
+    await armToken.getAddress(), deployer.address, MAX_PAUSE, tlAddr
+  );
+  await votingLocker.waitForDeployment();
+  log("DEPLOY", `VotingLocker: ${await votingLocker.getAddress()}`);
 
   // 1d. Treasury (owned by timelock from the start)
   const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
-  const treasury = await ArmadaTreasuryGov.deploy(await timelock.getAddress());
+  const treasury = await ArmadaTreasuryGov.deploy(tlAddr, deployer.address, MAX_PAUSE);
   await treasury.waitForDeployment();
   log("DEPLOY", `ArmadaTreasuryGov: ${await treasury.getAddress()}`);
 
@@ -157,8 +162,9 @@ async function main() {
   const governor = await ArmadaGovernor.deploy(
     await votingLocker.getAddress(),
     await armToken.getAddress(),
-    await timelock.getAddress(),
-    await treasury.getAddress()
+    tlAddr,
+    await treasury.getAddress(),
+    deployer.address, MAX_PAUSE
   );
   await governor.waitForDeployment();
   log("DEPLOY", `ArmadaGovernor: ${await governor.getAddress()}`);
@@ -166,7 +172,8 @@ async function main() {
   // 1f. TreasurySteward
   const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
   const stewardContract = await TreasurySteward.deploy(
-    await timelock.getAddress(), await treasury.getAddress(), await governor.getAddress(), STEWARD_ACTION_DELAY
+    tlAddr, await treasury.getAddress(), await governor.getAddress(), STEWARD_ACTION_DELAY,
+    deployer.address, MAX_PAUSE
   );
   await stewardContract.waitForDeployment();
   log("DEPLOY", `TreasurySteward: ${await stewardContract.getAddress()}`);

--- a/scripts/governance_demo.ts
+++ b/scripts/governance_demo.ts
@@ -61,24 +61,30 @@ async function main() {
   const armToken = await ArmadaToken.deploy(deployer.address);
   await armToken.waitForDeployment();
 
-  const VotingLocker = await ethers.getContractFactory("VotingLocker");
-  const votingLocker = await VotingLocker.deploy(await armToken.getAddress());
-  await votingLocker.waitForDeployment();
+  const MAX_PAUSE = 14 * ONE_DAY;
 
   const TimelockController = await ethers.getContractFactory("TimelockController");
   const timelock = await TimelockController.deploy(TWO_DAYS, [], [], deployer.address);
   await timelock.waitForDeployment();
+  const tlAddr = await timelock.getAddress();
+
+  const VotingLocker = await ethers.getContractFactory("VotingLocker");
+  const votingLocker = await VotingLocker.deploy(
+    await armToken.getAddress(), deployer.address, MAX_PAUSE, tlAddr
+  );
+  await votingLocker.waitForDeployment();
 
   const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
-  const treasury = await ArmadaTreasuryGov.deploy(await timelock.getAddress());
+  const treasury = await ArmadaTreasuryGov.deploy(tlAddr, deployer.address, MAX_PAUSE);
   await treasury.waitForDeployment();
 
   const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
   const governor = await ArmadaGovernor.deploy(
     await votingLocker.getAddress(),
     await armToken.getAddress(),
-    await timelock.getAddress(),
-    await treasury.getAddress()
+    tlAddr,
+    await treasury.getAddress(),
+    deployer.address, MAX_PAUSE
   );
   await governor.waitForDeployment();
 
@@ -86,7 +92,8 @@ async function main() {
   // Steward action delay: 120% of governance cycle (2d + 5d + 2d = 9d)
   const stewardActionDelay = Math.ceil((TWO_DAYS + FIVE_DAYS + TWO_DAYS) * 12000 / 10000);
   const stewardContract = await TreasurySteward.deploy(
-    await timelock.getAddress(), await treasury.getAddress(), await governor.getAddress(), stewardActionDelay
+    tlAddr, await treasury.getAddress(), await governor.getAddress(), stewardActionDelay,
+    deployer.address, MAX_PAUSE
   );
   await stewardContract.waitForDeployment();
 

--- a/test-foundry/GovernorInvariant.t.sol
+++ b/test-foundry/GovernorInvariant.t.sol
@@ -275,9 +275,6 @@ contract GovernorInvariantTest is Test {
         // Deploy ARM token
         armToken = new ArmadaToken(address(this));
 
-        // Deploy VotingLocker
-        locker = new VotingLocker(address(armToken));
-
         // Deploy TimelockController
         address[] memory proposers = new address[](1);
         proposers[0] = address(0); // will be set after governor deploy
@@ -290,6 +287,9 @@ contract GovernorInvariantTest is Test {
             address(this) // admin
         );
 
+        // Deploy VotingLocker
+        locker = new VotingLocker(address(armToken), address(this), 14 days, address(timelock));
+
         treasuryAddr = address(0xBABE);
 
         // Deploy Governor
@@ -297,7 +297,9 @@ contract GovernorInvariantTest is Test {
             address(locker),
             address(armToken),
             payable(address(timelock)),
-            treasuryAddr
+            treasuryAddr,
+            address(this),
+            14 days
         );
 
         // Grant governor the proposer role on timelock

--- a/test-foundry/StewardSecurity.t.sol
+++ b/test-foundry/StewardSecurity.t.sol
@@ -41,9 +41,6 @@ contract StewardSecurityTest is Test {
         // Deploy ARM token
         armToken = new ArmadaToken(address(this));
 
-        // Deploy VotingLocker
-        locker = new VotingLocker(address(armToken));
-
         // Deploy TimelockController (this test contract acts as admin)
         address[] memory proposers = new address[](0);
         address[] memory executors = new address[](0);
@@ -54,15 +51,20 @@ contract StewardSecurityTest is Test {
             address(this)
         );
 
+        // Deploy VotingLocker
+        locker = new VotingLocker(address(armToken), address(this), 14 days, address(timelock));
+
         // Deploy treasury
-        treasury = new ArmadaTreasuryGov(address(timelock));
+        treasury = new ArmadaTreasuryGov(address(timelock), address(this), 14 days);
 
         // Deploy governor
         governor = new ArmadaGovernor(
             address(locker),
             address(armToken),
             payable(address(timelock)),
-            address(treasury)
+            address(treasury),
+            address(this),
+            14 days
         );
 
         // Deploy steward with governor reference and valid delay
@@ -70,7 +72,9 @@ contract StewardSecurityTest is Test {
             address(this),  // this contract acts as timelock for test convenience
             address(treasury),
             address(governor),
-            TEST_ACTION_DELAY
+            TEST_ACTION_DELAY,
+            address(this),
+            14 days
         );
 
         // Elect steward person
@@ -87,7 +91,9 @@ contract StewardSecurityTest is Test {
             address(this),
             address(treasury),
             address(0),
-            TEST_ACTION_DELAY
+            TEST_ACTION_DELAY,
+            address(this),
+            14 days
         );
     }
 
@@ -97,7 +103,9 @@ contract StewardSecurityTest is Test {
             address(this),
             address(treasury),
             address(governor),
-            1 days // way below the ~10.8 day minimum
+            1 days, // way below the ~10.8 day minimum
+            address(this),
+            14 days
         );
     }
 
@@ -111,7 +119,9 @@ contract StewardSecurityTest is Test {
             address(this),
             address(treasury),
             address(governor),
-            EXPECTED_MIN_DELAY
+            EXPECTED_MIN_DELAY,
+            address(this),
+            14 days
         );
         assertEq(s.actionDelay(), EXPECTED_MIN_DELAY);
     }
@@ -288,7 +298,9 @@ contract StewardSecurityTest is Test {
             address(this),
             address(treasury),
             address(governor),
-            delay
+            delay,
+            address(this),
+            14 days
         );
     }
 

--- a/test-foundry/VotingLockerInvariant.t.sol
+++ b/test-foundry/VotingLockerInvariant.t.sol
@@ -96,7 +96,7 @@ contract VotingLockerInvariantTest is Test {
     function setUp() public {
         // Deploy
         armToken = new ArmadaToken(address(this));
-        locker = new VotingLocker(address(armToken));
+        locker = new VotingLocker(address(armToken), address(this), 14 days, address(this));
 
         // Create actors and fund them
         for (uint256 i = 0; i < 10; i++) {

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -80,9 +80,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     await armToken.transfer(await crowdfund.getAddress(), CROWDFUND_ARM_FUNDING);
 
     // Deploy governance
-    const VotingLocker = await ethers.getContractFactory("VotingLocker");
-    votingLocker = await VotingLocker.deploy(await armToken.getAddress());
-    await votingLocker.waitForDeployment();
+    const MAX_PAUSE_DURATION = 14 * ONE_DAY;
 
     const TimelockController = await ethers.getContractFactory("TimelockController");
     timelockController = await TimelockController.deploy(
@@ -92,13 +90,21 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       deployer.address
     );
     await timelockController.waitForDeployment();
+    const timelockAddr = await timelockController.getAddress();
+
+    const VotingLocker = await ethers.getContractFactory("VotingLocker");
+    votingLocker = await VotingLocker.deploy(
+      await armToken.getAddress(), deployer.address, MAX_PAUSE_DURATION, timelockAddr
+    );
+    await votingLocker.waitForDeployment();
 
     const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
     governor = await ArmadaGovernor.deploy(
       await votingLocker.getAddress(),
       await armToken.getAddress(),
-      await timelockController.getAddress(),
-      treasuryAddr.address
+      timelockAddr,
+      treasuryAddr.address,
+      deployer.address, MAX_PAUSE_DURATION
     );
     await governor.waitForDeployment();
 
@@ -109,7 +115,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     // Deploy TreasuryGov (holds ARM for governance distributions)
     // Owner is set to timelock at deployment and is immutable — governance controls the treasury
     const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
-    treasuryGov = await ArmadaTreasuryGov.deploy(await timelockController.getAddress());
+    treasuryGov = await ArmadaTreasuryGov.deploy(timelockAddr, deployer.address, MAX_PAUSE_DURATION);
     await treasuryGov.waitForDeployment();
 
     // Send most ARM to treasury address to make quorum reachable
@@ -624,9 +630,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await localArmToken.waitForDeployment();
 
       // Step 2: Deploy governance stack
-      const VotingLocker = await ethers.getContractFactory("VotingLocker");
-      localVotingLocker = await VotingLocker.deploy(await localArmToken.getAddress());
-      await localVotingLocker.waitForDeployment();
+      const LOCAL_MAX_PAUSE = 14 * ONE_DAY;
 
       const TimelockController = await ethers.getContractFactory("TimelockController");
       localTimelockController = await TimelockController.deploy(
@@ -636,10 +640,17 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         localDeployer.address
       );
       await localTimelockController.waitForDeployment();
+      const localTlAddr = await localTimelockController.getAddress();
+
+      const VotingLocker = await ethers.getContractFactory("VotingLocker");
+      localVotingLocker = await VotingLocker.deploy(
+        await localArmToken.getAddress(), localDeployer.address, LOCAL_MAX_PAUSE, localTlAddr
+      );
+      await localVotingLocker.waitForDeployment();
 
       const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
       localTreasury = await ArmadaTreasuryGov.deploy(
-        await localTimelockController.getAddress()
+        localTlAddr, localDeployer.address, LOCAL_MAX_PAUSE
       );
       await localTreasury.waitForDeployment();
 
@@ -647,8 +658,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       localGovernor = await ArmadaGovernor.deploy(
         await localVotingLocker.getAddress(),
         await localArmToken.getAddress(),
-        await localTimelockController.getAddress(),
-        await localTreasury.getAddress()
+        localTlAddr,
+        await localTreasury.getAddress(),
+        localDeployer.address, LOCAL_MAX_PAUSE
       );
       await localGovernor.waitForDeployment();
 
@@ -936,7 +948,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await localVotingLocker.getAddress(),
         await localArmToken.getAddress(),
         await localTimelockController.getAddress(),
-        await localTreasury.getAddress()
+        await localTreasury.getAddress(),
+        localDeployer.address, 14 * ONE_DAY
       );
       await freshGovernor.waitForDeployment();
 

--- a/test/crowdfund_integration.ts
+++ b/test/crowdfund_integration.ts
@@ -1196,7 +1196,9 @@ describe("Crowdfund Integration", function () {
 
       // Deploy VotingLocker and lock ARM
       const VotingLocker = await ethers.getContractFactory("VotingLocker");
-      const votingLocker = await VotingLocker.deploy(await armToken.getAddress());
+      const votingLocker = await VotingLocker.deploy(
+        await armToken.getAddress(), seeds[0].address, 14 * 86400, seeds[0].address
+      );
       await votingLocker.waitForDeployment();
 
       await armToken.connect(seeds[0]).approve(await votingLocker.getAddress(), armBalance);

--- a/test/gas_benchmark.ts
+++ b/test/gas_benchmark.ts
@@ -282,7 +282,7 @@ describe("Gas Benchmarks", function () {
       const armToken = await ArmadaToken.deploy(deployer.address);
 
       const VotingLocker = await ethers.getContractFactory("VotingLocker");
-      const locker = await VotingLocker.deploy(await armToken.getAddress());
+      const locker = await VotingLocker.deploy(await armToken.getAddress(), deployer.address, 14 * 86400, deployer.address);
 
       const alice = allSigners[1];
 
@@ -345,7 +345,7 @@ describe("Gas Benchmarks", function () {
       const armToken = await ArmadaToken.deploy(deployer.address);
 
       const VotingLocker = await ethers.getContractFactory("VotingLocker");
-      const locker = await VotingLocker.deploy(await armToken.getAddress());
+      const locker = await VotingLocker.deploy(await armToken.getAddress(), deployer.address, 14 * 86400, deployer.address);
 
       const proposers = [deployer]; // deployer proposes
       const voters = allSigners.slice(1, 6); // 5 voters with varying checkpoint depths
@@ -360,7 +360,9 @@ describe("Gas Benchmarks", function () {
         await locker.getAddress(),
         await armToken.getAddress(),
         await timelock.getAddress(),
-        deployer.address // treasury
+        deployer.address, // treasury
+        deployer.address, // guardian
+        14 * 86400         // maxPauseDuration
       );
 
       // Grant roles

--- a/test/governance_adversarial.ts
+++ b/test/governance_adversarial.ts
@@ -77,26 +77,34 @@ describe("Governance Adversarial", function () {
     armToken = await ArmadaToken.deploy(deployer.address);
     await armToken.waitForDeployment();
 
-    const VotingLocker = await ethers.getContractFactory("VotingLocker");
-    votingLocker = await VotingLocker.deploy(await armToken.getAddress());
-    await votingLocker.waitForDeployment();
-
     const TimelockController = await ethers.getContractFactory("TimelockController");
     timelockController = await TimelockController.deploy(
       TWO_DAYS, [], [], deployer.address
     );
     await timelockController.waitForDeployment();
+    const timelockAddr = await timelockController.getAddress();
+    const MAX_PAUSE_DURATION = 14 * ONE_DAY;
+
+    const VotingLocker = await ethers.getContractFactory("VotingLocker");
+    votingLocker = await VotingLocker.deploy(
+      await armToken.getAddress(),
+      deployer.address, MAX_PAUSE_DURATION, timelockAddr
+    );
+    await votingLocker.waitForDeployment();
 
     const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
-    treasuryContract = await ArmadaTreasuryGov.deploy(await timelockController.getAddress());
+    treasuryContract = await ArmadaTreasuryGov.deploy(
+      timelockAddr, deployer.address, MAX_PAUSE_DURATION
+    );
     await treasuryContract.waitForDeployment();
 
     const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
     governor = await ArmadaGovernor.deploy(
       await votingLocker.getAddress(),
       await armToken.getAddress(),
-      await timelockController.getAddress(),
-      await treasuryContract.getAddress()
+      timelockAddr,
+      await treasuryContract.getAddress(),
+      deployer.address, MAX_PAUSE_DURATION
     );
     await governor.waitForDeployment();
 
@@ -104,10 +112,11 @@ describe("Governance Adversarial", function () {
     // Minimum action delay = 120% of governance cycle (2d + 5d + 2d = 9d)
     const stewardActionDelay = Math.ceil((TWO_DAYS + FIVE_DAYS + TWO_DAYS) * 12000 / 10000);
     stewardContract = await TreasurySteward.deploy(
-      await timelockController.getAddress(),
+      timelockAddr,
       await treasuryContract.getAddress(),
       await governor.getAddress(),
-      stewardActionDelay
+      stewardActionDelay,
+      deployer.address, MAX_PAUSE_DURATION
     );
     await stewardContract.waitForDeployment();
 
@@ -485,6 +494,8 @@ describe("Governance Adversarial", function () {
   // ============================================================
 
   describe("Constructor Zero-Address Validation", function () {
+    const MAX_PAUSE = 14 * ONE_DAY;
+
     it("ArmadaGovernor rejects zero votingLocker", async function () {
       const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
       await expect(
@@ -492,7 +503,8 @@ describe("Governance Adversarial", function () {
           ethers.ZeroAddress,
           await armToken.getAddress(),
           await timelockController.getAddress(),
-          await treasuryContract.getAddress()
+          await treasuryContract.getAddress(),
+          deployer.address, MAX_PAUSE
         )
       ).to.be.revertedWith("ArmadaGovernor: zero votingLocker");
     });
@@ -504,21 +516,24 @@ describe("Governance Adversarial", function () {
           await votingLocker.getAddress(),
           ethers.ZeroAddress,
           await timelockController.getAddress(),
-          await treasuryContract.getAddress()
+          await treasuryContract.getAddress(),
+          deployer.address, MAX_PAUSE
         )
       ).to.be.revertedWith("ArmadaGovernor: zero armToken");
     });
 
     it("ArmadaGovernor rejects zero timelock", async function () {
       const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
+      // Zero timelock is caught by EmergencyPausable first
       await expect(
         ArmadaGovernor.deploy(
           await votingLocker.getAddress(),
           await armToken.getAddress(),
           ethers.ZeroAddress,
-          await treasuryContract.getAddress()
+          await treasuryContract.getAddress(),
+          deployer.address, MAX_PAUSE
         )
-      ).to.be.revertedWith("ArmadaGovernor: zero timelock");
+      ).to.be.revertedWith("EmergencyPausable: zero timelock");
     });
 
     it("ArmadaGovernor rejects zero treasury", async function () {
@@ -528,7 +543,8 @@ describe("Governance Adversarial", function () {
           await votingLocker.getAddress(),
           await armToken.getAddress(),
           await timelockController.getAddress(),
-          ethers.ZeroAddress
+          ethers.ZeroAddress,
+          deployer.address, MAX_PAUSE
         )
       ).to.be.revertedWith("ArmadaGovernor: zero treasury");
     });
@@ -536,14 +552,16 @@ describe("Governance Adversarial", function () {
     it("TreasurySteward rejects zero timelock", async function () {
       const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
       const stewardDelay = Math.ceil((TWO_DAYS + FIVE_DAYS + TWO_DAYS) * 12000 / 10000);
+      // Zero timelock is caught by EmergencyPausable first
       await expect(
         TreasurySteward.deploy(
           ethers.ZeroAddress,
           await treasuryContract.getAddress(),
           await governor.getAddress(),
-          stewardDelay
+          stewardDelay,
+          deployer.address, MAX_PAUSE
         )
-      ).to.be.revertedWith("TreasurySteward: zero timelock");
+      ).to.be.revertedWith("EmergencyPausable: zero timelock");
     });
 
     it("TreasurySteward rejects zero treasury", async function () {
@@ -554,7 +572,8 @@ describe("Governance Adversarial", function () {
           await timelockController.getAddress(),
           ethers.ZeroAddress,
           await governor.getAddress(),
-          stewardDelay
+          stewardDelay,
+          deployer.address, MAX_PAUSE
         )
       ).to.be.revertedWith("TreasurySteward: zero treasury");
     });
@@ -567,7 +586,8 @@ describe("Governance Adversarial", function () {
           await timelockController.getAddress(),
           await treasuryContract.getAddress(),
           ethers.ZeroAddress,
-          stewardDelay
+          stewardDelay,
+          deployer.address, MAX_PAUSE
         )
       ).to.be.revertedWith("TreasurySteward: zero governor");
     });
@@ -579,7 +599,8 @@ describe("Governance Adversarial", function () {
           await timelockController.getAddress(),
           await treasuryContract.getAddress(),
           await governor.getAddress(),
-          ONE_DAY // way below minimum
+          ONE_DAY, // way below minimum
+          deployer.address, MAX_PAUSE
         )
       ).to.be.revertedWith("TreasurySteward: delay below governance cycle");
     });
@@ -853,7 +874,7 @@ describe("Governance Adversarial", function () {
 
     async function setupBudgetTreasury() {
       const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
-      budgetTreasury = await ArmadaTreasuryGov.deploy(deployer.address);
+      budgetTreasury = await ArmadaTreasuryGov.deploy(deployer.address, deployer.address, 14 * ONE_DAY);
       await budgetTreasury.waitForDeployment();
 
       // Fund with USDC and set carol as steward
@@ -975,7 +996,7 @@ describe("Governance Adversarial", function () {
 
     async function setupStewardTest() {
       const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
-      testTreasury = await ArmadaTreasuryGov.deploy(deployer.address);
+      testTreasury = await ArmadaTreasuryGov.deploy(deployer.address, deployer.address, 14 * ONE_DAY);
       await testTreasury.waitForDeployment();
 
       const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
@@ -983,7 +1004,8 @@ describe("Governance Adversarial", function () {
         deployer.address,                    // deployer acts as timelock
         await testTreasury.getAddress(),
         await governor.getAddress(),
-        testStewardDelay
+        testStewardDelay,
+        deployer.address, 14 * ONE_DAY
       );
       await testSteward.waitForDeployment();
 

--- a/test/governance_emergency_pause.ts
+++ b/test/governance_emergency_pause.ts
@@ -1,0 +1,812 @@
+/**
+ * Emergency Pause Tests
+ *
+ * Tests the EmergencyPausable mechanism across all governance contracts:
+ * - Guardian can pause, auto-expiry works
+ * - Governance (timelock) can unpause and rotate guardian
+ * - Paused functions revert, unpaused functions work
+ * - Non-guardian/non-timelock cannot pause/unpause
+ * - Lock remains available during pause (VotingLocker)
+ * - Propose remains available during pause (ArmadaGovernor)
+ */
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
+import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+
+const ProposalType = { ParameterChange: 0, Treasury: 1, StewardElection: 2 };
+const Vote = { Against: 0, For: 1, Abstain: 2 };
+
+const ONE_DAY = 86400;
+const TWO_DAYS = 2 * ONE_DAY;
+const FIVE_DAYS = 5 * ONE_DAY;
+const SEVEN_DAYS = 7 * ONE_DAY;
+const FOUR_DAYS = 4 * ONE_DAY;
+const FOURTEEN_DAYS = 14 * ONE_DAY;
+const MAX_PAUSE_DURATION = FOURTEEN_DAYS;
+
+const ARM_DECIMALS = 18;
+const TOTAL_SUPPLY = ethers.parseUnits("100000000", ARM_DECIMALS); // 100M
+const TREASURY_AMOUNT = ethers.parseUnits("65000000", ARM_DECIMALS); // 65M
+const ALICE_AMOUNT = ethers.parseUnits("20000000", ARM_DECIMALS); // 20M
+const BOB_AMOUNT = ethers.parseUnits("15000000", ARM_DECIMALS); // 15M
+const USDC_DECIMALS = 6;
+const STEWARD_ACTION_DELAY = Math.ceil((TWO_DAYS + FIVE_DAYS + TWO_DAYS) * 12000 / 10000);
+
+describe("Governance Emergency Pause", function () {
+  let armToken: any;
+  let votingLocker: any;
+  let timelockController: any;
+  let governor: any;
+  let treasury: any;
+  let stewardContract: any;
+  let usdc: any;
+
+  let deployer: SignerWithAddress;
+  let guardian: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let carol: SignerWithAddress;
+  let dave: SignerWithAddress;
+
+  async function mineBlock() {
+    await mine(1);
+  }
+
+  // Helper: create, pass, queue a proposal (but don't execute — for testing paused execute)
+  async function passAndQueueProposal(
+    proposer: SignerWithAddress,
+    voters: { signer: SignerWithAddress; support: number }[],
+    proposalType: number,
+    targets: string[],
+    values: bigint[],
+    calldatas: string[],
+    description: string
+  ): Promise<number> {
+    const tx = await governor.connect(proposer).propose(
+      proposalType, targets, values, calldatas, description
+    );
+    await tx.wait();
+    const proposalId = Number(await governor.proposalCount());
+
+    await time.increase(TWO_DAYS + 1);
+    for (const v of voters) {
+      await governor.connect(v.signer).castVote(proposalId, v.support);
+    }
+
+    const votingPeriod = proposalType === ProposalType.StewardElection ? SEVEN_DAYS : FIVE_DAYS;
+    await time.increase(votingPeriod + 1);
+    await governor.queue(proposalId);
+
+    const executionDelay = proposalType === ProposalType.StewardElection ? FOUR_DAYS : TWO_DAYS;
+    await time.increase(executionDelay + 1);
+
+    return proposalId;
+  }
+
+  // Helper: full proposal lifecycle (including execute)
+  async function passProposal(
+    proposer: SignerWithAddress,
+    voters: { signer: SignerWithAddress; support: number }[],
+    proposalType: number,
+    targets: string[],
+    values: bigint[],
+    calldatas: string[],
+    description: string
+  ): Promise<number> {
+    const proposalId = await passAndQueueProposal(
+      proposer, voters, proposalType, targets, values, calldatas, description
+    );
+    await governor.execute(proposalId);
+    return proposalId;
+  }
+
+  beforeEach(async function () {
+    [deployer, guardian, alice, bob, carol, dave] = await ethers.getSigners();
+
+    // 1. Deploy ARM token
+    const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+    armToken = await ArmadaToken.deploy(deployer.address);
+    await armToken.waitForDeployment();
+
+    // 2. Deploy TimelockController
+    const TimelockController = await ethers.getContractFactory("TimelockController");
+    timelockController = await TimelockController.deploy(
+      TWO_DAYS, [], [], deployer.address
+    );
+    await timelockController.waitForDeployment();
+    const timelockAddr = await timelockController.getAddress();
+
+    // 3. Deploy VotingLocker
+    const VotingLocker = await ethers.getContractFactory("VotingLocker");
+    votingLocker = await VotingLocker.deploy(
+      await armToken.getAddress(),
+      guardian.address, MAX_PAUSE_DURATION, timelockAddr
+    );
+    await votingLocker.waitForDeployment();
+
+    // 4. Deploy ArmadaTreasuryGov
+    const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+    treasury = await ArmadaTreasuryGov.deploy(
+      timelockAddr, guardian.address, MAX_PAUSE_DURATION
+    );
+    await treasury.waitForDeployment();
+
+    // 5. Deploy ArmadaGovernor
+    const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
+    governor = await ArmadaGovernor.deploy(
+      await votingLocker.getAddress(),
+      await armToken.getAddress(),
+      timelockAddr,
+      await treasury.getAddress(),
+      guardian.address, MAX_PAUSE_DURATION
+    );
+    await governor.waitForDeployment();
+
+    // 6. Deploy TreasurySteward
+    const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
+    stewardContract = await TreasurySteward.deploy(
+      timelockAddr,
+      await treasury.getAddress(),
+      await governor.getAddress(),
+      STEWARD_ACTION_DELAY,
+      guardian.address, MAX_PAUSE_DURATION
+    );
+    await stewardContract.waitForDeployment();
+
+    // 7. Configure timelock roles
+    const PROPOSER_ROLE = await timelockController.PROPOSER_ROLE();
+    const EXECUTOR_ROLE = await timelockController.EXECUTOR_ROLE();
+    const ADMIN_ROLE = await timelockController.TIMELOCK_ADMIN_ROLE();
+
+    await timelockController.grantRole(PROPOSER_ROLE, await governor.getAddress());
+    await timelockController.grantRole(EXECUTOR_ROLE, await governor.getAddress());
+    await timelockController.renounceRole(ADMIN_ROLE, deployer.address);
+
+    // 8. Deploy mock USDC
+    const MockUSDCV2 = await ethers.getContractFactory("MockUSDCV2");
+    usdc = await MockUSDCV2.deploy("Mock USDC", "USDC");
+    await usdc.waitForDeployment();
+
+    // 9. Distribute ARM tokens
+    await armToken.transfer(await treasury.getAddress(), TREASURY_AMOUNT);
+    await armToken.transfer(alice.address, ALICE_AMOUNT);
+    await armToken.transfer(bob.address, BOB_AMOUNT);
+
+    // 10. Mint USDC to treasury
+    await usdc.mint(await treasury.getAddress(), ethers.parseUnits("100000", USDC_DECIMALS));
+
+    // 11. Alice and Bob lock tokens
+    await armToken.connect(alice).approve(await votingLocker.getAddress(), ALICE_AMOUNT);
+    await votingLocker.connect(alice).lock(ALICE_AMOUNT);
+
+    await armToken.connect(bob).approve(await votingLocker.getAddress(), BOB_AMOUNT);
+    await votingLocker.connect(bob).lock(BOB_AMOUNT);
+
+    await mineBlock();
+  });
+
+  // ============================================================
+  // 1. EmergencyPausable Base Behavior
+  // ============================================================
+
+  describe("EmergencyPausable Base Behavior", function () {
+    it("guardian can pause a contract", async function () {
+      expect(await votingLocker.paused()).to.be.false;
+      await votingLocker.connect(guardian).emergencyPause();
+      expect(await votingLocker.paused()).to.be.true;
+    });
+
+    it("non-guardian cannot pause", async function () {
+      await expect(
+        votingLocker.connect(alice).emergencyPause()
+      ).to.be.revertedWith("EmergencyPausable: not guardian");
+    });
+
+    it("cannot pause when already paused", async function () {
+      await votingLocker.connect(guardian).emergencyPause();
+      await expect(
+        votingLocker.connect(guardian).emergencyPause()
+      ).to.be.revertedWith("EmergencyPausable: already paused");
+    });
+
+    it("pause auto-expires after maxPauseDuration", async function () {
+      await votingLocker.connect(guardian).emergencyPause();
+      expect(await votingLocker.paused()).to.be.true;
+
+      // Advance past max pause duration
+      await time.increase(MAX_PAUSE_DURATION + 1);
+
+      // Should auto-expire
+      expect(await votingLocker.paused()).to.be.false;
+    });
+
+    it("pauseExpiry is set correctly", async function () {
+      const tx = await votingLocker.connect(guardian).emergencyPause();
+      const receipt = await tx.wait();
+      const block = await ethers.provider.getBlock(receipt.blockNumber);
+
+      const expiry = await votingLocker.pauseExpiry();
+      expect(expiry).to.equal(BigInt(block!.timestamp) + BigInt(MAX_PAUSE_DURATION));
+    });
+
+    it("emits EmergencyPaused event", async function () {
+      await expect(votingLocker.connect(guardian).emergencyPause())
+        .to.emit(votingLocker, "EmergencyPaused")
+        .withArgs(guardian.address, (value: bigint) => value > 0n);
+    });
+
+    it("guardian can re-pause after auto-expiry", async function () {
+      await votingLocker.connect(guardian).emergencyPause();
+      await time.increase(MAX_PAUSE_DURATION + 1);
+      expect(await votingLocker.paused()).to.be.false;
+
+      // Should be able to pause again
+      await votingLocker.connect(guardian).emergencyPause();
+      expect(await votingLocker.paused()).to.be.true;
+    });
+  });
+
+  // ============================================================
+  // 2. Governance Unpause
+  // ============================================================
+
+  describe("Governance Unpause", function () {
+    // For these tests, we use a standalone treasury where deployer is the owner/timelock
+    // so we can call emergencyUnpause directly without full governance cycle.
+    let standaloneTreasury: any;
+
+    beforeEach(async function () {
+      const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+      standaloneTreasury = await ArmadaTreasuryGov.deploy(
+        deployer.address, // deployer acts as timelock/owner
+        guardian.address,
+        MAX_PAUSE_DURATION
+      );
+      await standaloneTreasury.waitForDeployment();
+    });
+
+    it("timelock can unpause", async function () {
+      await standaloneTreasury.connect(guardian).emergencyPause();
+      expect(await standaloneTreasury.paused()).to.be.true;
+
+      await standaloneTreasury.connect(deployer).emergencyUnpause();
+      expect(await standaloneTreasury.paused()).to.be.false;
+    });
+
+    it("non-timelock cannot unpause", async function () {
+      await standaloneTreasury.connect(guardian).emergencyPause();
+      await expect(
+        standaloneTreasury.connect(alice).emergencyUnpause()
+      ).to.be.revertedWith("EmergencyPausable: not timelock");
+    });
+
+    it("cannot unpause when not paused", async function () {
+      await expect(
+        standaloneTreasury.connect(deployer).emergencyUnpause()
+      ).to.be.revertedWith("EmergencyPausable: not paused");
+    });
+
+    it("emits EmergencyUnpaused event", async function () {
+      await standaloneTreasury.connect(guardian).emergencyPause();
+      await expect(standaloneTreasury.connect(deployer).emergencyUnpause())
+        .to.emit(standaloneTreasury, "EmergencyUnpaused")
+        .withArgs(deployer.address);
+    });
+
+    it("unpause resets pauseExpiry to 0", async function () {
+      await standaloneTreasury.connect(guardian).emergencyPause();
+      expect(await standaloneTreasury.pauseExpiry()).to.be.gt(0n);
+
+      await standaloneTreasury.connect(deployer).emergencyUnpause();
+      expect(await standaloneTreasury.pauseExpiry()).to.equal(0n);
+    });
+  });
+
+  // ============================================================
+  // 3. Guardian Rotation
+  // ============================================================
+
+  describe("Guardian Rotation", function () {
+    let standaloneTreasury: any;
+
+    beforeEach(async function () {
+      const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+      standaloneTreasury = await ArmadaTreasuryGov.deploy(
+        deployer.address, guardian.address, MAX_PAUSE_DURATION
+      );
+      await standaloneTreasury.waitForDeployment();
+    });
+
+    it("timelock can rotate guardian", async function () {
+      await standaloneTreasury.connect(deployer).setGuardian(alice.address);
+      expect(await standaloneTreasury.guardian()).to.equal(alice.address);
+    });
+
+    it("non-timelock cannot rotate guardian", async function () {
+      await expect(
+        standaloneTreasury.connect(alice).setGuardian(alice.address)
+      ).to.be.revertedWith("EmergencyPausable: not timelock");
+    });
+
+    it("cannot set zero-address guardian", async function () {
+      await expect(
+        standaloneTreasury.connect(deployer).setGuardian(ethers.ZeroAddress)
+      ).to.be.revertedWith("EmergencyPausable: zero guardian");
+    });
+
+    it("old guardian cannot pause after rotation", async function () {
+      await standaloneTreasury.connect(deployer).setGuardian(alice.address);
+      await expect(
+        standaloneTreasury.connect(guardian).emergencyPause()
+      ).to.be.revertedWith("EmergencyPausable: not guardian");
+    });
+
+    it("new guardian can pause after rotation", async function () {
+      await standaloneTreasury.connect(deployer).setGuardian(alice.address);
+      await standaloneTreasury.connect(alice).emergencyPause();
+      expect(await standaloneTreasury.paused()).to.be.true;
+    });
+
+    it("emits GuardianUpdated event", async function () {
+      await expect(standaloneTreasury.connect(deployer).setGuardian(alice.address))
+        .to.emit(standaloneTreasury, "GuardianUpdated")
+        .withArgs(guardian.address, alice.address);
+    });
+  });
+
+  // ============================================================
+  // 4. Constructor Validation
+  // ============================================================
+
+  describe("Constructor Validation", function () {
+    it("rejects zero guardian", async function () {
+      const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+      await expect(
+        ArmadaTreasuryGov.deploy(deployer.address, ethers.ZeroAddress, MAX_PAUSE_DURATION)
+      ).to.be.revertedWith("EmergencyPausable: zero guardian");
+    });
+
+    it("rejects zero maxPauseDuration", async function () {
+      const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+      await expect(
+        ArmadaTreasuryGov.deploy(deployer.address, guardian.address, 0)
+      ).to.be.revertedWith("EmergencyPausable: zero duration");
+    });
+
+    it("rejects zero timelock", async function () {
+      const VotingLocker = await ethers.getContractFactory("VotingLocker");
+      await expect(
+        VotingLocker.deploy(await armToken.getAddress(), guardian.address, MAX_PAUSE_DURATION, ethers.ZeroAddress)
+      ).to.be.revertedWith("EmergencyPausable: zero timelock");
+    });
+  });
+
+  // ============================================================
+  // 5. VotingLocker Pause Behavior
+  // ============================================================
+
+  describe("VotingLocker Pause", function () {
+    // Use a standalone VotingLocker where deployer is the pauseTimelock for direct control
+    let standaloneLocker: any;
+
+    beforeEach(async function () {
+      const VotingLocker = await ethers.getContractFactory("VotingLocker");
+      standaloneLocker = await VotingLocker.deploy(
+        await armToken.getAddress(),
+        guardian.address, MAX_PAUSE_DURATION, deployer.address
+      );
+      await standaloneLocker.waitForDeployment();
+
+      // Deploy a fresh ARM token for this standalone test (main supply is fully allocated)
+      const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+      const standaloneArm = await ArmadaToken.deploy(deployer.address);
+      await standaloneArm.waitForDeployment();
+
+      const VotingLockerFactory = await ethers.getContractFactory("VotingLocker");
+      standaloneLocker = await VotingLockerFactory.deploy(
+        await standaloneArm.getAddress(),
+        guardian.address, MAX_PAUSE_DURATION, deployer.address
+      );
+      await standaloneLocker.waitForDeployment();
+
+      const carolAmount = ethers.parseUnits("1000", ARM_DECIMALS);
+      await standaloneArm.transfer(carol.address, carolAmount);
+      await standaloneArm.connect(carol).approve(await standaloneLocker.getAddress(), carolAmount);
+      await standaloneLocker.connect(carol).lock(ethers.parseUnits("500", ARM_DECIMALS));
+    });
+
+    it("unlock reverts when paused", async function () {
+      await standaloneLocker.connect(guardian).emergencyPause();
+
+      await expect(
+        standaloneLocker.connect(carol).unlock(ethers.parseUnits("100", ARM_DECIMALS))
+      ).to.be.revertedWith("Pausable: paused");
+    });
+
+    it("lock remains available when paused", async function () {
+      await standaloneLocker.connect(guardian).emergencyPause();
+
+      // Lock should still work
+      await standaloneLocker.connect(carol).lock(ethers.parseUnits("100", ARM_DECIMALS));
+      const balance = await standaloneLocker.getLockedBalance(carol.address);
+      expect(balance).to.equal(ethers.parseUnits("600", ARM_DECIMALS));
+    });
+
+    it("unlock works again after unpause", async function () {
+      await standaloneLocker.connect(guardian).emergencyPause();
+      await standaloneLocker.connect(deployer).emergencyUnpause();
+
+      await standaloneLocker.connect(carol).unlock(ethers.parseUnits("100", ARM_DECIMALS));
+      const balance = await standaloneLocker.getLockedBalance(carol.address);
+      expect(balance).to.equal(ethers.parseUnits("400", ARM_DECIMALS));
+    });
+
+    it("unlock works again after auto-expiry", async function () {
+      await standaloneLocker.connect(guardian).emergencyPause();
+      await time.increase(MAX_PAUSE_DURATION + 1);
+
+      await standaloneLocker.connect(carol).unlock(ethers.parseUnits("100", ARM_DECIMALS));
+      const balance = await standaloneLocker.getLockedBalance(carol.address);
+      expect(balance).to.equal(ethers.parseUnits("400", ARM_DECIMALS));
+    });
+  });
+
+  // ============================================================
+  // 6. ArmadaTreasuryGov Pause Behavior
+  // ============================================================
+
+  describe("ArmadaTreasuryGov Pause", function () {
+    let standaloneTreasury: any;
+
+    beforeEach(async function () {
+      const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+      standaloneTreasury = await ArmadaTreasuryGov.deploy(
+        deployer.address, guardian.address, MAX_PAUSE_DURATION
+      );
+      await standaloneTreasury.waitForDeployment();
+
+      // Fund with USDC
+      await usdc.mint(await standaloneTreasury.getAddress(), ethers.parseUnits("100000", USDC_DECIMALS));
+
+      // Set carol as steward
+      await standaloneTreasury.setSteward(carol.address);
+
+      // Create a claim for alice
+      await standaloneTreasury.createClaim(
+        await usdc.getAddress(), alice.address, ethers.parseUnits("10000", USDC_DECIMALS)
+      );
+    });
+
+    it("distribute reverts when paused", async function () {
+      await standaloneTreasury.connect(guardian).emergencyPause();
+
+      await expect(
+        standaloneTreasury.distribute(await usdc.getAddress(), bob.address, ethers.parseUnits("100", USDC_DECIMALS))
+      ).to.be.revertedWith("Pausable: paused");
+    });
+
+    it("exerciseClaim reverts when paused", async function () {
+      await standaloneTreasury.connect(guardian).emergencyPause();
+
+      await expect(
+        standaloneTreasury.connect(alice).exerciseClaim(1, ethers.parseUnits("100", USDC_DECIMALS))
+      ).to.be.revertedWith("Pausable: paused");
+    });
+
+    it("stewardSpend reverts when paused", async function () {
+      await standaloneTreasury.connect(guardian).emergencyPause();
+
+      await expect(
+        standaloneTreasury.connect(carol).stewardSpend(
+          await usdc.getAddress(), dave.address, ethers.parseUnits("100", USDC_DECIMALS)
+        )
+      ).to.be.revertedWith("Pausable: paused");
+    });
+
+    it("createClaim still works when paused (owner-only, no fund outflow)", async function () {
+      await standaloneTreasury.connect(guardian).emergencyPause();
+
+      // Creating a claim is safe — it doesn't move funds out
+      await standaloneTreasury.createClaim(
+        await usdc.getAddress(), bob.address, ethers.parseUnits("5000", USDC_DECIMALS)
+      );
+      const remaining = await standaloneTreasury.getClaimRemaining(2);
+      expect(remaining).to.equal(ethers.parseUnits("5000", USDC_DECIMALS));
+    });
+
+    it("all paused functions resume after unpause", async function () {
+      await standaloneTreasury.connect(guardian).emergencyPause();
+      await standaloneTreasury.connect(deployer).emergencyUnpause();
+
+      // distribute should work
+      await standaloneTreasury.distribute(
+        await usdc.getAddress(), bob.address, ethers.parseUnits("100", USDC_DECIMALS)
+      );
+
+      // exerciseClaim should work
+      await standaloneTreasury.connect(alice).exerciseClaim(1, ethers.parseUnits("100", USDC_DECIMALS));
+
+      // stewardSpend should work
+      await standaloneTreasury.connect(carol).stewardSpend(
+        await usdc.getAddress(), dave.address, ethers.parseUnits("100", USDC_DECIMALS)
+      );
+    });
+  });
+
+  // ============================================================
+  // 7. TreasurySteward Pause Behavior
+  // ============================================================
+
+  describe("TreasurySteward Pause", function () {
+    let standaloneSteward: any;
+    let standaloneTreasury: any;
+
+    beforeEach(async function () {
+      // Deploy standalone treasury + steward with deployer as timelock
+      const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+      standaloneTreasury = await ArmadaTreasuryGov.deploy(
+        deployer.address, guardian.address, MAX_PAUSE_DURATION
+      );
+      await standaloneTreasury.waitForDeployment();
+
+      const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
+      standaloneSteward = await TreasurySteward.deploy(
+        deployer.address,
+        await standaloneTreasury.getAddress(),
+        await governor.getAddress(),
+        STEWARD_ACTION_DELAY,
+        guardian.address, MAX_PAUSE_DURATION
+      );
+      await standaloneSteward.waitForDeployment();
+
+      // Elect carol as steward
+      await standaloneSteward.electSteward(carol.address);
+
+      // Fund treasury and set steward contract as treasury's steward
+      await usdc.mint(await standaloneTreasury.getAddress(), ethers.parseUnits("1000000", USDC_DECIMALS));
+      await standaloneTreasury.setSteward(await standaloneSteward.getAddress());
+    });
+
+    it("executeAction reverts when paused", async function () {
+      // Propose a valid action
+      const spendData = standaloneTreasury.interface.encodeFunctionData("stewardSpend", [
+        await usdc.getAddress(), dave.address, ethers.parseUnits("100", USDC_DECIMALS)
+      ]);
+      await standaloneSteward.connect(carol).proposeAction(
+        await standaloneTreasury.getAddress(), spendData, 0
+      );
+
+      // Wait for delay
+      await time.increase(STEWARD_ACTION_DELAY + 1);
+
+      // Pause the steward
+      await standaloneSteward.connect(guardian).emergencyPause();
+
+      // Execute should fail
+      await expect(
+        standaloneSteward.connect(carol).executeAction(1)
+      ).to.be.revertedWith("Pausable: paused");
+    });
+
+    it("proposeAction still works when paused (proposing is harmless)", async function () {
+      await standaloneSteward.connect(guardian).emergencyPause();
+
+      const spendData = standaloneTreasury.interface.encodeFunctionData("stewardSpend", [
+        await usdc.getAddress(), dave.address, ethers.parseUnits("100", USDC_DECIMALS)
+      ]);
+      await standaloneSteward.connect(carol).proposeAction(
+        await standaloneTreasury.getAddress(), spendData, 0
+      );
+
+      expect(await standaloneSteward.actionCount()).to.equal(1);
+    });
+
+    it("executeAction works after unpause", async function () {
+      const spendData = standaloneTreasury.interface.encodeFunctionData("stewardSpend", [
+        await usdc.getAddress(), dave.address, ethers.parseUnits("100", USDC_DECIMALS)
+      ]);
+      await standaloneSteward.connect(carol).proposeAction(
+        await standaloneTreasury.getAddress(), spendData, 0
+      );
+      await time.increase(STEWARD_ACTION_DELAY + 1);
+
+      // Pause then unpause
+      await standaloneSteward.connect(guardian).emergencyPause();
+      await standaloneSteward.connect(deployer).emergencyUnpause();
+
+      // Should execute successfully
+      await standaloneSteward.connect(carol).executeAction(1);
+      const [,,, executed] = await standaloneSteward.getAction(1);
+      expect(executed).to.be.true;
+    });
+  });
+
+  // ============================================================
+  // 8. ArmadaGovernor Pause Behavior
+  // ============================================================
+
+  describe("ArmadaGovernor Pause", function () {
+    // For governor, we need to test that execute() reverts when paused.
+    // We need a standalone governor where we can call emergencyPause via the guardian
+    // and emergencyUnpause via the timelock.
+    // The main governor's pauseTimelock is the real timelockController.
+
+    // Use a standalone governor with deployer as pauseTimelock for direct control
+    let standaloneGovernor: any;
+    let standaloneTimelock: any;
+
+    beforeEach(async function () {
+      // Deploy a separate timelock and governor where deployer keeps admin
+      const TimelockController = await ethers.getContractFactory("TimelockController");
+      standaloneTimelock = await TimelockController.deploy(
+        TWO_DAYS, [], [], deployer.address
+      );
+      await standaloneTimelock.waitForDeployment();
+      const tlAddr = await standaloneTimelock.getAddress();
+
+      // Deploy standalone governor with deployer as pauseTimelock via the guardian constructor param
+      // Actually, the pauseTimelock IS the timelock param. So we need the governor to use
+      // a timelock we control. Let's use the standaloneTimelock but keep deployer as admin.
+      const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
+      standaloneGovernor = await ArmadaGovernor.deploy(
+        await votingLocker.getAddress(),
+        await armToken.getAddress(),
+        tlAddr,
+        await treasury.getAddress(),
+        guardian.address, MAX_PAUSE_DURATION
+      );
+      await standaloneGovernor.waitForDeployment();
+
+      // Grant governor the proposer/executor roles on the timelock
+      const PROPOSER_ROLE = await standaloneTimelock.PROPOSER_ROLE();
+      const EXECUTOR_ROLE = await standaloneTimelock.EXECUTOR_ROLE();
+      await standaloneTimelock.grantRole(PROPOSER_ROLE, await standaloneGovernor.getAddress());
+      await standaloneTimelock.grantRole(EXECUTOR_ROLE, await standaloneGovernor.getAddress());
+    });
+
+    it("propose still works when paused", async function () {
+      await standaloneGovernor.connect(guardian).emergencyPause();
+
+      await standaloneGovernor.connect(alice).propose(
+        ProposalType.ParameterChange,
+        [await standaloneGovernor.getAddress()],
+        [0n],
+        [standaloneGovernor.interface.encodeFunctionData("proposalCount")],
+        "Test proposal while paused"
+      );
+      expect(await standaloneGovernor.proposalCount()).to.equal(1);
+    });
+
+    it("castVote still works when paused", async function () {
+      // Create a proposal first
+      await standaloneGovernor.connect(alice).propose(
+        ProposalType.ParameterChange,
+        [await standaloneGovernor.getAddress()],
+        [0n],
+        [standaloneGovernor.interface.encodeFunctionData("proposalCount")],
+        "Test vote while paused"
+      );
+
+      await time.increase(TWO_DAYS + 1);
+
+      // Pause, then vote
+      await standaloneGovernor.connect(guardian).emergencyPause();
+
+      await standaloneGovernor.connect(alice).castVote(1, Vote.For);
+      expect(await standaloneGovernor.hasVoted(1, alice.address)).to.be.true;
+    });
+
+    it("execute reverts when paused", async function () {
+      // Create and advance a proposal to Queued state
+      await standaloneGovernor.connect(alice).propose(
+        ProposalType.ParameterChange,
+        [await standaloneGovernor.getAddress()],
+        [0n],
+        [standaloneGovernor.interface.encodeFunctionData("proposalCount")],
+        "Test execute while paused"
+      );
+
+      await time.increase(TWO_DAYS + 1);
+      await standaloneGovernor.connect(alice).castVote(1, Vote.For);
+      await standaloneGovernor.connect(bob).castVote(1, Vote.For);
+      await time.increase(FIVE_DAYS + 1);
+      await standaloneGovernor.queue(1);
+      await time.increase(TWO_DAYS + 1);
+
+      // Pause the governor
+      await standaloneGovernor.connect(guardian).emergencyPause();
+
+      await expect(
+        standaloneGovernor.execute(1)
+      ).to.be.revertedWith("Pausable: paused");
+    });
+  });
+
+  // ============================================================
+  // 9. Adversarial: Guardian Cannot Permanently Freeze
+  // ============================================================
+
+  describe("Guardian Cannot Permanently Freeze", function () {
+    let standaloneTreasury: any;
+
+    beforeEach(async function () {
+      const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+      standaloneTreasury = await ArmadaTreasuryGov.deploy(
+        deployer.address, guardian.address, MAX_PAUSE_DURATION
+      );
+      await standaloneTreasury.waitForDeployment();
+
+      await usdc.mint(await standaloneTreasury.getAddress(), ethers.parseUnits("100000", USDC_DECIMALS));
+    });
+
+    it("pause auto-expires even if guardian does nothing", async function () {
+      await standaloneTreasury.connect(guardian).emergencyPause();
+      expect(await standaloneTreasury.paused()).to.be.true;
+
+      // Advance past max pause
+      await time.increase(MAX_PAUSE_DURATION + 1);
+      expect(await standaloneTreasury.paused()).to.be.false;
+
+      // distribute should work again
+      await standaloneTreasury.distribute(
+        await usdc.getAddress(), bob.address, ethers.parseUnits("100", USDC_DECIMALS)
+      );
+    });
+
+    it("guardian cannot extend pause beyond maxPauseDuration", async function () {
+      await standaloneTreasury.connect(guardian).emergencyPause();
+
+      // Advance to 1 second before expiry
+      await time.increase(MAX_PAUSE_DURATION - 2);
+      expect(await standaloneTreasury.paused()).to.be.true;
+
+      // Guardian cannot re-pause while still paused
+      await expect(
+        standaloneTreasury.connect(guardian).emergencyPause()
+      ).to.be.revertedWith("EmergencyPausable: already paused");
+    });
+
+    it("guardian can re-pause after expiry, but each pause is time-limited", async function () {
+      // First pause
+      await standaloneTreasury.connect(guardian).emergencyPause();
+      await time.increase(MAX_PAUSE_DURATION + 1);
+      expect(await standaloneTreasury.paused()).to.be.false;
+
+      // Second pause
+      await standaloneTreasury.connect(guardian).emergencyPause();
+      expect(await standaloneTreasury.paused()).to.be.true;
+      await time.increase(MAX_PAUSE_DURATION + 1);
+      expect(await standaloneTreasury.paused()).to.be.false;
+    });
+  });
+
+  // ============================================================
+  // 10. maxPauseDuration and guardian are correctly set
+  // ============================================================
+
+  describe("Immutable Configuration", function () {
+    it("maxPauseDuration is set correctly on all contracts", async function () {
+      expect(await votingLocker.maxPauseDuration()).to.equal(MAX_PAUSE_DURATION);
+      expect(await treasury.maxPauseDuration()).to.equal(MAX_PAUSE_DURATION);
+      expect(await governor.maxPauseDuration()).to.equal(MAX_PAUSE_DURATION);
+      expect(await stewardContract.maxPauseDuration()).to.equal(MAX_PAUSE_DURATION);
+    });
+
+    it("guardian is set correctly on all contracts", async function () {
+      expect(await votingLocker.guardian()).to.equal(guardian.address);
+      expect(await treasury.guardian()).to.equal(guardian.address);
+      expect(await governor.guardian()).to.equal(guardian.address);
+      expect(await stewardContract.guardian()).to.equal(guardian.address);
+    });
+
+    it("pauseTimelock is set correctly on all contracts", async function () {
+      const timelockAddr = await timelockController.getAddress();
+      expect(await votingLocker.pauseTimelock()).to.equal(timelockAddr);
+      expect(await treasury.pauseTimelock()).to.equal(timelockAddr);
+      expect(await governor.pauseTimelock()).to.equal(timelockAddr);
+      expect(await stewardContract.pauseTimelock()).to.equal(timelockAddr);
+    });
+  });
+});

--- a/test/governance_integration.ts
+++ b/test/governance_integration.ts
@@ -114,12 +114,7 @@ describe("Governance Integration", function () {
     armToken = await ArmadaToken.deploy(deployer.address);
     await armToken.waitForDeployment();
 
-    // 2. Deploy VotingLocker
-    const VotingLocker = await ethers.getContractFactory("VotingLocker");
-    votingLocker = await VotingLocker.deploy(await armToken.getAddress());
-    await votingLocker.waitForDeployment();
-
-    // 3. Deploy TimelockController (minDelay = 2 days, deployer as temp admin)
+    // 2. Deploy TimelockController (minDelay = 2 days, deployer as temp admin)
     const TimelockController = await ethers.getContractFactory("TimelockController");
     timelockController = await TimelockController.deploy(
       TWO_DAYS,
@@ -128,10 +123,28 @@ describe("Governance Integration", function () {
       deployer.address // admin
     );
     await timelockController.waitForDeployment();
+    const timelockAddr = await timelockController.getAddress();
+
+    // Emergency pause config: deployer as guardian, 14 day max pause duration
+    const MAX_PAUSE_DURATION = 14 * ONE_DAY;
+
+    // 3. Deploy VotingLocker
+    const VotingLocker = await ethers.getContractFactory("VotingLocker");
+    votingLocker = await VotingLocker.deploy(
+      await armToken.getAddress(),
+      deployer.address,        // guardian
+      MAX_PAUSE_DURATION,
+      timelockAddr             // pauseTimelock
+    );
+    await votingLocker.waitForDeployment();
 
     // 4. Deploy ArmadaTreasuryGov (owned by timelock)
     const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
-    treasury = await ArmadaTreasuryGov.deploy(await timelockController.getAddress());
+    treasury = await ArmadaTreasuryGov.deploy(
+      timelockAddr,
+      deployer.address,        // guardian
+      MAX_PAUSE_DURATION
+    );
     await treasury.waitForDeployment();
 
     // 5. Deploy ArmadaGovernor
@@ -139,18 +152,22 @@ describe("Governance Integration", function () {
     governor = await ArmadaGovernor.deploy(
       await votingLocker.getAddress(),
       await armToken.getAddress(),
-      await timelockController.getAddress(),
-      await treasury.getAddress()
+      timelockAddr,
+      await treasury.getAddress(),
+      deployer.address,        // guardian
+      MAX_PAUSE_DURATION
     );
     await governor.waitForDeployment();
 
     // 6. Deploy TreasurySteward
     const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
     stewardContract = await TreasurySteward.deploy(
-      await timelockController.getAddress(),
+      timelockAddr,
       await treasury.getAddress(),
       await governor.getAddress(),
-      STEWARD_ACTION_DELAY
+      STEWARD_ACTION_DELAY,
+      deployer.address,        // guardian
+      MAX_PAUSE_DURATION
     );
     await stewardContract.waitForDeployment();
 


### PR DESCRIPTION
## Summary

- Adds `EmergencyPausable` abstract contract: guardian-triggered pause with configurable auto-expiry, governance (timelock) unpause, and guardian rotation
- All 4 governance contracts inherit EmergencyPausable: ArmadaGovernor, ArmadaTreasuryGov, TreasurySteward, VotingLocker
- Only state-changing outflow functions are paused (`execute`, `distribute`, `exerciseClaim`, `stewardSpend`, `executeAction`, `unlock`); deliberation functions (propose, vote, lock) remain available during emergencies
- Deploy order updated: TimelockController now deploys before VotingLocker (needed for `pauseTimelock` param)

Closes #26

## Test plan

- [x] `npm run test:governance` — existing governance tests pass with updated constructor signatures
- [x] New `test/governance_emergency_pause.ts` (812 lines) covers: guardian pause/unpause, auto-expiry, guardian rotation, constructor validation, per-contract pause behavior, adversarial scenarios, immutable configuration checks
- [x] `npm run test:forge` — Foundry fuzz/invariant tests updated and passing


🤖 Generated with [Claude Code](https://claude.com/claude-code)