### PR TITLE
feat: launch team sentinel with budgeted invites and 150-seed cap

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -35,6 +35,9 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     uint256 public constant FINALIZE_GRACE_PERIOD = 30 days;
     uint256 public constant MIN_COMMIT = 10 * 1e6;               // $10 USDC minimum per commit
     uint16 public constant MAX_INVITES_RECEIVED = 10;            // cap on invite stacking per (address, hop) node
+    uint8 public constant MAX_SEEDS = 150;                       // max number of seeds (hop-0 participants)
+    uint8 public constant LAUNCH_TEAM_HOP1_BUDGET = 60;          // launch team direct hop-1 invite slots
+    uint8 public constant LAUNCH_TEAM_HOP2_BUDGET = 60;          // launch team direct hop-2 invite slots
 
     // ============ Immutable ============
 
@@ -46,6 +49,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     // so governance (timelock) can take over post-sale admin duties.
     // Tracked in Codeberg issue.
     address public immutable treasury;
+    /// @notice Launch team sentinel — issues predeclared invite budgets, not a participant.
+    address public immutable launchTeam;
 
     // ============ State ============
     Phase public phase;
@@ -81,6 +86,10 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     uint256 public proceedsWithdrawnAmount;
     bool public unallocatedArmWithdrawn;
 
+    // Launch team invite budget tracking
+    uint8 public launchTeamHop1Used;
+    uint8 public launchTeamHop2Used;
+
     // ============ Events ============
 
     event SeedAdded(address indexed seed);
@@ -109,13 +118,15 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
     // ============ Constructor ============
 
