### PR TITLE
feat: align crowdfund allocation with spec (#73)

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -1,3 +1,6 @@
+// ABOUTME: Word-of-mouth whitelist crowdfund with hop-based allocation.
+// ABOUTME: Implements overlapping ceilings, hop-2 floor, elastic expansion, and pro-rata refunds.
+
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
@@ -25,6 +28,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     uint32 public constant HOP1_ROLLOVER_MIN = 30;  // min unique hop-1 committers for rollover
     uint32 public constant HOP2_ROLLOVER_MIN = 50;  // min unique hop-2 committers for rollover
     uint8 public constant NUM_HOPS = 3;
+    uint256 public constant HOP2_FLOOR_BPS = 500;  // 5% of saleSize reserved for hop-2
 
     uint256 public constant INVITATION_DURATION = 14 days;
     uint256 public constant COMMITMENT_DURATION = 7 days;
@@ -66,7 +70,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     uint256 public saleSize;
     uint256 public totalAllocated;       // ARM (18 dec) — hop-level upper bound
     uint256 public totalAllocatedUsdc;   // USDC (6 dec) — hop-level upper bound
-    uint256[3] public finalReserves;     // hop reserves after rollover (stored at finalization)
+    uint256[3] public finalCeilings;     // budget-capped hop ceilings (stored at finalization)
     uint256[3] public finalDemands;      // hop demands (stored at finalization)
     uint256 public treasuryLeftoverUsdc; // USDC (6 dec) — unallocated reserve that goes to treasury
 
@@ -112,9 +116,9 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         treasury = _treasury;
         phase = Phase.Setup;
 
-        hopConfigs[0] = HopConfig({ reserveBps: 7000, capUsdc: 15_000 * 1e6, maxInvites: 3 });
-        hopConfigs[1] = HopConfig({ reserveBps: 2500, capUsdc: 4_000 * 1e6,  maxInvites: 2 });
-        hopConfigs[2] = HopConfig({ reserveBps: 500,  capUsdc: 1_000 * 1e6,  maxInvites: 0 });
+        hopConfigs[0] = HopConfig({ ceilingBps: 7000, capUsdc: 15_000 * 1e6, maxInvites: 3 });
+        hopConfigs[1] = HopConfig({ ceilingBps: 4500, capUsdc: 4_000 * 1e6,  maxInvites: 2 });
+        hopConfigs[2] = HopConfig({ ceilingBps: 1000, capUsdc: 1_000 * 1e6,  maxInvites: 0 });
     }
 
     // ============ Setup Phase ============
@@ -277,64 +281,66 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
             "ArmadaCrowdfund: insufficient ARM"
         );
 
-        // Step 2: Per-hop allocation with sequential rollover
-        uint256[3] memory reserves;
+        // Step 2: Per-hop allocation with overlapping ceilings and global budget constraint
+        //
+        // Hop-2 floor is reserved off the top. Hop-0/hop-1 ceilings are applied against
+        // the net raise (saleSize minus floor). Ceilings overlap (sum > 100%) so a global
+        // budget constraint (remaining) ensures total allocation never exceeds saleSize.
+
+        uint256 hop2Floor = (saleSize * HOP2_FLOOR_BPS) / 10000;
+        uint256 netRaise = saleSize - hop2Floor;
+
+        // Base ceilings: hop 0/1 against netRaise, hop 2 against full saleSize
+        uint256[3] memory effectiveCeilings;
+        effectiveCeilings[0] = (netRaise * hopConfigs[0].ceilingBps) / 10000;
+        effectiveCeilings[1] = (netRaise * hopConfigs[1].ceilingBps) / 10000;
+        effectiveCeilings[2] = (saleSize * hopConfigs[2].ceilingBps) / 10000;
+
         uint256[3] memory demands;
