### PR TITLE
feat: unify crowdfund into single sale window

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -30,8 +30,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     uint8 public constant NUM_HOPS = 3;
     uint256 public constant HOP2_FLOOR_BPS = 500;  // 5% of saleSize reserved for hop-2
 
-    uint256 public constant INVITATION_DURATION = 14 days;
-    uint256 public constant COMMITMENT_DURATION = 7 days;
+    uint256 public constant SALE_DURATION = 21 days;
     uint256 public constant FINALIZE_GRACE_PERIOD = 30 days;
     uint256 public constant MIN_COMMIT = 10 * 1e6;               // $10 USDC minimum per commit
 
@@ -50,10 +49,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     Phase public phase;
 
     // Timing
-    uint256 public invitationStart;
-    uint256 public invitationEnd;
-    uint256 public commitmentStart;
-    uint256 public commitmentEnd;
+    uint256 public saleStart;
+    uint256 public saleEnd;
 
     // Hop configuration (set in constructor)
     HopConfig[3] public hopConfigs;
@@ -83,7 +80,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     // ============ Events ============
 
     event SeedAdded(address indexed seed);
-    event InvitationStarted(uint256 invitationEnd, uint256 commitmentStart, uint256 commitmentEnd);
+    event SaleStarted(uint256 saleStart, uint256 saleEnd);
     event Invited(address indexed inviter, address indexed invitee, uint8 hop);
     event Committed(address indexed participant, uint256 amount, uint256 totalForParticipant, uint8 hop);
     event SaleFinalized(uint256 saleSize, uint256 totalAllocUsdc, uint256 totalAllocArm, uint256 treasuryLeftoverUsdc);
@@ -148,26 +145,24 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         emit SeedAdded(seed);
     }
 