-    constructor(address _usdc, address _armToken, address _admin, address _treasury) {
+    constructor(address _usdc, address _armToken, address _admin, address _treasury, address _launchTeam) {
         require(_admin != address(0), "ArmadaCrowdfund: zero admin");
         require(_treasury != address(0), "ArmadaCrowdfund: zero treasury");
+        require(_launchTeam != address(0), "ArmadaCrowdfund: zero launchTeam");
         usdc = IERC20(_usdc);
         armToken = IERC20(_armToken);
         admin = _admin;
         treasury = _treasury;
+        launchTeam = _launchTeam;
         phase = Phase.Setup;
 
         hopConfigs[0] = HopConfig({ ceilingBps: 7000, capUsdc: 15_000 * 1e6, maxInvites: 3 });
@@ -139,6 +150,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
     function _addSeed(address seed) internal {
         require(seed != address(0), "ArmadaCrowdfund: zero address");
+        require(hopStats[0].whitelistCount < MAX_SEEDS, "ArmadaCrowdfund: seed cap reached");
         require(!participants[seed][0].isWhitelisted, "ArmadaCrowdfund: already whitelisted");
 
         participants[seed][0].isWhitelisted = true;
@@ -215,6 +227,53 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         inviter.invitesSent++;
     }
 
+    /// @notice Launch team issues a direct invite at hop-1 or hop-2 (week 1 only).
+    ///         The launch team is a sentinel with predeclared invite budgets — it is not
+    ///         a participant and cannot commit USDC.
+    /// @param invitee Address to invite
+    /// @param hop Target hop level (must be 1 or 2)
+    function launchTeamInvite(address invitee, uint8 hop) external whenNotPaused {
+        require(msg.sender == launchTeam, "ArmadaCrowdfund: not launch team");
+        require(
+            phase == Phase.Invitation || phase == Phase.Commitment,
+            "ArmadaCrowdfund: not active"
+        );
+        require(
+            block.timestamp < invitationStart + 7 days,
+            "ArmadaCrowdfund: launch team invite window closed"
+        );
+        require(hop == 1 || hop == 2, "ArmadaCrowdfund: invalid hop for launch team");
+        require(invitee != address(0), "ArmadaCrowdfund: zero address");
+
+        if (hop == 1) {
+            require(launchTeamHop1Used < LAUNCH_TEAM_HOP1_BUDGET, "ArmadaCrowdfund: hop-1 budget exhausted");
+            launchTeamHop1Used++;
+        } else {
+            require(launchTeamHop2Used < LAUNCH_TEAM_HOP2_BUDGET, "ArmadaCrowdfund: hop-2 budget exhausted");
+            launchTeamHop2Used++;
+        }
+
+        Participant storage inviteeNode = participants[invitee][hop];
+
+        if (!inviteeNode.isWhitelisted) {
+            inviteeNode.isWhitelisted = true;
+            inviteeNode.invitesReceived = 1;
+            inviteeNode.invitedBy = msg.sender;
+            participantNodes.push(ParticipantNode(invitee, hop));
+            hopStats[hop].whitelistCount++;
+
+            emit Invited(msg.sender, invitee, hop);
+        } else {
+            require(
+                inviteeNode.invitesReceived < MAX_INVITES_RECEIVED,
+                "ArmadaCrowdfund: max invites received"
+            );
+            inviteeNode.invitesReceived++;
+
+            emit InviteAdded(msg.sender, invitee, hop, inviteeNode.invitesReceived);
+        }
+    }
+
     // ============ Commitment Phase ============
 
     /// @notice Commit USDC to the crowdfund at a specific hop level
@@ -231,6 +290,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
             phase = Phase.Commitment;
         }
 
+        require(msg.sender != launchTeam, "ArmadaCrowdfund: launch team cannot commit");
         require(hop < NUM_HOPS, "ArmadaCrowdfund: invalid hop");
         Participant storage p = participants[msg.sender][hop];
         require(p.isWhitelisted, "ArmadaCrowdfund: not whitelisted");
@@ -592,6 +652,12 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     /// @notice Get number of invites received at a specific hop
     function getInvitesReceived(address addr, uint8 hop) external view returns (uint16) {
         return participants[addr][hop].invitesReceived;
+    }
+
+    /// @notice Get remaining launch team invite budget
+    function getLaunchTeamBudgetRemaining() external view returns (uint8 hop1Remaining, uint8 hop2Remaining) {
+        hop1Remaining = LAUNCH_TEAM_HOP1_BUDGET - launchTeamHop1Used;
+        hop2Remaining = LAUNCH_TEAM_HOP2_BUDGET - launchTeamHop2Used;
     }
 
     /// @notice Get total number of (address, hop) nodes (not unique addresses)

--- a/scripts/crowdfund_demo.ts
+++ b/scripts/crowdfund_demo.ts
@@ -79,7 +79,8 @@ async function main() {
     await usdc.getAddress(),
     await armToken.getAddress(),
     deployer.address,
-    treasuryAddr.address
+    treasuryAddr.address,
+    deployer.address
   );
   await crowdfund.waitForDeployment();
 
@@ -211,7 +212,8 @@ async function main() {
     await usdc.getAddress(),
     await armToken.getAddress(),
     deployer.address,
-    treasuryAddr.address
+    treasuryAddr.address,
+    deployer.address
   );
   await cf2.waitForDeployment();
 

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -99,7 +99,7 @@ async function main() {
   console.log("3. Deploying ArmadaCrowdfund...");
   const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
   const crowdfund = await ArmadaCrowdfund.deploy(
-    usdcAddress, armTokenAddress, deployer.address, treasuryAddress, nm.override()
+    usdcAddress, armTokenAddress, deployer.address, treasuryAddress, deployer.address, nm.override()
   );
   await crowdfund.deploymentTransaction()!.wait();
   const crowdfundAddress = await crowdfund.getAddress();

--- a/scripts/full_lifecycle_demo.ts
+++ b/scripts/full_lifecycle_demo.ts
@@ -192,7 +192,8 @@ async function main() {
     await usdc.getAddress(),
     await armToken.getAddress(),
     deployer.address,       // admin
-    await treasury.getAddress()  // immutable treasury destination
+    await treasury.getAddress(),  // immutable treasury destination
+    deployer.address        // launchTeam
   );
   await crowdfund.waitForDeployment();
   log("DEPLOY", `ArmadaCrowdfund: ${await crowdfund.getAddress()}`);

--- a/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
+++ b/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
@@ -30,7 +30,8 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
             address(usdc),
             address(armToken),
             admin,
-            treasury
+            treasury,
+            admin
         );
 
         // Fund ARM tokens
@@ -95,7 +96,8 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
             address(usdc),
             address(armToken),
             admin,
-            treasury
+            treasury,
+            admin
         );
 
         vm.expectRevert("ArmadaCrowdfund: not finalized or canceled");
@@ -136,7 +138,8 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
             address(usdc),
             address(armToken),
             admin,