-        uint256 treasuryLeftover = 0;
-
-        for (uint8 h = 0; h < NUM_HOPS; h++) {
-            reserves[h] = (saleSize * hopConfigs[h].reserveBps) / 10000;
-            demands[h] = hopStats[h].totalCommitted;
-        }
-
-        // Process hops sequentially (0 → 1 → 2) with rollover
-        for (uint8 h = 0; h < NUM_HOPS; h++) {
-            if (demands[h] <= reserves[h]) {
-                // Under-subscribed: full allocation, compute leftover
-                uint256 hopLeftover = reserves[h] - demands[h];
-
-                // Apply rollover rules
-                if (h == 0) {
-                    if (hopStats[1].uniqueCommitters >= HOP1_ROLLOVER_MIN) {
-                        reserves[1] += hopLeftover;
-                    } else {
-                        treasuryLeftover += hopLeftover;
-                    }
-                } else if (h == 1) {
-                    if (hopStats[2].uniqueCommitters >= HOP2_ROLLOVER_MIN) {
-                        reserves[2] += hopLeftover;
-                    } else {
-                        treasuryLeftover += hopLeftover;
-                    }
-                } else {
-                    treasuryLeftover += hopLeftover;
-                }
-            }
-            // Over-subscribed: no leftover (all reserve used), no rollover
-        }
-
-        // Step 3: Store hop-level data for lazy evaluation in claim()
-        // Individual allocations are computed on-the-fly in claim() and getAllocation()
-        // using finalReserves[hop] and finalDemands[hop], making finalize() O(1).
+        uint256 remaining = netRaise;  // hops 0/1 compete for netRaise only
         uint256 totalAllocUsdc_ = 0;
         uint256 totalAllocArm_ = 0;
 
         for (uint8 h = 0; h < NUM_HOPS; h++) {
-            finalReserves[h] = reserves[h];
+            demands[h] = hopStats[h].totalCommitted;
+
+            // When we reach hop 2, add back the floor reservation to the remaining budget
+            if (h == 2) {
+                remaining += hop2Floor;
+            }
+
+            // Global budget constraint: cap effective ceiling against remaining supply
+            uint256 ceiling = effectiveCeilings[h] < remaining ? effectiveCeilings[h] : remaining;
+
+            uint256 allocated = demands[h] <= ceiling ? demands[h] : ceiling;
+            remaining -= allocated;
+
+            // Store budget-capped ceiling for lazy evaluation in claim() and getAllocation()
+            finalCeilings[h] = ceiling;
             finalDemands[h] = demands[h];
 
-            // Hop-level totals (upper bounds due to per-participant integer division)
-            uint256 hopAlloc = demands[h] <= reserves[h] ? demands[h] : reserves[h];
-            totalAllocUsdc_ += hopAlloc;
-            totalAllocArm_ += (hopAlloc * 1e18) / ARM_PRICE;
+            totalAllocUsdc_ += allocated;
+            totalAllocArm_ += (allocated * 1e18) / ARM_PRICE;
+
+            // Rollover: unused ceiling capacity flows to the next hop
+            uint256 leftover = ceiling - allocated;
+            if (leftover > 0) {
+                if (h == 0 && hopStats[1].uniqueCommitters >= HOP1_ROLLOVER_MIN) {
+                    effectiveCeilings[1] += leftover;
+                } else if (h == 1 && hopStats[2].uniqueCommitters >= HOP2_ROLLOVER_MIN) {
+                    effectiveCeilings[2] += leftover;
+                }
+                // If not rolled over, leftover remains in the budget pool (remaining)
+                // and becomes part of treasuryLeftoverUsdc at the end
+            }
         }
 
         totalAllocatedUsdc = totalAllocUsdc_;
         totalAllocated = totalAllocArm_;
-        treasuryLeftoverUsdc = treasuryLeftover;
+        treasuryLeftoverUsdc = saleSize - totalAllocUsdc_;
         phase = Phase.Finalized;
 
-        emit SaleFinalized(saleSize, totalAllocUsdc_, totalAllocArm_, treasuryLeftover);
+        emit SaleFinalized(saleSize, totalAllocUsdc_, totalAllocArm_, treasuryLeftoverUsdc);
     }
 
     // ============ Claims & Withdrawals ============
@@ -506,8 +512,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
     // ============ Internal ============
 
