### PR TITLE
feat: unify crowdfund into single 3-week active window

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -30,8 +30,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     uint8 public constant NUM_HOPS = 3;
     uint256 public constant HOP2_FLOOR_BPS = 500;  // 5% of saleSize reserved for hop-2
 
-    uint256 public constant INVITATION_DURATION = 14 days;
-    uint256 public constant COMMITMENT_DURATION = 7 days;
+    uint256 public constant WINDOW_DURATION = 21 days;
+    uint256 public constant LAUNCH_TEAM_INVITE_PERIOD = 7 days;
     uint256 public constant FINALIZE_GRACE_PERIOD = 30 days;
     uint256 public constant MIN_COMMIT = 10 * 1e6;               // $10 USDC minimum per commit
     uint16 public constant MAX_INVITES_RECEIVED = 10;            // cap on invite stacking per (address, hop) node
@@ -56,10 +56,9 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     Phase public phase;
 
     // Timing
-    uint256 public invitationStart;
-    uint256 public invitationEnd;
-    uint256 public commitmentStart;
-    uint256 public commitmentEnd;
+    uint256 public windowStart;
+    uint256 public windowEnd;
+    uint256 public launchTeamInviteEnd;
 
     // Hop configuration (set in constructor)
     HopConfig[3] public hopConfigs;
@@ -93,7 +92,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     // ============ Events ============
 
     event SeedAdded(address indexed seed);
-    event InvitationStarted(uint256 invitationEnd, uint256 commitmentStart, uint256 commitmentEnd);
+    event WindowStarted(uint256 windowStart, uint256 windowEnd, uint256 launchTeamInviteEnd);
     event Invited(address indexed inviter, address indexed invitee, uint8 hop);
     event InviteAdded(address indexed inviter, address indexed invitee, uint8 hop, uint16 newInviteCount);
     event Committed(address indexed participant, uint256 amount, uint256 totalForParticipant, uint8 hop);
@@ -136,15 +135,17 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
     // ============ Setup Phase ============
 