-            treasury
+            treasury,
+            admin
         );
         armToken.transfer(address(fuzzCrowdfund), funding);
 

--- a/test-foundry/ArmadaCrowdfundCancel.t.sol
+++ b/test-foundry/ArmadaCrowdfundCancel.t.sol
@@ -29,7 +29,8 @@ contract ArmadaCrowdfundCancelTest is Test {
             address(usdc),
             address(armToken),
             admin,
-            address(0xCAFE) // treasury
+            address(0xCAFE), // treasury
+            admin
         );
 
         // Fund ARM for MAX_SALE

--- a/test-foundry/CrowdfundFullInvariant.t.sol
+++ b/test-foundry/CrowdfundFullInvariant.t.sol
@@ -188,7 +188,8 @@ contract CrowdfundFullInvariantTest is Test {
             address(usdc),
             address(armToken),
             admin,
-            address(0xBEEF) // treasury
+            address(0xBEEF), // treasury
+            admin
         );
 
         // Fund ARM to crowdfund

--- a/test-foundry/CrowdfundInvariant.t.sol
+++ b/test-foundry/CrowdfundInvariant.t.sol
@@ -260,7 +260,8 @@ contract CrowdfundInvariantTest is Test {
             address(usdc),
             address(armToken),
             admin,
-            address(0xBEEF) // treasury
+            address(0xBEEF), // treasury
+            admin
         );
 
         // Fund ARM to crowdfund

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -79,7 +79,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await usdc.getAddress(),
       await armToken.getAddress(),
       deployer.address,
-      treasuryAddr.address
+      treasuryAddr.address,
+      deployer.address
     );
     await crowdfund.waitForDeployment();
 
@@ -685,7 +686,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await localUsdc.getAddress(),
         await localArmToken.getAddress(),
         localDeployer.address,
-        await localTreasury.getAddress()
+        await localTreasury.getAddress(),
+        localDeployer.address
       );
       await localCrowdfund.waitForDeployment();
 

--- a/test/crowdfund_adversarial.ts
+++ b/test/crowdfund_adversarial.ts
@@ -54,7 +54,8 @@ describe("Crowdfund Adversarial", function () {
       await usdc.getAddress(),
       await armToken.getAddress(),
       deployer.address,
-      treasuryAddr.address
+      treasuryAddr.address,
+      deployer.address
     );
     await crowdfund.waitForDeployment();
 
@@ -762,7 +763,8 @@ describe("Crowdfund Adversarial", function () {
           await usdc.getAddress(),
           await armToken.getAddress(),
           ethers.ZeroAddress,
-          treasuryAddr.address
+          treasuryAddr.address,
+          deployer.address
         )
       ).to.be.revertedWith("ArmadaCrowdfund: zero admin");
     });
@@ -774,7 +776,8 @@ describe("Crowdfund Adversarial", function () {
           await usdc.getAddress(),
           await armToken.getAddress(),
           deployer.address,
-          ethers.ZeroAddress
+          ethers.ZeroAddress,
+          deployer.address
         )
       ).to.be.revertedWith("ArmadaCrowdfund: zero treasury");
     });