-    /// @dev Compute allocation for a participant from stored hop-level reserves/demands.
-    ///      Identical math to the original finalize() loop, but evaluated lazily.
+    /// @dev Compute allocation for a participant from stored hop-level ceilings/demands.
+    ///      Uses the budget-capped ceiling stored at finalization for pro-rata scaling.
     function _computeAllocation(uint256 committed, uint8 hop) internal view returns (
         uint256 allocArm,
         uint256 allocUsdc,
@@ -515,15 +521,15 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     ) {
         if (committed == 0) return (0, 0, 0);
 
-        if (finalDemands[hop] <= finalReserves[hop]) {
+        if (finalDemands[hop] <= finalCeilings[hop]) {
             // Under-subscribed: full allocation
             allocUsdc = committed;
             allocArm = (committed * 1e18) / ARM_PRICE;
         } else {
             // Over-subscribed: pro-rata
-            allocUsdc = (committed * finalReserves[hop]) / finalDemands[hop];
+            allocUsdc = (committed * finalCeilings[hop]) / finalDemands[hop];
             // Compute ARM directly to avoid divide-before-multiply precision loss
-            allocArm = (committed * finalReserves[hop] * 1e18) / (finalDemands[hop] * ARM_PRICE);
+            allocArm = (committed * finalCeilings[hop] * 1e18) / (finalDemands[hop] * ARM_PRICE);
         }
         refundUsdc = committed - allocUsdc;
     }

--- a/contracts/crowdfund/IArmadaCrowdfund.sol
+++ b/contracts/crowdfund/IArmadaCrowdfund.sol
@@ -1,3 +1,6 @@
+// ABOUTME: Shared types (enums, structs) for the Armada crowdfund system.
+// ABOUTME: Imported by ArmadaCrowdfund.sol and test contracts.
+
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
@@ -16,7 +19,7 @@ enum Phase {
 // ========== Structs ==========
 
 struct HopConfig {
-    uint16 reserveBps;      // Reserve as basis points of sale size (7000, 2500, 500)
+    uint16 ceilingBps;      // Ceiling as basis points — overlapping, sum > 10000 (7000, 4500, 1000)
     uint256 capUsdc;        // Max individual commitment in USDC (6 decimals)
     uint8 maxInvites;       // How many addresses this hop can invite (3, 2, 0)
 }

--- a/crowdfund-frontend/src/config/abi.ts
+++ b/crowdfund-frontend/src/config/abi.ts
@@ -32,7 +32,7 @@ export const CROWDFUND_ABI = [
   'function participants(address) view returns (uint8 hop, bool isWhitelisted, uint256 committed, uint256 allocation, uint256 refund, bool claimed, address invitedBy, uint8 invitesSent)',
   'function participantList(uint256) view returns (address)',
   'function hopStats(uint8) view returns (uint256 totalCommitted, uint32 uniqueCommitters, uint32 whitelistCount)',
-  'function finalReserves(uint256) view returns (uint256)',
+  'function finalCeilings(uint256) view returns (uint256)',
   'function finalDemands(uint256) view returns (uint256)',
   'function totalProceedsAccrued() view returns (uint256)',
   'function totalArmClaimed() view returns (uint256)',

--- a/scripts/full_lifecycle_demo.ts
+++ b/scripts/full_lifecycle_demo.ts
@@ -325,13 +325,13 @@ async function main() {
 
   // Show allocation math per hop
   for (let h = 0; h < 3; h++) {
-    const reserve = await crowdfund.finalReserves(h);
+    const ceiling = await crowdfund.finalCeilings(h);
     const demand  = await crowdfund.finalDemands(h);
-    const overSub = demand > reserve;
+    const overSub = demand > ceiling;
     const allocLabel = overSub
-      ? `PRO-RATA (${((Number(reserve) / Number(demand)) * 100).toFixed(1)}%)`
+      ? `PRO-RATA (${((Number(ceiling) / Number(demand)) * 100).toFixed(1)}%)`
       : "FULL ALLOC";
-    log("ALLOC", `Hop ${h}: reserve ${fmtUsdc(reserve)} | demand ${fmtUsdc(demand)} \u2192 ${allocLabel}`);
+    log("ALLOC", `Hop ${h}: ceiling ${fmtUsdc(ceiling)} | demand ${fmtUsdc(demand)} \u2192 ${allocLabel}`);
   }
 
   const totalAllocArm  = await crowdfund.totalAllocated();

--- a/test-foundry/CrowdfundFullInvariant.t.sol
+++ b/test-foundry/CrowdfundFullInvariant.t.sol
@@ -8,8 +8,8 @@ import "../contracts/governance/ArmadaToken.sol";
 import "../contracts/cctp/MockUSDCV2.sol";
 
 // ══════════════════════════════════════════════════════════════════════════
-// INV-C2: Reserve BPS across hops sum to 10000
-// (Extends the existing CrowdfundInvariant.t.sol with this missing invariant)
+// INV-C2: Ceiling BPS match expected overlapping values
+// (Extends the existing CrowdfundInvariant.t.sol with this ceiling invariant)
 // ══════════════════════════════════════════════════════════════════════════
 
 /// @title CrowdfundFullHandler — Minimal handler to exercise crowdfund for BPS check
@@ -249,17 +249,17 @@ contract CrowdfundFullInvariantTest is Test {
     }
 
     // ══════════════════════════════════════════════════════════════════════
-    // INV-C2: Reserve BPS across hops sum to 10000
+    // INV-C2: Ceiling BPS match expected overlapping values (sum = 12500)
     // ══════════════════════════════════════════════════════════════════════
 
-    /// @notice Hop reserve basis points always sum to exactly 10000 (100%)
-    function invariant_reserveBpsSumTo10000() public view {
-        uint256 sum;
-        for (uint8 h = 0; h < 3; h++) {
-            (uint16 bps, , ) = crowdfund.hopConfigs(h);
-            sum += bps;
-        }
-        assertEq(sum, 10000, "INV-C2: Reserve BPS don't sum to 10000");
+    /// @notice Hop ceiling basis points match spec: 7000/4500/1000 (overlapping, sum > 10000)
+    function invariant_ceilingBpsAreValid() public view {
+        (uint16 bps0, , ) = crowdfund.hopConfigs(0);
+        (uint16 bps1, , ) = crowdfund.hopConfigs(1);
+        (uint16 bps2, , ) = crowdfund.hopConfigs(2);
+        assertEq(bps0, 7000, "INV-C2: Hop 0 ceiling should be 7000");
+        assertEq(bps1, 4500, "INV-C2: Hop 1 ceiling should be 4500");
+        assertEq(bps2, 1000, "INV-C2: Hop 2 ceiling should be 1000");
     }
 
     // ══════════════════════════════════════════════════════════════════════

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -299,18 +299,18 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       expect(quorum).to.equal(expectedQuorum);
       // Verify the quorum is reachable: 600K ARM, deployer has 200K locked,
-      // seeds claimed ~840K total (80 seeds * 10.5K each)
+      // seeds claimed ~798K total (80 seeds * ~9,975 each)
       expect(quorum).to.equal(ARM(600_000));
     });
 
     it("proposal threshold (0.1% of total supply = 100K ARM) is reachable by crowdfund participant", async function () {
       await runCrowdfundAndClaim();
 
-      // With BASE_SALE ($1.2M), hop-0 reserve = 70% = $840K.
-      // 80 seeds * $15K = $1.2M demand > $840K reserve → pro-rata.
-      // Each seed gets (15K * 840K) / 1.2M = $10,500 = 10,500 ARM.
+      // With BASE_SALE ($1.2M), hop-0 ceiling = 70% of netRaise = 70% of $1.14M = $798K.
+      // 80 seeds * $15K = $1.2M demand > $798K ceiling → pro-rata.
+      // Each seed gets (15K * 798K) / 1.2M = $9,975 = 9,975 ARM.
       // Threshold = 100M * 0.001 = 100,000 ARM.
-      // Need ceil(100K / 10.5K) = 10 seeds pooled.
+      // Need ceil(100K / 9.975K) = 11 seeds pooled.
 
       const threshold = await governor.proposalThreshold();
       expect(threshold).to.equal(ARM(100_000));
@@ -319,9 +319,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       const seedBalance = await armToken.balanceOf(seeds[0].address);
       expect(seedBalance).to.be.lt(threshold); // single seed can't propose
 
-      // 10 seeds pooling tokens: transfer to one address
+      // 11 seeds pooling tokens: transfer to one address
       const pooledSeed = seeds[0];
-      for (let i = 1; i < 10; i++) {
+      for (let i = 1; i < 11; i++) {
         const bal = await armToken.balanceOf(seeds[i].address);
         await armToken.connect(seeds[i]).transfer(pooledSeed.address, bal);
       }

--- a/test/crowdfund_adversarial.ts
+++ b/test/crowdfund_adversarial.ts
@@ -822,35 +822,34 @@ describe("Crowdfund Adversarial", function () {
 
   describe("Rollover Edge Cases", function () {
     it("hop-0 leftover rolls to hop-1 when hop-1 has >= 30 committers", async function () {
-      // 55 seeds commit $15K each = $825K. Hop-0 reserve = $840K → under-subscribed.
-      // 55 seeds × 3 invites = 165 possible hop-1 invitees.
-      // 44 hop-1 participants commit $4K each = $176K.
-      // Total = $825K + $176K = $1,001K >= MIN_SALE ($1M).
-      // Hop-1 has 44 committers >= HOP1_ROLLOVER_MIN (30) → rollover triggers.
-      // Hop-0 leftover = $840K - $825K = $15K rolls to hop-1.
-      // Hop-1 final reserve = $300K + $15K = $315K, demand = $176K → under-subscribed.
-      // Hop-1 participants get full allocation (no pro-rata).
+      // Under overlapping ceilings: hop-0 ceiling = 70% of netRaise = 70% of $1.14M = $798K.
+      // 53 seeds × $15K = $795K < $798K → under-subscribed.
+      // 52 hop-1 participants × $4K = $208K. Total = $1,003K >= MIN_SALE.
+      // Hop-1 has 52 committers >= HOP1_ROLLOVER_MIN (30) → rollover triggers.
+      // Hop-0 leftover = $798K - $795K = $3K rolls to hop-1.
+      // Hop-1 base ceiling = $513K, +$3K rollover = $516K, but budget-capped to $345K.
+      // Hop-1 demand $208K < $345K → full allocation, no pro-rata.
 
-      const seeds = allSigners.slice(1, 56); // 55 seeds (indices 1-55)
+      const seeds = allSigners.slice(1, 54); // 53 seeds (indices 1-53)
       await crowdfund.addSeeds(seeds.map(s => s.address));
       await crowdfund.startInvitations();
 
-      // Each of the first 44 seeds invites one hop-1 participant (signers 56-99)
+      // Each of the first 52 seeds invites one hop-1 participant (signers 54-105)
       const hop1Invitees: SignerWithAddress[] = [];
-      for (let i = 0; i < 44; i++) {
-        const invitee = allSigners[56 + i];
+      for (let i = 0; i < 52; i++) {
+        const invitee = allSigners[54 + i];
         await crowdfund.connect(seeds[i]).invite(invitee.address);
         hop1Invitees.push(invitee);
       }
 
       await time.increase(TWO_WEEKS + 1);
 
-      // All 55 seeds commit $15K
+      // All 53 seeds commit $15K
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      // 44 hop-1 participants commit $4K
+      // 52 hop-1 participants commit $4K
       for (const h of hop1Invitees) {
         await fundAndApprove(h, USDC(4_000));
         await crowdfund.connect(h).commit(USDC(4_000));
@@ -859,29 +858,28 @@ describe("Crowdfund Adversarial", function () {
       await time.increase(ONE_WEEK + 1);
       await crowdfund.finalize();
 
-      // Verify rollover happened: hop-1 finalReserve = $300K + $15K = $315K
-      const hop1Reserve = await crowdfund.finalReserves(1);
-      expect(hop1Reserve).to.equal(USDC(315_000));
+      // Verify hop-0 ceiling: $798K (budget not capped since remaining = $1.14M)
+      const hop0Ceiling = await crowdfund.finalCeilings(0);
+      expect(hop0Ceiling).to.equal(USDC(798_000));
 
-      // Hop-0 finalReserve stays at $840K
-      const hop0Reserve = await crowdfund.finalReserves(0);
-      expect(hop0Reserve).to.equal(USDC(840_000));
+      // Hop-1 ceiling: budget-capped to remaining $345K (< $516K effective ceiling)
+      const hop1Ceiling = await crowdfund.finalCeilings(1);
+      expect(hop1Ceiling).to.equal(USDC(345_000));
 
-      // Hop-1 is under-subscribed ($176K < $315K) → full allocation, no refund
+      // Hop-1 is under-subscribed ($208K < $345K) → full allocation, no refund
       const [alloc, refund] = await crowdfund.getAllocation(hop1Invitees[0].address);
       const allocArm = Number(alloc) / 1e18;
       expect(allocArm).to.be.closeTo(4_000, 1);
       expect(refund).to.equal(0n);
 
-      // Hop-1 leftover ($315K - $176K = $139K) → treasury (hop-2 has 0 committers < 50)
-      // Hop-2 leftover ($60K - $0 = $60K) → treasury
+      // Treasury leftover = saleSize - totalAllocated = $1.2M - ($795K + $208K) = $197K
       const treasuryLeftover = await crowdfund.treasuryLeftoverUsdc();
-      expect(treasuryLeftover).to.equal(USDC(139_000) + USDC(60_000));
+      expect(treasuryLeftover).to.equal(USDC(197_000));
     });
 
     it("over-subscribed hop-0 produces pro-rata with no rollover", async function () {
-      // 70 seeds × $15K = $1.05M. Hop-0 reserve = $840K → over-subscribed, no leftover.
-      // Hop-1/hop-2 have zero demand → full reserves go to treasury.
+      // 70 seeds × $15K = $1.05M. Hop-0 ceiling = 70% of $1.14M = $798K → over-subscribed.
+      // No leftover from hop-0. Hop-1/hop-2 have zero demand.
 
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
@@ -895,29 +893,29 @@ describe("Crowdfund Adversarial", function () {
       await time.increase(ONE_WEEK + 1);
       await crowdfund.finalize();
 
-      // Pro-rata: each gets $840K / 70 = $12K allocation, $3K refund
+      // Pro-rata: scale = $798K / $1.05M = 0.76
+      // Each $15K → $11,400 allocation, $3,600 refund
       const [alloc, refund] = await crowdfund.getAllocation(seeds[0].address);
       const allocArm = Number(alloc) / 1e18;
-      expect(allocArm).to.be.closeTo(12_000, 1);
-      expect(refund).to.be.closeTo(USDC(3_000), USDC(1));
+      expect(allocArm).to.be.closeTo(11_400, 1);
+      expect(refund).to.be.closeTo(USDC(3_600), USDC(1));
 
-      // No rollover from hop-0 (over-subscribed).
-      // Hop-1 ($300K) and hop-2 ($60K) reserves unused → treasury.
+      // Treasury leftover = saleSize - totalAllocated = $1.2M - $798K = $402K
       const treasuryLeftover = await crowdfund.treasuryLeftoverUsdc();
-      expect(treasuryLeftover).to.equal(USDC(300_000) + USDC(60_000));
+      expect(treasuryLeftover).to.equal(USDC(402_000));
     });
 
     it("rollover preserves sum-of-parts invariant: alloc + treasury = saleSize", async function () {
       // Same rollover scenario as test 1, verifies the global accounting invariant.
       // totalAllocatedUsdc + treasuryLeftoverUsdc must equal saleSize ($1.2M).
 
-      const seeds = allSigners.slice(1, 56); // 55 seeds
+      const seeds = allSigners.slice(1, 54); // 53 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
       await crowdfund.startInvitations();
 
       const hop1Invitees: SignerWithAddress[] = [];
-      for (let i = 0; i < 44; i++) {
-        const invitee = allSigners[56 + i];
+      for (let i = 0; i < 52; i++) {
+        const invitee = allSigners[54 + i];
         await crowdfund.connect(seeds[i]).invite(invitee.address);
         hop1Invitees.push(invitee);
       }
@@ -939,13 +937,13 @@ describe("Crowdfund Adversarial", function () {
       const totalAlloc = await crowdfund.totalAllocatedUsdc();
       const treasuryLeftover = await crowdfund.treasuryLeftoverUsdc();
 
-      // Hop-0: demand $825K <= reserve $840K → alloc = $825K
-      // Hop-1: demand $176K <= reserve $315K (after rollover) → alloc = $176K
-      // Hop-2: demand $0 <= reserve $60K → alloc = $0
-      expect(totalAlloc).to.equal(USDC(825_000) + USDC(176_000));
+      // Hop-0: demand $795K < ceiling $798K → alloc = $795K
+      // Hop-1: demand $208K < ceiling $345K (budget-capped after rollover) → alloc = $208K
+      // Hop-2: demand $0 → alloc = $0
+      expect(totalAlloc).to.equal(USDC(795_000) + USDC(208_000));
 
-      // Treasury: hop-1 leftover ($139K) + hop-2 leftover ($60K)
-      expect(treasuryLeftover).to.equal(USDC(139_000) + USDC(60_000));
+      // Treasury: saleSize - totalAllocated = $1.2M - $1,003K = $197K
+      expect(treasuryLeftover).to.equal(USDC(197_000));
 
       // Invariant: alloc + treasury = saleSize
       expect(totalAlloc + treasuryLeftover).to.equal(USDC(1_200_000));

--- a/test/crowdfund_integration.ts
+++ b/test/crowdfund_integration.ts
@@ -113,19 +113,19 @@ describe("Crowdfund Integration", function () {
       expect(await crowdfund.totalCommitted()).to.equal(0);
       expect(await crowdfund.getParticipantCount()).to.equal(0);
 
-      // Check hop configs
-      const [reserveBps0, cap0, maxInv0] = await crowdfund.hopConfigs(0);
-      expect(reserveBps0).to.equal(7000);
+      // Check hop configs (overlapping ceilings: 70/45/10, sum=125%)
+      const [ceilingBps0, cap0, maxInv0] = await crowdfund.hopConfigs(0);
+      expect(ceilingBps0).to.equal(7000);
       expect(cap0).to.equal(USDC(15_000));
       expect(maxInv0).to.equal(3);
 
-      const [reserveBps1, cap1, maxInv1] = await crowdfund.hopConfigs(1);
-      expect(reserveBps1).to.equal(2500);
+      const [ceilingBps1, cap1, maxInv1] = await crowdfund.hopConfigs(1);
+      expect(ceilingBps1).to.equal(4500);
       expect(cap1).to.equal(USDC(4_000));
       expect(maxInv1).to.equal(2);
 
-      const [reserveBps2, cap2, maxInv2] = await crowdfund.hopConfigs(2);
-      expect(reserveBps2).to.equal(500);
+      const [ceilingBps2, cap2, maxInv2] = await crowdfund.hopConfigs(2);
+      expect(ceilingBps2).to.equal(1000);
       expect(cap2).to.equal(USDC(1_000));
       expect(maxInv2).to.equal(0);
     });
@@ -485,7 +485,8 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should allocate fully when demand <= reserve", async function () {
-      // Setup: 1 seed commits $10K (below 70% of BASE=$840K reserve)
+      // Setup: 68 seeds at $15K = $1.02M demand.
+      // Hop-0 ceiling = 70% of netRaise = 70% of $1.14M = $798K, so demand > ceiling.
       // Need to reach MIN_SALE first — use many seeds
       const seeds = allSigners.slice(1, 80);
       for (const s of seeds) {
@@ -510,11 +511,9 @@ describe("Crowdfund Integration", function () {
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
       expect(await crowdfund.saleSize()).to.equal(USDC(1_200_000)); // BASE_SALE
 
-      // Each participant should get full allocation (demand < reserve)
-      // Hop 0 reserve = 70% of $1.2M = $840K. Demand = $1,020,000 > $840K → pro-rata
-      // Actually this IS oversubscribed. Let's verify the allocation is scaled.
+      // Hop 0 ceiling = 70% of $1.14M (netRaise) = $798K. Demand = $1,020,000 > $798K → pro-rata
       const [alloc, refund, claimed] = await crowdfund.getAllocation(seeds[0].address);
-      // Pro-rata: alloc = (15000 * 840000) / 1020000 ≈ 12352.94 USDC worth
+      // Pro-rata: alloc = (15000 * 798000) / 1020000 ≈ 11735.29 USDC worth
       expect(alloc).to.be.gt(0);
       expect(refund).to.be.gt(0); // some refund because oversubscribed
     });
@@ -539,14 +538,15 @@ describe("Crowdfund Integration", function () {
       await crowdfund.finalize();
 
       // saleSize = BASE_SALE = $1.2M
-      // Hop 0 reserve = 70% of $1.2M = $840,000
-      // Hop 0 demand = $1,050,000 > $840,000 → pro-rata
-      // scale = 840000 / 1050000 = 0.8
-      // Each $15K commit → $12,000 allocation → 12,000 ARM
+      // hop2Floor = 5% of $1.2M = $60K, netRaise = $1.14M
+      // Hop 0 ceiling = 70% of $1.14M = $798,000
+      // Hop 0 demand = $1,050,000 > $798,000 → pro-rata
+      // scale = 798000 / 1050000 = 0.76
+      // Each $15K commit → $11,400 allocation → 11,400 ARM
       const [alloc, refund] = await crowdfund.getAllocation(seeds[0].address);
       const allocArm = Number(alloc) / 1e18; // ARM allocation in whole tokens
-      expect(allocArm).to.be.closeTo(12_000, 1); // ~12,000 ARM ($12K at $1/ARM)
-      expect(refund).to.be.closeTo(USDC(3_000), USDC(1)); // ~$3K refund
+      expect(allocArm).to.be.closeTo(11_400, 1); // ~11,400 ARM ($11.4K at $1/ARM)
+      expect(refund).to.be.closeTo(USDC(3_600), USDC(1)); // ~$3.6K refund
     });
   });
 
@@ -591,7 +591,7 @@ describe("Crowdfund Integration", function () {
       await crowdfund.startInvitations();
       await time.increase(TWO_WEEKS + 1);
 
-      // Only 68 seeds commit — under-subscribes hop-0 (reserve = 70% of $1.2M = $840K)
+      // Only 68 seeds commit — hop-0 ceiling = 70% of $1.14M (netRaise) = $798K
       // 68 * $15K = $1.02M committed (above MIN_SALE), but all in hop-0
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000));
@@ -599,8 +599,8 @@ describe("Crowdfund Integration", function () {
       await time.increase(ONE_WEEK + 1);
       await crowdfund.finalize();
 
-      // Hop-0 demand ($1.02M) < reserve ($840K) is false, so hop-0 is over-subscribed.
-      // Hop-1 and hop-2 have 0 demand but non-zero reserves → all goes to treasury leftover.
+      // Hop-0 demand ($1.02M) > ceiling ($798K) → over-subscribed.
+      // Hop-1 and hop-2 have 0 demand → all remaining goes to treasury leftover.
       const leftover = await crowdfund.treasuryLeftoverUsdc();
       expect(leftover).to.be.gt(0);
     });
@@ -948,9 +948,9 @@ describe("Crowdfund Integration", function () {
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
       expect(await crowdfund.saleSize()).to.equal(USDC(1_200_000)); // BASE
 
-      // Hop-0 demand = $1,050,000, reserve = $840,000 → pro-rata
-      // scale = 840000/1050000 = 0.8
-      // Each $15K → $12K allocated → 12,000 ARM
+      // Hop-0 demand = $1,050,000, ceiling = 70% of $1.14M = $798,000 → pro-rata
+      // scale = 798000/1050000 = 0.76
+      // Each $15K → $11,400 allocated → 11,400 ARM
 
       // Claim first seed
       const armBefore = await armToken.balanceOf(seeds[0].address);


### PR DESCRIPTION
## Summary

- Replaces non-overlapping reserves (70/25/5, sum=100%) with overlapping ceilings (70/45/10, sum=125%) per CROWDFUND.md spec
- Adds 5% hop-2 floor reservation, carved out before hop-0/1 ceilings are calculated
- Introduces global budget constraint (`remaining`) to prevent over-allocation when ceilings overlap
- `treasuryLeftoverUsdc = saleSize - totalAllocUsdc` — clean invariant, no incremental tracking
- Renames `reserveBps` → `ceilingBps`, `finalReserves` → `finalCeilings` throughout contract, tests, frontend ABI, and scripts

Closes #73

## Test plan

- [x] All 422 Hardhat tests pass (0 fail, 1 intentionally pending)
- [x] All 152 Foundry fuzz/invariant tests pass
- [x] Rollover edge cases redesigned with correct numbers under new model
- [x] `invariant_reserveBpsSumTo10000` replaced with `invariant_ceilingBpsAreValid`
- [x] Cross-contract integration tests updated (threshold pooling: 11 seeds vs 10)
- [x] `totalAllocatedUsdc + treasuryLeftoverUsdc == saleSize` invariant verified in all scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)