-    /// @notice Start the invitation window
-    function startInvitations() external onlyAdmin inPhase(Phase.Setup) {
+    /// @notice Start the unified sale window (invites and commitments run concurrently)
+    function startSale() external onlyAdmin inPhase(Phase.Setup) {
         require(hopStats[0].whitelistCount > 0, "ArmadaCrowdfund: no seeds");
 
-        invitationStart = block.timestamp;
-        invitationEnd = block.timestamp + INVITATION_DURATION;
-        commitmentStart = invitationEnd;
-        commitmentEnd = commitmentStart + COMMITMENT_DURATION;
-        phase = Phase.Invitation;
+        saleStart = block.timestamp;
+        saleEnd = block.timestamp + SALE_DURATION;
+        phase = Phase.Active;
 
-        emit InvitationStarted(invitationEnd, commitmentStart, commitmentEnd);
+        emit SaleStarted(saleStart, saleEnd);
     }
 
-    // ============ Invitation Phase ============
+    // ============ Active Phase (Invitations + Commitments) ============
 
     /// @notice Invite an address to participate at (your hop + 1)
     function invite(address invitee) external whenNotPaused {
         require(
-            block.timestamp >= invitationStart && block.timestamp < invitationEnd,
-            "ArmadaCrowdfund: not invitation window"
+            block.timestamp >= saleStart && block.timestamp <= saleEnd,
+            "ArmadaCrowdfund: not in sale window"
         );
 
         Participant storage inviter = participants[msg.sender];
@@ -195,19 +190,12 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         emit Invited(msg.sender, invitee, inviteeHop);
     }
 
-    // ============ Commitment Phase ============
-
     /// @notice Commit USDC to the crowdfund
     function commit(uint256 amount) external nonReentrant whenNotPaused {
         require(
-            block.timestamp >= commitmentStart && block.timestamp <= commitmentEnd,
-            "ArmadaCrowdfund: not commitment window"
+            block.timestamp >= saleStart && block.timestamp <= saleEnd,
+            "ArmadaCrowdfund: not in sale window"
         );
-
-        // Lazy phase transition: first commit advances phase from Invitation
-        if (phase == Phase.Invitation) {
-            phase = Phase.Commitment;
-        }
 
         Participant storage p = participants[msg.sender];
         require(p.isWhitelisted, "ArmadaCrowdfund: not whitelisted");
@@ -241,11 +229,11 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     /// @dev Prevents permanent fund lockup if admin key is lost or admin is unresponsive
     function permissionlessCancel() external {
         require(
-            phase == Phase.Invitation || phase == Phase.Commitment,
+            phase == Phase.Active,
             "ArmadaCrowdfund: not in active phase"
         );
         require(
-            block.timestamp > commitmentEnd + FINALIZE_GRACE_PERIOD,
+            block.timestamp > saleEnd + FINALIZE_GRACE_PERIOD,
             "ArmadaCrowdfund: grace period not elapsed"
         );
         phase = Phase.Canceled;
@@ -254,9 +242,9 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
     /// @notice Finalize the crowdfund: compute allocations or cancel
     function finalize() external onlyAdmin nonReentrant {
-        require(block.timestamp > commitmentEnd, "ArmadaCrowdfund: commitment not ended");
+        require(block.timestamp > saleEnd, "ArmadaCrowdfund: sale not ended");
         require(
-            phase == Phase.Invitation || phase == Phase.Commitment,
+            phase == Phase.Active,
             "ArmadaCrowdfund: already finalized"
         );
 
@@ -453,10 +441,9 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     function getSaleStats() external view returns (
         uint256 _totalCommitted,
         Phase _phase,
-        uint256 _invitationEnd,
-        uint256 _commitmentEnd
+        uint256 _saleEnd
     ) {
-        return (totalCommitted, phase, invitationEnd, commitmentEnd);
+        return (totalCommitted, phase, saleEnd);
     }
 
     /// @notice Check if an address is whitelisted

--- a/contracts/crowdfund/IArmadaCrowdfund.sol
+++ b/contracts/crowdfund/IArmadaCrowdfund.sol
@@ -10,8 +10,7 @@ pragma solidity ^0.8.17;
 
 enum Phase {
     Setup,          // Admin configures seeds
-    Invitation,     // Seeds invite hop-1, hop-1 invites hop-2
-    Commitment,     // Whitelisted addresses commit USDC
+    Active,         // Unified sale window: invites and commitments run concurrently
     Finalized,      // Allocations computed, claims open
     Canceled        // Below minimum raise, full refunds
 }

--- a/crowdfund-frontend/src/atoms/crowdfund.ts
+++ b/crowdfund-frontend/src/atoms/crowdfund.ts
@@ -7,10 +7,8 @@ export interface CrowdfundState {
   // Contract phase and timing
   phase: Phase | null
   adminAddress: string | null
-  invitationStart: bigint
-  invitationEnd: bigint
-  commitmentStart: bigint
-  commitmentEnd: bigint
+  saleStart: bigint
+  saleEnd: bigint
   // Aggregate stats
   totalCommitted: bigint
   saleSize: bigint
@@ -35,10 +33,8 @@ export interface CrowdfundState {
 const DEFAULT_STATE: CrowdfundState = {
   phase: null,
   adminAddress: null,
-  invitationStart: 0n,
-  invitationEnd: 0n,
-  commitmentStart: 0n,
-  commitmentEnd: 0n,
+  saleStart: 0n,
+  saleEnd: 0n,
   totalCommitted: 0n,
   saleSize: 0n,
   hopStats: null,

--- a/crowdfund-frontend/src/components/AdminPanel.tsx
+++ b/crowdfund-frontend/src/components/AdminPanel.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Admin control panel for managing crowdfund lifecycle.
-// ABOUTME: Phase-conditional actions: add seeds, start invitations, finalize, withdraw.
+// ABOUTME: Phase-conditional actions: add seeds, start sale, finalize, withdraw.
 import { useEffect, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -96,9 +96,9 @@ export function AdminPanel({ state, crowdfund }: AdminPanelProps) {
     setSeedInput('')
   }
 
-  const handleStartInvitations = async () => {
+  const handleStartSale = async () => {
     setIsSubmitting(true)
-    await crowdfund.startInvitations()
+    await crowdfund.startSale()
     setIsSubmitting(false)
   }
 
@@ -173,12 +173,12 @@ export function AdminPanel({ state, crowdfund }: AdminPanelProps) {
             <Separator />
 
             <Button
-              onClick={handleStartInvitations}
+              onClick={handleStartSale}
               disabled={isSubmitting || !state.hopStats || state.hopStats[0].whitelistCount === 0}
               className="w-full gap-2"
             >
               <Play className="h-4 w-4" />
-              Start Invitations
+              Start Sale
             </Button>
             {state.hopStats && state.hopStats[0].whitelistCount === 0 && (
               <p className="text-xs text-muted-foreground">Add at least one seed first</p>
@@ -186,8 +186,8 @@ export function AdminPanel({ state, crowdfund }: AdminPanelProps) {
           </>
         )}
 
-        {/* After commitment window: Finalize */}
-        {(phase === Phase.Invitation || phase === Phase.Commitment) && (
+        {/* After sale window: Finalize */}
+        {phase === Phase.Active && (
           <div className="space-y-2">
             <Button
               onClick={handleFinalize}
@@ -199,7 +199,7 @@ export function AdminPanel({ state, crowdfund }: AdminPanelProps) {
               Finalize Sale
             </Button>
             <p className="text-xs text-muted-foreground">
-              Only works after the commitment window has ended.
+              Only works after the sale window has ended.
             </p>
           </div>
         )}

--- a/crowdfund-frontend/src/components/ParticipantPanel.tsx
+++ b/crowdfund-frontend/src/components/ParticipantPanel.tsx
@@ -35,15 +35,11 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
 
   // Use chain block timestamp (not Date.now()) — EVM time diverges from wall clock in local mode
   const now = state.blockTimestamp || Math.floor(Date.now() / 1000)
-  const inCommitmentWindow =
-    Number(state.commitmentStart) > 0 &&
-    now >= Number(state.commitmentStart) &&
-    now <= Number(state.commitmentEnd)
-
-  const inInvitationWindow =
-    phase === Phase.Invitation &&
-    Number(state.invitationEnd) > 0 &&
-    now <= Number(state.invitationEnd)
+  const inSaleWindow =
+    phase === Phase.Active &&
+    Number(state.saleStart) > 0 &&
+    now >= Number(state.saleStart) &&
+    now <= Number(state.saleEnd)
 
   const handleInvite = async () => {
     if (!isAddress(inviteInput)) return
@@ -110,7 +106,7 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
         </div>
 
         {/* Invite Section */}
-        {isWhitelisted && inInvitationWindow && state.currentInvitesRemaining > 0 && (
+        {isWhitelisted && inSaleWindow && state.currentInvitesRemaining > 0 && (
           <>
             <Separator />
             <div className="space-y-2">
@@ -138,7 +134,7 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
         )}
 
         {/* Commit Section */}
-        {isWhitelisted && inCommitmentWindow && remaining > 0n && (
+        {isWhitelisted && inSaleWindow && remaining > 0n && (
           <>
             <Separator />
             <div className="space-y-2">

--- a/crowdfund-frontend/src/components/SaleStatus.tsx
+++ b/crowdfund-frontend/src/components/SaleStatus.tsx
@@ -21,33 +21,16 @@ interface SaleStatusProps {
 
 /**
  * Derive the "effective" phase for display.
- * The contract phase() stays Invitation during the commitment window,
- * so we infer Commitment from timestamps.
+ * With the unified sale window, the contract phase is authoritative.
  */
-function getEffectivePhase(state: CrowdfundState, now: number): Phase {
+function getEffectivePhase(state: CrowdfundState): Phase {
   if (state.phase === null) return Phase.Setup
-  if (state.phase === Phase.Invitation) {
-    const commitStart = Number(state.commitmentStart)
-    const commitEnd = Number(state.commitmentEnd)
-    if (commitStart > 0 && now >= commitStart && now <= commitEnd) {
-      return Phase.Commitment
-    }
-    if (commitEnd > 0 && now > commitEnd) {
-      // Past commitment window but not yet finalized
-      return Phase.Commitment
-    }
-  }
   return state.phase
 }
 
 function getTimeRemaining(state: CrowdfundState, effectivePhase: Phase, now: number): string | null {
-  if (effectivePhase === Phase.Invitation) {
-    const end = Number(state.invitationEnd)
-    if (end > 0 && now < end) return formatCountdown(end - now)
-    return 'expired'
-  }
-  if (effectivePhase === Phase.Commitment) {
-    const end = Number(state.commitmentEnd)
+  if (effectivePhase === Phase.Active) {
+    const end = Number(state.saleEnd)
     if (end > 0 && now < end) return formatCountdown(end - now)
     return 'expired — ready to finalize'
   }
@@ -82,7 +65,7 @@ export function SaleStatus({ state }: SaleStatusProps) {
     )
   }
 
-  const effectivePhase = getEffectivePhase(state, now)
+  const effectivePhase = getEffectivePhase(state)
   const timeRemaining = getTimeRemaining(state, effectivePhase, now)
 
   // Progress calculation
@@ -141,7 +124,7 @@ export function SaleStatus({ state }: SaleStatusProps) {
             <TableHeader>
               <TableRow>
                 <TableHead>Hop</TableHead>
-                <TableHead className="text-right">Reserve</TableHead>
+                <TableHead className="text-right">Ceiling</TableHead>
                 <TableHead className="text-right">Cap/Person</TableHead>
                 <TableHead className="text-right">Whitelisted</TableHead>
                 <TableHead className="text-right">Committers</TableHead>
@@ -152,7 +135,7 @@ export function SaleStatus({ state }: SaleStatusProps) {
               {state.hopStats.map((hop, i) => (
                 <TableRow key={i}>
                   <TableCell className="font-medium">{hopLabel(i)}</TableCell>
-                  <TableCell className="text-right">{CROWDFUND_CONSTANTS.HOP_RESERVE_BPS[i] / 100}%</TableCell>
+                  <TableCell className="text-right">{CROWDFUND_CONSTANTS.HOP_CEILING_BPS[i] / 100}%</TableCell>
                   <TableCell className="text-right">{formatUsdc(CROWDFUND_CONSTANTS.HOP_CAPS[i])}</TableCell>
                   <TableCell className="text-right">{hop.whitelistCount}</TableCell>
                   <TableCell className="text-right">{hop.uniqueCommitters}</TableCell>

--- a/crowdfund-frontend/src/components/TimeControls.tsx
+++ b/crowdfund-frontend/src/components/TimeControls.tsx
@@ -1,10 +1,10 @@
 // ABOUTME: Anvil time manipulation controls for local testing.
-// ABOUTME: Allows fast-forwarding through invitation and commitment windows.
+// ABOUTME: Allows fast-forwarding through the sale window.
 import { useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Clock, FastForward, SkipForward } from 'lucide-react'
+import { Clock, SkipForward } from 'lucide-react'
 import { Phase } from '@/types/crowdfund'
 import type { CrowdfundState } from '@/atoms/crowdfund'
 import type { useCrowdfund } from '@/hooks/useCrowdfund'
@@ -32,16 +32,11 @@ export function TimeControls({ state, crowdfund }: TimeControlsProps) {
   }
 
   const phase = state.phase
-  const invEnd = Number(state.invitationEnd)
-  const commitEnd = Number(state.commitmentEnd)
-
+  const saleEnd = Number(state.saleEnd)
   const blockTs = state.blockTimestamp
 
-  // Seconds from now until the invitation window ends (commitment starts)
-  const skipToCommitmentSecs = invEnd > blockTs ? invEnd - blockTs + 1 : 0
-
-  // Seconds from now until the commitment window ends
-  const skipPastCommitmentSecs = commitEnd > blockTs ? commitEnd - blockTs + 1 : 0
+  // Seconds from now until the sale window ends
+  const skipPastSaleSecs = saleEnd > blockTs ? saleEnd - blockTs + 1 : 0
 
   return (
     <Card>
@@ -54,31 +49,17 @@ export function TimeControls({ state, crowdfund }: TimeControlsProps) {
       </CardHeader>
       <CardContent>
         <div className="flex flex-wrap gap-2">
-          {/* Skip to Commitment Window */}
-          {phase === Phase.Invitation && invEnd > 0 && (
+          {/* Skip Past Sale */}
+          {phase === Phase.Active && saleEnd > 0 && (
             <Button
               variant="outline"
               size="sm"
-              onClick={() => handleAdvance(skipToCommitmentSecs)}
-              disabled={isAdvancing}
-              className="gap-1.5"
-            >
-              <FastForward className="h-3.5 w-3.5" />
-              Skip to Commitment
-            </Button>
-          )}
-
-          {/* Skip Past Commitment */}
-          {phase === Phase.Invitation && commitEnd > 0 && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => handleAdvance(skipPastCommitmentSecs)}
+              onClick={() => handleAdvance(skipPastSaleSecs)}
               disabled={isAdvancing}
               className="gap-1.5"
             >
               <SkipForward className="h-3.5 w-3.5" />
-              Skip Past Commitment
+              Skip Past Sale
             </Button>
           )}
 

--- a/crowdfund-frontend/src/config/abi.ts
+++ b/crowdfund-frontend/src/config/abi.ts
@@ -5,7 +5,7 @@ export const CROWDFUND_ABI = [
   // Admin actions (Setup)
   'function addSeed(address seed) external',
   'function addSeeds(address[] calldata seeds) external',
-  'function startInvitations() external',
+  'function startSale() external',
   'function finalize() external',
   'function withdrawProceeds() external',
   'function withdrawUnallocatedArm() external',
@@ -25,10 +25,8 @@ export const CROWDFUND_ABI = [
   'function saleSize() view returns (uint256)',
   'function totalAllocated() view returns (uint256)',
   'function totalAllocatedUsdc() view returns (uint256)',
-  'function invitationStart() view returns (uint256)',
-  'function invitationEnd() view returns (uint256)',
-  'function commitmentStart() view returns (uint256)',
-  'function commitmentEnd() view returns (uint256)',
+  'function saleStart() view returns (uint256)',
+  'function saleEnd() view returns (uint256)',
   'function participants(address) view returns (uint8 hop, bool isWhitelisted, uint256 committed, uint256 allocation, uint256 refund, bool claimed, address invitedBy, uint8 invitesSent)',
   'function participantList(uint256) view returns (address)',
   'function hopStats(uint8) view returns (uint256 totalCommitted, uint32 uniqueCommitters, uint32 whitelistCount)',
@@ -41,7 +39,7 @@ export const CROWDFUND_ABI = [
 
   // View functions
   'function getHopStats(uint8 hop) view returns (uint256 totalCommitted, uint32 uniqueCommitters, uint32 whitelistCount)',
-  'function getSaleStats() view returns (uint256 totalCommitted, uint8 phase, uint256 invitationEnd, uint256 commitmentEnd)',
+  'function getSaleStats() view returns (uint256 totalCommitted, uint8 phase, uint256 saleEnd)',
   'function isWhitelisted(address addr) view returns (bool)',
   'function getCommitment(address addr) view returns (uint256 committed, uint8 hop)',
   'function getInvitesRemaining(address addr) view returns (uint8)',
@@ -51,7 +49,7 @@ export const CROWDFUND_ABI = [
 
   // Events
   'event SeedAdded(address indexed seed)',
-  'event InvitationStarted(uint256 invitationEnd, uint256 commitmentStart, uint256 commitmentEnd)',
+  'event SaleStarted(uint256 saleStart, uint256 saleEnd)',
   'event Invited(address indexed inviter, address indexed invitee, uint8 hop)',
   'event Committed(address indexed participant, uint256 amount, uint256 totalForParticipant, uint8 hop)',
   'event SaleFinalized(uint256 saleSize, uint256 totalAllocUsdc, uint256 totalAllocArm, uint256 treasuryLeftoverUsdc)',

--- a/crowdfund-frontend/src/hooks/useCrowdfund.ts
+++ b/crowdfund-frontend/src/hooks/useCrowdfund.ts
@@ -58,10 +58,8 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
         admin,
         totalCommitted,
         saleSize,
-        invitationStart,
-        invitationEnd,
-        commitmentStart,
-        commitmentEnd,
+        saleStart,
+        saleEnd,
         participantCount,
         hop0Stats,
         hop1Stats,
@@ -76,10 +74,8 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
         contract.admin(),
         contract.totalCommitted(),
         contract.saleSize(),
-        contract.invitationStart(),
-        contract.invitationEnd(),
-        contract.commitmentStart(),
-        contract.commitmentEnd(),
+        contract.saleStart(),
+        contract.saleEnd(),
         contract.getParticipantCount(),
         contract.getHopStats(0),
         contract.getHopStats(1),
@@ -96,7 +92,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
 
       // Fetch allocation if finalized and participant has committed
       let currentAllocation = null
-      if (parsedPhase === 3 && parsedParticipant.committed > 0n) {
+      if (parsedPhase === 2 && parsedParticipant.committed > 0n) {
         try {
           const allocResult = await contract.getAllocation(currentAddress)
           currentAllocation = {
@@ -114,10 +110,8 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
         adminAddress: admin as string,
         totalCommitted: BigInt(totalCommitted),
         saleSize: BigInt(saleSize),
-        invitationStart: BigInt(invitationStart),
-        invitationEnd: BigInt(invitationEnd),
-        commitmentStart: BigInt(commitmentStart),
-        commitmentEnd: BigInt(commitmentEnd),
+        saleStart: BigInt(saleStart),
+        saleEnd: BigInt(saleEnd),
         hopStats: [
           parseHopStats(hop0Stats),
           parseHopStats(hop1Stats),
@@ -281,11 +275,11 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
     [executeTx],
   )
 
-  const startInvitations = useCallback(
+  const startSale = useCallback(
     () =>
-      executeTx('Starting invitations', (signer, dep) => {
+      executeTx('Starting sale', (signer, dep) => {
         const contract = getCrowdfundContract(dep, signer)
-        return contract.startInvitations()
+        return contract.startSale()
       }),
     [executeTx],
   )
@@ -431,7 +425,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
     refreshParticipantList,
     // Write operations
     addSeeds,
-    startInvitations,
+    startSale,
     invite,
     approveAndCommit,
     finalize,

--- a/crowdfund-frontend/src/types/crowdfund.test.ts
+++ b/crowdfund-frontend/src/types/crowdfund.test.ts
@@ -6,10 +6,9 @@ import { Phase, CROWDFUND_CONSTANTS } from './crowdfund'
 describe('Phase', () => {
   it('has correct numeric values', () => {
     expect(Phase.Setup).toBe(0)
-    expect(Phase.Invitation).toBe(1)
-    expect(Phase.Commitment).toBe(2)
-    expect(Phase.Finalized).toBe(3)
-    expect(Phase.Canceled).toBe(4)
+    expect(Phase.Active).toBe(1)
+    expect(Phase.Finalized).toBe(2)
+    expect(Phase.Canceled).toBe(3)
   })
 })
 
@@ -24,9 +23,8 @@ describe('CROWDFUND_CONSTANTS', () => {
     expect(CROWDFUND_CONSTANTS.ARM_PRICE).toBe(1_000_000n)
   })
 
-  it('has correct durations', () => {
-    expect(CROWDFUND_CONSTANTS.INVITATION_DURATION).toBe(14 * 86400)
-    expect(CROWDFUND_CONSTANTS.COMMITMENT_DURATION).toBe(7 * 86400)
+  it('has correct duration', () => {
+    expect(CROWDFUND_CONSTANTS.SALE_DURATION).toBe(21 * 86400)
   })
 
   it('hop caps are correct', () => {
@@ -35,9 +33,9 @@ describe('CROWDFUND_CONSTANTS', () => {
     expect(CROWDFUND_CONSTANTS.HOP_CAPS[2]).toBe(1_000_000_000n)  // $1,000
   })
 
-  it('hop reserves sum to 100%', () => {
-    const sum = CROWDFUND_CONSTANTS.HOP_RESERVE_BPS.reduce((a, b) => a + b, 0)
-    expect(sum).toBe(10_000)
+  it('hop ceilings are overlapping (sum > 100%)', () => {
+    const sum = CROWDFUND_CONSTANTS.HOP_CEILING_BPS.reduce((a, b) => a + b, 0)
+    expect(sum).toBe(12_500)
   })
 
   it('hop max invites are correct', () => {

--- a/crowdfund-frontend/src/types/crowdfund.ts
+++ b/crowdfund-frontend/src/types/crowdfund.ts
@@ -3,10 +3,9 @@
 
 export const Phase = {
   Setup: 0,
-  Invitation: 1,
-  Commitment: 2,
-  Finalized: 3,
-  Canceled: 4,
+  Active: 1,
+  Finalized: 2,
+  Canceled: 3,
 } as const
 
 export type Phase = (typeof Phase)[keyof typeof Phase]
@@ -67,10 +66,9 @@ export const CROWDFUND_CONSTANTS = {
   MAX_SALE: 1_800_000n * 1_000_000n,
   MIN_SALE: 1_000_000n * 1_000_000n,
   ARM_PRICE: 1_000_000n,
-  INVITATION_DURATION: 14 * 86400,
-  COMMITMENT_DURATION: 7 * 86400,
+  SALE_DURATION: 21 * 86400,
   HOP_CAPS: [15_000n * 1_000_000n, 4_000n * 1_000_000n, 1_000n * 1_000_000n] as const,
-  HOP_RESERVE_BPS: [7000, 2500, 500] as const,
+  HOP_CEILING_BPS: [7000, 4500, 1000] as const,
   HOP_MAX_INVITES: [3, 2, 0] as const,
   HOP1_ROLLOVER_MIN: 30,
   HOP2_ROLLOVER_MIN: 50,

--- a/crowdfund-frontend/src/utils/format.test.ts
+++ b/crowdfund-frontend/src/utils/format.test.ts
@@ -98,8 +98,7 @@ describe('formatCountdown', () => {
 describe('phaseName', () => {
   it('returns correct names', () => {
     expect(phaseName(Phase.Setup)).toBe('Setup')
-    expect(phaseName(Phase.Invitation)).toBe('Invitation')
-    expect(phaseName(Phase.Commitment)).toBe('Commitment')
+    expect(phaseName(Phase.Active)).toBe('Active')
     expect(phaseName(Phase.Finalized)).toBe('Finalized')
     expect(phaseName(Phase.Canceled)).toBe('Canceled')
   })

--- a/crowdfund-frontend/src/utils/format.ts
+++ b/crowdfund-frontend/src/utils/format.ts
@@ -51,8 +51,7 @@ export function formatCountdown(seconds: number): string {
 export function phaseName(phase: Phase): string {
   switch (phase) {
     case Phase.Setup: return 'Setup'
-    case Phase.Invitation: return 'Invitation'
-    case Phase.Commitment: return 'Commitment'
+    case Phase.Active: return 'Active'
     case Phase.Finalized: return 'Finalized'
     case Phase.Canceled: return 'Canceled'
     default: return 'Unknown'
@@ -63,8 +62,7 @@ export function phaseName(phase: Phase): string {
 export function phaseColor(phase: Phase): string {
   switch (phase) {
     case Phase.Setup: return 'bg-muted text-muted-foreground'
-    case Phase.Invitation: return 'bg-info/20 text-info'
-    case Phase.Commitment: return 'bg-warning/20 text-warning'
+    case Phase.Active: return 'bg-info/20 text-info'
     case Phase.Finalized: return 'bg-success/20 text-success'
     case Phase.Canceled: return 'bg-destructive/20 text-destructive'
     default: return 'bg-muted text-muted-foreground'

--- a/docs/CROWDFUND_TEST_SCENARIOS.md
+++ b/docs/CROWDFUND_TEST_SCENARIOS.md
@@ -38,27 +38,27 @@ Exhaustive catalog of testing scenarios for ArmadaCrowdfund, organized by lifecy
 | 2.6 | Add duplicate seed (same address twice) | Revert: "already whitelisted" | Integration |
 | 2.7 | `addSeeds()` with empty array | Succeeds (no-op, no revert) | **None** |
 | 2.8 | `addSeeds()` with mixed valid/duplicate entries | Reverts mid-array on the duplicate (all-or-nothing within tx) | **None** |
-| 2.9 | Add seeds after `startInvitations()` | Revert: "wrong phase" | Integration |
+| 2.9 | Add seeds after `startSale()` | Revert: "wrong phase" | Integration |
 | 2.10 | Add seed in Finalized phase | Revert: "wrong phase" | **None** |
 | 2.11 | Add seed in Canceled phase | Revert: "wrong phase" | **None** |
 | 2.12 | Verify `SeedAdded` event emitted per seed | Event with correct indexed address | **None** |
 
-### Starting Invitations
+### Starting Sale
 
 | # | Scenario | Expected Outcome | Coverage |
 |---|----------|-----------------|----------|
-| 2.13 | Start invitations with >= 1 seed | Phase → Invitation, timing windows set correctly | Integration |
-| 2.14 | Start invitations with zero seeds | Revert: "no seeds" | Integration |
-| 2.15 | Non-admin calls `startInvitations()` | Revert: "not admin" | **None** |
-| 2.16 | Call `startInvitations()` twice | First succeeds, second reverts: "wrong phase" | **None** |
-| 2.17 | Verify timing: `invitationEnd = invitationStart + 14 days` | Exact match | **None** |
-| 2.18 | Verify timing: `commitmentStart = invitationEnd` (no gap, no overlap) | Exact match | **None** |
-| 2.19 | Verify timing: `commitmentEnd = commitmentStart + 7 days` | Exact match | **None** |
-| 2.20 | Verify `InvitationStarted` event emitted with correct timestamps | Correct invitationEnd, commitmentStart, commitmentEnd | **None** |
+| 2.13 | Start sale with >= 1 seed | Phase → Active, timing window set correctly | Integration |
+| 2.14 | Start sale with zero seeds | Revert: "no seeds" | Integration |
+| 2.15 | Non-admin calls `startSale()` | Revert: "not admin" | **None** |
+| 2.16 | Call `startSale()` twice | First succeeds, second reverts: "wrong phase" | **None** |
+| 2.17 | Verify timing: `saleEnd = saleStart + 21 days` | Exact match | **None** |
+| 2.18 | Verify `SaleStarted` event emitted with correct timestamps | Correct saleStart, saleEnd | **None** |
 
 ---
 
-## 3. Invitation Phase
+## 3. Sale Window
+
+During the 21-day sale window (Phase.Active), invitations and commitments happen concurrently. Both `invite()` and `commit()` are open from `saleStart` through `saleEnd`.
 
 ### Basic Invitation Mechanics
 
@@ -67,10 +67,10 @@ Exhaustive catalog of testing scenarios for ArmadaCrowdfund, organized by lifecy
 | 3.1 | Seed invites valid address → hop 1 | Invitee whitelisted at hop 1, invitedBy = seed | Integration |
 | 3.2 | Hop-1 invites valid address → hop 2 | Invitee whitelisted at hop 2, invitedBy = hop-1 addr | Integration |
 | 3.3 | Hop-2 attempts to invite | Revert: "max hop reached" (hop 2 is NUM_HOPS-1) | Integration |
-| 3.4 | Invite at exact `invitationStart` timestamp | Succeeds (>= check) | **None** |
-| 3.5 | Invite at exact `invitationEnd` timestamp | Succeeds (<= check) | **None** |
-| 3.6 | Invite at `invitationEnd + 1` | Revert: "not invitation window" | Integration |
-| 3.7 | Invite before `invitationStart` (if possible to manipulate) | Revert: "not invitation window" | **None** |
+| 3.4 | Invite at exact `saleStart` timestamp | Succeeds (>= check) | **None** |
+| 3.5 | Invite at exact `saleEnd` timestamp | Succeeds (<= check) | **None** |
+| 3.6 | Invite at `saleEnd + 1` | Revert: "not in sale window" | Integration |
+| 3.7 | Invite before `saleStart` (Setup phase) | Revert: "not in sale window" (saleStart = 0, timestamp > 0) | **None** |
 
 ### Invite Limits
 
@@ -93,79 +93,79 @@ Exhaustive catalog of testing scenarios for ArmadaCrowdfund, organized by lifecy
 | 3.17 | Invite `address(0)` | Revert: "zero address" | **None** |
 | 3.18 | Invite the admin/deployer address (non-whitelisted) | Succeeds (admin is not whitelisted by default) | **None** |
 | 3.19 | Invite a contract address | Succeeds (no EOA check) | **None** |
-| 3.20 | Invite during Setup phase (before `startInvitations()`) | Revert: "not invitation window" (invitationStart = 0, timestamp > 0) | **None** |
-| 3.21 | Invite during Commitment window | Revert: "not invitation window" | Adversarial |
-| 3.22 | Invite during Finalized phase | Revert: "not invitation window" | **None** |
-
-### Invitation Graph Integrity
-
-| # | Scenario | Expected Outcome | Coverage |
-|---|----------|-----------------|----------|
-| 3.23 | Verify hop assignment: seed = 0, invitee of seed = 1, invitee of hop-1 = 2 | Correct hop values | Integration |
-| 3.24 | Verify `invitedBy` is `address(0)` for seeds | Correct | Integration |
-| 3.25 | Verify `invitedBy` points to actual inviter for hop-1 and hop-2 | Correct | **None** |
-| 3.26 | Verify `whitelistCount` increments per hop on each invite | Correct per hop | Integration |
-| 3.27 | Verify `Invited` event emitted with correct inviter, invitee, hop | Correct event fields | **None** |
-| 3.28 | Multiple seeds inviting distinct addresses — no cross-contamination | Each invitee's hop and invitedBy correct | **None** |
-
----
-
-## 4. Commitment Phase
+| 3.20 | Invite during Finalized phase | Revert: "not in sale window" | **None** |
 
 ### Basic Commitment
 
 | # | Scenario | Expected Outcome | Coverage |
 |---|----------|-----------------|----------|
-| 4.1 | Whitelisted seed commits valid USDC amount | p.committed updates, totalCommitted updates, USDC transferred | Integration |
-| 4.2 | Multiple commits from same address accumulate | p.committed = sum of commits | Integration |
-| 4.3 | Multiple commits reaching exactly cap | Last commit brings total to cap exactly | Adversarial |
-| 4.4 | Commit at exact `commitmentStart` timestamp | Succeeds (>= check) | **None** |
-| 4.5 | Commit at exact `commitmentEnd` timestamp | Succeeds (<= check) | **None** |
-| 4.6 | Commit at `commitmentEnd + 1` | Revert: "not commitment window" | **None** |
-| 4.7 | Commit at `commitmentStart - 1` (during invitation window) | Revert: "not commitment window" | Integration |
+| 3.21 | Whitelisted seed commits valid USDC amount | p.committed updates, totalCommitted updates, USDC transferred | Integration |
+| 3.22 | Multiple commits from same address accumulate | p.committed = sum of commits | Integration |
+| 3.23 | Multiple commits reaching exactly cap | Last commit brings total to cap exactly | Adversarial |
+| 3.24 | Commit at exact `saleStart` timestamp | Succeeds (>= check) | **None** |
+| 3.25 | Commit at exact `saleEnd` timestamp | Succeeds (<= check) | **None** |
+| 3.26 | Commit at `saleEnd + 1` | Revert: "not in sale window" | **None** |
+| 3.27 | Commit during Setup phase (before `startSale()`) | Revert: "not in sale window" (saleStart = 0, timestamp > 0) | **None** |
+
+### Concurrent Invite and Commit
+
+| # | Scenario | Expected Outcome | Coverage |
+|---|----------|-----------------|----------|
+| 3.28 | Seed invites and commits in same window | Both succeed; no ordering constraint | Integration |
+| 3.29 | Participant receives invite mid-window then immediately commits | Both succeed without waiting | **None** |
 
 ### Cap Enforcement
 
 | # | Scenario | Expected Outcome | Coverage |
 |---|----------|-----------------|----------|
-| 4.8 | Hop-0: commit exactly $15,000 | Succeeds | Adversarial |
-| 4.9 | Hop-0: commit $15,001 | Revert: "exceeds hop cap" | Integration |
-| 4.10 | Hop-0: commit $10K then $5,001 (cumulative over cap) | Revert: "exceeds hop cap" | **None** |
-| 4.11 | Hop-1: commit exactly $4,000 | Succeeds | **None** |
-| 4.12 | Hop-1: commit $4,001 | Revert: "exceeds hop cap" | Integration |
-| 4.13 | Hop-2: commit exactly $1,000 | Succeeds | **None** |
-| 4.14 | Hop-2: commit $1,001 | Revert: "exceeds hop cap" | Integration |
-| 4.15 | Commit 1 wei over cap (after prior commits) | Revert: "exceeds hop cap" | Adversarial |
+| 3.30 | Hop-0: commit exactly $15,000 | Succeeds | Adversarial |
+| 3.31 | Hop-0: commit $15,001 | Revert: "exceeds hop cap" | Integration |
+| 3.32 | Hop-0: commit $10K then $5,001 (cumulative over cap) | Revert: "exceeds hop cap" | **None** |
+| 3.33 | Hop-1: commit exactly $4,000 | Succeeds | **None** |
+| 3.34 | Hop-1: commit $4,001 | Revert: "exceeds hop cap" | Integration |
+| 3.35 | Hop-2: commit exactly $1,000 | Succeeds | **None** |
+| 3.36 | Hop-2: commit $1,001 | Revert: "exceeds hop cap" | Integration |
+| 3.37 | Commit 1 wei over cap (after prior commits) | Revert: "exceeds hop cap" | Adversarial |
 
 ### Invalid Commits
 
 | # | Scenario | Expected Outcome | Coverage |
 |---|----------|-----------------|----------|
-| 4.16 | Non-whitelisted address commits | Revert: "not whitelisted" | Integration |
-| 4.17 | Zero amount commit | Revert: "zero amount" | Integration |
-| 4.18 | Commit with insufficient USDC balance (approved but not held) | Revert from SafeERC20 transferFrom | **None** |
-| 4.19 | Commit with no USDC approval | Revert from SafeERC20 transferFrom | **None** |
-| 4.20 | Commit with partial approval (approve < amount) | Revert from SafeERC20 transferFrom | **None** |
-| 4.21 | Commit during Setup phase | Revert: "not commitment window" | **None** |
-| 4.22 | Commit during Finalized phase | Revert: "not commitment window" | **None** |
-| 4.23 | Commit during Canceled phase | Revert: "not commitment window" | **None** |
+| 3.38 | Non-whitelisted address commits | Revert: "not whitelisted" | Integration |
+| 3.39 | Zero amount commit | Revert: "zero amount" | Integration |
+| 3.40 | Commit with insufficient USDC balance (approved but not held) | Revert from SafeERC20 transferFrom | **None** |
+| 3.41 | Commit with no USDC approval | Revert from SafeERC20 transferFrom | **None** |
+| 3.42 | Commit with partial approval (approve < amount) | Revert from SafeERC20 transferFrom | **None** |
+| 3.43 | Commit during Finalized phase | Revert: "not in sale window" | **None** |
+| 3.44 | Commit during Canceled phase | Revert: "not in sale window" | **None** |
 
 ### Aggregate Tracking
 
 | # | Scenario | Expected Outcome | Coverage |
 |---|----------|-----------------|----------|
-| 4.24 | `hopStats[h].totalCommitted` accumulates correctly per hop | Sum matches expected | Integration |
-| 4.25 | `uniqueCommitters` increments on first commit, not subsequent | First commit: +1, second commit same addr: no change | Integration |
-| 4.26 | `totalCommitted` equals sum across all hops | Global sum correct | Integration |
-| 4.27 | Contract USDC balance equals `totalCommitted` before finalization | Exact match | Foundry INV-C3 |
-| 4.28 | Verify `Committed` event with correct participant, amount, total, hop | Correct event fields | **None** |
+| 3.45 | `hopStats[h].totalCommitted` accumulates correctly per hop | Sum matches expected | Integration |
+| 3.46 | `uniqueCommitters` increments on first commit, not subsequent | First commit: +1, second commit same addr: no change | Integration |
+| 3.47 | `totalCommitted` equals sum across all hops | Global sum correct | Integration |
+| 3.48 | Contract USDC balance equals `totalCommitted` before finalization | Exact match | Foundry INV-C3 |
+| 3.49 | Verify `Committed` event with correct participant, amount, total, hop | Correct event fields | **None** |
+
+### Invitation Graph Integrity
+
+| # | Scenario | Expected Outcome | Coverage |
+|---|----------|-----------------|----------|
+| 3.50 | Verify hop assignment: seed = 0, invitee of seed = 1, invitee of hop-1 = 2 | Correct hop values | Integration |
+| 3.51 | Verify `invitedBy` is `address(0)` for seeds | Correct | Integration |
+| 3.52 | Verify `invitedBy` points to actual inviter for hop-1 and hop-2 | Correct | **None** |
+| 3.53 | Verify `whitelistCount` increments per hop on each invite | Correct per hop | Integration |
+| 3.54 | Verify `Invited` event emitted with correct inviter, invitee, hop | Correct event fields | **None** |
+| 3.55 | Multiple seeds inviting distinct addresses — no cross-contamination | Each invitee's hop and invitedBy correct | **None** |
 
 ### Minimum Commit Amount
 
 | # | Scenario | Expected Outcome | Coverage |
 |---|----------|-----------------|----------|
-| 4.29 | Commit 1 wei USDC (smallest possible) | Succeeds (only zero is rejected) | Adversarial |
-| 4.30 | Commit 1 wei, then finalize and check allocation rounding | Allocation math doesn't overflow/underflow on tiny amounts | **None** |
+| 3.56 | Commit 1 wei USDC (smallest possible) | Succeeds (only zero is rejected) | Adversarial |
+| 3.57 | Commit 1 wei, then finalize and check allocation rounding | Allocation math doesn't overflow/underflow on tiny amounts | **None** |
 
 ---
 
@@ -175,14 +175,14 @@ Exhaustive catalog of testing scenarios for ArmadaCrowdfund, organized by lifecy
 
 | # | Scenario | Expected Outcome | Coverage |
 |---|----------|-----------------|----------|
-| 5.1 | Finalize after commitmentEnd by admin | Succeeds | Integration |
-| 5.2 | Finalize at exactly `commitmentEnd` (not past) | Revert: "commitment not ended" (> check, not >=) | **None** |
-| 5.3 | Finalize at `commitmentEnd + 1` | Succeeds | **None** |
-| 5.4 | Finalize before commitmentEnd | Revert: "commitment not ended" | Integration |
+| 5.1 | Finalize after saleEnd by admin | Succeeds | Integration |
+| 5.2 | Finalize at exactly `saleEnd` (not past) | Revert: "sale not ended" (> check, not >=) | **None** |
+| 5.3 | Finalize at `saleEnd + 1` | Succeeds | **None** |
+| 5.4 | Finalize before saleEnd | Revert: "sale not ended" | Integration |
 | 5.5 | Non-admin calls `finalize()` | Revert: "not admin" | Adversarial |
 | 5.6 | Double finalization (after successful finalize) | Revert: "already finalized" | Integration |
 | 5.7 | Finalize after cancellation | Revert: "already finalized" (same guard) | **None** |
-| 5.8 | Finalize during Setup phase (commitmentEnd = 0, timestamp > 0) | Succeeds if `block.timestamp > 0` and phase is not Finalized/Canceled... but phase guard only checks Invitation\|Commitment. **Interesting edge: if phase is Setup, the phase check passes (it's neither Finalized nor Canceled), and timestamp > 0 > commitmentEnd(0). Behavior: would attempt finalization from Setup phase.** | **None — potential bug** |
+| 5.8 | Finalize during Setup phase (saleEnd = 0, timestamp > 0) | Phase guard rejects: phase is not Active. **Safe** — phase guard covers it. | **None** |
 
 ### Cancellation Path
 
@@ -235,7 +235,6 @@ Exhaustive catalog of testing scenarios for ArmadaCrowdfund, organized by lifecy
 | 5.33 | `totalAllocated` (ARM) is hop-level upper bound | sum of min(demand, reserve) * 1e18 / ARM_PRICE per hop | Integration |
 | 5.34 | `totalAllocatedUsdc` is hop-level upper bound | sum of min(demand, reserve) per hop | Integration |
 | 5.35 | Verify `SaleFinalized` event fields: saleSize, totalAllocUsdc, totalAllocArm, treasuryLeftoverUsdc | All correct | **None** |
-| 5.36 | Phase.Commitment enum value is never written to `phase` storage | Observable quirk — phase goes Invitation → Finalized/Canceled | **None** |
 
 ---
 
@@ -290,7 +289,7 @@ Exhaustive catalog of testing scenarios for ArmadaCrowdfund, organized by lifecy
 |---|----------|-----------------|----------|
 | 7.7 | Claim in Canceled phase | Revert: "not finalized" | Adversarial |
 | 7.8 | Claim in Setup phase | Revert: "not finalized" | **None** |
-| 7.9 | Claim in Invitation/Commitment phase | Revert: "not finalized" | **None** |
+| 7.9 | Claim in Active phase (sale window open) | Revert: "not finalized" | **None** |
 | 7.10 | Double claim | Revert: "already claimed" | Integration |
 | 7.11 | Claim with 0 committed (whitelisted but no commitment) | Revert: "no commitment" | Adversarial |
 | 7.12 | Claim by non-participant (never whitelisted) | Revert: "no commitment" (committed = 0) | Adversarial |
@@ -374,8 +373,7 @@ Exhaustive catalog of testing scenarios for ArmadaCrowdfund, organized by lifecy
 | # | Scenario | Expected Outcome | Coverage |
 |---|----------|-----------------|----------|
 | 10.10 | `getInviteEdge()` during Setup phase | Revert: "graph hidden during sale" | **None** |
-| 10.11 | `getInviteEdge()` during Invitation phase | Revert: "graph hidden during sale" | Integration |
-| 10.12 | `getInviteEdge()` during Commitment window | Revert: "graph hidden during sale" | **None** |
+| 10.11 | `getInviteEdge()` during Active phase (sale window open) | Revert: "graph hidden during sale" | Integration |
 | 10.13 | `getInviteEdge()` after Finalized | Returns correct inviter and hop | Integration |
 | 10.14 | `getInviteEdge()` after Canceled | Returns correct inviter and hop | **None** |
 | 10.15 | `getInviteEdge()` for seed — invitedBy = address(0) | Correct | Integration |
@@ -436,8 +434,7 @@ Exhaustive catalog of testing scenarios for ArmadaCrowdfund, organized by lifecy
 
 | # | Scenario | Expected Outcome | Coverage |
 |---|----------|-----------------|----------|
-| 14.1 | Phase only moves forward: Setup → Invitation → Finalized\|Canceled | Never regresses | Foundry invariant |
-| 14.2 | Phase.Commitment enum value is never written to storage | Observable quirk — contract goes Invitation → Finalized/Canceled | **None** |
+| 14.1 | Phase only moves forward: Setup → Active → Finalized\|Canceled | Never regresses | Foundry invariant |
 | 14.3 | All state-mutating functions have appropriate phase guards | Verified per function | Integration + Adversarial |
 | 14.4 | No function can move phase backward | Verified by inspection | Code review |
 | 14.5 | After Finalized: only claim, withdrawProceeds, withdrawUnallocatedArm, and views work | All other mutations revert | **None** |
@@ -474,13 +471,12 @@ These scenarios arose from code review and may represent actual bugs or known-ac
 
 | # | Finding | Risk | Status |
 |---|---------|------|--------|
-| 17.1 | **`finalize()` callable from Setup phase if `commitmentEnd` is 0:** The guard `block.timestamp > commitmentEnd` passes when `commitmentEnd = 0` (not yet set). The phase guard checks `phase == Invitation \|\| phase == Commitment`, so Setup would fail. **Actually safe** — the phase guard rejects it. | Low | Safe (phase guard covers it) |
-| 17.2 | **`Phase.Commitment` never set:** The enum exists but is never written. `finalize()` checks for it in the phase guard (`phase == Phase.Invitation \|\| phase == Phase.Commitment`), meaning the Commitment check is dead code. | Info | Known quirk |
-| 17.3 | **No constructor validation on USDC/ARM addresses:** Deploying with zero or wrong token addresses would create a broken contract with no recovery mechanism. | Medium | Document in deploy checklist |
-| 17.4 | **`withdrawProceeds` and `withdrawUnallocatedArm` lack `nonReentrant`:** Both use SafeERC20 and don't have callback surfaces, but adding the modifier would be belt-and-suspenders. | Low | Acceptable for POC |
-| 17.5 | **No emergency stop / pause mechanism:** If a bug is discovered post-deployment, there's no way to pause claims. | Medium | Tracked in POC shortcuts |
-| 17.6 | **No admin recovery of accidentally-sent tokens:** If someone sends a random ERC20 to the contract, it's stuck forever. | Low | Acceptable |
-| 17.7 | **Rollover thresholds (30 hop-1, 50 hop-2) may be structurally unreachable** given the sale minimums and per-hop caps. Test which rollover paths are actually exercisable. | Info | Documented in adversarial tests |
+| 17.1 | **`finalize()` callable from Setup phase if `saleEnd` is 0:** The guard `block.timestamp > saleEnd` passes when `saleEnd = 0` (not yet set). The phase guard checks `phase == Active`, so Setup would fail. **Actually safe** — the phase guard rejects it. | Low | Safe (phase guard covers it) |
+| 17.2 | **No constructor validation on USDC/ARM addresses:** Deploying with zero or wrong token addresses would create a broken contract with no recovery mechanism. | Medium | Document in deploy checklist |
+| 17.3 | **`withdrawProceeds` and `withdrawUnallocatedArm` lack `nonReentrant`:** Both use SafeERC20 and don't have callback surfaces, but adding the modifier would be belt-and-suspenders. | Low | Acceptable for POC |
+| 17.4 | **No emergency stop / pause mechanism:** If a bug is discovered post-deployment, there's no way to pause claims. | Medium | Tracked in POC shortcuts |
+| 17.5 | **No admin recovery of accidentally-sent tokens:** If someone sends a random ERC20 to the contract, it's stuck forever. | Low | Acceptable |
+| 17.6 | **Rollover thresholds (30 hop-1, 50 hop-2) may be structurally unreachable** given the sale minimums and per-hop caps. Test which rollover paths are actually exercisable. | Info | Documented in adversarial tests |
 
 ---
 
@@ -489,21 +485,20 @@ These scenarios arose from code review and may represent actual bugs or known-ac
 | Category | Covered | Gaps | Total |
 |----------|---------|------|-------|
 | Constructor & Deployment | 3 | 5 | 8 |
-| Setup Phase | 7 | 13 | 20 |
-| Invitation Phase | 14 | 14 | 28 |
-| Commitment Phase | 12 | 18 | 30 |
-| Finalization | 12 | 24 | 36 |
+| Setup Phase | 7 | 11 | 18 |
+| Sale Window (invites + commits) | 18 | 39 | 57 |
+| Finalization | 12 | 23 | 35 |
 | Allocation Algorithm | 4 | 9 | 13 |
 | Claims | 6 | 11 | 17 |
 | Refunds | 4 | 5 | 9 |
 | Admin Withdrawals | 6 | 13 | 19 |
-| View Functions | 7 | 14 | 21 |
+| View Functions | 7 | 13 | 20 |
 | Access Control | 2 | 2 | 4 |
 | Reentrancy | 3 | 6 | 9 |
 | Token Interactions | 0 | 5 | 5 |
-| State Machine | 2 | 4 | 6 |
+| State Machine | 2 | 3 | 5 |
 | End-to-End | 4 | 2 | 6 |
 | Governance Integration | 1 | 2 | 3 |
-| **Totals** | **~87** | **~147** | **~234** |
+| **Totals** | **~79** | **~149** | **~228** |
 
 Many gaps are event emission checks, timestamp boundary tests, and view function edge cases — lower severity but important for completeness. The high-value gaps are in rollover logic (5.24–5.29), incremental admin withdrawals (9.2–9.3), and the allocation precision edge cases (6.9–6.13).

--- a/mcp-server/src/tools/contract-state.ts
+++ b/mcp-server/src/tools/contract-state.ts
@@ -52,8 +52,8 @@ const TREASURY_ABI = [
 const CROWDFUND_ABI = [
   "function totalCommitted() view returns (uint256)",
   "function phase() view returns (uint8)",
-  "function commitmentEnd() view returns (uint256)",
-  "function getSaleStats() view returns (uint256 totalCommitted, uint8 phase, uint256 invitationEnd, uint256 commitmentEnd)",
+  "function saleEnd() view returns (uint256)",
+  "function getSaleStats() view returns (uint256 totalCommitted, uint8 phase, uint256 saleEnd)",
   "function BASE_SALE() view returns (uint256)",
   "function MAX_SALE() view returns (uint256)",
   "function MIN_SALE() view returns (uint256)",
@@ -253,11 +253,10 @@ async function queryCrowdfund(env: DeployEnv): Promise<ContractQueryResult> {
 
   const cf = deployments.hub.crowdfund.contracts;
 
-  // Phase enum: 0 = Setup, 1 = Invitation, 2 = Commitment, 3 = Finalized, 4 = Canceled
+  // Phase enum: 0 = Setup, 1 = Active, 2 = Finalized, 3 = Canceled
   const CROWDFUND_PHASES = [
     "Setup",
-    "Invitation",
-    "Commitment",
+    "Active",
     "Finalized",
     "Canceled",
   ];
@@ -270,17 +269,15 @@ async function queryCrowdfund(env: DeployEnv): Promise<ContractQueryResult> {
       safeCall("hub", cf.crowdfund, CROWDFUND_ABI, "MIN_SALE"),
     ]);
 
-  // getSaleStats returns (totalCommitted, phase, invitationEnd, commitmentEnd)
+  // getSaleStats returns (totalCommitted, phase, saleEnd)
   let totalCommitted: unknown = null;
   let phase: unknown = null;
-  let commitmentEnd: unknown = null;
-  let invitationEnd: unknown = null;
+  let saleEnd: unknown = null;
 
-  if (Array.isArray(saleStats) && saleStats.length >= 4) {
+  if (Array.isArray(saleStats) && saleStats.length >= 3) {
     totalCommitted = saleStats[0];
     phase = saleStats[1];
-    invitationEnd = saleStats[2];
-    commitmentEnd = saleStats[3];
+    saleEnd = saleStats[2];
   } else {
     totalCommitted = saleStats;
   }
@@ -292,14 +289,10 @@ async function queryCrowdfund(env: DeployEnv): Promise<ContractQueryResult> {
     address: cf.crowdfund,
     totalCommitted: formatUsdc(totalCommitted),
     phase: phaseNum !== null ? CROWDFUND_PHASES[phaseNum] ?? `Unknown(${phaseNum})` : phase,
-    invitationEnd:
-      typeof invitationEnd === "bigint"
-        ? invitationEnd > 0n ? new Date(Number(invitationEnd) * 1000).toISOString() : "not set"
-        : invitationEnd,
-    commitmentEnd:
-      typeof commitmentEnd === "bigint"
-        ? commitmentEnd > 0n ? new Date(Number(commitmentEnd) * 1000).toISOString() : "not set"
-        : commitmentEnd,
+    saleEnd:
+      typeof saleEnd === "bigint"
+        ? saleEnd > 0n ? new Date(Number(saleEnd) * 1000).toISOString() : "not set"
+        : saleEnd,
     saleLimits: {
       base: formatUsdc(baseSale),
       min: formatUsdc(minSale),

--- a/scripts/crowdfund_demo.ts
+++ b/scripts/crowdfund_demo.ts
@@ -22,10 +22,9 @@
 
 import { ethers, network } from "hardhat";
 
-const PhaseNames = ["SETUP", "INVITATION", "COMMITMENT", "FINALIZED", "CANCELED"];
+const PhaseNames = ["SETUP", "ACTIVE", "FINALIZED", "CANCELED"];
 
-const TWO_WEEKS = 14 * 86400;
-const ONE_WEEK = 7 * 86400;
+const THREE_WEEKS = 21 * 86400;
 
 function log(tag: string, msg: string) {
   const padded = `[${tag}]`.padEnd(12);
@@ -107,15 +106,15 @@ async function main() {
     log("SEED", `  Seed-${String.fromCharCode(65 + i)}: ${seeds[i].address.slice(0, 10)}...`);
   }
 
-  // ============ PHASE: INVITATION ============
+  // ============ PHASE: SALE (unified window) ============
   console.log("");
   console.log("-".repeat(70));
-  console.log("  PHASE: INVITATION (2-week window)");
+  console.log("  PHASE: SALE (3-week unified window)");
   console.log("-".repeat(70));
   console.log("");
 
-  await crowdfund.startInvitations();
-  log("START", `Invitation window opened`);
+  await crowdfund.startSale();
+  log("START", `Sale window opened (invites + commits concurrent)`);
 
   // Each seed invites 3 hop-1 addresses
   let hop1Count = 0;
@@ -143,15 +142,7 @@ async function main() {
   const [, , wc2] = await crowdfund.getHopStats(2);
   log("STATS", `Hop 0: ${wc0} whitelisted | Hop 1: ${wc1} | Hop 2: ${wc2}`);
 
-  await fastForward(TWO_WEEKS, "2 weeks (invitation window)");
-
-  // ============ PHASE: COMMITMENT ============
-  console.log("-".repeat(70));
-  console.log("  PHASE: COMMITMENT (1-week window)");
-  console.log("-".repeat(70));
-  console.log("");
-
-  // Fund and commit: seeds at max cap
+  // Fund and commit: seeds at max cap (no time skip needed — unified window)
   for (let i = 0; i < seeds.length; i++) {
     const amount = ethers.parseUnits("15000", 6);
     await usdc.mint(seeds[i].address, amount);
@@ -223,10 +214,8 @@ async function main() {
   await cf2.addSeeds(bigSeeds.map(s => s.address));
   log("SETUP", `Added ${bigSeeds.length} seeds to second crowdfund`);
 
-  await cf2.startInvitations();
-  await network.provider.send("evm_increaseTime", [TWO_WEEKS + 1]);
-  await network.provider.send("evm_mine");
-  log("TIME", "Fast-forwarded past invitation window");
+  await cf2.startSale();
+  log("START", "Sale window opened");
 
   // Each seed commits $15K
   for (const s of bigSeeds) {
@@ -238,7 +227,7 @@ async function main() {
   const total2 = await cf2.totalCommitted();
   log("COMMIT", `${bigSeeds.length} seeds commit $15K each = ${fmtUsdc(total2)}`);
 
-  await network.provider.send("evm_increaseTime", [ONE_WEEK + 1]);
+  await network.provider.send("evm_increaseTime", [THREE_WEEKS + 1]);
   await network.provider.send("evm_mine");
 
   // Finalize

--- a/scripts/crowdfund_populate.ts
+++ b/scripts/crowdfund_populate.ts
@@ -212,10 +212,10 @@ async function main() {
     log("SEEDS", `  Batch ${Math.floor(i / SEED_BATCH_SIZE) + 1}: added ${batch.length} seeds`);
   }
 
-  // ============ START INVITATIONS ============
-  const startTx = await crowdfund.startInvitations();
+  // ============ START SALE ============
+  const startTx = await crowdfund.startSale();
   await startTx.wait();
-  log("PHASE", "Invitation window opened");
+  log("PHASE", "Sale window opened (invites + commits)");
 
   // ============ INVITATIONS (if hops enabled) ============
   if (includeHops) {
@@ -245,20 +245,6 @@ async function main() {
     }
     log("INVITE", `${h2idx} hop-2 addresses invited`);
   }
-
-  // ============ ADVANCE TO COMMITMENT ============
-  console.log("-".repeat(70));
-
-  // Read exact commitment window from contract and jump to it
-  const commStart = Number(await crowdfund.commitmentStart());
-  const commEnd = Number(await crowdfund.commitmentEnd());
-  const curBlock = await ethers.provider.getBlock("latest");
-  const curTs = curBlock!.timestamp;
-  const jump = commStart - curTs + 1;
-
-  log("TIME", `Advancing to commitment window (${jump}s jump)...`);
-  await network.provider.send("evm_increaseTime", [jump]);
-  await network.provider.send("evm_mine");
 
   // ============ MINT + APPROVE + COMMIT ============
   console.log("-".repeat(70));

--- a/scripts/full_lifecycle_demo.ts
+++ b/scripts/full_lifecycle_demo.ts
@@ -58,7 +58,7 @@ const TIMELOCK_MIN_DELAY   = TWO_DAYS;
 // Governance enums
 const ProposalType = { ParameterChange: 0, Treasury: 1, StewardElection: 2 };
 const Vote = { Against: 0, For: 1, Abstain: 2 };
-const PhaseNames  = ["SETUP", "INVITATION", "COMMITMENT", "FINALIZED", "CANCELED"];
+const PhaseNames  = ["SETUP", "ACTIVE", "FINALIZED", "CANCELED"];
 const StateNames  = ["PENDING", "ACTIVE", "DEFEATED", "SUCCEEDED", "QUEUED", "EXECUTED", "CANCELED"];
 
 // ============ Utility Functions ============
@@ -246,9 +246,9 @@ async function main() {
   await crowdfund.addSeeds(seeds.map(s => s.address));
   log("SEED", `Added ${seeds.length} seeds (hop 0, $${SEED_CAP} cap, 3 invites each)`);
 
-  // 2b: Start invitations
-  await crowdfund.startInvitations();
-  log("START", "Invitation window opened (2-week duration)");
+  // 2b: Start sale (unified 3-week window — invites + commits concurrent)
+  await crowdfund.startSale();
+  log("START", "Sale window opened (3-week unified window)");
 
   // 2c: Invitation chains — first 3 seeds invite hop-1, hop-1 invite hop-2
   let hop1Count = 0;
@@ -274,10 +274,7 @@ async function main() {
   const [, , wc2] = await crowdfund.getHopStats(2);
   log("STATS", `Whitelisted \u2014 Hop 0: ${wc0} | Hop 1: ${wc1} | Hop 2: ${wc2}`);
 
-  await fastForward(TWO_WEEKS, "2 weeks (invitation window)");
-
-  // 2d: Commitment phase
-  log("PHASE", "Commitment window open (1-week duration)");
+  // 2d: Commitment (no time skip needed — unified window)
 
   // Seeds commit at max cap
   for (const s of seeds) {
@@ -313,7 +310,7 @@ async function main() {
     log("STATS", `  Hop ${h}: ${uc} committers, ${fmtUsdc(tc)}`);
   }
 
-  await fastForward(ONE_WEEK, "1 week (commitment window)");
+  await fastForward(21 * ONE_DAY, "3 weeks (sale window)");
 
   // 2e: Finalize
   await crowdfund.finalize();
@@ -367,7 +364,7 @@ async function main() {
   const [h2Alloc, h2Refund] = await crowdfund.getAllocation(hop2Addrs[0].address);
   log("CLAIM", `  ${hop2Claimers} hop-2 claim: ${fmtArm(h2Alloc)} + ${fmtUsdc(h2Refund)} refund each`);
 
-  verify("Phase is FINALIZED", phase === 3);
+  verify("Phase is FINALIZED", phase === 2);
   verify("Total committed > MIN_SALE ($1M)", totalCommitted > ethers.parseUnits("1000000", 6));
 
   // ================================================================

--- a/tasks/crowdfund.ts
+++ b/tasks/crowdfund.ts
@@ -19,7 +19,7 @@ import { task } from "hardhat/config";
 import * as fs from "fs";
 import * as path from "path";
 
-const PhaseNames = ["SETUP", "INVITATION", "COMMITMENT", "FINALIZED", "CANCELED"];
+const PhaseNames = ["SETUP", "ACTIVE", "FINALIZED", "CANCELED"];
 
 function loadCrowdfundDeployment(networkName: string) {
   const filePath = path.join(__dirname, "..", "deployments", `crowdfund-${networkName}.json`);
@@ -52,23 +52,21 @@ task("cf-add-seeds", "Add seed addresses (hop 0)")
     console.log(`Added ${seeds.length} seed(s): ${seeds.join(", ")}`);
   });
 
-task("cf-start", "Start the invitation window")
+task("cf-start", "Start the sale window")
   .setAction(async (_, hre) => {
     const { ethers } = hre;
     const chainId = Number((await ethers.provider.getNetwork()).chainId);
     const deployment = loadCrowdfundDeployment(getNetworkName(chainId));
 
     const crowdfund = await ethers.getContractAt("ArmadaCrowdfund", deployment.contracts.crowdfund);
-    await crowdfund.startInvitations();
+    await crowdfund.startSale();
 
-    const invEnd = await crowdfund.invitationEnd();
-    const commEnd = await crowdfund.commitmentEnd();
-    console.log("Invitation window started");
-    console.log(`  Invitation ends: ${new Date(Number(invEnd) * 1000).toISOString()}`);
-    console.log(`  Commitment ends: ${new Date(Number(commEnd) * 1000).toISOString()}`);
+    const saleEnd = await crowdfund.saleEnd();
+    console.log("Sale window started");
+    console.log(`  Sale ends: ${new Date(Number(saleEnd) * 1000).toISOString()}`);
   });
 
-// ============ Invitation ============
+// ============ Sale ============
 
 task("cf-invite", "Invite an address to participate")
   .addParam("invitee", "Address to invite")
@@ -119,7 +117,7 @@ task("cf-finalize", "Finalize the crowdfund (compute allocations or cancel)")
 
     const phase = Number(await crowdfund.phase());
     console.log(`Crowdfund finalized: ${PhaseNames[phase]}`);
-    if (phase === 3) {
+    if (phase === 2) {
       // Finalized
       const saleSize = await crowdfund.saleSize();
       const totalAlloc = await crowdfund.totalAllocated();
@@ -140,7 +138,7 @@ task("cf-claim", "Claim ARM allocation and USDC refund")
     const crowdfund = await ethers.getContractAt("ArmadaCrowdfund", deployment.contracts.crowdfund);
     const phase = Number(await crowdfund.phase());
 
-    if (phase === 4) {
+    if (phase === 3) {
       // Canceled — use refund()
       await crowdfund.refund();
       console.log("Full USDC refund claimed (sale was canceled)");
@@ -161,13 +159,12 @@ task("cf-stats", "Show crowdfund statistics")
 
     const crowdfund = await ethers.getContractAt("ArmadaCrowdfund", deployment.contracts.crowdfund);
 
-    const [totalComm, phase, invEnd, commEnd] = await crowdfund.getSaleStats();
+    const [totalComm, phase, saleEnd] = await crowdfund.getSaleStats();
     console.log("Crowdfund Status:");
     console.log(`  Phase: ${PhaseNames[Number(phase)]}`);
     console.log(`  Total committed: $${ethers.formatUnits(totalComm, 6)}`);
-    if (Number(invEnd) > 0) {
-      console.log(`  Invitation ends: ${new Date(Number(invEnd) * 1000).toISOString()}`);
-      console.log(`  Commitment ends: ${new Date(Number(commEnd) * 1000).toISOString()}`);
+    if (Number(saleEnd) > 0) {
+      console.log(`  Sale ends: ${new Date(Number(saleEnd) * 1000).toISOString()}`);
     }
     console.log(`  Participants: ${await crowdfund.getParticipantCount()}`);
 
@@ -177,7 +174,7 @@ task("cf-stats", "Show crowdfund statistics")
       console.log(`  Hop ${h}: ${wc} whitelisted, ${uc} committed, $${ethers.formatUnits(tc, 6)} total`);
     }
 
-    if (Number(phase) === 3) {
+    if (Number(phase) === 2) {
       console.log(`\n  Sale size: $${ethers.formatUnits(await crowdfund.saleSize(), 6)}`);
       console.log(`  Total ARM allocated: ${ethers.formatUnits(await crowdfund.totalAllocated(), 18)}`);
     }
@@ -201,7 +198,7 @@ task("cf-allocation", "Check allocation for an address")
     console.log(`  Committed: $${ethers.formatUnits(committed, 6)}`);
 
     const phase = Number(await crowdfund.phase());
-    if (phase === 3) {
+    if (phase === 2) {
       const [alloc, refund, claimed] = await crowdfund.getAllocation(args.address);
       console.log(`  Allocation: ${ethers.formatUnits(alloc, 18)} ARM`);
       console.log(`  Refund: $${ethers.formatUnits(refund, 6)}`);

--- a/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
+++ b/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
@@ -36,17 +36,17 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
         // Fund ARM tokens
         armToken.transfer(address(crowdfund), ARM_FUNDING);
 
-        // Start invitations to set commitmentEnd
+        // Start sale to set saleEnd
         address[] memory seeds = new address[](1);
         seeds[0] = address(0xA);
         crowdfund.addSeeds(seeds);
-        crowdfund.startInvitations();
+        crowdfund.startSale();
     }
 
-    /// @notice Helper: advance past commitment period and cancel via finalize (under-subscribed)
+    /// @notice Helper: advance past sale period and cancel via finalize (under-subscribed)
     function _cancelViaTooFewCommitments() internal {
-        // Warp past commitment end so finalize() can be called
-        vm.warp(crowdfund.commitmentEnd() + 1);
+        // Warp past sale end so finalize() can be called
+        vm.warp(crowdfund.saleEnd() + 1);
         // No commitments made, so totalCommitted == 0 < MIN_SALE → cancel path
         crowdfund.finalize();
         assertEq(uint256(crowdfund.phase()), uint256(Phase.Canceled));
@@ -102,23 +102,11 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
         fresh.withdrawUnallocatedArm();
     }
 
-    /// @notice Reverts in Invitation phase
-    function test_withdrawUnallocatedArm_invitationPhase_reverts() public {
-        // setUp already moved crowdfund to Invitation phase
-        assertEq(uint256(crowdfund.phase()), uint256(Phase.Invitation));
+    /// @notice Reverts in Active phase
+    function test_withdrawUnallocatedArm_activePhase_reverts() public {
+        // setUp already moved crowdfund to Active phase
+        assertEq(uint256(crowdfund.phase()), uint256(Phase.Active));
 
-        vm.expectRevert("ArmadaCrowdfund: not finalized or canceled");
-        crowdfund.withdrawUnallocatedArm();
-    }
-
-    /// @notice Reverts in Commitment phase
-    function test_withdrawUnallocatedArm_commitmentPhase_reverts() public {
-        // Warp past invitation period to enter Commitment phase
-        vm.warp(crowdfund.commitmentEnd() - 1);
-        // Phase transitions to Commitment when commitment period starts
-        // Actually, the contract uses commitmentEnd which is set at startInvitations.
-        // The phase stays Invitation until someone commits or finalize is called.
-        // Let's just verify it reverts at current phase.
         vm.expectRevert("ArmadaCrowdfund: not finalized or canceled");
         crowdfund.withdrawUnallocatedArm();
     }
@@ -143,10 +131,10 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
         address[] memory seeds = new address[](1);
         seeds[0] = address(0xA);
         fuzzCrowdfund.addSeeds(seeds);
-        fuzzCrowdfund.startInvitations();
+        fuzzCrowdfund.startSale();
 
         // Cancel
-        vm.warp(fuzzCrowdfund.commitmentEnd() + 1);
+        vm.warp(fuzzCrowdfund.saleEnd() + 1);
         fuzzCrowdfund.finalize();
 
         // Recover

--- a/test-foundry/ArmadaCrowdfundCancel.t.sol
+++ b/test-foundry/ArmadaCrowdfundCancel.t.sol
@@ -35,20 +35,20 @@ contract ArmadaCrowdfundCancelTest is Test {
         // Fund ARM for MAX_SALE
         armToken.transfer(address(crowdfund), 1_800_000 * 1e18);
 
-        // Start invitations to set commitmentEnd
+        // Start sale to set saleEnd
         address[] memory seeds = new address[](1);
         seeds[0] = address(0xA);
         crowdfund.addSeeds(seeds);
-        crowdfund.startInvitations();
+        crowdfund.startSale();
     }
 
     /// @notice permissionlessCancel always reverts when elapsed <= FINALIZE_GRACE_PERIOD
     function testFuzz_revertsBeforeGracePeriod(uint256 elapsed) public {
-        uint256 commitmentEnd = crowdfund.commitmentEnd();
+        uint256 saleEnd = crowdfund.saleEnd();
         // Bound elapsed to [0, FINALIZE_GRACE_PERIOD] (inclusive — should revert at boundary)
         elapsed = bound(elapsed, 0, THIRTY_DAYS);
 
-        vm.warp(commitmentEnd + elapsed);
+        vm.warp(saleEnd + elapsed);
 
         vm.prank(caller);
         vm.expectRevert("ArmadaCrowdfund: grace period not elapsed");
@@ -57,11 +57,11 @@ contract ArmadaCrowdfundCancelTest is Test {
 
     /// @notice permissionlessCancel always succeeds when elapsed > FINALIZE_GRACE_PERIOD
     function testFuzz_succeedsAfterGracePeriod(uint256 elapsed) public {
-        uint256 commitmentEnd = crowdfund.commitmentEnd();
+        uint256 saleEnd = crowdfund.saleEnd();
         // Bound elapsed to (FINALIZE_GRACE_PERIOD, FINALIZE_GRACE_PERIOD + 365 days]
         elapsed = bound(elapsed, THIRTY_DAYS + 1, THIRTY_DAYS + 365 days);
 
-        vm.warp(commitmentEnd + elapsed);
+        vm.warp(saleEnd + elapsed);
 
         vm.prank(caller);
         crowdfund.permissionlessCancel();

--- a/test-foundry/CrowdfundFullInvariant.t.sol
+++ b/test-foundry/CrowdfundFullInvariant.t.sol
@@ -133,6 +133,12 @@ contract CrowdfundFullHandler is Test {
         vm.stopPrank();
     }
 
+    /// @dev Skip past sale end to enable finalization
+    function skipPastSale() external {
+        if (ghost_finalized || ghost_canceled) return;
+        vm.warp(crowdfund.saleEnd() + 1);
+    }
+
     /// @dev Finalize the crowdfund
     function finalize() external {
         if (ghost_finalized || ghost_canceled) return;
@@ -204,8 +210,8 @@ contract CrowdfundFullInvariantTest is Test {
         // Setup phase: add seeds
         crowdfund.addSeeds(seeds);
 
-        // Start invitations
-        crowdfund.startInvitations();
+        // Start sale
+        crowdfund.startSale();
 
         // Do invitations
         uint256 hop1Idx = 0;
@@ -230,8 +236,7 @@ contract CrowdfundFullInvariantTest is Test {
             }
         }
 
-        // Fast-forward past invitation window into commitment window
-        vm.warp(crowdfund.commitmentStart() + 1);
+        // Commits are valid as soon as the sale starts
 
         // Create handler
         handler = new CrowdfundFullHandler(

--- a/test-foundry/CrowdfundInvariant.t.sol
+++ b/test-foundry/CrowdfundInvariant.t.sol
@@ -140,6 +140,12 @@ contract CrowdfundHandler is Test {
         vm.stopPrank();
     }
 
+    /// @dev Skip past sale end to enable finalization
+    function skipPastSale() external {
+        if (ghost_finalized || ghost_canceled) return;
+        vm.warp(crowdfund.saleEnd() + 1);
+    }
+
     /// @dev Finalize the crowdfund (admin)
     function finalize() external {
         if (ghost_finalized || ghost_canceled) return;
@@ -276,8 +282,8 @@ contract CrowdfundInvariantTest is Test {
         // Setup phase: add seeds
         crowdfund.addSeeds(seeds);
 
-        // Start invitations
-        crowdfund.startInvitations();
+        // Start sale
+        crowdfund.startSale();
 
         // Do invitations: each seed invites up to 3 hop-1 addresses
         uint256 hop1Idx = 0;
@@ -304,8 +310,7 @@ contract CrowdfundInvariantTest is Test {
             }
         }
 
-        // Fast-forward past invitation window into commitment window
-        vm.warp(crowdfund.commitmentStart() + 1);
+        // Commits are valid as soon as the sale starts
 
         // Create handler
         handler = new CrowdfundHandler(
@@ -366,7 +371,7 @@ contract CrowdfundInvariantTest is Test {
     /// @notice Phase only moves forward, never backward
     function invariant_phaseMonotonicity() public view {
         Phase currentPhase = crowdfund.phase();
-        // We started in Invitation (after setUp), moved to Commitment window via warp
+        // We started in Active (after setUp), may have moved to Finalized/Canceled
         // Phase should never go backward
         if (handler.ghost_finalized()) {
             assertEq(uint256(currentPhase), uint256(Phase.Finalized), "Phase should be Finalized");

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -22,8 +22,7 @@ const Vote = { Against: 0, For: 1, Abstain: 2 };
 const ONE_DAY = 86400;
 const TWO_DAYS = 2 * ONE_DAY;
 const FIVE_DAYS = 5 * ONE_DAY;
-const TWO_WEEKS = 14 * ONE_DAY;
-const ONE_WEEK = 7 * ONE_DAY;
+const THREE_WEEKS = 21 * ONE_DAY;
 
 const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
 const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
@@ -134,17 +133,14 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // 1. Add seeds and start invitations
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
+      await crowdfund.startSale();
 
       // 2. Seeds invite hop-1 addresses
       for (let i = 0; i < 3 && i < hop1Addrs.length; i++) {
         await crowdfund.connect(seeds[i]).invite(hop1Addrs[i].address);
       }
 
-      // 3. Fast-forward past invitation window into commitment window
-      await time.increase(TWO_WEEKS + 1);
-
-      // 4. All seeds commit $15K each = $1.2M (meets MIN_SALE)
+      // 3. All seeds commit $15K each = $1.2M (meets MIN_SALE)
       for (const seed of seeds) {
         const amount = USDC(15_000);
         await usdc.mint(seed.address, amount);
@@ -152,12 +148,12 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await crowdfund.connect(seed).commit(amount);
       }
 
-      // 5. Fast-forward past commitment window
-      await time.increase(ONE_WEEK + 1);
+      // 4. Fast-forward past sale window
+      await time.increase(THREE_WEEKS + 1);
 
-      // 6. Finalize
+      // 5. Finalize
       await crowdfund.finalize();
-      expect(await crowdfund.phase()).to.equal(3); // Finalized
+      expect(await crowdfund.phase()).to.equal(2); // Finalized
 
       // 7. Seeds claim their ARM
       const claimedSeeds = seeds.slice(0, 5); // claim first 5 for governance testing
@@ -244,8 +240,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
   describe("Token Supply Consistency", function () {
     async function runCrowdfundAndClaim() {
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const seed of seeds) {
         const amount = USDC(15_000);
@@ -254,7 +249,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await crowdfund.connect(seed).commit(amount);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Claim all
@@ -353,8 +348,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     async function setupCrowdfundAndGovernance() {
       // Run crowdfund
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const seed of seeds) {
         const amount = USDC(15_000);
@@ -362,7 +356,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await usdc.connect(seed).approve(await crowdfund.getAddress(), amount);
         await crowdfund.connect(seed).commit(amount);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Claim first 10 seeds
@@ -554,8 +548,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("unclaimed crowdfund participant cannot vote (no ARM, no lock, no voting power)", async function () {
       // Run crowdfund but DON'T claim
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const seed of seeds) {
         const amount = USDC(15_000);
@@ -563,7 +556,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await usdc.connect(seed).approve(await crowdfund.getAddress(), amount);
         await crowdfund.connect(seed).commit(amount);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // DON'T claim — seeds have 0 ARM balance
@@ -746,8 +739,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("quorum denominator shifts as participants claim ARM from crowdfund", async function () {
       // Run crowdfund lifecycle
       await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
-      await localCrowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await localCrowdfund.startSale();
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
@@ -756,7 +748,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await localCrowdfund.connect(seed).commit(amount);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await localCrowdfund.finalize();
 
       // Before any claims: crowdfund still holds all ARM
@@ -806,8 +798,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("withdrawProceeds sends USDC to treasury contract", async function () {
       // Run crowdfund
       await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
-      await localCrowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await localCrowdfund.startSale();
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
@@ -816,7 +807,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await localCrowdfund.connect(seed).commit(amount);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await localCrowdfund.finalize();
 
       // All seeds claim
@@ -840,8 +831,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("withdrawUnallocatedArm sends ARM to treasury contract", async function () {
       // Run crowdfund
       await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
-      await localCrowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await localCrowdfund.startSale();
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
@@ -850,7 +840,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await localCrowdfund.connect(seed).commit(amount);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await localCrowdfund.finalize();
 
       const treasuryAddress = await localTreasury.getAddress();
@@ -866,8 +856,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("full lifecycle: crowdfund → claim → lock → propose → vote → execute", async function () {
       // Run crowdfund
       await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
-      await localCrowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await localCrowdfund.startSale();
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
@@ -876,7 +865,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await localCrowdfund.connect(seed).commit(amount);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await localCrowdfund.finalize();
 
       // 5 seeds claim

--- a/test/crowdfund_adversarial.ts
+++ b/test/crowdfund_adversarial.ts
@@ -13,11 +13,10 @@ import { ethers } from "hardhat";
 import { time } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
-const Phase = { Setup: 0, Invitation: 1, Commitment: 2, Finalized: 3, Canceled: 4 };
+const Phase = { Setup: 0, Active: 1, Finalized: 2, Canceled: 3 };
 
 const ONE_DAY = 86400;
-const TWO_WEEKS = 14 * ONE_DAY;
-const ONE_WEEK = 7 * ONE_DAY;
+const THREE_WEEKS = 21 * ONE_DAY;
 
 const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
 const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
@@ -102,15 +101,15 @@ describe("Crowdfund Adversarial", function () {
   describe("Permissionless Cancel Boundaries", function () {
     const THIRTY_DAYS = 30 * ONE_DAY;
 
-    it("reverts at exact boundary (commitmentEnd + FINALIZE_GRACE_PERIOD)", async function () {
+    it("reverts at exact boundary (saleEnd + FINALIZE_GRACE_PERIOD)", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      const commitmentEnd = await crowdfund.commitmentEnd();
+      await crowdfund.startSale();
+      const saleEnd = await crowdfund.saleEnd();
 
       // time.increaseTo mines a block at the given timestamp, so the next tx
-      // runs at timestamp + 1. To get block.timestamp == commitmentEnd + 30 days
+      // runs at timestamp + 1. To get block.timestamp == saleEnd + 30 days
       // when permissionlessCancel() executes, we target one second earlier.
-      await time.increaseTo(commitmentEnd + BigInt(THIRTY_DAYS) - 1n);
+      await time.increaseTo(saleEnd + BigInt(THIRTY_DAYS) - 1n);
 
       await expect(
         crowdfund.connect(allSigners[2]).permissionlessCancel()
@@ -119,11 +118,11 @@ describe("Crowdfund Adversarial", function () {
 
     it("succeeds at boundary + 1 second", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      const commitmentEnd = await crowdfund.commitmentEnd();
+      await crowdfund.startSale();
+      const saleEnd = await crowdfund.saleEnd();
 
-      // Mine block at commitmentEnd + 30 days, so next tx runs at + 30 days + 1
-      await time.increaseTo(commitmentEnd + BigInt(THIRTY_DAYS));
+      // Mine block at saleEnd + 30 days, so next tx runs at + 30 days + 1
+      await time.increaseTo(saleEnd + BigInt(THIRTY_DAYS));
 
       await expect(crowdfund.connect(allSigners[2]).permissionlessCancel())
         .to.emit(crowdfund, "SaleCanceled");
@@ -137,36 +136,34 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
 
-      // Past commitmentEnd but within grace period
-      await time.increase(ONE_WEEK + 1);
+      // Past saleEnd but within grace period
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
     });
 
     it("reverts in Setup phase", async function () {
-      // Never started invitations, commitmentEnd is 0
+      // Never started sale, saleEnd is 0
       await expect(
         crowdfund.connect(allSigners[1]).permissionlessCancel()
       ).to.be.revertedWith("ArmadaCrowdfund: not in active phase");
     });
 
-    it("succeeds from Phase.Commitment (after someone has committed)", async function () {
+    it("succeeds from Phase.Active (after someone has committed)", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       await fundAndApprove(allSigners[1], USDC(1_000));
       await crowdfund.connect(allSigners[1]).commit(USDC(1_000));
-      expect(await crowdfund.phase()).to.equal(Phase.Commitment);
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
 
-      await time.increase(ONE_WEEK + THIRTY_DAYS + 1);
+      await time.increase(THREE_WEEKS + THIRTY_DAYS + 1);
       await expect(crowdfund.connect(allSigners[2]).permissionlessCancel())
         .to.emit(crowdfund, "SaleCanceled");
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
@@ -174,8 +171,8 @@ describe("Crowdfund Adversarial", function () {
 
     it("reverts if already canceled by admin via finalize()", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + ONE_WEEK + 1);
+      await crowdfund.startSale();
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize(); // cancels (below MIN_SALE)
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
 
@@ -194,15 +191,14 @@ describe("Crowdfund Adversarial", function () {
     it("sum of allocations + refunds == totalCommitted (70 seeds, pro-rata)", async function () {
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       // All commit at max cap = 70 * $15K = $1.05M > MIN_SALE
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Verify sum of parts
@@ -247,7 +243,7 @@ describe("Crowdfund Adversarial", function () {
       // Setup: 70 seeds → each invites up to 3 hop-1 addresses
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
+      await crowdfund.startSale();
 
       // Seeds invite hop-1 addresses (use signers 71-140)
       const hop1Addrs = allSigners.slice(71, 141);
@@ -258,7 +254,6 @@ describe("Crowdfund Adversarial", function () {
         hop1Count++;
       }
 
-      await time.increase(TWO_WEEKS + 1);
 
       // Seeds commit $15K each
       for (const s of seeds) {
@@ -272,7 +267,7 @@ describe("Crowdfund Adversarial", function () {
         await crowdfund.connect(hop1Addrs[i]).commit(USDC(4_000));
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Sum-of-parts check across all participants
@@ -298,14 +293,13 @@ describe("Crowdfund Adversarial", function () {
     it("contract ARM balance covers all allocations after finalization", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       const totalAllocated = await crowdfund.totalAllocated();
@@ -316,14 +310,13 @@ describe("Crowdfund Adversarial", function () {
     it("after all claims, contract balances are non-negative", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // All participants claim
@@ -352,8 +345,7 @@ describe("Crowdfund Adversarial", function () {
   describe("Boundary Conditions", function () {
     it("commit exactly at hop cap succeeds", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       await fundAndApprove(allSigners[1], USDC(15_000));
       await crowdfund.connect(allSigners[1]).commit(USDC(15_000));
@@ -364,8 +356,7 @@ describe("Crowdfund Adversarial", function () {
 
     it("commit over hop cap reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       await fundAndApprove(allSigners[1], USDC(15_010));
       await crowdfund.connect(allSigners[1]).commit(USDC(15_000));
@@ -384,8 +375,7 @@ describe("Crowdfund Adversarial", function () {
       // Let's use 66 seeds at $15K ($990K) + 1 seed at $10K ($10K) = $1,000,000
       const seeds = allSigners.slice(1, 68); // 67 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       // 66 seeds at $15K
       for (let i = 0; i < 66; i++) {
@@ -399,7 +389,7 @@ describe("Crowdfund Adversarial", function () {
       const total = await crowdfund.totalCommitted();
       expect(total).to.equal(USDC(1_000_000));
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
@@ -409,8 +399,7 @@ describe("Crowdfund Adversarial", function () {
       // 66 seeds at $15K = $990K. 1 seed at $9,999.999999 = $999,999.999999 < $1M
       const seeds = allSigners.slice(1, 68);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (let i = 0; i < 66; i++) {
         await fundAndApprove(seeds[i], USDC(15_000));
@@ -424,7 +413,7 @@ describe("Crowdfund Adversarial", function () {
       const total = await crowdfund.totalCommitted();
       expect(total).to.be.lt(USDC(1_000_000));
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
@@ -435,8 +424,7 @@ describe("Crowdfund Adversarial", function () {
       // Need 120 seeds at $15K each = $1,800,000
       const seeds = allSigners.slice(1, 121); // 120 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -446,7 +434,7 @@ describe("Crowdfund Adversarial", function () {
       const total = await crowdfund.totalCommitted();
       expect(total).to.equal(USDC(1_800_000));
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
@@ -457,8 +445,7 @@ describe("Crowdfund Adversarial", function () {
       // 119 seeds at $15K = $1,785,000. 1 seed at $14,999.999999
       const seeds = allSigners.slice(1, 121);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (let i = 0; i < 119; i++) {
         await fundAndApprove(seeds[i], USDC(15_000));
@@ -472,7 +459,7 @@ describe("Crowdfund Adversarial", function () {
       const total = await crowdfund.totalCommitted();
       expect(total).to.be.lt(USDC(1_800_000));
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.saleSize()).to.equal(USDC(1_200_000)); // BASE_SALE
@@ -483,14 +470,13 @@ describe("Crowdfund Adversarial", function () {
       // Rollover from hop-0 leftover should go to treasury (no hop-1 committers = 0 < 30)
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
@@ -505,11 +491,10 @@ describe("Crowdfund Adversarial", function () {
     it("finalize with all whitelisted but 0 committers cancels", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
-      // Nobody commits — just fast-forward through commitment window
-      await time.increase(ONE_WEEK + 1);
+      // Nobody commits — just fast-forward through sale window
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
@@ -517,8 +502,7 @@ describe("Crowdfund Adversarial", function () {
 
     it("commit below MIN_COMMIT ($10 USDC) reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       await fundAndApprove(allSigners[1], USDC(10));
 
@@ -541,7 +525,7 @@ describe("Crowdfund Adversarial", function () {
     it("invite self reverts (self not whitelisted initially is ok, but if already whitelisted)", async function () {
       const seed = allSigners[1];
       await crowdfund.addSeeds([seed.address]);
-      await crowdfund.startInvitations();
+      await crowdfund.startSale();
 
       // Seed tries to invite self — already whitelisted
       await expect(
@@ -549,43 +533,41 @@ describe("Crowdfund Adversarial", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: already whitelisted");
     });
 
-    it("invite reverts at exact invitationEnd (strict < boundary)", async function () {
+    it("invite reverts at exact saleEnd (strict < boundary)", async function () {
       const seed = allSigners[1];
       const invitee = allSigners[2];
       await crowdfund.addSeeds([seed.address]);
-      await crowdfund.startInvitations();
+      await crowdfund.startSale();
 
-      const invitationEnd = await crowdfund.invitationEnd();
-      // Warp to exactly invitationEnd — invite should fail (strict <)
-      await time.increaseTo(invitationEnd);
+      const saleEnd = await crowdfund.saleEnd();
+      // Warp to exactly saleEnd — invite should fail (strict <)
+      await time.increaseTo(saleEnd);
       await expect(
         crowdfund.connect(seed).invite(invitee.address)
-      ).to.be.revertedWith("ArmadaCrowdfund: not invitation window");
+      ).to.be.revertedWith("ArmadaCrowdfund: not in sale window");
     });
 
-    it("invite succeeds 1 second before invitationEnd", async function () {
+    it("invite succeeds 1 second before saleEnd", async function () {
       const seed = allSigners[1];
       const invitee = allSigners[2];
       await crowdfund.addSeeds([seed.address]);
-      await crowdfund.startInvitations();
+      await crowdfund.startSale();
 
-      const invitationEnd = await crowdfund.invitationEnd();
-      // Warp to 2 seconds before invitationEnd — next tx executes at invitationEnd - 1
-      await time.increaseTo(invitationEnd - 2n);
+      const saleEnd = await crowdfund.saleEnd();
+      // Warp to 2 seconds before saleEnd — next tx executes at saleEnd - 1
+      await time.increaseTo(saleEnd - 2n);
       await crowdfund.connect(seed).invite(invitee.address);
 
       const p = await crowdfund.participants(invitee.address);
       expect(p.isWhitelisted).to.be.true;
     });
 
-    it("commit succeeds at exact invitationEnd (== commitmentStart)", async function () {
+    it("commit succeeds immediately during sale (no separate commitment window)", async function () {
       const seed = allSigners[1];
       await crowdfund.addSeeds([seed.address]);
-      await crowdfund.startInvitations();
+      await crowdfund.startSale();
 
-      const commitmentStart = await crowdfund.commitmentStart();
-      await time.increaseTo(commitmentStart);
-
+      // Commit works right away — no need to wait for a separate commitment window
       await fundAndApprove(seed, USDC(100));
       await crowdfund.connect(seed).commit(USDC(100));
 
@@ -599,41 +581,54 @@ describe("Crowdfund Adversarial", function () {
   // ============================================================
 
   describe("Access Control & State Machine", function () {
-    it("commit during Invitation phase (before commitment window) reverts", async function () {
+    it("commit works during active sale (unified window)", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
+      await crowdfund.startSale();
 
-      // We're in invitation phase — commitment window hasn't started
+      // In the unified window, commits work immediately
+      await fundAndApprove(allSigners[1], USDC(15_000));
+      await crowdfund.connect(allSigners[1]).commit(USDC(15_000));
+      const [committed] = await crowdfund.getCommitment(allSigners[1].address);
+      expect(committed).to.equal(USDC(15_000));
+    });
+
+    it("invite works during active sale (unified window)", async function () {
+      await crowdfund.addSeeds([allSigners[1].address]);
+      await crowdfund.startSale();
+
+      // Invites also work during the same window
+      await crowdfund.connect(allSigners[1]).invite(allSigners[2].address);
+      expect(await crowdfund.isWhitelisted(allSigners[2].address)).to.be.true;
+    });
+
+    it("commit and invite both fail after sale ends", async function () {
+      await crowdfund.addSeeds([allSigners[1].address]);
+      await crowdfund.startSale();
+      await time.increase(THREE_WEEKS + 1);
+
       await fundAndApprove(allSigners[1], USDC(15_000));
       await expect(
         crowdfund.connect(allSigners[1]).commit(USDC(15_000))
-      ).to.be.revertedWith("ArmadaCrowdfund: not commitment window");
-    });
-
-    it("invite during Commitment phase (after invitation window) reverts", async function () {
-      await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1); // past invitation window
+      ).to.be.revertedWith("ArmadaCrowdfund: not in sale window");
 
       await expect(
         crowdfund.connect(allSigners[1]).invite(allSigners[2].address)
-      ).to.be.revertedWith("ArmadaCrowdfund: not invitation window");
+      ).to.be.revertedWith("ArmadaCrowdfund: not in sale window");
     });
 
-    it("finalize before commitment ends reverts", async function () {
+    it("finalize before sale ends reverts", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1); // in commitment window
+      await crowdfund.startSale();
 
       await expect(
         crowdfund.finalize()
-      ).to.be.revertedWith("ArmadaCrowdfund: commitment not ended");
+      ).to.be.revertedWith("ArmadaCrowdfund: sale not ended");
     });
 
-    it("addSeeds after invitation starts reverts", async function () {
+    it("addSeeds after sale starts reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
+      await crowdfund.startSale();
 
       await expect(
         crowdfund.addSeeds([allSigners[2].address])
@@ -643,13 +638,12 @@ describe("Crowdfund Adversarial", function () {
     it("claim when phase is Canceled reverts (should use refund)", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       await fundAndApprove(seeds[0], USDC(15_000));
       await crowdfund.connect(seeds[0]).commit(USDC(15_000));
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize(); // should cancel (below MIN_SALE)
 
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
@@ -662,15 +656,14 @@ describe("Crowdfund Adversarial", function () {
     it("refund when phase is Finalized reverts", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000));
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
 
@@ -682,8 +675,8 @@ describe("Crowdfund Adversarial", function () {
     it("non-admin cannot finalize", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + ONE_WEEK + 2);
+      await crowdfund.startSale();
+      await time.increase(THREE_WEEKS + 1);
 
       await expect(
         crowdfund.connect(allSigners[1]).finalize()
@@ -693,14 +686,13 @@ describe("Crowdfund Adversarial", function () {
     it("non-admin cannot withdrawProceeds", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       await expect(
@@ -711,14 +703,13 @@ describe("Crowdfund Adversarial", function () {
     it("double withdrawProceeds reverts after all proceeds withdrawn", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Claims must happen before proceeds withdrawal (lazy eval)
@@ -736,14 +727,13 @@ describe("Crowdfund Adversarial", function () {
     it("double withdrawUnallocatedArm reverts", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       await crowdfund.withdrawUnallocatedArm();
@@ -780,14 +770,13 @@ describe("Crowdfund Adversarial", function () {
     it("non-participant cannot claim", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // outsider never committed
@@ -799,15 +788,14 @@ describe("Crowdfund Adversarial", function () {
     it("whitelisted-but-uncommitted participant cannot claim", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       // Only first 69 seeds commit, seeds[69] does not
       for (let i = 0; i < 69; i++) {
         await fundAndApprove(seeds[i], USDC(15_000));
         await crowdfund.connect(seeds[i]).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       await expect(
@@ -832,7 +820,7 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 54); // 53 seeds (indices 1-53)
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
+      await crowdfund.startSale();
 
       // Each of the first 52 seeds invites one hop-1 participant (signers 54-105)
       const hop1Invitees: SignerWithAddress[] = [];
@@ -842,7 +830,6 @@ describe("Crowdfund Adversarial", function () {
         hop1Invitees.push(invitee);
       }
 
-      await time.increase(TWO_WEEKS + 1);
 
       // All 53 seeds commit $15K
       for (const s of seeds) {
@@ -855,7 +842,7 @@ describe("Crowdfund Adversarial", function () {
         await crowdfund.connect(h).commit(USDC(4_000));
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Verify hop-0 ceiling: $798K (budget not capped since remaining = $1.14M)
@@ -883,14 +870,13 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Pro-rata: scale = $798K / $1.05M = 0.76
@@ -911,7 +897,7 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 54); // 53 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
+      await crowdfund.startSale();
 
       const hop1Invitees: SignerWithAddress[] = [];
       for (let i = 0; i < 52; i++) {
@@ -920,7 +906,6 @@ describe("Crowdfund Adversarial", function () {
         hop1Invitees.push(invitee);
       }
 
-      await time.increase(TWO_WEEKS + 1);
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -931,7 +916,7 @@ describe("Crowdfund Adversarial", function () {
         await crowdfund.connect(h).commit(USDC(4_000));
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       const totalAlloc = await crowdfund.totalAllocatedUsdc();
@@ -959,14 +944,13 @@ describe("Crowdfund Adversarial", function () {
       // Deploy the attacker contract
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Verify claim works normally (proving nonReentrant doesn't block legitimate calls)
@@ -983,13 +967,12 @@ describe("Crowdfund Adversarial", function () {
     it("refund() is protected by nonReentrant", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       await fundAndApprove(seeds[0], USDC(15_000));
       await crowdfund.connect(seeds[0]).commit(USDC(15_000));
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize(); // cancels (below MIN_SALE)
 
       // Refund works
@@ -1007,12 +990,11 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Claim some so proceeds accrue
@@ -1033,12 +1015,11 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // First withdrawal works
@@ -1053,8 +1034,7 @@ describe("Crowdfund Adversarial", function () {
     it("commit() is protected by nonReentrant", async function () {
       // Verify commit guard by confirming correct behavior under normal conditions
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       await fundAndApprove(allSigners[1], USDC(15_000));
       await crowdfund.connect(allSigners[1]).commit(USDC(10_000));

--- a/test/crowdfund_integration.ts
+++ b/test/crowdfund_integration.ts
@@ -18,12 +18,11 @@ import { time } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
 // Phase enum (must match IArmadaCrowdfund.sol)
-const Phase = { Setup: 0, Invitation: 1, Commitment: 2, Finalized: 3, Canceled: 4 };
+const Phase = { Setup: 0, Active: 1, Finalized: 2, Canceled: 3 };
 
 // Time constants
 const ONE_DAY = 86400;
-const TWO_WEEKS = 14 * ONE_DAY;
-const ONE_WEEK = 7 * ONE_DAY;
+const THREE_WEEKS = 21 * ONE_DAY;
 
 // USDC amounts (6 decimals)
 const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
@@ -56,16 +55,15 @@ describe("Crowdfund Integration", function () {
     await usdc.connect(signer).approve(await crowdfund.getAddress(), amount);
   }
 
-  // Setup helper: add seeds and start invitations
+  // Setup helper: add seeds and start sale
   async function setupWithSeeds(seeds: SignerWithAddress[]) {
     await crowdfund.addSeeds(seeds.map(s => s.address));
-    await crowdfund.startInvitations();
+    await crowdfund.startSale();
   }
 
-  // Full setup through commitment phase: seeds, invites, fast-forward to commitment
-  async function setupThroughCommitment(seeds: SignerWithAddress[]) {
+  // Setup through active sale phase (seeds can invite and commit immediately)
+  async function setupActiveSale(seeds: SignerWithAddress[]) {
     await setupWithSeeds(seeds);
-    await time.increase(TWO_WEEKS + 1); // past invitation window into commitment
   }
 
   beforeEach(async function () {
@@ -168,7 +166,7 @@ describe("Crowdfund Integration", function () {
 
     it("should reject adding seeds after invitations start", async function () {
       await crowdfund.addSeed(seed1.address);
-      await crowdfund.startInvitations();
+      await crowdfund.startSale();
       await expect(
         crowdfund.addSeed(seed2.address)
       ).to.be.revertedWith("ArmadaCrowdfund: wrong phase");
@@ -176,21 +174,20 @@ describe("Crowdfund Integration", function () {
   });
 
   // ============================================================
-  // 2. Invitation Phase
+  // 2. Active Phase — Invitations
   // ============================================================
 
-  describe("Invitation Phase", function () {
-    it("should transition to invitation phase", async function () {
+  describe("Active Phase — Invitations", function () {
+    it("should transition to active phase", async function () {
       await crowdfund.addSeed(seed1.address);
-      await crowdfund.startInvitations();
-      expect(await crowdfund.phase()).to.equal(Phase.Invitation);
-      expect(await crowdfund.invitationEnd()).to.be.gt(0);
-      expect(await crowdfund.commitmentEnd()).to.be.gt(0);
+      await crowdfund.startSale();
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
+      expect(await crowdfund.saleEnd()).to.be.gt(0);
     });
 
     it("should reject starting with no seeds", async function () {
       await expect(
-        crowdfund.startInvitations()
+        crowdfund.startSale()
       ).to.be.revertedWith("ArmadaCrowdfund: no seeds");
     });
 
@@ -261,13 +258,13 @@ describe("Crowdfund Integration", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: not whitelisted");
     });
 
-    it("should reject invites outside invitation window", async function () {
+    it("should reject invites outside sale window", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + 1); // past invitation window
+      await time.increase(THREE_WEEKS + 1); // past sale window
 
       await expect(
         crowdfund.connect(seed1).invite(hop1a.address)
-      ).to.be.revertedWith("ArmadaCrowdfund: not invitation window");
+      ).to.be.revertedWith("ArmadaCrowdfund: not in sale window");
     });
 
     it("should track whitelistCount correctly per hop", async function () {
@@ -295,12 +292,12 @@ describe("Crowdfund Integration", function () {
   });
 
   // ============================================================
-  // 3. Commitment Phase
+  // 3. Active Phase — Commitments
   // ============================================================
 
-  describe("Commitment Phase", function () {
+  describe("Active Phase — Commitments", function () {
     it("should allow whitelisted address to commit USDC", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActiveSale([seed1]);
 
       await crowdfund.connect(seed1).commit(USDC(5_000));
 
@@ -310,7 +307,7 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should allow multiple commits up to cap", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActiveSale([seed1]);
 
       await crowdfund.connect(seed1).commit(USDC(5_000));
       await crowdfund.connect(seed1).commit(USDC(5_000));
@@ -321,7 +318,7 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should enforce per-hop cap ($15K for hop 0)", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActiveSale([seed1]);
 
       await expect(
         crowdfund.connect(seed1).commit(USDC(15_001))
@@ -331,7 +328,6 @@ describe("Crowdfund Integration", function () {
     it("should enforce per-hop cap ($4K for hop 1)", async function () {
       await setupWithSeeds([seed1]);
       await crowdfund.connect(seed1).invite(hop1a.address);
-      await time.increase(TWO_WEEKS + 1);
 
       await expect(
         crowdfund.connect(hop1a).commit(USDC(4_001))
@@ -342,7 +338,6 @@ describe("Crowdfund Integration", function () {
       await setupWithSeeds([seed1]);
       await crowdfund.connect(seed1).invite(hop1a.address);
       await crowdfund.connect(hop1a).invite(hop2a.address);
-      await time.increase(TWO_WEEKS + 1);
 
       await expect(
         crowdfund.connect(hop2a).commit(USDC(1_001))
@@ -350,7 +345,7 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should reject commit from non-whitelisted address", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActiveSale([seed1]);
 
       await fundAndApprove(outsider, USDC(1_000));
       await expect(
@@ -358,16 +353,16 @@ describe("Crowdfund Integration", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: not whitelisted");
     });
 
-    it("should reject commit outside commitment window", async function () {
+    it("should reject commit outside sale window", async function () {
       await setupWithSeeds([seed1]);
-      // Still in invitation window, not commitment
+      await time.increase(THREE_WEEKS + 1); // past sale window
       await expect(
         crowdfund.connect(seed1).commit(USDC(1_000))
-      ).to.be.revertedWith("ArmadaCrowdfund: not commitment window");
+      ).to.be.revertedWith("ArmadaCrowdfund: not in sale window");
     });
 
     it("should reject commit below $10 USDC minimum", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActiveSale([seed1]);
 
       await expect(
         crowdfund.connect(seed1).commit(USDC(9))
@@ -379,7 +374,7 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should accept commit of exactly $10 USDC", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActiveSale([seed1]);
 
       await crowdfund.connect(seed1).commit(USDC(10));
       const [committed] = await crowdfund.getCommitment(seed1.address);
@@ -389,7 +384,6 @@ describe("Crowdfund Integration", function () {
     it("should track aggregate stats correctly", async function () {
       await setupWithSeeds([seed1, seed2]);
       await crowdfund.connect(seed1).invite(hop1a.address);
-      await time.increase(TWO_WEEKS + 1);
 
       await crowdfund.connect(seed1).commit(USDC(10_000));
       await crowdfund.connect(seed2).commit(USDC(8_000));
@@ -407,7 +401,7 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should track unique committers correctly", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActiveSale([seed1]);
 
       // First commit: uniqueCommitters should go from 0 to 1
       await crowdfund.connect(seed1).commit(USDC(1_000));
@@ -422,44 +416,52 @@ describe("Crowdfund Integration", function () {
   });
 
   // ============================================================
-  // 3b. Phase Transition to Commitment
+  // 3b. Unified Sale Window (Concurrent Invites + Commits)
   // ============================================================
 
-  describe("Phase Transition to Commitment", function () {
-    it("phase is Invitation before first commit", async function () {
-      await setupThroughCommitment([seed1]);
-      expect(await crowdfund.phase()).to.equal(Phase.Invitation);
-    });
+  describe("Unified Sale Window", function () {
+    it("phase stays Active throughout the sale", async function () {
+      await setupActiveSale([seed1]);
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
 
-    it("first commit transitions phase to Commitment", async function () {
-      await setupThroughCommitment([seed1]);
       await crowdfund.connect(seed1).commit(USDC(1_000));
-      expect(await crowdfund.phase()).to.equal(Phase.Commitment);
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
     });
 
-    it("phase stays Commitment after subsequent commits", async function () {
-      await setupThroughCommitment([seed1, seed2]);
-      await crowdfund.connect(seed1).commit(USDC(1_000));
-      expect(await crowdfund.phase()).to.equal(Phase.Commitment);
+    it("participant can commit immediately after being invited", async function () {
+      await setupWithSeeds([seed1]);
+      await crowdfund.connect(seed1).invite(hop1a.address);
 
-      await crowdfund.connect(seed2).commit(USDC(1_000));
-      expect(await crowdfund.phase()).to.equal(Phase.Commitment);
+      // hop1a can commit as soon as they are invited and the sale is active
+      await crowdfund.connect(hop1a).commit(USDC(1_000));
+      const [committed] = await crowdfund.getCommitment(hop1a.address);
+      expect(committed).to.equal(USDC(1_000));
     });
 
-    it("finalize() works from Phase.Commitment", async function () {
+    it("invite and commit can happen in same block", async function () {
+      await setupWithSeeds([seed1]);
+
+      // Seed invites and commits in the same window
+      await crowdfund.connect(seed1).invite(hop1a.address);
+      await crowdfund.connect(seed1).commit(USDC(5_000));
+      await crowdfund.connect(hop1a).commit(USDC(1_000));
+
+      expect(await crowdfund.totalCommitted()).to.equal(USDC(6_000));
+    });
+
+    it("finalize() works from Phase.Active", async function () {
       const seeds = allSigners.slice(1, 71);
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      expect(await crowdfund.phase()).to.equal(Phase.Commitment);
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
     });
@@ -471,13 +473,13 @@ describe("Crowdfund Integration", function () {
 
   describe("Allocation Algorithm", function () {
     it("should use BASE_SALE when demand < elastic trigger", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActiveSale([seed1]);
 
       // Commit well below elastic trigger ($1.8M)
       await crowdfund.connect(seed1).commit(USDC(15_000));
       // Need to reach minimum ($1M), so fund many more seeds
       // For this test, let's just check elastic trigger logic with a known total
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
 
       // totalCommitted = $15K, below min → will cancel
       // We need a different approach to test elastic: use enough signers
@@ -493,8 +495,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       // Each seed commits $15K, 80 seeds = $1.2M (above minimum, at base trigger)
       for (const s of seeds.slice(0, 68)) {
@@ -505,7 +506,7 @@ describe("Crowdfund Integration", function () {
       // Wait, that's only $1.02M. Need 67 more to hit $1M. Let's do 67 × $15K = $1,005,000
       // Actually 68 × 15000 = 1,020,000 which is above MIN_SALE of 1,000,000. Good.
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
@@ -526,15 +527,14 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       // 70 seeds × $15K = $1,050,000 total committed (above min, below elastic trigger)
       for (const s of seeds.slice(0, 70)) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // saleSize = BASE_SALE = $1.2M
@@ -561,14 +561,13 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
@@ -588,15 +587,14 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       // Only 68 seeds commit — hop-0 ceiling = 70% of $1.14M (netRaise) = $798K
       // 68 * $15K = $1.02M committed (above MIN_SALE), but all in hop-0
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Hop-0 demand ($1.02M) > ceiling ($798K) → over-subscribed.
@@ -605,13 +603,12 @@ describe("Crowdfund Integration", function () {
       expect(leftover).to.be.gt(0);
     });
 
-    it("should reject finalize before commitment ends", async function () {
+    it("should reject finalize before sale ends", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + 1); // into commitment window, but not past it
 
       await expect(
         crowdfund.finalize()
-      ).to.be.revertedWith("ArmadaCrowdfund: commitment not ended");
+      ).to.be.revertedWith("ArmadaCrowdfund: sale not ended");
     });
 
     it("should reject double finalization", async function () {
@@ -620,12 +617,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       await expect(
@@ -634,10 +630,10 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should cancel if below minimum raise", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActiveSale([seed1]);
       await crowdfund.connect(seed1).commit(USDC(15_000)); // way below $1M min
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
@@ -661,12 +657,11 @@ describe("Crowdfund Integration", function () {
         await usdc.connect(s).approve(await unfundedCrowdfund.getAddress(), USDC(15_000));
       }
       await unfundedCrowdfund.addSeeds(seeds.map(s => s.address));
-      await unfundedCrowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await unfundedCrowdfund.startSale();
       for (const s of seeds.slice(0, 68)) {
         await unfundedCrowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
 
       await expect(
         unfundedCrowdfund.finalize()
@@ -686,12 +681,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of seeds.slice(0, 70)) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       const armBefore = await armToken.balanceOf(seeds[0].address);
@@ -716,12 +710,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       await crowdfund.connect(seeds[0]).claim();
@@ -731,11 +724,11 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should allow full refund after cancellation", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActiveSale([seed1]);
       await crowdfund.connect(seed1).commit(USDC(10_000));
 
       const usdcBefore = await usdc.balanceOf(seed1.address);
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize(); // cancels (below min)
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
 
@@ -745,7 +738,7 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should reject refund in wrong phase", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActiveSale([seed1]);
       await crowdfund.connect(seed1).commit(USDC(10_000));
 
       await expect(
@@ -760,12 +753,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of committers) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Proceeds accrue as participants claim (lazy evaluation)
@@ -789,12 +781,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of committers) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // totalAllocated is hop-level upper bound, totalArmClaimed tracks claims
@@ -819,13 +810,11 @@ describe("Crowdfund Integration", function () {
     it("should return correct aggregate stats during sale", async function () {
       await setupWithSeeds([seed1, seed2]);
       await crowdfund.connect(seed1).invite(hop1a.address);
-      await time.increase(TWO_WEEKS + 1);
       await crowdfund.connect(seed1).commit(USDC(10_000));
 
-      const [tc, phase_, ie, ce] = await crowdfund.getSaleStats();
+      const [tc, phase_, se] = await crowdfund.getSaleStats();
       expect(tc).to.equal(USDC(10_000));
-      expect(ie).to.be.gt(0);
-      expect(ce).to.be.gt(0);
+      expect(se).to.be.gt(0);
     });
 
     it("should hide invite graph during sale", async function () {
@@ -843,12 +832,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Seeds have invitedBy = address(0)
@@ -863,12 +851,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       const [alloc, refund, claimed] = await crowdfund.getAllocation(seeds[0].address);
@@ -891,7 +878,7 @@ describe("Crowdfund Integration", function () {
 
       // Setup
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
+      await crowdfund.startSale();
 
       // Invitations (some seeds invite hop-1 participants)
       // Use remaining signers for hop-1
@@ -907,7 +894,6 @@ describe("Crowdfund Integration", function () {
       }
 
       // Fast-forward to commitment
-      await time.increase(TWO_WEEKS + 1);
 
       // Commitments
       for (const s of seeds) {
@@ -934,15 +920,14 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
       // 70 × $15K = $1,050,000 > MIN_SALE, < ELASTIC_TRIGGER
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
@@ -976,12 +961,12 @@ describe("Crowdfund Integration", function () {
     });
 
     it("cancellation (below minimum)", async function () {
-      await setupThroughCommitment([seed1, seed2]);
+      await setupActiveSale([seed1, seed2]);
       await crowdfund.connect(seed1).commit(USDC(15_000));
       await crowdfund.connect(seed2).commit(USDC(10_000));
       // Total: $25K << $1M minimum
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
@@ -1006,7 +991,7 @@ describe("Crowdfund Integration", function () {
 
     it("reverts if called before grace period elapses", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + ONE_WEEK + 1); // past commitmentEnd
+      await time.increase(THREE_WEEKS + 1); // past saleEnd
 
       await expect(
         crowdfund.connect(outsider).permissionlessCancel()
@@ -1020,12 +1005,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
 
@@ -1038,7 +1022,7 @@ describe("Crowdfund Integration", function () {
 
     it("succeeds after grace period, sets Phase.Canceled, emits SaleCanceled", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + ONE_WEEK + THIRTY_DAYS + 1);
+      await time.increase(THREE_WEEKS + THIRTY_DAYS + 1);
 
       await expect(crowdfund.connect(outsider).permissionlessCancel())
         .to.emit(crowdfund, "SaleCanceled")
@@ -1049,14 +1033,13 @@ describe("Crowdfund Integration", function () {
 
     it("refund() works for all participants after permissionless cancel", async function () {
       await setupWithSeeds([seed1, seed2]);
-      await time.increase(TWO_WEEKS + 1);
       await fundAndApprove(seed1, USDC(15_000));
       await fundAndApprove(seed2, USDC(10_000));
       await crowdfund.connect(seed1).commit(USDC(15_000));
       await crowdfund.connect(seed2).commit(USDC(10_000));
 
       // Wait past commitment + grace period
-      await time.increase(ONE_WEEK + THIRTY_DAYS + 1);
+      await time.increase(THREE_WEEKS + THIRTY_DAYS + 1);
       await crowdfund.connect(outsider).permissionlessCancel();
 
       // Both participants can refund
@@ -1071,7 +1054,7 @@ describe("Crowdfund Integration", function () {
 
     it("finalize() reverts after permissionless cancel", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + ONE_WEEK + THIRTY_DAYS + 1);
+      await time.increase(THREE_WEEKS + THIRTY_DAYS + 1);
       await crowdfund.connect(outsider).permissionlessCancel();
 
       await expect(
@@ -1093,7 +1076,6 @@ describe("Crowdfund Integration", function () {
         crowdfund.connect(seed1).invite(hop1a.address)
       ).to.be.revertedWith("Pausable: paused");
 
-      await time.increase(TWO_WEEKS + 1);
       await expect(
         crowdfund.connect(seed1).commit(USDC(1_000))
       ).to.be.revertedWith("Pausable: paused");
@@ -1107,7 +1089,6 @@ describe("Crowdfund Integration", function () {
       await crowdfund.connect(seed1).invite(hop1a.address);
       expect(await crowdfund.isWhitelisted(hop1a.address)).to.be.true;
 
-      await time.increase(TWO_WEEKS + 1);
       await crowdfund.connect(seed1).commit(USDC(1_000));
       const [committed] = await crowdfund.getCommitment(seed1.address);
       expect(committed).to.equal(USDC(1_000));
@@ -1119,12 +1100,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       await crowdfund.pause();
@@ -1135,10 +1115,9 @@ describe("Crowdfund Integration", function () {
 
     it("refund() works while paused", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + 1);
       await fundAndApprove(seed1, USDC(1_000));
       await crowdfund.connect(seed1).commit(USDC(1_000));
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize(); // cancels (below MIN_SALE)
 
       await crowdfund.pause();
@@ -1149,7 +1128,7 @@ describe("Crowdfund Integration", function () {
 
     it("finalize() works while paused", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
 
       await crowdfund.pause();
       await crowdfund.finalize();
@@ -1181,12 +1160,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Claim ARM

--- a/test/gas_benchmark.ts
+++ b/test/gas_benchmark.ts
@@ -17,8 +17,7 @@ import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
 const ONE_DAY = 86400;
-const TWO_WEEKS = 14 * ONE_DAY;
-const ONE_WEEK = 7 * ONE_DAY;
+const THREE_WEEKS = 21 * ONE_DAY;
 
 const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
 const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
@@ -71,12 +70,9 @@ describe("Gas Benchmarks", function () {
         // Add seeds — all participants are hop-0 for simplicity
         const seeds = allSigners.slice(1, count + 1);
         await crowdfund.addSeeds(seeds.map(s => s.address));
-        await crowdfund.startInvitations();
+        await crowdfund.startSale();
 
-        // Skip to commitment window
-        await time.increase(TWO_WEEKS + 1);
-
-        // Each seed commits $15K (max hop-0 cap)
+        // Each seed commits $15K (max hop-0 cap) — commits are valid during the active sale
         // Total: count * $15K. For 50 participants = $750K (below MIN_SALE $1M, would cancel)
         // For 50 participants, use larger amounts or accept cancellation
         // We need >= $1M. At $15K/participant, need >= 67 participants.
@@ -102,8 +98,8 @@ describe("Gas Benchmarks", function () {
           await crowdfund.connect(s).commit(commitAmount);
         }
 
-        // Skip to after commitment window
-        await time.increase(ONE_WEEK + 1);
+        // Skip to after sale window
+        await time.increase(THREE_WEEKS + 1);
 
         // Measure finalize gas
         const tx = await crowdfund.finalize();
@@ -230,8 +226,7 @@ describe("Gas Benchmarks", function () {
       const count = 100;
       const seeds = allSigners.slice(1, count + 1);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       for (const s of seeds) {
         await usdc.mint(s.address, USDC(15_000));
@@ -239,7 +234,7 @@ describe("Gas Benchmarks", function () {
         await crowdfund.connect(s).commit(USDC(15_000));
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Measure gas for first, middle, and last claims
@@ -489,8 +484,7 @@ describe("Gas Benchmarks", function () {
 
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startSale();
 
       // Fund all seeds
       for (const s of seeds) {


### PR DESCRIPTION
## Summary

- Collapse the two-phase Invitation+Commitment flow into a single 21-day Active sale window where invites and commitments run concurrently
- Removes friction for late-invited participants and simplifies the state machine by one phase
- Phase enum: `{Setup, Invitation, Commitment, Finalized, Canceled}` → `{Setup, Active, Finalized, Canceled}`
- Timing: `invitationStart/invitationEnd/commitmentStart/commitmentEnd` → `saleStart/saleEnd`

Also includes review fixes:
- Harmonize `invite()`/`commit()` boundary check (both use `<= saleEnd`)
- Update stale ABOUTME comments in AdminPanel and TimeControls
- Rename "Reserve" UI label to "Ceiling" in SaleStatus hop table
- Rewrite temporal comments to be evergreen per CLAUDE.md

Relates to #44

## Test plan

- [ ] `npm run test:crowdfund` — crowdfund integration + adversarial tests pass
- [ ] `npm run test:forge` — Foundry fuzz/invariant tests pass
- [ ] `npm run crowdfund-ui` — frontend displays correct phase names and timing
- [ ] Verify invite and commit both work in the same block during Active phase
- [ ] Verify finalize only works after `saleEnd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)