--- a/test/crowdfund_integration.ts
+++ b/test/crowdfund_integration.ts
@@ -88,7 +88,8 @@ describe("Crowdfund Integration", function () {
       await usdc.getAddress(),
       await armToken.getAddress(),
       deployer.address,
-      treasury.address
+      treasury.address,
+      deployer.address
     );
     await crowdfund.waitForDeployment();
 
@@ -651,7 +652,8 @@ describe("Crowdfund Integration", function () {
         await usdc.getAddress(),
         await armToken.getAddress(),
         deployer.address,
-        treasury.address
+        treasury.address,
+        deployer.address
       );
       await unfundedCrowdfund.waitForDeployment();
 

--- a/test/crowdfund_launch_team.ts
+++ b/test/crowdfund_launch_team.ts
@@ -1,0 +1,418 @@
+// ABOUTME: Tests for the launch team sentinel invite mechanism and seed cap.
+// ABOUTME: Covers budget limits, timing window, re-invite behavior, and constructor validation.
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+
+// Phase enum (must match IArmadaCrowdfund.sol)
+const Phase = { Setup: 0, Invitation: 1, Commitment: 2, Finalized: 3, Canceled: 4 };
+
+// Time constants
+const ONE_DAY = 86400;
+const ONE_WEEK = 7 * ONE_DAY;
+const TWO_WEEKS = 14 * ONE_DAY;
+
+// USDC amounts (6 decimals)
+const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
+
+describe("Launch Team & Seed Cap", function () {
+  let crowdfund: any;
+  let armToken: any;
+  let usdc: any;
+
+  let deployer: SignerWithAddress; // also admin and launchTeam for testing
+  let treasury: SignerWithAddress;
+  let outsider: SignerWithAddress;
+  let allSigners: SignerWithAddress[];
+
+  // Generate deterministic addresses for bulk operations
+  function makeAddresses(count: number, startIndex: number = 100): string[] {
+    const addrs: string[] = [];
+    for (let i = 0; i < count; i++) {
+      // Deterministic non-zero addresses
+      addrs.push(ethers.zeroPadValue(ethers.toBeHex(startIndex + i), 20));
+    }
+    return addrs;
+  }
+
+  async function fundAndApprove(signer: SignerWithAddress, amount: bigint) {
+    await usdc.mint(signer.address, amount);
+    await usdc.connect(signer).approve(await crowdfund.getAddress(), amount);
+  }
+
+  beforeEach(async function () {
+    allSigners = await ethers.getSigners();
+    [deployer, treasury, outsider] = allSigners;
+
+    const MockUSDCV2 = await ethers.getContractFactory("MockUSDCV2");
+    usdc = await MockUSDCV2.deploy("Mock USDC", "USDC");
+    await usdc.waitForDeployment();
+
+    const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+    armToken = await ArmadaToken.deploy(deployer.address);
+    await armToken.waitForDeployment();
+
+    const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+    crowdfund = await ArmadaCrowdfund.deploy(
+      await usdc.getAddress(),
+      await armToken.getAddress(),
+      deployer.address,   // admin
+      treasury.address,   // treasury
+      deployer.address    // launchTeam (same as admin for local testing)
+    );
+    await crowdfund.waitForDeployment();
+  });
+
+  // ============ 150-Seed Cap ============
+
+  describe("150-Seed Cap", function () {
+    it("allows up to 150 seeds", async function () {
+      const seeds = makeAddresses(150);
+      // Add in batches to avoid gas limits
+      for (let i = 0; i < 150; i += 50) {
+        await crowdfund.addSeeds(seeds.slice(i, i + 50));
+      }
+      const stats = await crowdfund.getHopStats(0);
+      expect(stats._whitelistCount).to.equal(150);
+    });
+
+    it("reverts on 151st seed", async function () {
+      const seeds = makeAddresses(150);
+      for (let i = 0; i < 150; i += 50) {
+        await crowdfund.addSeeds(seeds.slice(i, i + 50));
+      }
+      const extraSeed = makeAddresses(1, 999);
+      await expect(
+        crowdfund.addSeed(extraSeed[0])
+      ).to.be.revertedWith("ArmadaCrowdfund: seed cap reached");
+    });
+
+    it("reverts mid-batch when cap would be exceeded", async function () {
+      // Add 148 first
+      const seeds148 = makeAddresses(148);
+      for (let i = 0; i < 148; i += 50) {
+        await crowdfund.addSeeds(seeds148.slice(i, Math.min(i + 50, 148)));
+      }
+      // Try to add 5 more (only 2 slots remain)
+      const seeds5 = makeAddresses(5, 500);
+      await expect(
+        crowdfund.addSeeds(seeds5)
+      ).to.be.revertedWith("ArmadaCrowdfund: seed cap reached");
+    });
+  });
+
+  // ============ Launch Team Sentinel ============
+
+  describe("Launch Team Invite Basics", function () {
+    let invitee1: SignerWithAddress;
+    let invitee2: SignerWithAddress;
+    let seed1: SignerWithAddress;
+
+    beforeEach(async function () {
+      [, , , invitee1, invitee2, seed1] = allSigners;
+      // Add a seed and start invitations
+      await crowdfund.addSeed(seed1.address);
+      await crowdfund.startInvitations();
+    });
+
+    it("launch team can invite to hop-1", async function () {
+      await crowdfund.launchTeamInvite(invitee1.address, 1);
+      expect(await crowdfund.isWhitelisted(invitee1.address, 1)).to.be.true;
+    });
+
+    it("launch team can invite to hop-2", async function () {
+      await crowdfund.launchTeamInvite(invitee1.address, 2);
+      expect(await crowdfund.isWhitelisted(invitee1.address, 2)).to.be.true;
+    });
+
+    it("reverts if hop is 0 (launch team cannot place seeds)", async function () {
+      await expect(
+        crowdfund.launchTeamInvite(invitee1.address, 0)
+      ).to.be.revertedWith("ArmadaCrowdfund: invalid hop for launch team");
+    });
+
+    it("reverts if caller is not launch team", async function () {
+      await expect(
+        crowdfund.connect(outsider).launchTeamInvite(invitee1.address, 1)
+      ).to.be.revertedWith("ArmadaCrowdfund: not launch team");
+    });
+
+    it("reverts if invitee is zero address", async function () {
+      await expect(
+        crowdfund.launchTeamInvite(ethers.ZeroAddress, 1)
+      ).to.be.revertedWith("ArmadaCrowdfund: zero address");
+    });
+
+    it("reverts before invitations start (Setup phase)", async function () {
+      // Deploy a fresh crowdfund still in Setup
+      const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      const freshCrowdfund = await ArmadaCrowdfund.deploy(
+        await usdc.getAddress(),
+        await armToken.getAddress(),
+        deployer.address,
+        treasury.address,
+        deployer.address
+      );
+      await expect(
+        freshCrowdfund.launchTeamInvite(invitee1.address, 1)
+      ).to.be.revertedWith("ArmadaCrowdfund: not active");
+    });
+
+    it("invite graph shows launch team as inviter", async function () {
+      await crowdfund.launchTeamInvite(invitee1.address, 1);
+      const inviter = await crowdfund.getInviteEdge(invitee1.address, 1);
+      expect(inviter).to.equal(deployer.address); // launchTeam == deployer in test
+    });
+
+    it("hop-1 invitee has standard 2 hop-2 invite slots", async function () {
+      await crowdfund.launchTeamInvite(invitee1.address, 1);
+      // invitee1 is hop-1, should be able to invite 2 hop-2 addresses
+      const remaining = await crowdfund.getInvitesRemaining(invitee1.address, 1);
+      expect(remaining).to.equal(2);
+    });
+
+    it("hop-1 invitee can use their invite slots normally", async function () {
+      await crowdfund.launchTeamInvite(invitee1.address, 1);
+      // invitee1 invites invitee2 to hop-2
+      await crowdfund.connect(invitee1).invite(invitee2.address, 1);
+      expect(await crowdfund.isWhitelisted(invitee2.address, 2)).to.be.true;
+    });
+
+    it("hop-2 invitee cannot invite (maxInvites = 0)", async function () {
+      await crowdfund.launchTeamInvite(invitee1.address, 2);
+      // hop-2 has maxInvites = 0, so inviterHop must be < NUM_HOPS - 1
+      await expect(
+        crowdfund.connect(invitee1).invite(invitee2.address, 2)
+      ).to.be.revertedWith("ArmadaCrowdfund: max hop reached");
+    });
+
+    it("whitelistCount increments correctly for launch team invites", async function () {
+      await crowdfund.launchTeamInvite(invitee1.address, 1);
+      await crowdfund.launchTeamInvite(invitee2.address, 2);
+      const hop1Stats = await crowdfund.getHopStats(1);
+      const hop2Stats = await crowdfund.getHopStats(2);
+      expect(hop1Stats._whitelistCount).to.equal(1);
+      expect(hop2Stats._whitelistCount).to.equal(1);
+    });
+  });
+
+  describe("Budget Exhaustion", function () {
+    beforeEach(async function () {
+      await crowdfund.addSeed(allSigners[3].address);
+      await crowdfund.startInvitations();
+    });
+
+    it("allows exactly 60 hop-1 invites", async function () {
+      const addrs = makeAddresses(60);
+      for (const addr of addrs) {
+        await crowdfund.launchTeamInvite(addr, 1);
+      }
+      const [hop1Rem, hop2Rem] = await crowdfund.getLaunchTeamBudgetRemaining();
+      expect(hop1Rem).to.equal(0);
+      expect(hop2Rem).to.equal(60);
+    });
+
+    it("61st hop-1 invite reverts", async function () {
+      const addrs = makeAddresses(61);
+      for (let i = 0; i < 60; i++) {
+        await crowdfund.launchTeamInvite(addrs[i], 1);
+      }
+      await expect(
+        crowdfund.launchTeamInvite(addrs[60], 1)
+      ).to.be.revertedWith("ArmadaCrowdfund: hop-1 budget exhausted");
+    });
+
+    it("allows exactly 60 hop-2 invites", async function () {
+      const addrs = makeAddresses(60);
+      for (const addr of addrs) {
+        await crowdfund.launchTeamInvite(addr, 2);
+      }
+      const [hop1Rem, hop2Rem] = await crowdfund.getLaunchTeamBudgetRemaining();
+      expect(hop1Rem).to.equal(60);
+      expect(hop2Rem).to.equal(0);
+    });
+
+    it("61st hop-2 invite reverts", async function () {
+      const addrs = makeAddresses(61);
+      for (let i = 0; i < 60; i++) {
+        await crowdfund.launchTeamInvite(addrs[i], 2);
+      }
+      await expect(
+        crowdfund.launchTeamInvite(addrs[60], 2)
+      ).to.be.revertedWith("ArmadaCrowdfund: hop-2 budget exhausted");
+    });
+
+    it("getLaunchTeamBudgetRemaining tracks correctly", async function () {
+      // Initial state
+      let [h1, h2] = await crowdfund.getLaunchTeamBudgetRemaining();
+      expect(h1).to.equal(60);
+      expect(h2).to.equal(60);
+
+      // Use some
+      await crowdfund.launchTeamInvite(makeAddresses(1, 200)[0], 1);
+      await crowdfund.launchTeamInvite(makeAddresses(1, 300)[0], 2);
+      await crowdfund.launchTeamInvite(makeAddresses(1, 301)[0], 2);
+
+      [h1, h2] = await crowdfund.getLaunchTeamBudgetRemaining();
+      expect(h1).to.equal(59);
+      expect(h2).to.equal(58);
+    });
+  });
+
+  describe("7-Day Invite Window Timing", function () {
+    beforeEach(async function () {
+      await crowdfund.addSeed(allSigners[3].address);
+      await crowdfund.startInvitations();
+    });
+
+    it("launch team invite on day 6 succeeds", async function () {
+      await time.increase(6 * ONE_DAY);
+      await crowdfund.launchTeamInvite(allSigners[4].address, 1);
+      expect(await crowdfund.isWhitelisted(allSigners[4].address, 1)).to.be.true;
+    });
+
+    it("launch team invite on day 8 reverts (past week 1)", async function () {
+      await time.increase(7 * ONE_DAY + 1);
+      await expect(
+        crowdfund.launchTeamInvite(allSigners[4].address, 1)
+      ).to.be.revertedWith("ArmadaCrowdfund: launch team invite window closed");
+    });
+
+    it("launch team invite at exactly 7 days reverts (boundary)", async function () {
+      // At exactly invitationStart + 7 days, the condition is NOT strictly less than
+      await time.increase(7 * ONE_DAY);
+      await expect(
+        crowdfund.launchTeamInvite(allSigners[4].address, 1)
+      ).to.be.revertedWith("ArmadaCrowdfund: launch team invite window closed");
+    });
+
+    it("regular seed invites still work after week 1", async function () {
+      // Seeds can invite throughout the full invitation window
+      await time.increase(10 * ONE_DAY);
+      const seed = allSigners[3];
+      await crowdfund.connect(seed).invite(allSigners[4].address, 0);
+      expect(await crowdfund.isWhitelisted(allSigners[4].address, 1)).to.be.true;
+    });
+  });
+
+  describe("Launch Team Cannot Commit", function () {
+    beforeEach(async function () {
+      await crowdfund.addSeed(allSigners[3].address);
+      await crowdfund.startInvitations();
+    });
+
+    it("launch team address cannot commit USDC", async function () {
+      // Even if somehow whitelisted (e.g., added as seed), commit should revert
+      // In practice, deployer == launchTeam == admin in this test, and deployer
+      // is not a seed, but let's test the guard directly.
+      // First, make the launchTeam address a seed-like participant manually
+      // by deploying a separate crowdfund where launchTeam is a different address
+      const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      const ltSigner = allSigners[5];
+      const cf = await ArmadaCrowdfund.deploy(
+        await usdc.getAddress(),
+        await armToken.getAddress(),
+        deployer.address,
+        treasury.address,
+        ltSigner.address  // separate launch team
+      );
+      await cf.waitForDeployment();
+
+      // Add launchTeam as a seed (admin can do this)
+      await cf.addSeed(ltSigner.address);
+      await cf.startInvitations();
+
+      // Fast-forward to commitment window
+      await time.increase(TWO_WEEKS + 1);
+
+      // Fund the launch team address
+      await fundAndApprove(ltSigner, USDC(15000));
+
+      // Try to commit — should be blocked by launch team guard
+      await expect(
+        cf.connect(ltSigner).commit(USDC(100), 0)
+      ).to.be.revertedWith("ArmadaCrowdfund: launch team cannot commit");
+    });
+  });
+
+  describe("Re-Invite Behavior", function () {
+    let invitee: SignerWithAddress;
+
+    beforeEach(async function () {
+      invitee = allSigners[4];
+      await crowdfund.addSeed(allSigners[3].address);
+      await crowdfund.startInvitations();
+    });
+
+    it("re-invite to same (address, hop) increments invitesReceived", async function () {
+      await crowdfund.launchTeamInvite(invitee.address, 1);
+      expect(await crowdfund.getInvitesReceived(invitee.address, 1)).to.equal(1);
+
+      await crowdfund.launchTeamInvite(invitee.address, 1);
+      expect(await crowdfund.getInvitesReceived(invitee.address, 1)).to.equal(2);
+    });
+
+    it("re-invite consumes budget", async function () {
+      await crowdfund.launchTeamInvite(invitee.address, 1);
+      await crowdfund.launchTeamInvite(invitee.address, 1);
+
+      const [hop1Rem] = await crowdfund.getLaunchTeamBudgetRemaining();
+      expect(hop1Rem).to.equal(58); // 60 - 2
+    });
+
+    it("re-invite scales effective cap", async function () {
+      await crowdfund.launchTeamInvite(invitee.address, 1);
+      let cap = await crowdfund.getEffectiveCap(invitee.address, 1);
+      expect(cap).to.equal(USDC(4000)); // 1 × $4k
+
+      await crowdfund.launchTeamInvite(invitee.address, 1);
+      cap = await crowdfund.getEffectiveCap(invitee.address, 1);
+      expect(cap).to.equal(USDC(8000)); // 2 × $4k
+    });
+
+    it("re-invite scales outgoing invite budget", async function () {
+      await crowdfund.launchTeamInvite(invitee.address, 1);
+      expect(await crowdfund.getInvitesRemaining(invitee.address, 1)).to.equal(2);
+
+      await crowdfund.launchTeamInvite(invitee.address, 1);
+      expect(await crowdfund.getInvitesRemaining(invitee.address, 1)).to.equal(4); // 2 × 2
+    });
+
+    it("re-invite capped at MAX_INVITES_RECEIVED", async function () {
+      // Invite 10 times (uses 10 budget slots)
+      for (let i = 0; i < 10; i++) {
+        await crowdfund.launchTeamInvite(invitee.address, 1);
+      }
+      expect(await crowdfund.getInvitesReceived(invitee.address, 1)).to.equal(10);
+
+      // 11th re-invite should revert
+      await expect(
+        crowdfund.launchTeamInvite(invitee.address, 1)
+      ).to.be.revertedWith("ArmadaCrowdfund: max invites received");
+    });
+
+    it("emits InviteAdded on re-invite", async function () {
+      await crowdfund.launchTeamInvite(invitee.address, 1);
+      await expect(crowdfund.launchTeamInvite(invitee.address, 1))
+        .to.emit(crowdfund, "InviteAdded")
+        .withArgs(deployer.address, invitee.address, 1, 2);
+    });
+  });
+
+  describe("Constructor Validation", function () {
+    it("rejects zero launchTeam address", async function () {
+      const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      await expect(
+        ArmadaCrowdfund.deploy(
+          await usdc.getAddress(),
+          await armToken.getAddress(),
+          deployer.address,
+          treasury.address,
+          ethers.ZeroAddress
+        )
+      ).to.be.revertedWith("ArmadaCrowdfund: zero launchTeam");
+    });
+  });
+});

--- a/test/crowdfund_multinode.ts
+++ b/test/crowdfund_multinode.ts
@@ -54,7 +54,8 @@ describe("Crowdfund Multi-Node", function () {
       await usdc.getAddress(),
       await armToken.getAddress(),
       deployer.address,
-      treasury.address
+      treasury.address,
+      deployer.address
     );
     await crowdfund.waitForDeployment();
 

--- a/test/gas_benchmark.ts
+++ b/test/gas_benchmark.ts
@@ -2,7 +2,7 @@
  * Gas Profiling Under Load — Phase 4
  *
  * Benchmarks:
- * 1. Crowdfund finalize() gas at varying participant counts (50, 100, 150, 199)
+ * 1. Crowdfund finalize() gas at varying participant counts (50, 100, 150)
  * 2. Crowdfund addSeeds() batch gas
  * 3. Crowdfund claim() gas (should be constant)
  * 4. VotingLocker castVote() gas with varying checkpoint counts (binary search depth)
@@ -45,7 +45,7 @@ describe("Gas Benchmarks", function () {
   // ============================================================
 
   describe("Crowdfund finalize() gas scaling", function () {
-    const participantCounts = [50, 100, 150, 199]; // max 199 with 200 signers (deployer + N)
+    const participantCounts = [50, 100, 150]; // max 150 seeds (MAX_SEEDS cap)
     const results: { count: number; gas: bigint; perParticipant: bigint }[] = [];
 
     for (const count of participantCounts) {
@@ -62,7 +62,8 @@ describe("Gas Benchmarks", function () {
           await usdc.getAddress(),
           await armToken.getAddress(),
           deployer.address,
-          deployer.address // treasury
+          deployer.address, // treasury
+          deployer.address  // launchTeam
         );
 
         // Fund ARM for MAX_SALE
@@ -171,7 +172,7 @@ describe("Gas Benchmarks", function () {
   // ============================================================
 
   describe("Crowdfund addSeeds() batch gas", function () {
-    const batchSizes = [10, 50, 100, 199];
+    const batchSizes = [10, 50, 100, 150];
 
     for (const batchSize of batchSizes) {
       it(`addSeeds() batch of ${batchSize}`, async function () {
@@ -186,7 +187,8 @@ describe("Gas Benchmarks", function () {
           await usdc.getAddress(),
           await armToken.getAddress(),
           deployer.address,
-          deployer.address // treasury
+          deployer.address, // treasury
+          deployer.address  // launchTeam
         );
 
         const seeds = allSigners.slice(1, batchSize + 1);
@@ -222,7 +224,8 @@ describe("Gas Benchmarks", function () {
         await usdc.getAddress(),
         await armToken.getAddress(),
         deployer.address,
-        deployer.address // treasury
+        deployer.address, // treasury
+        deployer.address  // launchTeam
       );
 
       await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
@@ -484,7 +487,8 @@ describe("Gas Benchmarks", function () {
         await usdc.getAddress(),
         await armToken.getAddress(),
         deployer.address,
-        deployer.address // treasury
+        deployer.address, // treasury
+        deployer.address  // launchTeam
       );
 
       const seeds = allSigners.slice(1, 4);


### PR DESCRIPTION
## Summary

- Add `launchTeam` immutable address as a non-participant sentinel that can issue direct hop-1 and hop-2 invites during the first 7 days of the invitation window (60 slots per hop)
- Enforce a 150-seed cap (`MAX_SEEDS`) on hop-0 participants via `_addSeed`
- Block the launch team address from committing USDC
- Add `getLaunchTeamBudgetRemaining()` view function
- Full test coverage in new `test/crowdfund_launch_team.ts` (seed cap, invite basics, budget exhaustion, timing window, commit guard, re-invite behavior, constructor validation)
- Update all existing test/script files with the new constructor argument

## Test plan

- [ ] `npm run test:crowdfund` — crowdfund lifecycle + adversarial tests pass with new constructor arg
- [ ] `npm run test:forge` — Foundry fuzz/invariant tests pass with new constructor arg
- [ ] New launch team tests cover seed cap, budget limits, timing, commit guard, re-invites

🤖 Generated with [Claude Code](https://claude.com/claude-code)