-    /// @notice Add seed addresses (hop 0)
-    function addSeeds(address[] calldata seeds) external onlyAdmin inPhase(Phase.Setup) {
+    /// @notice Add seed addresses (hop 0). Allowed during Setup or week 1 of the active window.
+    function addSeeds(address[] calldata seeds) external onlyAdmin {
+        _requireSetupOrWeek1();
         for (uint256 i = 0; i < seeds.length; i++) {
             _addSeed(seeds[i]);
         }
     }
 
-    /// @notice Add a single seed address (hop 0)
-    function addSeed(address seed) external onlyAdmin inPhase(Phase.Setup) {
+    /// @notice Add a single seed address (hop 0). Allowed during Setup or week 1 of the active window.
+    function addSeed(address seed) external onlyAdmin {
+        _requireSetupOrWeek1();
         _addSeed(seed);
     }
 
@@ -162,17 +163,16 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         emit SeedAdded(seed);
     }
 
-    /// @notice Start the invitation window
-    function startInvitations() external onlyAdmin inPhase(Phase.Setup) {
+    /// @notice Start the 3-week active window (invites + commits concurrent)
+    function startWindow() external onlyAdmin inPhase(Phase.Setup) {
         require(hopStats[0].whitelistCount > 0, "ArmadaCrowdfund: no seeds");
 
-        invitationStart = block.timestamp;
-        invitationEnd = block.timestamp + INVITATION_DURATION;
-        commitmentStart = invitationEnd;
-        commitmentEnd = commitmentStart + COMMITMENT_DURATION;
-        phase = Phase.Invitation;
+        windowStart = block.timestamp;
+        windowEnd = block.timestamp + WINDOW_DURATION;
+        launchTeamInviteEnd = block.timestamp + LAUNCH_TEAM_INVITE_PERIOD;
+        phase = Phase.Active;
 
-        emit InvitationStarted(invitationEnd, commitmentStart, commitmentEnd);
+        emit WindowStarted(windowStart, windowEnd, launchTeamInviteEnd);
     }
 
     // ============ Invitation Phase ============
@@ -183,10 +183,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     /// @param invitee Address to invite
     /// @param inviterHop Which of the caller's hop-level nodes is doing the inviting
     function invite(address invitee, uint8 inviterHop) external whenNotPaused {
-        require(
-            block.timestamp >= invitationStart && block.timestamp < invitationEnd,
-            "ArmadaCrowdfund: not invitation window"
-        );
+        require(phase == Phase.Active, "ArmadaCrowdfund: not active");
+        require(block.timestamp < windowEnd, "ArmadaCrowdfund: window closed");
 
         Participant storage inviter = participants[msg.sender][inviterHop];
         require(inviter.isWhitelisted, "ArmadaCrowdfund: not whitelisted");
@@ -234,12 +232,9 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     /// @param hop Target hop level (must be 1 or 2)
     function launchTeamInvite(address invitee, uint8 hop) external whenNotPaused {
         require(msg.sender == launchTeam, "ArmadaCrowdfund: not launch team");
+        require(phase == Phase.Active, "ArmadaCrowdfund: not active");
         require(
-            phase == Phase.Invitation || phase == Phase.Commitment,
-            "ArmadaCrowdfund: not active"
-        );
-        require(
-            block.timestamp < invitationStart + 7 days,
+            block.timestamp < launchTeamInviteEnd,
             "ArmadaCrowdfund: launch team invite window closed"
         );
         require(hop == 1 || hop == 2, "ArmadaCrowdfund: invalid hop for launch team");
@@ -280,15 +275,11 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     /// @param amount USDC amount to commit (6 decimals)
     /// @param hop Which of the caller's (address, hop) nodes to commit to
     function commit(uint256 amount, uint8 hop) external nonReentrant whenNotPaused {
+        require(phase == Phase.Active, "ArmadaCrowdfund: not active");
         require(
-            block.timestamp >= commitmentStart && block.timestamp <= commitmentEnd,
-            "ArmadaCrowdfund: not commitment window"
+            block.timestamp >= windowStart && block.timestamp <= windowEnd,
+            "ArmadaCrowdfund: not active window"
         );
-
-        // Lazy phase transition: first commit advances phase from Invitation
-        if (phase == Phase.Invitation) {
-            phase = Phase.Commitment;
-        }
 
         require(msg.sender != launchTeam, "ArmadaCrowdfund: launch team cannot commit");
         require(hop < NUM_HOPS, "ArmadaCrowdfund: invalid hop");
@@ -324,12 +315,9 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     /// @notice Anyone can cancel the sale if admin hasn't finalized within the grace period
     /// @dev Prevents permanent fund lockup if admin key is lost or admin is unresponsive
     function permissionlessCancel() external {
+        require(phase == Phase.Active, "ArmadaCrowdfund: not in active phase");
         require(
-            phase == Phase.Invitation || phase == Phase.Commitment,
-            "ArmadaCrowdfund: not in active phase"
-        );
-        require(
-            block.timestamp > commitmentEnd + FINALIZE_GRACE_PERIOD,
+            block.timestamp > windowEnd + FINALIZE_GRACE_PERIOD,
             "ArmadaCrowdfund: grace period not elapsed"
         );
         phase = Phase.Canceled;
@@ -338,11 +326,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
     /// @notice Finalize the crowdfund: compute allocations or cancel
     function finalize() external onlyAdmin nonReentrant {
-        require(block.timestamp > commitmentEnd, "ArmadaCrowdfund: commitment not ended");
-        require(
-            phase == Phase.Invitation || phase == Phase.Commitment,
-            "ArmadaCrowdfund: already finalized"
-        );
+        require(block.timestamp > windowEnd, "ArmadaCrowdfund: window not ended");
+        require(phase == Phase.Active, "ArmadaCrowdfund: already finalized");
 
         // Check minimum raise
         if (totalCommitted < MIN_SALE) {
@@ -564,10 +549,10 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     function getSaleStats() external view returns (
         uint256 _totalCommitted,
         Phase _phase,
-        uint256 _invitationEnd,
-        uint256 _commitmentEnd
+        uint256 _windowStart,
+        uint256 _windowEnd
     ) {
-        return (totalCommitted, phase, invitationEnd, commitmentEnd);
+        return (totalCommitted, phase, windowStart, windowEnd);
     }
 
     /// @notice Check if an address is whitelisted at a specific hop
@@ -666,6 +651,15 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     }
 
     // ============ Internal ============
+
+    /// @dev Enforces that seeds can only be added during Setup or week 1 of the active window.
+    function _requireSetupOrWeek1() internal view {
+        require(
+            phase == Phase.Setup ||
+            (phase == Phase.Active && block.timestamp < launchTeamInviteEnd),
+            "ArmadaCrowdfund: seeds only during setup or week 1"
+        );
+    }
 
     /// @dev Compute allocation for a participant from stored hop-level ceilings/demands.
     ///      Uses the budget-capped ceiling stored at finalization for pro-rata scaling.

--- a/contracts/crowdfund/IArmadaCrowdfund.sol
+++ b/contracts/crowdfund/IArmadaCrowdfund.sol
@@ -10,8 +10,7 @@ pragma solidity ^0.8.17;
 
 enum Phase {
     Setup,          // Admin configures seeds
-    Invitation,     // Seeds invite hop-1, hop-1 invites hop-2
-    Commitment,     // Whitelisted addresses commit USDC
+    Active,         // Invites + commits happen concurrently (3-week window)
     Finalized,      // Allocations computed, claims open
     Canceled        // Below minimum raise, full refunds
 }

--- a/crowdfund-frontend/src/atoms/crowdfund.ts
+++ b/crowdfund-frontend/src/atoms/crowdfund.ts
@@ -7,10 +7,9 @@ export interface CrowdfundState {
   // Contract phase and timing
   phase: Phase | null
   adminAddress: string | null
-  invitationStart: bigint
-  invitationEnd: bigint
-  commitmentStart: bigint
-  commitmentEnd: bigint
+  windowStart: bigint
+  windowEnd: bigint
+  launchTeamInviteEnd: bigint
   // Aggregate stats
   totalCommitted: bigint
   saleSize: bigint
@@ -36,10 +35,9 @@ export interface CrowdfundState {
 const DEFAULT_STATE: CrowdfundState = {
   phase: null,
   adminAddress: null,
-  invitationStart: 0n,
-  invitationEnd: 0n,
-  commitmentStart: 0n,
-  commitmentEnd: 0n,
+  windowStart: 0n,
+  windowEnd: 0n,
+  launchTeamInviteEnd: 0n,
   totalCommitted: 0n,
   saleSize: 0n,
   hopStats: null,

--- a/crowdfund-frontend/src/components/AdminPanel.tsx
+++ b/crowdfund-frontend/src/components/AdminPanel.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Admin control panel for managing crowdfund lifecycle.
-// ABOUTME: Phase-conditional actions: add seeds, start invitations, finalize, withdraw.
+// ABOUTME: Phase-conditional actions: add seeds, start window, finalize, withdraw.
 import { useEffect, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -96,9 +96,9 @@ export function AdminPanel({ state, crowdfund }: AdminPanelProps) {
     setSeedInput('')
   }
 
-  const handleStartInvitations = async () => {
+  const handleStartWindow = async () => {
     setIsSubmitting(true)
-    await crowdfund.startInvitations()
+    await crowdfund.startWindow()
     setIsSubmitting(false)
   }
 
@@ -173,12 +173,12 @@ export function AdminPanel({ state, crowdfund }: AdminPanelProps) {
             <Separator />
 
             <Button
-              onClick={handleStartInvitations}
+              onClick={handleStartWindow}
               disabled={isSubmitting || !state.hopStats || state.hopStats[0].whitelistCount === 0}
               className="w-full gap-2"
             >
               <Play className="h-4 w-4" />
-              Start Invitations
+              Start Window
             </Button>
             {state.hopStats && state.hopStats[0].whitelistCount === 0 && (
               <p className="text-xs text-muted-foreground">Add at least one seed first</p>
@@ -186,8 +186,8 @@ export function AdminPanel({ state, crowdfund }: AdminPanelProps) {
           </>
         )}
 
-        {/* After commitment window: Finalize */}
-        {(phase === Phase.Invitation || phase === Phase.Commitment) && (
+        {/* After window ends: Finalize */}
+        {phase === Phase.Active && (
           <div className="space-y-2">
             <Button
               onClick={handleFinalize}
@@ -199,7 +199,7 @@ export function AdminPanel({ state, crowdfund }: AdminPanelProps) {
               Finalize Sale
             </Button>
             <p className="text-xs text-muted-foreground">
-              Only works after the commitment window has ended.
+              Only works after the 3-week window has ended.
             </p>
           </div>
         )}

--- a/crowdfund-frontend/src/components/ParticipantPanel.tsx
+++ b/crowdfund-frontend/src/components/ParticipantPanel.tsx
@@ -36,15 +36,12 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
 
   // Use chain block timestamp (not Date.now()) — EVM time diverges from wall clock in local mode
   const now = state.blockTimestamp || Math.floor(Date.now() / 1000)
-  const inCommitmentWindow =
-    Number(state.commitmentStart) > 0 &&
-    now >= Number(state.commitmentStart) &&
-    now <= Number(state.commitmentEnd)
 
-  const inInvitationWindow =
-    phase === Phase.Invitation &&
-    Number(state.invitationEnd) > 0 &&
-    now <= Number(state.invitationEnd)
+  // Both invites and commits are permitted while the active window is open
+  const inActiveWindow =
+    phase === Phase.Active &&
+    Number(state.windowStart) > 0 &&
+    now <= Number(state.windowEnd)
 
   const handleInvite = async () => {
     if (!isAddress(inviteInput)) return
@@ -111,7 +108,7 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
         </div>
 
         {/* Invite Section */}
-        {isWhitelisted && inInvitationWindow && state.currentInvitesRemaining > 0 && (
+        {isWhitelisted && inActiveWindow && state.currentInvitesRemaining > 0 && (
           <>
             <Separator />
             <div className="space-y-2">
@@ -139,7 +136,7 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
         )}
 
         {/* Commit Section */}
-        {isWhitelisted && inCommitmentWindow && remaining > 0n && (
+        {isWhitelisted && inActiveWindow && remaining > 0n && (
           <>
             <Separator />
             <div className="space-y-2">

--- a/crowdfund-frontend/src/components/SaleStatus.tsx
+++ b/crowdfund-frontend/src/components/SaleStatus.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Sale status dashboard showing phase, timing, progress, and per-hop stats.
-// ABOUTME: Reads from crowdfund state atom and derives effective phase from timestamps.
+// ABOUTME: Reads from crowdfund state atom and displays the current phase.
 import { useEffect, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -20,34 +20,17 @@ interface SaleStatusProps {
 }
 
 /**
- * Derive the "effective" phase for display.
- * The contract phase() stays Invitation during the commitment window,
- * so we infer Commitment from timestamps.
+ * Return the contract phase for display.
+ * The contract phase maps directly to display state.
  */
-function getEffectivePhase(state: CrowdfundState, now: number): Phase {
+function getEffectivePhase(state: CrowdfundState, _now: number): Phase {
   if (state.phase === null) return Phase.Setup
-  if (state.phase === Phase.Invitation) {
-    const commitStart = Number(state.commitmentStart)
-    const commitEnd = Number(state.commitmentEnd)
-    if (commitStart > 0 && now >= commitStart && now <= commitEnd) {
-      return Phase.Commitment
-    }
-    if (commitEnd > 0 && now > commitEnd) {
-      // Past commitment window but not yet finalized
-      return Phase.Commitment
-    }
-  }
   return state.phase
 }
 
 function getTimeRemaining(state: CrowdfundState, effectivePhase: Phase, now: number): string | null {
-  if (effectivePhase === Phase.Invitation) {
-    const end = Number(state.invitationEnd)
-    if (end > 0 && now < end) return formatCountdown(end - now)
-    return 'expired'
-  }
-  if (effectivePhase === Phase.Commitment) {
-    const end = Number(state.commitmentEnd)
+  if (effectivePhase === Phase.Active) {
+    const end = Number(state.windowEnd)
     if (end > 0 && now < end) return formatCountdown(end - now)
     return 'expired — ready to finalize'
   }
@@ -152,7 +135,7 @@ export function SaleStatus({ state }: SaleStatusProps) {
               {state.hopStats.map((hop, i) => (
                 <TableRow key={i}>
                   <TableCell className="font-medium">{hopLabel(i)}</TableCell>
-                  <TableCell className="text-right">{CROWDFUND_CONSTANTS.HOP_RESERVE_BPS[i] / 100}%</TableCell>
+                  <TableCell className="text-right">{CROWDFUND_CONSTANTS.HOP_CEILING_BPS[i] / 100}%</TableCell>
                   <TableCell className="text-right">{formatUsdc(CROWDFUND_CONSTANTS.HOP_CAPS[i])}</TableCell>
                   <TableCell className="text-right">{hop.whitelistCount}</TableCell>
                   <TableCell className="text-right">{hop.uniqueCommitters}</TableCell>

--- a/crowdfund-frontend/src/components/TimeControls.tsx
+++ b/crowdfund-frontend/src/components/TimeControls.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Anvil time manipulation controls for local testing.
-// ABOUTME: Allows fast-forwarding through invitation and commitment windows.
+// ABOUTME: Allows fast-forwarding through the active window phases.
 import { useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -32,16 +32,16 @@ export function TimeControls({ state, crowdfund }: TimeControlsProps) {
   }
 
   const phase = state.phase
-  const invEnd = Number(state.invitationEnd)
-  const commitEnd = Number(state.commitmentEnd)
+  const windowEnd = Number(state.windowEnd)
+  const launchTeamInviteEnd = Number(state.launchTeamInviteEnd)
 
   const blockTs = state.blockTimestamp
 
-  // Seconds from now until the invitation window ends (commitment starts)
-  const skipToCommitmentSecs = invEnd > blockTs ? invEnd - blockTs + 1 : 0
+  // Seconds from now until the launch team invite period ends (first 7 days)
+  const skipPastInvitePeriodSecs = launchTeamInviteEnd > blockTs ? launchTeamInviteEnd - blockTs + 1 : 0
 
-  // Seconds from now until the commitment window ends
-  const skipPastCommitmentSecs = commitEnd > blockTs ? commitEnd - blockTs + 1 : 0
+  // Seconds from now until the full window ends (21 days)
+  const skipPastWindowSecs = windowEnd > blockTs ? windowEnd - blockTs + 1 : 0
 
   return (
     <Card>
@@ -54,31 +54,31 @@ export function TimeControls({ state, crowdfund }: TimeControlsProps) {
       </CardHeader>
       <CardContent>
         <div className="flex flex-wrap gap-2">
-          {/* Skip to Commitment Window */}
-          {phase === Phase.Invitation && invEnd > 0 && (
+          {/* Skip past launch team invite period (first 7 days) */}
+          {phase === Phase.Active && launchTeamInviteEnd > 0 && blockTs < launchTeamInviteEnd && (
             <Button
               variant="outline"
               size="sm"
-              onClick={() => handleAdvance(skipToCommitmentSecs)}
+              onClick={() => handleAdvance(skipPastInvitePeriodSecs)}
               disabled={isAdvancing}
               className="gap-1.5"
             >
               <FastForward className="h-3.5 w-3.5" />
-              Skip to Commitment
+              Skip Past Invite Period
             </Button>
           )}
 
-          {/* Skip Past Commitment */}
-          {phase === Phase.Invitation && commitEnd > 0 && (
+          {/* Skip past full window (21 days) */}
+          {phase === Phase.Active && windowEnd > 0 && (
             <Button
               variant="outline"
               size="sm"
-              onClick={() => handleAdvance(skipPastCommitmentSecs)}
+              onClick={() => handleAdvance(skipPastWindowSecs)}
               disabled={isAdvancing}
               className="gap-1.5"
             >
               <SkipForward className="h-3.5 w-3.5" />
-              Skip Past Commitment
+              Skip Past Window
             </Button>
           )}
 

--- a/crowdfund-frontend/src/config/abi.ts
+++ b/crowdfund-frontend/src/config/abi.ts
@@ -5,7 +5,7 @@ export const CROWDFUND_ABI = [
   // Admin actions (Setup)
   'function addSeed(address seed) external',
   'function addSeeds(address[] calldata seeds) external',
-  'function startInvitations() external',
+  'function startWindow() external',
   'function finalize() external',
   'function withdrawProceeds() external',
   'function withdrawUnallocatedArm() external',
@@ -30,10 +30,9 @@ export const CROWDFUND_ABI = [
   'function saleSize() view returns (uint256)',
   'function totalAllocated() view returns (uint256)',
   'function totalAllocatedUsdc() view returns (uint256)',
-  'function invitationStart() view returns (uint256)',
-  'function invitationEnd() view returns (uint256)',
-  'function commitmentStart() view returns (uint256)',
-  'function commitmentEnd() view returns (uint256)',
+  'function windowStart() view returns (uint256)',
+  'function windowEnd() view returns (uint256)',
+  'function launchTeamInviteEnd() view returns (uint256)',
   'function participants(address, uint8) view returns (bool isWhitelisted, uint16 invitesReceived, uint256 committed, uint256 allocation, uint256 refund, bool claimed, address invitedBy, uint16 invitesSent)',
   'function participantNodes(uint256) view returns (address addr, uint8 hop)',
   'function hopStats(uint256) view returns (uint256 totalCommitted, uint32 uniqueCommitters, uint32 whitelistCount)',
@@ -48,7 +47,7 @@ export const CROWDFUND_ABI = [
 
   // View functions
   'function getHopStats(uint8 hop) view returns (uint256 totalCommitted, uint32 uniqueCommitters, uint32 whitelistCount)',
-  'function getSaleStats() view returns (uint256 totalCommitted, uint8 phase, uint256 invitationEnd, uint256 commitmentEnd)',
+  'function getSaleStats() view returns (uint256 totalCommitted, uint8 phase, uint256 windowStart, uint256 windowEnd)',
   'function isWhitelisted(address addr, uint8 hop) view returns (bool)',
   'function getCommitment(address addr, uint8 hop) view returns (uint256 committed)',
   'function getInvitesRemaining(address addr, uint8 hop) view returns (uint16)',
@@ -61,7 +60,7 @@ export const CROWDFUND_ABI = [
 
   // Events
   'event SeedAdded(address indexed seed)',
-  'event InvitationStarted(uint256 invitationEnd, uint256 commitmentStart, uint256 commitmentEnd)',
+  'event WindowStarted(uint256 windowStart, uint256 windowEnd, uint256 launchTeamInviteEnd)',
   'event Invited(address indexed inviter, address indexed invitee, uint8 hop)',
   'event InviteAdded(address indexed inviter, address indexed invitee, uint8 hop, uint16 newInviteCount)',
   'event Committed(address indexed participant, uint256 amount, uint256 totalForParticipant, uint8 hop)',

--- a/crowdfund-frontend/src/hooks/useCrowdfund.ts
+++ b/crowdfund-frontend/src/hooks/useCrowdfund.ts
@@ -58,10 +58,9 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
         admin,
         totalCommitted,
         saleSize,
-        invitationStart,
-        invitationEnd,
-        commitmentStart,
-        commitmentEnd,
+        windowStart,
+        windowEnd,
+        launchTeamInviteEnd,
         participantCount,
         hop0Stats,
         hop1Stats,
@@ -74,10 +73,9 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
         contract.admin(),
         contract.totalCommitted(),
         contract.saleSize(),
-        contract.invitationStart(),
-        contract.invitationEnd(),
-        contract.commitmentStart(),
-        contract.commitmentEnd(),
+        contract.windowStart(),
+        contract.windowEnd(),
+        contract.launchTeamInviteEnd(),
         contract.getParticipantCount(),
         contract.getHopStats(0),
         contract.getHopStats(1),
@@ -111,7 +109,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
 
       // Fetch allocation if finalized and participant has committed
       let currentAllocation = null
-      if (parsedPhase === 3 && parsedParticipant.committed > 0n) {
+      if (parsedPhase === 2 && parsedParticipant.committed > 0n) {
         try {
           const allocResult = await contract.getAllocation(currentAddress)
           currentAllocation = {
@@ -129,10 +127,9 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
         adminAddress: admin as string,
         totalCommitted: BigInt(totalCommitted),
         saleSize: BigInt(saleSize),
-        invitationStart: BigInt(invitationStart),
-        invitationEnd: BigInt(invitationEnd),
-        commitmentStart: BigInt(commitmentStart),
-        commitmentEnd: BigInt(commitmentEnd),
+        windowStart: BigInt(windowStart),
+        windowEnd: BigInt(windowEnd),
+        launchTeamInviteEnd: BigInt(launchTeamInviteEnd),
         hopStats: [
           parseHopStats(hop0Stats),
           parseHopStats(hop1Stats),
@@ -169,7 +166,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
       const contract = getCrowdfundContract(deployment, provider)
       const count = Number(await contract.getParticipantCount())
       const phase = Number(await contract.phase())
-      const isFinalized = phase === 3 // Phase.Finalized
+      const isFinalized = phase === 2 // Phase.Finalized
       const rows: ParticipantRow[] = []
 
       // Fetch in batches of 20. participantNodes returns (address, hop) tuples.
@@ -303,11 +300,11 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
     [executeTx],
   )
 
-  const startInvitations = useCallback(
+  const startWindow = useCallback(
     () =>
-      executeTx('Starting invitations', (signer, dep) => {
+      executeTx('Starting window', (signer, dep) => {
         const contract = getCrowdfundContract(dep, signer)
-        return contract.startInvitations()
+        return contract.startWindow()
       }),
     [executeTx],
   )
@@ -453,7 +450,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
     refreshParticipantList,
     // Write operations
     addSeeds,
-    startInvitations,
+    startWindow,
     invite,
     approveAndCommit,
     finalize,

--- a/crowdfund-frontend/src/types/crowdfund.test.ts
+++ b/crowdfund-frontend/src/types/crowdfund.test.ts
@@ -6,10 +6,9 @@ import { Phase, CROWDFUND_CONSTANTS } from './crowdfund'
 describe('Phase', () => {
   it('has correct numeric values', () => {
     expect(Phase.Setup).toBe(0)
-    expect(Phase.Invitation).toBe(1)
-    expect(Phase.Commitment).toBe(2)
-    expect(Phase.Finalized).toBe(3)
-    expect(Phase.Canceled).toBe(4)
+    expect(Phase.Active).toBe(1)
+    expect(Phase.Finalized).toBe(2)
+    expect(Phase.Canceled).toBe(3)
   })
 })
 
@@ -25,8 +24,8 @@ describe('CROWDFUND_CONSTANTS', () => {
   })
 
   it('has correct durations', () => {
-    expect(CROWDFUND_CONSTANTS.INVITATION_DURATION).toBe(14 * 86400)
-    expect(CROWDFUND_CONSTANTS.COMMITMENT_DURATION).toBe(7 * 86400)
+    expect(CROWDFUND_CONSTANTS.WINDOW_DURATION).toBe(21 * 86400)
+    expect(CROWDFUND_CONSTANTS.LAUNCH_TEAM_INVITE_PERIOD).toBe(7 * 86400)
   })
 
   it('hop caps are correct', () => {
@@ -35,9 +34,10 @@ describe('CROWDFUND_CONSTANTS', () => {
     expect(CROWDFUND_CONSTANTS.HOP_CAPS[2]).toBe(1_000_000_000n)  // $1,000
   })
 
-  it('hop reserves sum to 100%', () => {
-    const sum = CROWDFUND_CONSTANTS.HOP_RESERVE_BPS.reduce((a, b) => a + b, 0)
-    expect(sum).toBe(10_000)
+  it('hop ceilings have correct values (overlapping by design)', () => {
+    expect(CROWDFUND_CONSTANTS.HOP_CEILING_BPS[0]).toBe(7000) // 70%
+    expect(CROWDFUND_CONSTANTS.HOP_CEILING_BPS[1]).toBe(4500) // 45%
+    expect(CROWDFUND_CONSTANTS.HOP_CEILING_BPS[2]).toBe(1000) // 10%
   })
 
   it('hop max invites are correct', () => {

--- a/crowdfund-frontend/src/types/crowdfund.ts
+++ b/crowdfund-frontend/src/types/crowdfund.ts
@@ -3,10 +3,9 @@
 
 export const Phase = {
   Setup: 0,
-  Invitation: 1,
-  Commitment: 2,
-  Finalized: 3,
-  Canceled: 4,
+  Active: 1,
+  Finalized: 2,
+  Canceled: 3,
 } as const
 
 export type Phase = (typeof Phase)[keyof typeof Phase]
@@ -67,10 +66,10 @@ export const CROWDFUND_CONSTANTS = {
   MAX_SALE: 1_800_000n * 1_000_000n,
   MIN_SALE: 1_000_000n * 1_000_000n,
   ARM_PRICE: 1_000_000n,
-  INVITATION_DURATION: 14 * 86400,
-  COMMITMENT_DURATION: 7 * 86400,
+  WINDOW_DURATION: 21 * 86400,
+  LAUNCH_TEAM_INVITE_PERIOD: 7 * 86400,
   HOP_CAPS: [15_000n * 1_000_000n, 4_000n * 1_000_000n, 1_000n * 1_000_000n] as const,
-  HOP_RESERVE_BPS: [7000, 2500, 500] as const,
+  HOP_CEILING_BPS: [7000, 4500, 1000] as const,
   HOP_MAX_INVITES: [3, 2, 0] as const,
   HOP1_ROLLOVER_MIN: 30,
   HOP2_ROLLOVER_MIN: 50,

--- a/crowdfund-frontend/src/utils/format.test.ts
+++ b/crowdfund-frontend/src/utils/format.test.ts
@@ -98,8 +98,7 @@ describe('formatCountdown', () => {
 describe('phaseName', () => {
   it('returns correct names', () => {
     expect(phaseName(Phase.Setup)).toBe('Setup')
-    expect(phaseName(Phase.Invitation)).toBe('Invitation')
-    expect(phaseName(Phase.Commitment)).toBe('Commitment')
+    expect(phaseName(Phase.Active)).toBe('Active')
     expect(phaseName(Phase.Finalized)).toBe('Finalized')
     expect(phaseName(Phase.Canceled)).toBe('Canceled')
   })

--- a/crowdfund-frontend/src/utils/format.ts
+++ b/crowdfund-frontend/src/utils/format.ts
@@ -51,8 +51,7 @@ export function formatCountdown(seconds: number): string {
 export function phaseName(phase: Phase): string {
   switch (phase) {
     case Phase.Setup: return 'Setup'
-    case Phase.Invitation: return 'Invitation'
-    case Phase.Commitment: return 'Commitment'
+    case Phase.Active: return 'Active'
     case Phase.Finalized: return 'Finalized'
     case Phase.Canceled: return 'Canceled'
     default: return 'Unknown'
@@ -63,8 +62,7 @@ export function phaseName(phase: Phase): string {
 export function phaseColor(phase: Phase): string {
   switch (phase) {
     case Phase.Setup: return 'bg-muted text-muted-foreground'
-    case Phase.Invitation: return 'bg-info/20 text-info'
-    case Phase.Commitment: return 'bg-warning/20 text-warning'
+    case Phase.Active: return 'bg-info/20 text-info'
     case Phase.Finalized: return 'bg-success/20 text-success'
     case Phase.Canceled: return 'bg-destructive/20 text-destructive'
     default: return 'bg-muted text-muted-foreground'

--- a/scripts/crowdfund_demo.ts
+++ b/scripts/crowdfund_demo.ts
@@ -2,7 +2,7 @@
  * Crowdfund Demo — Narrated end-to-end walkthrough (standalone)
  *
  * Deploys the crowdfund system and runs through:
- *   Flow 1: Full crowdfund lifecycle (seeds → invite → commit → finalize → claim)
+ *   Flow 1: Full crowdfund lifecycle (seeds → window → invite + commit → finalize → claim)
  *   Flow 2: Governance bridge (claimed ARM → lock in VotingLocker → voting power)
  *
  * Uses time.increase() to fast-forward through delays.
@@ -22,10 +22,9 @@
 
 import { ethers, network } from "hardhat";
 
-const PhaseNames = ["SETUP", "INVITATION", "COMMITMENT", "FINALIZED", "CANCELED"];
+const PhaseNames = ["SETUP", "ACTIVE", "FINALIZED", "CANCELED"];
 
-const TWO_WEEKS = 14 * 86400;
-const ONE_WEEK = 7 * 86400;
+const THREE_WEEKS = 21 * 86400;
 
 function log(tag: string, msg: string) {
   const padded = `[${tag}]`.padEnd(12);
@@ -108,15 +107,15 @@ async function main() {
     log("SEED", `  Seed-${String.fromCharCode(65 + i)}: ${seeds[i].address.slice(0, 10)}...`);
   }
 
-  // ============ PHASE: INVITATION ============
+  // ============ PHASE: ACTIVE (3-week unified window) ============
   console.log("");
   console.log("-".repeat(70));
-  console.log("  PHASE: INVITATION (2-week window)");
+  console.log("  PHASE: ACTIVE (3-week window — invites + commits concurrent)");
   console.log("-".repeat(70));
   console.log("");
 
-  await crowdfund.startInvitations();
-  log("START", `Invitation window opened`);
+  await crowdfund.startWindow();
+  log("START", `Crowdfund window opened`);
 
   // Each seed invites 3 hop-1 addresses
   let hop1Count = 0;
@@ -144,13 +143,7 @@ async function main() {
   const [, , wc2] = await crowdfund.getHopStats(2);
   log("STATS", `Hop 0: ${wc0} whitelisted | Hop 1: ${wc1} | Hop 2: ${wc2}`);
 
-  await fastForward(TWO_WEEKS, "2 weeks (invitation window)");
-
-  // ============ PHASE: COMMITMENT ============
-  console.log("-".repeat(70));
-  console.log("  PHASE: COMMITMENT (1-week window)");
-  console.log("-".repeat(70));
-  console.log("");
+  // Commits happen concurrently — no time jump needed
 
   // Fund and commit: seeds at max cap
   for (let i = 0; i < seeds.length; i++) {
@@ -225,10 +218,8 @@ async function main() {
   await cf2.addSeeds(bigSeeds.map(s => s.address));
   log("SETUP", `Added ${bigSeeds.length} seeds to second crowdfund`);
 
-  await cf2.startInvitations();
-  await network.provider.send("evm_increaseTime", [TWO_WEEKS + 1]);
-  await network.provider.send("evm_mine");
-  log("TIME", "Fast-forwarded past invitation window");
+  await cf2.startWindow();
+  log("START", "Crowdfund window opened");
 
   // Each seed commits $15K
   for (const s of bigSeeds) {
@@ -240,8 +231,9 @@ async function main() {
   const total2 = await cf2.totalCommitted();
   log("COMMIT", `${bigSeeds.length} seeds commit $15K each = ${fmtUsdc(total2)}`);
 
-  await network.provider.send("evm_increaseTime", [ONE_WEEK + 1]);
+  await network.provider.send("evm_increaseTime", [THREE_WEEKS + 1]);
   await network.provider.send("evm_mine");
+  log("TIME", "Fast-forwarded past 3-week window");
 
   // Finalize
   await cf2.finalize();
@@ -296,7 +288,7 @@ async function main() {
   console.log("=".repeat(70));
   console.log("");
   console.log("  Flows demonstrated:");
-  console.log("  1. Crowdfund: seeds \u2192 invite \u2192 commit \u2192 finalize \u2192 claim");
+  console.log("  1. Crowdfund: seeds \u2192 window \u2192 invite + commit \u2192 finalize \u2192 claim");
   console.log("  2. Governance bridge: claimed ARM \u2192 VotingLocker \u2192 voting power");
   console.log("");
 }

--- a/scripts/crowdfund_populate.ts
+++ b/scripts/crowdfund_populate.ts
@@ -4,8 +4,8 @@
  * Crowdfund Populate — Fill a deployed crowdfund to a target commitment level
  *
  * Loads the existing deployment from deployments/crowdfund-hub.json and runs
- * through the full lifecycle: add seeds → start invitations → (optional hops)
- * → advance time → mint USDC → commit → advance past commitment.
+ * through the full lifecycle: add seeds → start window → invite + commit
+ * (concurrent) → advance past window.
  *
  * Leaves the contract ready for admin to finalize via the UI or CLI.
  *
@@ -24,8 +24,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { getCrowdfundDeploymentFile } from "../config/networks";
 
-const TWO_WEEKS = 14 * 86400;
-const ONE_WEEK = 7 * 86400;
+const THREE_WEEKS = 21 * 86400;
 
 const SEED_CAP = 15_000;  // $15,000 per seed
 const HOP1_CAP = 4_000;   // $4,000 per hop-1
@@ -95,7 +94,7 @@ async function main() {
 
   // Check phase
   const phase = Number(await crowdfund.phase());
-  const PhaseNames = ["SETUP", "INVITATION", "COMMITMENT", "FINALIZED", "CANCELED"];
+  const PhaseNames = ["SETUP", "ACTIVE", "FINALIZED", "CANCELED"];
   if (phase !== 0) {
     throw new Error(
       `Contract is in ${PhaseNames[phase]} phase (expected SETUP).\n` +
@@ -212,10 +211,10 @@ async function main() {
     log("SEEDS", `  Batch ${Math.floor(i / SEED_BATCH_SIZE) + 1}: added ${batch.length} seeds`);
   }
 
-  // ============ START INVITATIONS ============
-  const startTx = await crowdfund.startInvitations();
+  // ============ START WINDOW ============
+  const startTx = await crowdfund.startWindow();
   await startTx.wait();
-  log("PHASE", "Invitation window opened");
+  log("PHASE", "Crowdfund window opened (invites + commits concurrent)");
 
   // ============ INVITATIONS (if hops enabled) ============
   if (includeHops) {
@@ -246,21 +245,8 @@ async function main() {
     log("INVITE", `${h2idx} hop-2 addresses invited`);
   }
 
-  // ============ ADVANCE TO COMMITMENT ============
-  console.log("-".repeat(70));
-
-  // Read exact commitment window from contract and jump to it
-  const commStart = Number(await crowdfund.commitmentStart());
-  const commEnd = Number(await crowdfund.commitmentEnd());
-  const curBlock = await ethers.provider.getBlock("latest");
-  const curTs = curBlock!.timestamp;
-  const jump = commStart - curTs + 1;
-
-  log("TIME", `Advancing to commitment window (${jump}s jump)...`);
-  await network.provider.send("evm_increaseTime", [jump]);
-  await network.provider.send("evm_mine");
-
   // ============ MINT + APPROVE + COMMIT ============
+  // Invites and commits are both open from window start.
   console.log("-".repeat(70));
   log("COMMIT", "Minting USDC and committing...");
 
@@ -314,10 +300,17 @@ async function main() {
     await commitBatch(hop2Signers, HOP2_CAP, 2, "Hop-2");
   }
 
-  // ============ ADVANCE PAST COMMITMENT ============
+  // ============ ADVANCE PAST WINDOW ============
   console.log("-".repeat(70));
-  log("TIME", "Advancing past commitment window (1 week)...");
-  await network.provider.send("evm_increaseTime", [ONE_WEEK + 1]);
+
+  // Read exact window end from contract and jump past it
+  const windowEnd = Number(await crowdfund.windowEnd());
+  const curBlock = await ethers.provider.getBlock("latest");
+  const curTs = curBlock!.timestamp;
+  const jump = windowEnd - curTs + 1;
+
+  log("TIME", `Advancing past crowdfund window (${jump}s jump)...`);
+  await network.provider.send("evm_increaseTime", [jump]);
   await network.provider.send("evm_mine");
 
   // ============ SUMMARY ============

--- a/scripts/full_lifecycle_demo.ts
+++ b/scripts/full_lifecycle_demo.ts
@@ -8,7 +8,7 @@
  * through six phases that mirror the real activation sequence:
  *
  *   Phase 1: Deploy — governance stack + crowdfund with shared ARM + unified treasury
- *   Phase 2: Crowdfund — seeds → invite → commit → finalize → claim
+ *   Phase 2: Crowdfund — seeds → window → invite + commit → finalize → claim
  *   Phase 3: Treasury Reclaim — withdrawProceeds + withdrawUnallocatedArm → treasury
  *   Phase 4: Governance Activation — lock ARM → quorum analysis
  *   Phase 5: Treasury Proposal — governance distributes USDC from treasury
@@ -36,8 +36,7 @@ const TWO_DAYS   = 2 * ONE_DAY;
 const FIVE_DAYS  = 5 * ONE_DAY;
 const SEVEN_DAYS = 7 * ONE_DAY;
 const FOUR_DAYS  = 4 * ONE_DAY;
-const ONE_WEEK   = 7 * ONE_DAY;
-const TWO_WEEKS  = 14 * ONE_DAY;
+const THREE_WEEKS = 21 * ONE_DAY;
 
 // Crowdfund parameters
 const NUM_SEEDS = 80;                // enough to exceed MIN_SALE ($1M)
@@ -59,7 +58,7 @@ const TIMELOCK_MIN_DELAY   = TWO_DAYS;
 // Governance enums
 const ProposalType = { ParameterChange: 0, Treasury: 1, StewardElection: 2 };
 const Vote = { Against: 0, For: 1, Abstain: 2 };
-const PhaseNames  = ["SETUP", "INVITATION", "COMMITMENT", "FINALIZED", "CANCELED"];
+const PhaseNames  = ["SETUP", "ACTIVE", "FINALIZED", "CANCELED"];
 const StateNames  = ["PENDING", "ACTIVE", "DEFEATED", "SUCCEEDED", "QUEUED", "EXECUTED", "CANCELED"];
 
 // ============ Utility Functions ============
@@ -242,15 +241,15 @@ async function main() {
   //  PHASE 2: CROWDFUND LIFECYCLE
   // ================================================================
 
-  section("PHASE 2: Crowdfund \u2014 Seeds \u2192 Invite \u2192 Commit \u2192 Finalize \u2192 Claim");
+  section("PHASE 2: Crowdfund \u2014 Seeds \u2192 Window \u2192 Invite + Commit \u2192 Finalize \u2192 Claim");
 
   // 2a: Add seeds
   await crowdfund.addSeeds(seeds.map(s => s.address));
   log("SEED", `Added ${seeds.length} seeds (hop 0, $${SEED_CAP} cap, 3 invites each)`);
 
-  // 2b: Start invitations
-  await crowdfund.startInvitations();
-  log("START", "Invitation window opened (2-week duration)");
+  // 2b: Start window (invites + commits concurrent for 3 weeks)
+  await crowdfund.startWindow();
+  log("START", "Crowdfund window opened (3-week duration, invites + commits concurrent)");
 
   // 2c: Invitation chains — first 3 seeds invite hop-1, hop-1 invite hop-2
   let hop1Count = 0;
@@ -276,10 +275,7 @@ async function main() {
   const [, , wc2] = await crowdfund.getHopStats(2);
   log("STATS", `Whitelisted \u2014 Hop 0: ${wc0} | Hop 1: ${wc1} | Hop 2: ${wc2}`);
 
-  await fastForward(TWO_WEEKS, "2 weeks (invitation window)");
-
-  // 2d: Commitment phase
-  log("PHASE", "Commitment window open (1-week duration)");
+  // 2d: Commitments (concurrent with invitations — no time jump needed)
 
   // Seeds commit at max cap
   for (const s of seeds) {
@@ -315,7 +311,7 @@ async function main() {
     log("STATS", `  Hop ${h}: ${uc} committers, ${fmtUsdc(tc)}`);
   }
 
-  await fastForward(ONE_WEEK, "1 week (commitment window)");
+  await fastForward(THREE_WEEKS, "3 weeks (crowdfund window)");
 
   // 2e: Finalize
   await crowdfund.finalize();
@@ -369,7 +365,7 @@ async function main() {
   const [h2Alloc, h2Refund] = await crowdfund.getAllocation(hop2Addrs[0].address);
   log("CLAIM", `  ${hop2Claimers} hop-2 claim: ${fmtArm(h2Alloc)} + ${fmtUsdc(h2Refund)} refund each`);
 
-  verify("Phase is FINALIZED", phase === 3);
+  verify("Phase is FINALIZED", phase === 2);
   verify("Total committed > MIN_SALE ($1M)", totalCommitted > ethers.parseUnits("1000000", 6));
 
   // ================================================================
@@ -655,7 +651,7 @@ async function main() {
 
   console.log("  Lifecycle demonstrated:");
   console.log("  1. Deploy: canonical ARM token + governance stack + crowdfund (unified treasury)");
-  console.log("  2. Crowdfund: seeds \u2192 invite \u2192 commit \u2192 finalize \u2192 claim");
+  console.log("  2. Crowdfund: seeds \u2192 window \u2192 invite + commit \u2192 finalize \u2192 claim");
   console.log("  3. Treasury reclaim: USDC proceeds + unallocated ARM \u2192 treasury");
   console.log("  4. Governance activation: lock ARM, verify quorum reachability");
   console.log("  5. Treasury proposal: distribute USDC via governance vote");

--- a/tasks/crowdfund.ts
+++ b/tasks/crowdfund.ts
@@ -19,7 +19,7 @@ import { task } from "hardhat/config";
 import * as fs from "fs";
 import * as path from "path";
 
-const PhaseNames = ["SETUP", "INVITATION", "COMMITMENT", "FINALIZED", "CANCELED"];
+const PhaseNames = ["SETUP", "ACTIVE", "FINALIZED", "CANCELED"];
 
 function loadCrowdfundDeployment(networkName: string) {
   const filePath = path.join(__dirname, "..", "deployments", `crowdfund-${networkName}.json`);
@@ -52,23 +52,25 @@ task("cf-add-seeds", "Add seed addresses (hop 0)")
     console.log(`Added ${seeds.length} seed(s): ${seeds.join(", ")}`);
   });
 
-task("cf-start", "Start the invitation window")
+task("cf-start", "Start the active window (invites + commits)")
   .setAction(async (_, hre) => {
     const { ethers } = hre;
     const chainId = Number((await ethers.provider.getNetwork()).chainId);
     const deployment = loadCrowdfundDeployment(getNetworkName(chainId));
 
     const crowdfund = await ethers.getContractAt("ArmadaCrowdfund", deployment.contracts.crowdfund);
-    await crowdfund.startInvitations();
+    await crowdfund.startWindow();
 
-    const invEnd = await crowdfund.invitationEnd();
-    const commEnd = await crowdfund.commitmentEnd();
-    console.log("Invitation window started");
-    console.log(`  Invitation ends: ${new Date(Number(invEnd) * 1000).toISOString()}`);
-    console.log(`  Commitment ends: ${new Date(Number(commEnd) * 1000).toISOString()}`);
+    const winStart = await crowdfund.windowStart();
+    const winEnd = await crowdfund.windowEnd();
+    const ltEnd = await crowdfund.launchTeamInviteEnd();
+    console.log("Active window started (invites + commits concurrent)");
+    console.log(`  Window start: ${new Date(Number(winStart) * 1000).toISOString()}`);
+    console.log(`  Launch team invite cutoff: ${new Date(Number(ltEnd) * 1000).toISOString()}`);
+    console.log(`  Window ends: ${new Date(Number(winEnd) * 1000).toISOString()}`);
   });
 
-// ============ Invitation ============
+// ============ Active Window ============
 
 task("cf-invite", "Invite an address to participate")
   .addParam("invitee", "Address to invite")
@@ -87,7 +89,7 @@ task("cf-invite", "Invite an address to participate")
     console.log(`Invited ${args.invitee}. Invites remaining: ${remaining}`);
   });
 
-// ============ Commitment ============
+// ============ Commitment (during active window) ============
 
 task("cf-commit", "Commit USDC to the crowdfund")
   .addParam("amount", "Amount of USDC (in whole dollars)")
@@ -123,7 +125,7 @@ task("cf-finalize", "Finalize the crowdfund (compute allocations or cancel)")
 
     const phase = Number(await crowdfund.phase());
     console.log(`Crowdfund finalized: ${PhaseNames[phase]}`);
-    if (phase === 3) {
+    if (phase === 2) {
       // Finalized
       const saleSize = await crowdfund.saleSize();
       const totalAlloc = await crowdfund.totalAllocated();
@@ -144,7 +146,7 @@ task("cf-claim", "Claim ARM allocation and USDC refund")
     const crowdfund = await ethers.getContractAt("ArmadaCrowdfund", deployment.contracts.crowdfund);
     const phase = Number(await crowdfund.phase());
 
-    if (phase === 4) {
+    if (phase === 3) {
       // Canceled — use refund()
       await crowdfund.refund();
       console.log("Full USDC refund claimed (sale was canceled)");
@@ -165,13 +167,13 @@ task("cf-stats", "Show crowdfund statistics")
 
     const crowdfund = await ethers.getContractAt("ArmadaCrowdfund", deployment.contracts.crowdfund);
 
-    const [totalComm, phase, invEnd, commEnd] = await crowdfund.getSaleStats();
+    const [totalComm, phase, winStart, winEnd] = await crowdfund.getSaleStats();
     console.log("Crowdfund Status:");
     console.log(`  Phase: ${PhaseNames[Number(phase)]}`);
     console.log(`  Total committed: $${ethers.formatUnits(totalComm, 6)}`);
-    if (Number(invEnd) > 0) {
-      console.log(`  Invitation ends: ${new Date(Number(invEnd) * 1000).toISOString()}`);
-      console.log(`  Commitment ends: ${new Date(Number(commEnd) * 1000).toISOString()}`);
+    if (Number(winStart) > 0) {
+      console.log(`  Window start: ${new Date(Number(winStart) * 1000).toISOString()}`);
+      console.log(`  Window ends: ${new Date(Number(winEnd) * 1000).toISOString()}`);
     }
     console.log(`  Participants: ${await crowdfund.getParticipantCount()}`);
 
@@ -181,7 +183,7 @@ task("cf-stats", "Show crowdfund statistics")
       console.log(`  Hop ${h}: ${wc} whitelisted, ${uc} committed, $${ethers.formatUnits(tc, 6)} total`);
     }
 
-    if (Number(phase) === 3) {
+    if (Number(phase) === 2) {
       console.log(`\n  Sale size: $${ethers.formatUnits(await crowdfund.saleSize(), 6)}`);
       console.log(`  Total ARM allocated: ${ethers.formatUnits(await crowdfund.totalAllocated(), 18)}`);
     }
@@ -207,7 +209,7 @@ task("cf-allocation", "Check allocation for an address")
     console.log(`  Committed: $${ethers.formatUnits(committed, 6)}`);
 
     const phase = Number(await crowdfund.phase());
-    if (phase === 3) {
+    if (phase === 2) {
       const [alloc, refund, claimed] = await crowdfund.getAllocation(args.address);
       console.log(`  Allocation: ${ethers.formatUnits(alloc, 18)} ARM`);
       console.log(`  Refund: $${ethers.formatUnits(refund, 6)}`);

--- a/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
+++ b/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
@@ -37,17 +37,17 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
         // Fund ARM tokens
         armToken.transfer(address(crowdfund), ARM_FUNDING);
 
-        // Start invitations to set commitmentEnd
+        // Start window to set windowEnd
         address[] memory seeds = new address[](1);
         seeds[0] = address(0xA);
         crowdfund.addSeeds(seeds);
-        crowdfund.startInvitations();
+        crowdfund.startWindow();
     }
 
     /// @notice Helper: advance past commitment period and cancel via finalize (under-subscribed)
     function _cancelViaTooFewCommitments() internal {
         // Warp past commitment end so finalize() can be called
-        vm.warp(crowdfund.commitmentEnd() + 1);
+        vm.warp(crowdfund.windowEnd() + 1);
         // No commitments made, so totalCommitted == 0 < MIN_SALE → cancel path
         crowdfund.finalize();
         assertEq(uint256(crowdfund.phase()), uint256(Phase.Canceled));
@@ -104,23 +104,19 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
         fresh.withdrawUnallocatedArm();
     }
 
-    /// @notice Reverts in Invitation phase
-    function test_withdrawUnallocatedArm_invitationPhase_reverts() public {
-        // setUp already moved crowdfund to Invitation phase
-        assertEq(uint256(crowdfund.phase()), uint256(Phase.Invitation));
+    /// @notice Reverts in Active phase
+    function test_withdrawUnallocatedArm_activePhase_reverts() public {
+        // setUp already moved crowdfund to Active phase
+        assertEq(uint256(crowdfund.phase()), uint256(Phase.Active));
 
         vm.expectRevert("ArmadaCrowdfund: not finalized or canceled");
         crowdfund.withdrawUnallocatedArm();
     }
 
-    /// @notice Reverts in Commitment phase
-    function test_withdrawUnallocatedArm_commitmentPhase_reverts() public {
-        // Warp past invitation period to enter Commitment phase
-        vm.warp(crowdfund.commitmentEnd() - 1);
-        // Phase transitions to Commitment when commitment period starts
-        // Actually, the contract uses commitmentEnd which is set at startInvitations.
-        // The phase stays Invitation until someone commits or finalize is called.
-        // Let's just verify it reverts at current phase.
+    /// @notice Reverts in Active phase (near window end)
+    function test_withdrawUnallocatedArm_activePhaseNearEnd_reverts() public {
+        // Warp to near the end of the active window — still Active phase
+        vm.warp(crowdfund.windowEnd() - 1);
         vm.expectRevert("ArmadaCrowdfund: not finalized or canceled");
         crowdfund.withdrawUnallocatedArm();
     }
@@ -146,10 +142,10 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
         address[] memory seeds = new address[](1);
         seeds[0] = address(0xA);
         fuzzCrowdfund.addSeeds(seeds);
-        fuzzCrowdfund.startInvitations();
+        fuzzCrowdfund.startWindow();
 
         // Cancel
-        vm.warp(fuzzCrowdfund.commitmentEnd() + 1);
+        vm.warp(fuzzCrowdfund.windowEnd() + 1);
         fuzzCrowdfund.finalize();
 
         // Recover

--- a/test-foundry/ArmadaCrowdfundCancel.t.sol
+++ b/test-foundry/ArmadaCrowdfundCancel.t.sol
@@ -36,20 +36,20 @@ contract ArmadaCrowdfundCancelTest is Test {
         // Fund ARM for MAX_SALE
         armToken.transfer(address(crowdfund), 1_800_000 * 1e18);
 
-        // Start invitations to set commitmentEnd
+        // Start window to set windowEnd
         address[] memory seeds = new address[](1);
         seeds[0] = address(0xA);
         crowdfund.addSeeds(seeds);
-        crowdfund.startInvitations();
+        crowdfund.startWindow();
     }
 
     /// @notice permissionlessCancel always reverts when elapsed <= FINALIZE_GRACE_PERIOD
     function testFuzz_revertsBeforeGracePeriod(uint256 elapsed) public {
-        uint256 commitmentEnd = crowdfund.commitmentEnd();
+        uint256 windowEnd = crowdfund.windowEnd();
         // Bound elapsed to [0, FINALIZE_GRACE_PERIOD] (inclusive — should revert at boundary)
         elapsed = bound(elapsed, 0, THIRTY_DAYS);
 
-        vm.warp(commitmentEnd + elapsed);
+        vm.warp(windowEnd + elapsed);
 
         vm.prank(caller);
         vm.expectRevert("ArmadaCrowdfund: grace period not elapsed");
@@ -58,11 +58,11 @@ contract ArmadaCrowdfundCancelTest is Test {
 
     /// @notice permissionlessCancel always succeeds when elapsed > FINALIZE_GRACE_PERIOD
     function testFuzz_succeedsAfterGracePeriod(uint256 elapsed) public {
-        uint256 commitmentEnd = crowdfund.commitmentEnd();
+        uint256 windowEnd = crowdfund.windowEnd();
         // Bound elapsed to (FINALIZE_GRACE_PERIOD, FINALIZE_GRACE_PERIOD + 365 days]
         elapsed = bound(elapsed, THIRTY_DAYS + 1, THIRTY_DAYS + 365 days);
 
-        vm.warp(commitmentEnd + elapsed);
+        vm.warp(windowEnd + elapsed);
 
         vm.prank(caller);
         crowdfund.permissionlessCancel();

--- a/test-foundry/CrowdfundFullInvariant.t.sol
+++ b/test-foundry/CrowdfundFullInvariant.t.sol
@@ -209,8 +209,8 @@ contract CrowdfundFullInvariantTest is Test {
         // Setup phase: add seeds
         crowdfund.addSeeds(seeds);
 
-        // Start invitations
-        crowdfund.startInvitations();
+        // Start window
+        crowdfund.startWindow();
 
         // Do invitations
         uint256 hop1Idx = 0;
@@ -235,8 +235,8 @@ contract CrowdfundFullInvariantTest is Test {
             }
         }
 
-        // Fast-forward past invitation window into commitment window
-        vm.warp(crowdfund.commitmentStart() + 1);
+        // Fast-forward into the active window (invites + commits concurrent)
+        vm.warp(crowdfund.windowStart() + 1);
 
         // Create handler
         handler = new CrowdfundFullHandler(

--- a/test-foundry/CrowdfundInvariant.t.sol
+++ b/test-foundry/CrowdfundInvariant.t.sol
@@ -282,8 +282,8 @@ contract CrowdfundInvariantTest is Test {
         // Setup phase: add seeds
         crowdfund.addSeeds(seeds);
 
-        // Start invitations
-        crowdfund.startInvitations();
+        // Start window
+        crowdfund.startWindow();
 
         // Do invitations: each seed invites up to 3 hop-1 addresses
         uint256 hop1Idx = 0;
@@ -310,8 +310,8 @@ contract CrowdfundInvariantTest is Test {
             }
         }
 
-        // Fast-forward past invitation window into commitment window
-        vm.warp(crowdfund.commitmentStart() + 1);
+        // Fast-forward into the active window (invites + commits concurrent)
+        vm.warp(crowdfund.windowStart() + 1);
 
         // Create handler
         handler = new CrowdfundHandler(
@@ -373,7 +373,7 @@ contract CrowdfundInvariantTest is Test {
     /// @notice Phase only moves forward, never backward
     function invariant_phaseMonotonicity() public view {
         Phase currentPhase = crowdfund.phase();
-        // We started in Invitation (after setUp), moved to Commitment window via warp
+        // We started in Active (after setUp), warped into the active window
         // Phase should never go backward
         if (handler.ghost_finalized()) {
             assertEq(uint256(currentPhase), uint256(Phase.Finalized), "Phase should be Finalized");

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -22,8 +22,7 @@ const Vote = { Against: 0, For: 1, Abstain: 2 };
 const ONE_DAY = 86400;
 const TWO_DAYS = 2 * ONE_DAY;
 const FIVE_DAYS = 5 * ONE_DAY;
-const TWO_WEEKS = 14 * ONE_DAY;
-const ONE_WEEK = 7 * ONE_DAY;
+const THREE_WEEKS = 21 * ONE_DAY;
 
 const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
 const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
@@ -141,17 +140,14 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // 1. Add seeds and start invitations
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
 
       // 2. Seeds invite hop-1 addresses
       for (let i = 0; i < 3 && i < hop1Addrs.length; i++) {
         await crowdfund.connect(seeds[i]).invite(hop1Addrs[i].address, 0);
       }
 
-      // 3. Fast-forward past invitation window into commitment window
-      await time.increase(TWO_WEEKS + 1);
-
-      // 4. All seeds commit $15K each = $1.2M (meets MIN_SALE)
+      // 3. All seeds commit $15K each = $1.2M (meets MIN_SALE)
       for (const seed of seeds) {
         const amount = USDC(15_000);
         await usdc.mint(seed.address, amount);
@@ -159,14 +155,14 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await crowdfund.connect(seed).commit(amount, 0);
       }
 
-      // 5. Fast-forward past commitment window
-      await time.increase(ONE_WEEK + 1);
+      // 4. Fast-forward past active window
+      await time.increase(THREE_WEEKS + 1);
 
-      // 6. Finalize
+      // 5. Finalize
       await crowdfund.finalize();
-      expect(await crowdfund.phase()).to.equal(3); // Finalized
+      expect(await crowdfund.phase()).to.equal(2); // Finalized
 
-      // 7. Seeds claim their ARM
+      // 6. Seeds claim their ARM
       const claimedSeeds = seeds.slice(0, 5); // claim first 5 for governance testing
       for (const seed of claimedSeeds) {
         await crowdfund.connect(seed).claim();
@@ -178,13 +174,13 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // === GOVERNANCE PHASE ===
 
-      // 8. Deployer needs voting power to propose AND reach quorum.
+      // 7. Deployer needs voting power to propose AND reach quorum.
       // Deployer kept DEPLOYER_KEEP ARM. Lock most of it.
       const deployerLock = DEPLOYER_KEEP / 2n;
       await armToken.approve(await votingLocker.getAddress(), deployerLock);
       await votingLocker.lock(deployerLock);
 
-      // 9. Seeds lock their claimed ARM in VotingLocker
+      // 8. Seeds lock their claimed ARM in VotingLocker
       for (const seed of claimedSeeds) {
         const balance = await armToken.balanceOf(seed.address);
         await armToken.connect(seed).approve(await votingLocker.getAddress(), balance);
@@ -196,7 +192,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       const seed0VotingPower = await votingLocker.getLockedBalance(claimedSeeds[0].address);
       expect(seed0VotingPower).to.equal(seed0Arm);
 
-      // 10. Create a governance proposal (treasury owner is already the timelock from deployment)
+      // 9. Create a governance proposal (treasury owner is already the timelock from deployment)
       const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
       const proposalTx = await governor.propose(
         ProposalType.ParameterChange,
@@ -208,11 +204,11 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       const receipt = await proposalTx.wait();
       const proposalId = 1;
 
-      // 11. Wait for voting delay (2 days)
+      // 10. Wait for voting delay (2 days)
       await time.increase(TWO_DAYS + 1);
       expect(await governor.state(proposalId)).to.equal(ProposalState.Active);
 
-      // 12. Seeds vote FOR the proposal
+      // 11. Seeds vote FOR the proposal
       for (const seed of claimedSeeds) {
         await governor.connect(seed).castVote(proposalId, Vote.For);
       }
@@ -220,26 +216,26 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       // Deployer also votes
       await governor.castVote(proposalId, Vote.For);
 
-      // 13. Verify vote tallies
+      // 12. Verify vote tallies
       const [, , , , forVotes, againstVotes, abstainVotes] = await governor.getProposal(proposalId);
       expect(forVotes).to.be.gt(0);
       expect(againstVotes).to.equal(0);
 
-      // 14. Wait for voting period to end (5 days)
+      // 13. Wait for voting period to end (5 days)
       await time.increase(FIVE_DAYS + 1);
 
       // Check quorum is reached
       const state = await governor.state(proposalId);
       expect(state).to.equal(ProposalState.Succeeded);
 
-      // 15. Queue to timelock
+      // 14. Queue to timelock
       await governor.queue(proposalId);
       expect(await governor.state(proposalId)).to.equal(ProposalState.Queued);
 
-      // 16. Wait for execution delay (2 days timelock)
+      // 15. Wait for execution delay (2 days timelock)
       await time.increase(TWO_DAYS + 1);
 
-      // 17. Execute
+      // 16. Execute
       await governor.execute(proposalId);
       expect(await governor.state(proposalId)).to.equal(ProposalState.Executed);
     });
@@ -250,8 +246,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
   describe("Token Supply Consistency", function () {
     async function runCrowdfundAndClaim() {
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const seed of seeds) {
         const amount = USDC(15_000);
@@ -260,7 +255,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await crowdfund.connect(seed).commit(amount, 0);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Claim all
@@ -355,8 +350,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     async function setupCrowdfundAndGovernance() {
       // Run crowdfund
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const seed of seeds) {
         const amount = USDC(15_000);
@@ -364,7 +358,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await usdc.connect(seed).approve(await crowdfund.getAddress(), amount);
         await crowdfund.connect(seed).commit(amount, 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Claim first 10 seeds
@@ -556,8 +550,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("unclaimed crowdfund participant cannot vote (no ARM, no lock, no voting power)", async function () {
       // Run crowdfund but DON'T claim
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const seed of seeds) {
         const amount = USDC(15_000);
@@ -565,7 +558,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await usdc.connect(seed).approve(await crowdfund.getAddress(), amount);
         await crowdfund.connect(seed).commit(amount, 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // DON'T claim — seeds have 0 ARM balance
@@ -748,8 +741,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("quorum denominator shifts as participants claim ARM from crowdfund", async function () {
       // Run crowdfund lifecycle
       await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
-      await localCrowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await localCrowdfund.startWindow();
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
@@ -758,7 +750,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await localCrowdfund.connect(seed).commit(amount, 0);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await localCrowdfund.finalize();
 
       // Before any claims: crowdfund still holds all ARM
@@ -808,8 +800,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("withdrawProceeds sends USDC to treasury contract", async function () {
       // Run crowdfund
       await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
-      await localCrowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await localCrowdfund.startWindow();
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
@@ -818,7 +809,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await localCrowdfund.connect(seed).commit(amount, 0);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await localCrowdfund.finalize();
 
       // All seeds claim
@@ -842,8 +833,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("withdrawUnallocatedArm sends ARM to treasury contract", async function () {
       // Run crowdfund
       await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
-      await localCrowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await localCrowdfund.startWindow();
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
@@ -852,7 +842,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await localCrowdfund.connect(seed).commit(amount, 0);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await localCrowdfund.finalize();
 
       const treasuryAddress = await localTreasury.getAddress();
@@ -868,8 +858,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("full lifecycle: crowdfund → claim → lock → propose → vote → execute", async function () {
       // Run crowdfund
       await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
-      await localCrowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await localCrowdfund.startWindow();
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
@@ -878,7 +867,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await localCrowdfund.connect(seed).commit(amount, 0);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await localCrowdfund.finalize();
 
       // 5 seeds claim

--- a/test/crowdfund_adversarial.ts
+++ b/test/crowdfund_adversarial.ts
@@ -13,10 +13,10 @@ import { ethers } from "hardhat";
 import { time } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
-const Phase = { Setup: 0, Invitation: 1, Commitment: 2, Finalized: 3, Canceled: 4 };
+const Phase = { Setup: 0, Active: 1, Finalized: 2, Canceled: 3 };
 
 const ONE_DAY = 86400;
-const TWO_WEEKS = 14 * ONE_DAY;
+const THREE_WEEKS = 21 * ONE_DAY;
 const ONE_WEEK = 7 * ONE_DAY;
 
 const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
@@ -103,15 +103,15 @@ describe("Crowdfund Adversarial", function () {
   describe("Permissionless Cancel Boundaries", function () {
     const THIRTY_DAYS = 30 * ONE_DAY;
 
-    it("reverts at exact boundary (commitmentEnd + FINALIZE_GRACE_PERIOD)", async function () {
+    it("reverts at exact boundary (windowEnd + FINALIZE_GRACE_PERIOD)", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      const commitmentEnd = await crowdfund.commitmentEnd();
+      await crowdfund.startWindow();
+      const windowEnd = await crowdfund.windowEnd();
 
       // time.increaseTo mines a block at the given timestamp, so the next tx
-      // runs at timestamp + 1. To get block.timestamp == commitmentEnd + 30 days
+      // runs at timestamp + 1. To get block.timestamp == windowEnd + 30 days
       // when permissionlessCancel() executes, we target one second earlier.
-      await time.increaseTo(commitmentEnd + BigInt(THIRTY_DAYS) - 1n);
+      await time.increaseTo(windowEnd + BigInt(THIRTY_DAYS) - 1n);
 
       await expect(
         crowdfund.connect(allSigners[2]).permissionlessCancel()
@@ -120,11 +120,11 @@ describe("Crowdfund Adversarial", function () {
 
     it("succeeds at boundary + 1 second", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      const commitmentEnd = await crowdfund.commitmentEnd();
+      await crowdfund.startWindow();
+      const windowEnd = await crowdfund.windowEnd();
 
-      // Mine block at commitmentEnd + 30 days, so next tx runs at + 30 days + 1
-      await time.increaseTo(commitmentEnd + BigInt(THIRTY_DAYS));
+      // Mine block at windowEnd + 30 days, so next tx runs at + 30 days + 1
+      await time.increaseTo(windowEnd + BigInt(THIRTY_DAYS));
 
       await expect(crowdfund.connect(allSigners[2]).permissionlessCancel())
         .to.emit(crowdfund, "SaleCanceled");
@@ -138,36 +138,34 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
 
-      // Past commitmentEnd but within grace period
-      await time.increase(ONE_WEEK + 1);
+      // Past windowEnd but within grace period
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
     });
 
     it("reverts in Setup phase", async function () {
-      // Never started invitations, commitmentEnd is 0
+      // Never started window, windowEnd is 0
       await expect(
         crowdfund.connect(allSigners[1]).permissionlessCancel()
       ).to.be.revertedWith("ArmadaCrowdfund: not in active phase");
     });
 
-    it("succeeds from Phase.Commitment (after someone has committed)", async function () {
+    it("succeeds from Phase.Active (after someone has committed)", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       await fundAndApprove(allSigners[1], USDC(1_000));
       await crowdfund.connect(allSigners[1]).commit(USDC(1_000), 0);
-      expect(await crowdfund.phase()).to.equal(Phase.Commitment);
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
 
-      await time.increase(ONE_WEEK + THIRTY_DAYS + 1);
+      await time.increase(THREE_WEEKS + THIRTY_DAYS + 1);
       await expect(crowdfund.connect(allSigners[2]).permissionlessCancel())
         .to.emit(crowdfund, "SaleCanceled");
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
@@ -175,8 +173,8 @@ describe("Crowdfund Adversarial", function () {
 
     it("reverts if already canceled by admin via finalize()", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + ONE_WEEK + 1);
+      await crowdfund.startWindow();
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize(); // cancels (below MIN_SALE)
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
 
@@ -195,15 +193,14 @@ describe("Crowdfund Adversarial", function () {
     it("sum of allocations + refunds == totalCommitted (70 seeds, pro-rata)", async function () {
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       // All commit at max cap = 70 * $15K = $1.05M > MIN_SALE
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Verify sum of parts
@@ -248,7 +245,7 @@ describe("Crowdfund Adversarial", function () {
       // Setup: 70 seeds → each invites up to 3 hop-1 addresses
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
 
       // Seeds invite hop-1 addresses (use signers 71-140)
       const hop1Addrs = allSigners.slice(71, 141);
@@ -258,8 +255,6 @@ describe("Crowdfund Adversarial", function () {
         await crowdfund.connect(seeds[i]).invite(hop1Addrs[hop1Count].address, 0);
         hop1Count++;
       }
-
-      await time.increase(TWO_WEEKS + 1);
 
       // Seeds commit $15K each
       for (const s of seeds) {
@@ -273,7 +268,7 @@ describe("Crowdfund Adversarial", function () {
         await crowdfund.connect(hop1Addrs[i]).commit(USDC(4_000), 1);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Sum-of-parts check across all participants
@@ -301,14 +296,13 @@ describe("Crowdfund Adversarial", function () {
     it("contract ARM balance covers all allocations after finalization", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       const totalAllocated = await crowdfund.totalAllocated();
@@ -319,14 +313,13 @@ describe("Crowdfund Adversarial", function () {
     it("after all claims, contract balances are non-negative", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // All participants claim
@@ -355,8 +348,7 @@ describe("Crowdfund Adversarial", function () {
   describe("Boundary Conditions", function () {
     it("commit exactly at hop cap succeeds", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       await fundAndApprove(allSigners[1], USDC(15_000));
       await crowdfund.connect(allSigners[1]).commit(USDC(15_000), 0);
@@ -367,8 +359,7 @@ describe("Crowdfund Adversarial", function () {
 
     it("commit over hop cap reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       await fundAndApprove(allSigners[1], USDC(15_010));
       await crowdfund.connect(allSigners[1]).commit(USDC(15_000), 0);
@@ -387,8 +378,7 @@ describe("Crowdfund Adversarial", function () {
       // Let's use 66 seeds at $15K ($990K) + 1 seed at $10K ($10K) = $1,000,000
       const seeds = allSigners.slice(1, 68); // 67 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       // 66 seeds at $15K
       for (let i = 0; i < 66; i++) {
@@ -402,7 +392,7 @@ describe("Crowdfund Adversarial", function () {
       const total = await crowdfund.totalCommitted();
       expect(total).to.equal(USDC(1_000_000));
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
@@ -412,8 +402,7 @@ describe("Crowdfund Adversarial", function () {
       // 66 seeds at $15K = $990K. 1 seed at $9,999.999999 = $999,999.999999 < $1M
       const seeds = allSigners.slice(1, 68);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (let i = 0; i < 66; i++) {
         await fundAndApprove(seeds[i], USDC(15_000));
@@ -427,7 +416,7 @@ describe("Crowdfund Adversarial", function () {
       const total = await crowdfund.totalCommitted();
       expect(total).to.be.lt(USDC(1_000_000));
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
@@ -438,8 +427,7 @@ describe("Crowdfund Adversarial", function () {
       // Need 120 seeds at $15K each = $1,800,000
       const seeds = allSigners.slice(1, 121); // 120 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -449,7 +437,7 @@ describe("Crowdfund Adversarial", function () {
       const total = await crowdfund.totalCommitted();
       expect(total).to.equal(USDC(1_800_000));
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
@@ -460,8 +448,7 @@ describe("Crowdfund Adversarial", function () {
       // 119 seeds at $15K = $1,785,000. 1 seed at $14,999.999999
       const seeds = allSigners.slice(1, 121);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (let i = 0; i < 119; i++) {
         await fundAndApprove(seeds[i], USDC(15_000));
@@ -475,7 +462,7 @@ describe("Crowdfund Adversarial", function () {
       const total = await crowdfund.totalCommitted();
       expect(total).to.be.lt(USDC(1_800_000));
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.saleSize()).to.equal(USDC(1_200_000)); // BASE_SALE
@@ -486,14 +473,13 @@ describe("Crowdfund Adversarial", function () {
       // Rollover from hop-0 leftover should go to treasury (no hop-1 committers = 0 < 30)
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
@@ -508,11 +494,10 @@ describe("Crowdfund Adversarial", function () {
     it("finalize with all whitelisted but 0 committers cancels", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
-      // Nobody commits — just fast-forward through commitment window
-      await time.increase(ONE_WEEK + 1);
+      // Nobody commits — just fast-forward through the active window
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
@@ -520,8 +505,7 @@ describe("Crowdfund Adversarial", function () {
 
     it("commit below MIN_COMMIT ($10 USDC) reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       await fundAndApprove(allSigners[1], USDC(10));
 
@@ -544,7 +528,7 @@ describe("Crowdfund Adversarial", function () {
     it("seed self-invite creates a hop-1 node (permitted in multi-node model)", async function () {
       const seed = allSigners[1];
       await crowdfund.addSeeds([seed.address]);
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
 
       // Seed invites self — creates (seed, 1) node
       await crowdfund.connect(seed).invite(seed.address, 0);
@@ -552,42 +536,39 @@ describe("Crowdfund Adversarial", function () {
       expect(await crowdfund.getInvitesReceived(seed.address, 1)).to.equal(1);
     });
 
-    it("invite reverts at exact invitationEnd (strict < boundary)", async function () {
+    it("invite reverts at exact windowEnd (strict < boundary)", async function () {
       const seed = allSigners[1];
       const invitee = allSigners[2];
       await crowdfund.addSeeds([seed.address]);
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
 
-      const invitationEnd = await crowdfund.invitationEnd();
-      // Warp to exactly invitationEnd — invite should fail (strict <)
-      await time.increaseTo(invitationEnd);
+      const windowEnd = await crowdfund.windowEnd();
+      // Warp to exactly windowEnd — invite should fail (strict <)
+      await time.increaseTo(windowEnd);
       await expect(
         crowdfund.connect(seed).invite(invitee.address, 0)
-      ).to.be.revertedWith("ArmadaCrowdfund: not invitation window");
+      ).to.be.revertedWith("ArmadaCrowdfund: window closed");
     });
 
-    it("invite succeeds 1 second before invitationEnd", async function () {
+    it("invite succeeds 1 second before windowEnd", async function () {
       const seed = allSigners[1];
       const invitee = allSigners[2];
       await crowdfund.addSeeds([seed.address]);
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
 
-      const invitationEnd = await crowdfund.invitationEnd();
-      // Warp to 2 seconds before invitationEnd — next tx executes at invitationEnd - 1
-      await time.increaseTo(invitationEnd - 2n);
+      const windowEnd = await crowdfund.windowEnd();
+      // Warp to 2 seconds before windowEnd — next tx executes at windowEnd - 1
+      await time.increaseTo(windowEnd - 2n);
       await crowdfund.connect(seed).invite(invitee.address, 0);
 
       const p = await crowdfund.participants(invitee.address, 1);
       expect(p.isWhitelisted).to.be.true;
     });
 
-    it("commit succeeds at exact invitationEnd (== commitmentStart)", async function () {
+    it("commit succeeds immediately after startWindow", async function () {
       const seed = allSigners[1];
       await crowdfund.addSeeds([seed.address]);
-      await crowdfund.startInvitations();
-
-      const commitmentStart = await crowdfund.commitmentStart();
-      await time.increaseTo(commitmentStart);
+      await crowdfund.startWindow();
 
       await fundAndApprove(seed, USDC(100));
       await crowdfund.connect(seed).commit(USDC(100), 0);
@@ -602,57 +583,55 @@ describe("Crowdfund Adversarial", function () {
   // ============================================================
 
   describe("Access Control & State Machine", function () {
-    it("commit during Invitation phase (before commitment window) reverts", async function () {
+    it("commit during Setup phase reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
 
-      // We're in invitation phase — commitment window hasn't started
+      // We're in Setup phase — active window hasn't started
       await fundAndApprove(allSigners[1], USDC(15_000));
       await expect(
         crowdfund.connect(allSigners[1]).commit(USDC(15_000), 0)
-      ).to.be.revertedWith("ArmadaCrowdfund: not commitment window");
+      ).to.be.revertedWith("ArmadaCrowdfund: not active");
     });
 
-    it("invite during Commitment phase (after invitation window) reverts", async function () {
+    it("invite after window ends reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1); // past invitation window
+      await crowdfund.startWindow();
+      await time.increase(THREE_WEEKS + 1); // past active window
 
       await expect(
         crowdfund.connect(allSigners[1]).invite(allSigners[2].address, 0)
-      ).to.be.revertedWith("ArmadaCrowdfund: not invitation window");
+      ).to.be.revertedWith("ArmadaCrowdfund: window closed");
     });
 
-    it("finalize before commitment ends reverts", async function () {
+    it("finalize before window ends reverts", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1); // in commitment window
+      await crowdfund.startWindow();
 
       await expect(
         crowdfund.finalize()
-      ).to.be.revertedWith("ArmadaCrowdfund: commitment not ended");
+      ).to.be.revertedWith("ArmadaCrowdfund: window not ended");
     });
 
-    it("addSeeds after invitation starts reverts", async function () {
+    it("addSeeds after week 1 of active window reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
+      await time.increase(ONE_WEEK + 1); // past launch team invite period
 
       await expect(
         crowdfund.addSeeds([allSigners[2].address])
-      ).to.be.revertedWith("ArmadaCrowdfund: wrong phase");
+      ).to.be.revertedWith("ArmadaCrowdfund: seeds only during setup or week 1");
     });
 
     it("claim when phase is Canceled reverts (should use refund)", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       await fundAndApprove(seeds[0], USDC(15_000));
       await crowdfund.connect(seeds[0]).commit(USDC(15_000), 0);
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize(); // should cancel (below MIN_SALE)
 
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
@@ -665,15 +644,14 @@ describe("Crowdfund Adversarial", function () {
     it("refund when phase is Finalized reverts", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
 
@@ -685,8 +663,8 @@ describe("Crowdfund Adversarial", function () {
     it("non-admin cannot finalize", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + ONE_WEEK + 2);
+      await crowdfund.startWindow();
+      await time.increase(THREE_WEEKS + 1);
 
       await expect(
         crowdfund.connect(allSigners[1]).finalize()
@@ -696,14 +674,13 @@ describe("Crowdfund Adversarial", function () {
     it("non-admin cannot withdrawProceeds", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       await expect(
@@ -714,14 +691,13 @@ describe("Crowdfund Adversarial", function () {
     it("double withdrawProceeds reverts after all proceeds withdrawn", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Claims must happen before proceeds withdrawal (lazy eval)
@@ -739,14 +715,13 @@ describe("Crowdfund Adversarial", function () {
     it("double withdrawUnallocatedArm reverts", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       await crowdfund.withdrawUnallocatedArm();
@@ -785,14 +760,13 @@ describe("Crowdfund Adversarial", function () {
     it("non-participant cannot claim", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // outsider never committed
@@ -804,15 +778,14 @@ describe("Crowdfund Adversarial", function () {
     it("whitelisted-but-uncommitted participant cannot claim", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       // Only first 69 seeds commit, seeds[69] does not
       for (let i = 0; i < 69; i++) {
         await fundAndApprove(seeds[i], USDC(15_000));
         await crowdfund.connect(seeds[i]).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       await expect(
@@ -837,7 +810,7 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 54); // 53 seeds (indices 1-53)
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
 
       // Each of the first 52 seeds invites one hop-1 participant (signers 54-105)
       const hop1Invitees: SignerWithAddress[] = [];
@@ -846,8 +819,6 @@ describe("Crowdfund Adversarial", function () {
         await crowdfund.connect(seeds[i]).invite(invitee.address, 0);
         hop1Invitees.push(invitee);
       }
-
-      await time.increase(TWO_WEEKS + 1);
 
       // All 53 seeds commit $15K
       for (const s of seeds) {
@@ -860,7 +831,7 @@ describe("Crowdfund Adversarial", function () {
         await crowdfund.connect(h).commit(USDC(4_000), 1);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Verify hop-0 ceiling: $798K (budget not capped since remaining = $1.14M)
@@ -888,14 +859,13 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Pro-rata: scale = $798K / $1.05M = 0.76
@@ -916,7 +886,7 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 54); // 53 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
 
       const hop1Invitees: SignerWithAddress[] = [];
       for (let i = 0; i < 52; i++) {
@@ -924,8 +894,6 @@ describe("Crowdfund Adversarial", function () {
         await crowdfund.connect(seeds[i]).invite(invitee.address, 0);
         hop1Invitees.push(invitee);
       }
-
-      await time.increase(TWO_WEEKS + 1);
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -936,7 +904,7 @@ describe("Crowdfund Adversarial", function () {
         await crowdfund.connect(h).commit(USDC(4_000), 1);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       const totalAlloc = await crowdfund.totalAllocatedUsdc();
@@ -964,14 +932,13 @@ describe("Crowdfund Adversarial", function () {
       // Deploy the attacker contract
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Verify claim works normally (proving nonReentrant doesn't block legitimate calls)
@@ -988,13 +955,12 @@ describe("Crowdfund Adversarial", function () {
     it("refund() is protected by nonReentrant", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       await fundAndApprove(seeds[0], USDC(15_000));
       await crowdfund.connect(seeds[0]).commit(USDC(15_000), 0);
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize(); // cancels (below MIN_SALE)
 
       // Refund works
@@ -1012,12 +978,11 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Claim some so proceeds accrue
@@ -1038,12 +1003,11 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // First withdrawal works
@@ -1058,8 +1022,7 @@ describe("Crowdfund Adversarial", function () {
     it("commit() is protected by nonReentrant", async function () {
       // Verify commit guard by confirming correct behavior under normal conditions
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       await fundAndApprove(allSigners[1], USDC(15_000));
       await crowdfund.connect(allSigners[1]).commit(USDC(10_000), 0);

--- a/test/crowdfund_integration.ts
+++ b/test/crowdfund_integration.ts
@@ -3,8 +3,7 @@
  *
  * Tests the full Armada crowdfund system:
  * - Setup: seed management, phase transitions
- * - Invitation: hop chains, invite limits, access control
- * - Commitment: USDC escrow, cap enforcement, aggregate tracking
+ * - Active window: invites, commits, cap enforcement
  * - Allocation: elastic expansion, pro-rata, rollover, cancellation
  * - Claims & refunds: ARM distribution, USDC refunds, admin withdrawals
  * - View functions & graph privacy
@@ -18,12 +17,12 @@ import { time } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
 // Phase enum (must match IArmadaCrowdfund.sol)
-const Phase = { Setup: 0, Invitation: 1, Commitment: 2, Finalized: 3, Canceled: 4 };
+const Phase = { Setup: 0, Active: 1, Finalized: 2, Canceled: 3 };
 
 // Time constants
 const ONE_DAY = 86400;
-const TWO_WEEKS = 14 * ONE_DAY;
 const ONE_WEEK = 7 * ONE_DAY;
+const THREE_WEEKS = 21 * ONE_DAY;
 
 // USDC amounts (6 decimals)
 const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
@@ -56,16 +55,16 @@ describe("Crowdfund Integration", function () {
     await usdc.connect(signer).approve(await crowdfund.getAddress(), amount);
   }
 
-  // Setup helper: add seeds and start invitations
+  // Setup helper: add seeds and start the 3-week active window
   async function setupWithSeeds(seeds: SignerWithAddress[]) {
     await crowdfund.addSeeds(seeds.map(s => s.address));
-    await crowdfund.startInvitations();
+    await crowdfund.startWindow();
   }
 
-  // Full setup through commitment phase: seeds, invites, fast-forward to commitment
-  async function setupThroughCommitment(seeds: SignerWithAddress[]) {
+  // Setup through active phase: seeds added and window started.
+  // Commits are permitted immediately after startWindow().
+  async function setupActive(seeds: SignerWithAddress[]) {
     await setupWithSeeds(seeds);
-    await time.increase(TWO_WEEKS + 1); // past invitation window into commitment
   }
 
   beforeEach(async function () {
@@ -167,31 +166,32 @@ describe("Crowdfund Integration", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: already whitelisted");
     });
 
-    it("should reject adding seeds after invitations start", async function () {
+    it("should reject adding seeds after week 1 of active window", async function () {
       await crowdfund.addSeed(seed1.address);
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
+      // Seeds allowed during week 1; fast-forward past launchTeamInviteEnd
+      await time.increase(ONE_WEEK + 1);
       await expect(
         crowdfund.addSeed(seed2.address)
-      ).to.be.revertedWith("ArmadaCrowdfund: wrong phase");
+      ).to.be.revertedWith("ArmadaCrowdfund: seeds only during setup or week 1");
     });
   });
 
   // ============================================================
-  // 2. Invitation Phase
+  // 2. Active Window — Invitations
   // ============================================================
 
-  describe("Invitation Phase", function () {
-    it("should transition to invitation phase", async function () {
+  describe("Active Window — Invitations", function () {
+    it("should transition to active phase", async function () {
       await crowdfund.addSeed(seed1.address);
-      await crowdfund.startInvitations();
-      expect(await crowdfund.phase()).to.equal(Phase.Invitation);
-      expect(await crowdfund.invitationEnd()).to.be.gt(0);
-      expect(await crowdfund.commitmentEnd()).to.be.gt(0);
+      await crowdfund.startWindow();
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
+      expect(await crowdfund.windowEnd()).to.be.gt(0);
     });
 
     it("should reject starting with no seeds", async function () {
       await expect(
-        crowdfund.startInvitations()
+        crowdfund.startWindow()
       ).to.be.revertedWith("ArmadaCrowdfund: no seeds");
     });
 
@@ -263,13 +263,13 @@ describe("Crowdfund Integration", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: not whitelisted");
     });
 
-    it("should reject invites outside invitation window", async function () {
+    it("should reject invites outside active window", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + 1); // past invitation window
+      await time.increase(THREE_WEEKS + 1); // past window end
 
       await expect(
         crowdfund.connect(seed1).invite(hop1a.address, 0)
-      ).to.be.revertedWith("ArmadaCrowdfund: not invitation window");
+      ).to.be.revertedWith("ArmadaCrowdfund: window closed");
     });
 
     it("should track whitelistCount correctly per hop", async function () {
@@ -297,12 +297,12 @@ describe("Crowdfund Integration", function () {
   });
 
   // ============================================================
-  // 3. Commitment Phase
+  // 3. Active Window — Commitments
   // ============================================================
 
-  describe("Commitment Phase", function () {
+  describe("Active Window — Commitments", function () {
     it("should allow whitelisted address to commit USDC", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActive([seed1]);
 
       await crowdfund.connect(seed1).commit(USDC(5_000), 0);
 
@@ -312,7 +312,7 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should allow multiple commits up to cap", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActive([seed1]);
 
       await crowdfund.connect(seed1).commit(USDC(5_000), 0);
       await crowdfund.connect(seed1).commit(USDC(5_000), 0);
@@ -323,7 +323,7 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should enforce per-hop cap ($15K for hop 0)", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActive([seed1]);
 
       await expect(
         crowdfund.connect(seed1).commit(USDC(15_001), 0)
@@ -333,7 +333,6 @@ describe("Crowdfund Integration", function () {
     it("should enforce per-hop cap ($4K for hop 1)", async function () {
       await setupWithSeeds([seed1]);
       await crowdfund.connect(seed1).invite(hop1a.address, 0);
-      await time.increase(TWO_WEEKS + 1);
 
       await expect(
         crowdfund.connect(hop1a).commit(USDC(4_001), 1)
@@ -344,7 +343,6 @@ describe("Crowdfund Integration", function () {
       await setupWithSeeds([seed1]);
       await crowdfund.connect(seed1).invite(hop1a.address, 0);
       await crowdfund.connect(hop1a).invite(hop2a.address, 1);
-      await time.increase(TWO_WEEKS + 1);
 
       await expect(
         crowdfund.connect(hop2a).commit(USDC(1_001), 2)
@@ -352,7 +350,7 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should reject commit from non-whitelisted address", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActive([seed1]);
 
       await fundAndApprove(outsider, USDC(1_000));
       await expect(
@@ -360,16 +358,16 @@ describe("Crowdfund Integration", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: not whitelisted");
     });
 
-    it("should reject commit outside commitment window", async function () {
+    it("should reject commit outside active window", async function () {
       await setupWithSeeds([seed1]);
-      // Still in invitation window, not commitment
+      await time.increase(THREE_WEEKS + 1); // past window end
       await expect(
         crowdfund.connect(seed1).commit(USDC(1_000), 0)
-      ).to.be.revertedWith("ArmadaCrowdfund: not commitment window");
+      ).to.be.revertedWith("ArmadaCrowdfund: not active window");
     });
 
     it("should reject commit below $10 USDC minimum", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActive([seed1]);
 
       await expect(
         crowdfund.connect(seed1).commit(USDC(9), 0)
@@ -381,7 +379,7 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should accept commit of exactly $10 USDC", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActive([seed1]);
 
       await crowdfund.connect(seed1).commit(USDC(10), 0);
       const committed = await crowdfund.getCommitment(seed1.address, 0);
@@ -391,7 +389,6 @@ describe("Crowdfund Integration", function () {
     it("should track aggregate stats correctly", async function () {
       await setupWithSeeds([seed1, seed2]);
       await crowdfund.connect(seed1).invite(hop1a.address, 0);
-      await time.increase(TWO_WEEKS + 1);
 
       await crowdfund.connect(seed1).commit(USDC(10_000), 0);
       await crowdfund.connect(seed2).commit(USDC(8_000), 0);
@@ -409,7 +406,7 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should track unique committers correctly", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActive([seed1]);
 
       // First commit: uniqueCommitters should go from 0 to 1
       await crowdfund.connect(seed1).commit(USDC(1_000), 0);
@@ -424,44 +421,37 @@ describe("Crowdfund Integration", function () {
   });
 
   // ============================================================
-  // 3b. Phase Transition to Commitment
+  // 3b. Phase Stays Active During Window
   // ============================================================
 
-  describe("Phase Transition to Commitment", function () {
-    it("phase is Invitation before first commit", async function () {
-      await setupThroughCommitment([seed1]);
-      expect(await crowdfund.phase()).to.equal(Phase.Invitation);
+  describe("Phase Stays Active During Window", function () {
+    it("phase is Active before any commits", async function () {
+      await setupActive([seed1]);
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
     });
 
-    it("first commit transitions phase to Commitment", async function () {
-      await setupThroughCommitment([seed1]);
+    it("phase stays Active after commits", async function () {
+      await setupActive([seed1, seed2]);
       await crowdfund.connect(seed1).commit(USDC(1_000), 0);
-      expect(await crowdfund.phase()).to.equal(Phase.Commitment);
-    });
-
-    it("phase stays Commitment after subsequent commits", async function () {
-      await setupThroughCommitment([seed1, seed2]);
-      await crowdfund.connect(seed1).commit(USDC(1_000), 0);
-      expect(await crowdfund.phase()).to.equal(Phase.Commitment);
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
 
       await crowdfund.connect(seed2).commit(USDC(1_000), 0);
-      expect(await crowdfund.phase()).to.equal(Phase.Commitment);
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
     });
 
-    it("finalize() works from Phase.Commitment", async function () {
+    it("finalize() works from Phase.Active after window ends", async function () {
       const seeds = allSigners.slice(1, 71);
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      expect(await crowdfund.phase()).to.equal(Phase.Commitment);
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
     });
@@ -473,13 +463,13 @@ describe("Crowdfund Integration", function () {
 
   describe("Allocation Algorithm", function () {
     it("should use BASE_SALE when demand < elastic trigger", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActive([seed1]);
 
       // Commit well below elastic trigger ($1.8M)
       await crowdfund.connect(seed1).commit(USDC(15_000), 0);
       // Need to reach minimum ($1M), so fund many more seeds
       // For this test, let's just check elastic trigger logic with a known total
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
 
       // totalCommitted = $15K, below min → will cancel
       // We need a different approach to test elastic: use enough signers
@@ -495,8 +485,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       // Each seed commits $15K, 80 seeds = $1.2M (above minimum, at base trigger)
       for (const s of seeds.slice(0, 68)) {
@@ -507,7 +496,7 @@ describe("Crowdfund Integration", function () {
       // Wait, that's only $1.02M. Need 67 more to hit $1M. Let's do 67 × $15K = $1,005,000
       // Actually 68 × 15000 = 1,020,000 which is above MIN_SALE of 1,000,000. Good.
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
@@ -528,15 +517,14 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       // 70 seeds × $15K = $1,050,000 total committed (above min, below elastic trigger)
       for (const s of seeds.slice(0, 70)) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // saleSize = BASE_SALE = $1.2M
@@ -557,20 +545,19 @@ describe("Crowdfund Integration", function () {
   // ============================================================
 
   describe("Finalization & Cancellation", function () {
-    it("should finalize successfully after commitment ends", async function () {
+    it("should finalize successfully after window ends", async function () {
       const seeds = allSigners.slice(1, 80);
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
@@ -590,15 +577,14 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       // Only 68 seeds commit — hop-0 ceiling = 70% of $1.14M (netRaise) = $798K
       // 68 * $15K = $1.02M committed (above MIN_SALE), but all in hop-0
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Hop-0 demand ($1.02M) > ceiling ($798K) → over-subscribed.
@@ -607,13 +593,13 @@ describe("Crowdfund Integration", function () {
       expect(leftover).to.be.gt(0);
     });
 
-    it("should reject finalize before commitment ends", async function () {
+    it("should reject finalize before window ends", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + 1); // into commitment window, but not past it
+      // Still within the 3-week active window
 
       await expect(
         crowdfund.finalize()
-      ).to.be.revertedWith("ArmadaCrowdfund: commitment not ended");
+      ).to.be.revertedWith("ArmadaCrowdfund: window not ended");
     });
 
     it("should reject double finalization", async function () {
@@ -622,12 +608,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       await expect(
@@ -636,10 +621,10 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should cancel if below minimum raise", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActive([seed1]);
       await crowdfund.connect(seed1).commit(USDC(15_000), 0); // way below $1M min
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
@@ -664,12 +649,11 @@ describe("Crowdfund Integration", function () {
         await usdc.connect(s).approve(await unfundedCrowdfund.getAddress(), USDC(15_000));
       }
       await unfundedCrowdfund.addSeeds(seeds.map(s => s.address));
-      await unfundedCrowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await unfundedCrowdfund.startWindow();
       for (const s of seeds.slice(0, 68)) {
         await unfundedCrowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
 
       await expect(
         unfundedCrowdfund.finalize()
@@ -689,12 +673,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of seeds.slice(0, 70)) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       const armBefore = await armToken.balanceOf(seeds[0].address);
@@ -719,12 +702,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       await crowdfund.connect(seeds[0]).claim();
@@ -734,11 +716,11 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should allow full refund after cancellation", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActive([seed1]);
       await crowdfund.connect(seed1).commit(USDC(10_000), 0);
 
       const usdcBefore = await usdc.balanceOf(seed1.address);
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize(); // cancels (below min)
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
 
@@ -748,7 +730,7 @@ describe("Crowdfund Integration", function () {
     });
 
     it("should reject refund in wrong phase", async function () {
-      await setupThroughCommitment([seed1]);
+      await setupActive([seed1]);
       await crowdfund.connect(seed1).commit(USDC(10_000), 0);
 
       await expect(
@@ -763,12 +745,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of committers) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Proceeds accrue as participants claim (lazy evaluation)
@@ -792,12 +773,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of committers) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // totalAllocated is hop-level upper bound, totalArmClaimed tracks claims
@@ -822,13 +802,12 @@ describe("Crowdfund Integration", function () {
     it("should return correct aggregate stats during sale", async function () {
       await setupWithSeeds([seed1, seed2]);
       await crowdfund.connect(seed1).invite(hop1a.address, 0);
-      await time.increase(TWO_WEEKS + 1);
       await crowdfund.connect(seed1).commit(USDC(10_000), 0);
 
-      const [tc, phase_, ie, ce] = await crowdfund.getSaleStats();
+      const [tc, phase_, ws, we] = await crowdfund.getSaleStats();
       expect(tc).to.equal(USDC(10_000));
-      expect(ie).to.be.gt(0);
-      expect(ce).to.be.gt(0);
+      expect(ws).to.be.gt(0);
+      expect(we).to.be.gt(0);
     });
 
     it("should expose invite graph during sale (no phase restriction)", async function () {
@@ -845,12 +824,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Seeds have invitedBy = address(0)
@@ -864,12 +842,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       const [alloc, refund, claimed] = await crowdfund.getAllocation(seeds[0].address);
@@ -892,7 +869,7 @@ describe("Crowdfund Integration", function () {
 
       // Setup
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
 
       // Invitations (some seeds invite hop-1 participants)
       // Use remaining signers for hop-1
@@ -906,9 +883,6 @@ describe("Crowdfund Integration", function () {
         await crowdfund.connect(seeds[i]).invite(hop1Signers[hop1Idx].address, 0);
         hop1Idx++;
       }
-
-      // Fast-forward to commitment
-      await time.increase(TWO_WEEKS + 1);
 
       // Commitments
       for (const s of seeds) {
@@ -935,15 +909,14 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
       // 70 × $15K = $1,050,000 > MIN_SALE, < ELASTIC_TRIGGER
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
@@ -977,12 +950,12 @@ describe("Crowdfund Integration", function () {
     });
 
     it("cancellation (below minimum)", async function () {
-      await setupThroughCommitment([seed1, seed2]);
+      await setupActive([seed1, seed2]);
       await crowdfund.connect(seed1).commit(USDC(15_000), 0);
       await crowdfund.connect(seed2).commit(USDC(10_000), 0);
       // Total: $25K << $1M minimum
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
@@ -1007,7 +980,7 @@ describe("Crowdfund Integration", function () {
 
     it("reverts if called before grace period elapses", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + ONE_WEEK + 1); // past commitmentEnd
+      await time.increase(THREE_WEEKS + 1); // past windowEnd
 
       await expect(
         crowdfund.connect(outsider).permissionlessCancel()
@@ -1021,12 +994,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
 
@@ -1039,7 +1011,7 @@ describe("Crowdfund Integration", function () {
 
     it("succeeds after grace period, sets Phase.Canceled, emits SaleCanceled", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + ONE_WEEK + THIRTY_DAYS + 1);
+      await time.increase(THREE_WEEKS + THIRTY_DAYS + 1);
 
       await expect(crowdfund.connect(outsider).permissionlessCancel())
         .to.emit(crowdfund, "SaleCanceled")
@@ -1050,14 +1022,13 @@ describe("Crowdfund Integration", function () {
 
     it("refund() works for all participants after permissionless cancel", async function () {
       await setupWithSeeds([seed1, seed2]);
-      await time.increase(TWO_WEEKS + 1);
       await fundAndApprove(seed1, USDC(15_000));
       await fundAndApprove(seed2, USDC(10_000));
       await crowdfund.connect(seed1).commit(USDC(15_000), 0);
       await crowdfund.connect(seed2).commit(USDC(10_000), 0);
 
-      // Wait past commitment + grace period
-      await time.increase(ONE_WEEK + THIRTY_DAYS + 1);
+      // Wait past window end + grace period
+      await time.increase(THREE_WEEKS + THIRTY_DAYS + 1);
       await crowdfund.connect(outsider).permissionlessCancel();
 
       // Both participants can refund
@@ -1072,7 +1043,7 @@ describe("Crowdfund Integration", function () {
 
     it("finalize() reverts after permissionless cancel", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + ONE_WEEK + THIRTY_DAYS + 1);
+      await time.increase(THREE_WEEKS + THIRTY_DAYS + 1);
       await crowdfund.connect(outsider).permissionlessCancel();
 
       await expect(
@@ -1094,7 +1065,6 @@ describe("Crowdfund Integration", function () {
         crowdfund.connect(seed1).invite(hop1a.address, 0)
       ).to.be.revertedWith("Pausable: paused");
 
-      await time.increase(TWO_WEEKS + 1);
       await expect(
         crowdfund.connect(seed1).commit(USDC(1_000), 0)
       ).to.be.revertedWith("Pausable: paused");
@@ -1108,7 +1078,6 @@ describe("Crowdfund Integration", function () {
       await crowdfund.connect(seed1).invite(hop1a.address, 0);
       expect(await crowdfund.isWhitelisted(hop1a.address, 1)).to.be.true;
 
-      await time.increase(TWO_WEEKS + 1);
       await crowdfund.connect(seed1).commit(USDC(1_000), 0);
       const committed = await crowdfund.getCommitment(seed1.address, 0);
       expect(committed).to.equal(USDC(1_000));
@@ -1120,12 +1089,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       await crowdfund.pause();
@@ -1136,10 +1104,9 @@ describe("Crowdfund Integration", function () {
 
     it("refund() works while paused", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + 1);
       await fundAndApprove(seed1, USDC(1_000));
       await crowdfund.connect(seed1).commit(USDC(1_000), 0);
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize(); // cancels (below MIN_SALE)
 
       await crowdfund.pause();
@@ -1150,7 +1117,7 @@ describe("Crowdfund Integration", function () {
 
     it("finalize() works while paused", async function () {
       await setupWithSeeds([seed1]);
-      await time.increase(TWO_WEEKS + ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
 
       await crowdfund.pause();
       await crowdfund.finalize();
@@ -1182,12 +1149,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Claim ARM

--- a/test/crowdfund_launch_team.ts
+++ b/test/crowdfund_launch_team.ts
@@ -7,12 +7,12 @@ import { time } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
 // Phase enum (must match IArmadaCrowdfund.sol)
-const Phase = { Setup: 0, Invitation: 1, Commitment: 2, Finalized: 3, Canceled: 4 };
+const Phase = { Setup: 0, Active: 1, Finalized: 2, Canceled: 3 };
 
 // Time constants
 const ONE_DAY = 86400;
 const ONE_WEEK = 7 * ONE_DAY;
-const TWO_WEEKS = 14 * ONE_DAY;
+const THREE_WEEKS = 21 * ONE_DAY;
 
 // USDC amounts (6 decimals)
 const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
@@ -112,9 +112,9 @@ describe("Launch Team & Seed Cap", function () {
 
     beforeEach(async function () {
       [, , , invitee1, invitee2, seed1] = allSigners;
-      // Add a seed and start invitations
+      // Add a seed and start the active window
       await crowdfund.addSeed(seed1.address);
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
     });
 
     it("launch team can invite to hop-1", async function () {
@@ -145,7 +145,7 @@ describe("Launch Team & Seed Cap", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: zero address");
     });
 
-    it("reverts before invitations start (Setup phase)", async function () {
+    it("reverts before window starts (Setup phase)", async function () {
       // Deploy a fresh crowdfund still in Setup
       const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
       const freshCrowdfund = await ArmadaCrowdfund.deploy(
@@ -201,7 +201,7 @@ describe("Launch Team & Seed Cap", function () {
   describe("Budget Exhaustion", function () {
     beforeEach(async function () {
       await crowdfund.addSeed(allSigners[3].address);
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
     });
 
     it("allows exactly 60 hop-1 invites", async function () {
@@ -264,7 +264,7 @@ describe("Launch Team & Seed Cap", function () {
   describe("7-Day Invite Window Timing", function () {
     beforeEach(async function () {
       await crowdfund.addSeed(allSigners[3].address);
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
     });
 
     it("launch team invite on day 6 succeeds", async function () {
@@ -281,7 +281,7 @@ describe("Launch Team & Seed Cap", function () {
     });
 
     it("launch team invite at exactly 7 days reverts (boundary)", async function () {
-      // At exactly invitationStart + 7 days, the condition is NOT strictly less than
+      // At exactly windowStart + 7 days, the condition is NOT strictly less than
       await time.increase(7 * ONE_DAY);
       await expect(
         crowdfund.launchTeamInvite(allSigners[4].address, 1)
@@ -289,7 +289,7 @@ describe("Launch Team & Seed Cap", function () {
     });
 
     it("regular seed invites still work after week 1", async function () {
-      // Seeds can invite throughout the full invitation window
+      // Seeds can invite throughout the full active window
       await time.increase(10 * ONE_DAY);
       const seed = allSigners[3];
       await crowdfund.connect(seed).invite(allSigners[4].address, 0);
@@ -300,7 +300,7 @@ describe("Launch Team & Seed Cap", function () {
   describe("Launch Team Cannot Commit", function () {
     beforeEach(async function () {
       await crowdfund.addSeed(allSigners[3].address);
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
     });
 
     it("launch team address cannot commit USDC", async function () {
@@ -322,10 +322,7 @@ describe("Launch Team & Seed Cap", function () {
 
       // Add launchTeam as a seed (admin can do this)
       await cf.addSeed(ltSigner.address);
-      await cf.startInvitations();
-
-      // Fast-forward to commitment window
-      await time.increase(TWO_WEEKS + 1);
+      await cf.startWindow();
 
       // Fund the launch team address
       await fundAndApprove(ltSigner, USDC(15000));
@@ -343,7 +340,7 @@ describe("Launch Team & Seed Cap", function () {
     beforeEach(async function () {
       invitee = allSigners[4];
       await crowdfund.addSeed(allSigners[3].address);
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
     });
 
     it("re-invite to same (address, hop) increments invitesReceived", async function () {

--- a/test/crowdfund_multinode.ts
+++ b/test/crowdfund_multinode.ts
@@ -6,10 +6,10 @@ import { ethers } from "hardhat";
 import { time } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
-const Phase = { Setup: 0, Invitation: 1, Commitment: 2, Finalized: 3, Canceled: 4 };
+const Phase = { Setup: 0, Active: 1, Finalized: 2, Canceled: 3 };
 
 const ONE_DAY = 86400;
-const TWO_WEEKS = 14 * ONE_DAY;
+const THREE_WEEKS = 21 * ONE_DAY;
 
 const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
 const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
@@ -34,7 +34,7 @@ describe("Crowdfund Multi-Node", function () {
 
   async function setupWithSeeds(seeds: SignerWithAddress[]) {
     await crowdfund.addSeeds(seeds.map(s => s.address));
-    await crowdfund.startInvitations();
+    await crowdfund.startWindow();
   }
 
   beforeEach(async function () {
@@ -141,8 +141,6 @@ describe("Crowdfund Multi-Node", function () {
       await crowdfund.connect(seed1).invite(alice.address, 0);
       await crowdfund.connect(seed2).invite(alice.address, 0);
 
-      await time.increase(TWO_WEEKS + 1);
-
       // Alice can commit up to $8000
       await crowdfund.connect(alice).commit(USDC(8_000), 1);
       expect(await crowdfund.getCommitment(alice.address, 1)).to.equal(USDC(8_000));
@@ -153,8 +151,6 @@ describe("Crowdfund Multi-Node", function () {
 
       // One invite → cap = 1 * $4000 = $4000
       await crowdfund.connect(seed1).invite(alice.address, 0);
-
-      await time.increase(TWO_WEEKS + 1);
 
       await expect(
         crowdfund.connect(alice).commit(USDC(4_001), 1)
@@ -259,8 +255,6 @@ describe("Crowdfund Multi-Node", function () {
       expect(await crowdfund.getEffectiveCap(seed1.address, 1)).to.equal(USDC(12_000)); // 3 * $4k
       expect(await crowdfund.getEffectiveCap(seed1.address, 2)).to.equal(USDC(6_000));  // 6 * $1k
 
-      await time.increase(TWO_WEEKS + 1);
-
       // Commit at all three hops
       await crowdfund.connect(seed1).commit(USDC(15_000), 0);
       await crowdfund.connect(seed1).commit(USDC(12_000), 1);
@@ -285,8 +279,6 @@ describe("Crowdfund Multi-Node", function () {
       await setupWithSeeds([seed1]);
       await crowdfund.connect(seed1).invite(seed1.address, 0);
 
-      await time.increase(TWO_WEEKS + 1);
-
       await crowdfund.connect(seed1).commit(USDC(100), 0);
       await crowdfund.connect(seed1).commit(USDC(100), 1);
 
@@ -300,8 +292,6 @@ describe("Crowdfund Multi-Node", function () {
     it("should enforce caps independently per node", async function () {
       await setupWithSeeds([seed1]);
       await crowdfund.connect(seed1).invite(seed1.address, 0);
-
-      await time.increase(TWO_WEEKS + 1);
 
       // Max out hop-0 cap
       await crowdfund.connect(seed1).commit(USDC(15_000), 0);
@@ -340,12 +330,10 @@ describe("Crowdfund Multi-Node", function () {
       // Use many seeds to get above MIN_SALE
       const seeds = signers.slice(1, 80);
       await crowdfund.addSeeds(seeds.map((s: SignerWithAddress) => s.address));
-      await crowdfund.startInvitations();
+      await crowdfund.startWindow();
 
       // seed1 self-invites to hop-1
       await crowdfund.connect(seed1).invite(seed1.address, 0);
-
-      await time.increase(TWO_WEEKS + 1);
 
       // Each seed commits $15k → 79 seeds * $15k = $1.185M
       // seed1 needs extra for hop-1 commit
@@ -358,7 +346,7 @@ describe("Crowdfund Multi-Node", function () {
       // seed1 also commits $4k at hop-1
       await crowdfund.connect(seed1).commit(USDC(4_000), 1);
 
-      await time.increase(ONE_DAY * 7 + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
     }
 
@@ -395,13 +383,11 @@ describe("Crowdfund Multi-Node", function () {
       await setupWithSeeds([seed1]);
       await crowdfund.connect(seed1).invite(seed1.address, 0);
 
-      await time.increase(TWO_WEEKS + 1);
-
       await crowdfund.connect(seed1).commit(USDC(15_000), 0);
       await crowdfund.connect(seed1).commit(USDC(4_000), 1);
 
       // Not enough total → cancel
-      await time.increase(ONE_DAY * 7 + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize(); // below MIN_SALE → Canceled
 
       const usdcBefore = await usdc.balanceOf(seed1.address);
@@ -446,7 +432,7 @@ describe("Crowdfund Multi-Node", function () {
       await setupWithSeeds([seed1]);
       await crowdfund.connect(seed1).invite(alice.address, 0);
 
-      // Should be readable during Invitation phase
+      // Should be readable during Active phase
       const inviter = await crowdfund.getInviteEdge(alice.address, 1);
       expect(inviter).to.equal(seed1.address);
     });

--- a/test/gas_benchmark.ts
+++ b/test/gas_benchmark.ts
@@ -17,8 +17,7 @@ import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
 const ONE_DAY = 86400;
-const TWO_WEEKS = 14 * ONE_DAY;
-const ONE_WEEK = 7 * ONE_DAY;
+const THREE_WEEKS = 21 * ONE_DAY;
 
 const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
 const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
@@ -72,10 +71,7 @@ describe("Gas Benchmarks", function () {
         // Add seeds — all participants are hop-0 for simplicity
         const seeds = allSigners.slice(1, count + 1);
         await crowdfund.addSeeds(seeds.map(s => s.address));
-        await crowdfund.startInvitations();
-
-        // Skip to commitment window
-        await time.increase(TWO_WEEKS + 1);
+        await crowdfund.startWindow();
 
         // Each seed commits $15K (max hop-0 cap)
         // Total: count * $15K. For 50 participants = $750K (below MIN_SALE $1M, would cancel)
@@ -103,8 +99,8 @@ describe("Gas Benchmarks", function () {
           await crowdfund.connect(s).commit(commitAmount, 0);
         }
 
-        // Skip to after commitment window
-        await time.increase(ONE_WEEK + 1);
+        // Skip to after active window
+        await time.increase(THREE_WEEKS + 1);
 
         // Measure finalize gas
         const tx = await crowdfund.finalize();
@@ -233,8 +229,7 @@ describe("Gas Benchmarks", function () {
       const count = 100;
       const seeds = allSigners.slice(1, count + 1);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       for (const s of seeds) {
         await usdc.mint(s.address, USDC(15_000));
@@ -242,7 +237,7 @@ describe("Gas Benchmarks", function () {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
 
-      await time.increase(ONE_WEEK + 1);
+      await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Measure gas for first, middle, and last claims
@@ -493,8 +488,7 @@ describe("Gas Benchmarks", function () {
 
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startInvitations();
-      await time.increase(TWO_WEEKS + 1);
+      await crowdfund.startWindow();
 
       // Fund all seeds
       for (const s of seeds) {


### PR DESCRIPTION
## Summary

- Replace sequential two-phase model (14-day Invitation → 7-day Commitment) with a single 21-day Active window where invites and commits happen concurrently
- `Phase.Invitation` and `Phase.Commitment` collapsed into `Phase.Active`; `Finalized` and `Canceled` shift down by one
- Seeds can be added during Setup or during the first 7 days of the Active window (launch team invite period)
- Fix frontend `HOP_RESERVE_BPS` → `HOP_CEILING_BPS` with correct values `[7000, 4500, 1000]` matching the contract's overlapping ceiling model
- Update stale ABOUTME comments and replace temporal/refactor-referencing comments with evergreen alternatives
- All scripts, tasks, Hardhat tests, and Foundry tests updated for the new model

## Test plan

- [x] Frontend unit tests pass (59/59)
- [ ] `npm run test:crowdfund` — Hardhat integration tests
- [ ] `npm run test:forge` — Foundry fuzz/invariant tests
- [ ] Manual verification via `npm run crowdfund-ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)