### PR TITLE
feat: permissionless finalize, refundMode, and claimRefund

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -89,6 +89,10 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     // ARM pre-load verification
     bool public armLoaded;
 
+    // Post-allocation minimum raise check: true when finalize() ran but
+    // net proceeds fell below MIN_SALE. All USDC is refundable via claimRefund().
+    bool public refundMode;
+
     // ============ Events ============
 
     event SeedAdded(address indexed seed);
@@ -103,6 +107,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     event ProceedsWithdrawn(address indexed treasury, uint256 amount);
     event UnallocatedArmWithdrawn(address indexed treasury, uint256 amount);
     event ArmLoaded(uint256 balance);
+    event SaleFinalizedRefundMode(uint256 totalCommitted, uint256 netProceeds);
 
     // ============ Modifiers ============
 
@@ -341,17 +346,13 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         emit SaleCanceled(totalCommitted);
     }
 
-    /// @notice Finalize the crowdfund: compute allocations or cancel
-    function finalize() external onlyAdmin nonReentrant {
+    /// @notice Finalize the crowdfund: compute allocations.
+    ///         Permissionless — anyone may call once the window has ended and
+    ///         totalCommitted meets the minimum raise.
+    function finalize() external nonReentrant {
         require(block.timestamp > windowEnd, "ArmadaCrowdfund: window not ended");
         require(phase == Phase.Active, "ArmadaCrowdfund: already finalized");
-
-        // Check minimum raise
-        if (totalCommitted < MIN_SALE) {
-            phase = Phase.Canceled;
-            emit SaleCanceled(totalCommitted);
-            return;
-        }
+        require(totalCommitted >= MIN_SALE, "ArmadaCrowdfund: below minimum raise");
 
         // Step 1: Elastic expansion
         if (totalCommitted >= ELASTIC_TRIGGER) {
@@ -359,13 +360,6 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         } else {
             saleSize = BASE_SALE;
         }
-
-        // Ensure contract holds enough ARM
-        uint256 requiredArm = (saleSize * 1e18) / ARM_PRICE;
-        require(
-            armToken.balanceOf(address(this)) >= requiredArm,
-            "ArmadaCrowdfund: insufficient ARM"
-        );
 
         // Step 2: Per-hop allocation (matches spec pseudocode steps 3–6)
         //
@@ -376,6 +370,18 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         // Rollover is unconditional: leftover always flows to the next hop.
 
         (uint256 totalAllocUsdc_, uint256 totalAllocArm_) = _computeHopAllocations(saleSize);
+
+        // Post-allocation minimum raise check: if net proceeds (allocated USDC) fall
+        // below MIN_SALE, enter refundMode. Participants get full USDC refunds via
+        // claimRefund(); no ARM is distributed. This can occur at BASE_SALE when hop-0
+        // is oversubscribed and later hops don't close the gap to $1M. Cannot occur
+        // after expansion (hop-0 ceiling alone exceeds MIN_SALE).
+        if (totalAllocUsdc_ < MIN_SALE) {
+            refundMode = true;
+            phase = Phase.Finalized;
+            emit SaleFinalizedRefundMode(totalCommitted, totalAllocUsdc_);
+            return;
+        }
 
         totalAllocatedUsdc = totalAllocUsdc_;
         totalAllocated = totalAllocArm_;
@@ -392,6 +398,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     /// @dev Allocation is computed lazily from stored hop-level reserves/demands
     function claim() external nonReentrant {
         require(phase == Phase.Finalized, "ArmadaCrowdfund: not finalized");
+        require(!refundMode, "ArmadaCrowdfund: sale in refund mode");
 
         uint256 totalAllocArm = 0;
         uint256 totalAllocUsdc = 0;
@@ -431,10 +438,19 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         emit Claimed(msg.sender, totalAllocArm, totalRefundUsdc);
     }
 
-    /// @notice Full USDC refund if sale was canceled (below minimum).
+    /// @notice Full USDC refund when the sale did not succeed.
     ///         Aggregates across all hops where the caller has committed.
-    function refund() external nonReentrant {
-        require(phase == Phase.Canceled, "ArmadaCrowdfund: not canceled");
+    ///         Three eligibility paths (any one suffices):
+    ///         1. refundMode — finalized but net proceeds below MIN_SALE
+    ///         2. Phase.Canceled — admin or permissionless cancel
+    ///         3. Deadline fallback — window expired, not finalized, below MIN_SALE
+    function claimRefund() external nonReentrant {
+        require(
+            refundMode ||
+            phase == Phase.Canceled ||
+            (block.timestamp > windowEnd && phase != Phase.Finalized && totalCommitted < MIN_SALE),
+            "ArmadaCrowdfund: refund not available"
+        );
 
         uint256 totalAmount = 0;
         bool hasCommitment = false;
@@ -560,6 +576,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         bool claimed
     ) {
         require(phase == Phase.Finalized, "ArmadaCrowdfund: not finalized");
+        require(!refundMode, "ArmadaCrowdfund: sale in refund mode");
 
         uint256 totalAllocArm = 0;
         uint256 totalRefundUsdc = 0;
@@ -592,6 +609,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         bool claimed
     ) {
         require(phase == Phase.Finalized, "ArmadaCrowdfund: not finalized");
+        require(!refundMode, "ArmadaCrowdfund: sale in refund mode");
         Participant storage p = participants[addr][hop];
         if (p.claimed) {
             return (p.allocation, p.refund, true);

--- a/contracts/test/ReentrancyAttacker.sol
+++ b/contracts/test/ReentrancyAttacker.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface ICrowdfundClaim {
     function claim() external;
-    function refund() external;
+    function claimRefund() external;
 }
 
 interface IVotingLockerAttack {
@@ -44,7 +44,7 @@ contract CrowdfundClaimAttacker {
     }
 }
 
-/// @notice Attacker that tries to re-enter ArmadaCrowdfund.refund()
+/// @notice Attacker that tries to re-enter ArmadaCrowdfund.claimRefund()
 contract CrowdfundRefundAttacker {
     ICrowdfundClaim public target;
     uint256 public attackCount;
@@ -54,13 +54,13 @@ contract CrowdfundRefundAttacker {
     }
 
     function attack() external {
-        target.refund();
+        target.claimRefund();
     }
 
     receive() external payable {
         if (attackCount < 1) {
             attackCount++;
-            target.refund();
+            target.claimRefund();
         }
     }
 }

--- a/crowdfund-frontend/src/atoms/crowdfund.ts
+++ b/crowdfund-frontend/src/atoms/crowdfund.ts
@@ -12,6 +12,8 @@ export interface CrowdfundState {
   launchTeamInviteEnd: bigint
   // ARM pre-load status
   armLoaded: boolean
+  // Post-allocation refund mode (totalAllocUsdc < MIN_SALE after finalization)
+  refundMode: boolean
   // Aggregate stats
   totalCommitted: bigint
   saleSize: bigint
@@ -41,6 +43,7 @@ const DEFAULT_STATE: CrowdfundState = {
   windowEnd: 0n,
   launchTeamInviteEnd: 0n,
   armLoaded: false,
+  refundMode: false,
   totalCommitted: 0n,
   saleSize: 0n,
   hopStats: null,

--- a/crowdfund-frontend/src/components/ParticipantPanel.tsx
+++ b/crowdfund-frontend/src/components/ParticipantPanel.tsx
@@ -73,7 +73,7 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
 
   const handleRefund = async () => {
     setIsSubmitting(true)
-    await crowdfund.refund()
+    await crowdfund.claimRefund()
     setIsSubmitting(false)
   }
 

--- a/crowdfund-frontend/src/config/abi.ts
+++ b/crowdfund-frontend/src/config/abi.ts
@@ -18,7 +18,7 @@ export const CROWDFUND_ABI = [
   'function invite(address invitee, uint8 inviterHop) external',
   'function commit(uint256 amount, uint8 hop) external',
   'function claim() external',
-  'function refund() external',
+  'function claimRefund() external',
 
   // State variables (public getters)
   'function phase() view returns (uint8)',
@@ -28,6 +28,7 @@ export const CROWDFUND_ABI = [
   'function treasury() view returns (address)',
   'function paused() view returns (bool)',
   'function armLoaded() view returns (bool)',
+  'function refundMode() view returns (bool)',
   'function totalCommitted() view returns (uint256)',
   'function saleSize() view returns (uint256)',
   'function totalAllocated() view returns (uint256)',
@@ -67,6 +68,7 @@ export const CROWDFUND_ABI = [
   'event InviteAdded(address indexed inviter, address indexed invitee, uint8 hop, uint16 newInviteCount)',
   'event Committed(address indexed participant, uint256 amount, uint256 totalForParticipant, uint8 hop)',
   'event SaleFinalized(uint256 saleSize, uint256 totalAllocUsdc, uint256 totalAllocArm, uint256 treasuryLeftoverUsdc)',
+  'event SaleFinalizedRefundMode(uint256 totalCommitted, uint256 netProceeds)',
   'event SaleCanceled(uint256 totalCommitted)',
   'event Claimed(address indexed participant, uint256 armAmount, uint256 usdcRefund)',
   'event Refunded(address indexed participant, uint256 amount)',

--- a/crowdfund-frontend/src/hooks/useCrowdfund.ts
+++ b/crowdfund-frontend/src/hooks/useCrowdfund.ts
@@ -69,6 +69,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
         usdcBalance,
         armBalance,
         usdcAllowance,
+        isRefundMode,
       ] = await Promise.all([
         contract.phase(),
         contract.admin(),
@@ -85,6 +86,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
         usdc.balanceOf(currentAddress),
         arm.balanceOf(currentAddress),
         usdc.allowance(currentAddress, deployment.contracts.crowdfund),
+        contract.refundMode(),
       ])
 
       const parsedPhase = Number(phase) as Phase
@@ -109,9 +111,9 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
       ])
       const parsedParticipant = parseParticipant(participantData)
 
-      // Fetch allocation if finalized and participant has committed
+      // Fetch allocation if finalized (and not in refund mode) and participant has committed
       let currentAllocation = null
-      if (parsedPhase === 2 && parsedParticipant.committed > 0n) {
+      if (parsedPhase === 2 && !isRefundMode && parsedParticipant.committed > 0n) {
         try {
           const allocResult = await contract.getAllocation(currentAddress)
           currentAllocation = {
@@ -146,6 +148,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
         usdcBalance: BigInt(usdcBalance),
         armBalance: BigInt(armBalance),
         usdcAllowance: BigInt(usdcAllowance),
+        refundMode: isRefundMode as boolean,
         blockTimestamp,
         isLoading: false,
         lastUpdated: Date.now(),
@@ -375,7 +378,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
     () =>
       executeTx('Claiming refund', (signer, dep) => {
         const contract = getCrowdfundContract(dep, signer)
-        return contract.refund()
+        return contract.claimRefund()
       }),
     [executeTx],
   )

--- a/tasks/crowdfund.ts
+++ b/tasks/crowdfund.ts
@@ -155,10 +155,11 @@ task("cf-claim", "Claim ARM allocation and USDC refund")
     const crowdfund = await ethers.getContractAt("ArmadaCrowdfund", deployment.contracts.crowdfund);
     const phase = Number(await crowdfund.phase());
 
-    if (phase === 3) {
-      // Canceled — use refund()
-      await crowdfund.refund();
-      console.log("Full USDC refund claimed (sale was canceled)");
+    const inRefundMode = await crowdfund.refundMode();
+    if (phase === 3 || inRefundMode) {
+      // Canceled or refundMode — use claimRefund()
+      await crowdfund.claimRefund();
+      console.log("Full USDC refund claimed (sale was canceled or in refund mode)");
     } else {
       await crowdfund.claim();
       const [alloc, refund] = await crowdfund.getAllocation(signer.address);

--- a/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
+++ b/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
@@ -45,12 +45,13 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
         crowdfund.startWindow();
     }
 
-    /// @notice Helper: advance past commitment period and cancel via finalize (under-subscribed)
+    /// @notice Helper: advance past commitment period and cancel via permissionlessCancel
     function _cancelViaTooFewCommitments() internal {
-        // Warp past commitment end so finalize() can be called
-        vm.warp(crowdfund.windowEnd() + 1);
-        // No commitments made, so totalCommitted == 0 < MIN_SALE → cancel path
-        crowdfund.finalize();
+        // Warp past window end + grace period so permissionlessCancel() can be called.
+        // finalize() reverts when totalCommitted < MIN_SALE; the cancel path
+        // is handled by permissionlessCancel() or claimRefund() directly.
+        vm.warp(crowdfund.windowEnd() + THIRTY_DAYS + 1);
+        crowdfund.permissionlessCancel();
         assertEq(uint256(crowdfund.phase()), uint256(Phase.Canceled));
     }
 
@@ -145,9 +146,9 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
         fuzzCrowdfund.addSeeds(seeds);
         fuzzCrowdfund.startWindow();
 
-        // Cancel
-        vm.warp(fuzzCrowdfund.windowEnd() + 1);
-        fuzzCrowdfund.finalize();
+        // Cancel via permissionlessCancel (finalize reverts when below MIN_SALE)
+        vm.warp(fuzzCrowdfund.windowEnd() + THIRTY_DAYS + 1);
+        fuzzCrowdfund.permissionlessCancel();
 
         // Recover
         uint256 treasuryBefore = armToken.balanceOf(treasury);

--- a/test-foundry/ArmadaCrowdfundRefundMode.t.sol
+++ b/test-foundry/ArmadaCrowdfundRefundMode.t.sol
@@ -1,0 +1,371 @@
+// ABOUTME: Tests for refundMode — the post-allocation minimum raise check.
+// ABOUTME: Verifies behavior when finalize() succeeds but net proceeds < MIN_SALE.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/crowdfund/ArmadaCrowdfund.sol";
+import "../contracts/crowdfund/IArmadaCrowdfund.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/cctp/MockUSDCV2.sol";
+
+contract ArmadaCrowdfundRefundModeTest is Test {
+    ArmadaCrowdfund public crowdfund;
+    MockUSDCV2 public usdc;
+    ArmadaToken public armToken;
+    address public admin;
+    address public treasury;
+
+    uint256 constant ARM_FUNDING = 1_800_000 * 1e18;
+    uint256 constant MIN_SALE = 1_000_000 * 1e6;
+    uint256 constant THREE_WEEKS = 21 days;
+
+    address[] public seeds;
+
+    function setUp() public {
+        admin = address(this);
+        treasury = address(0xCAFE);
+
+        usdc = new MockUSDCV2("Mock USDC", "USDC");
+        armToken = new ArmadaToken(admin);
+        crowdfund = new ArmadaCrowdfund(
+            address(usdc),
+            address(armToken),
+            admin,
+            treasury,
+            admin
+        );
+
+        armToken.transfer(address(crowdfund), ARM_FUNDING);
+        crowdfund.loadArm();
+
+        // Add 80 seeds for refundMode tests.
+        // 80 × $15K = $1.2M — above MIN_SALE ($1M) but below ELASTIC_TRIGGER ($1.5M).
+        // At BASE_SALE: hop-0 ceiling = 70% × ($1.2M - $60K) = $798K < MIN_SALE → refundMode.
+        for (uint256 i = 0; i < 80; i++) {
+            seeds.push(address(uint160(0xA000 + i)));
+        }
+        crowdfund.addSeeds(seeds);
+        crowdfund.startWindow();
+    }
+
+    /// @notice Helper: each seed commits full $15K at hop-0
+    function _allSeedsCommitFull() internal {
+        for (uint256 i = 0; i < seeds.length; i++) {
+            uint256 amount = 15_000 * 1e6;
+            usdc.mint(seeds[i], amount);
+            vm.startPrank(seeds[i]);
+            usdc.approve(address(crowdfund), amount);
+            crowdfund.commit(amount, 0);
+            vm.stopPrank();
+        }
+    }
+
+    // ============ RefundMode trigger ============
+
+    /// @notice 80 seeds × $15K = $1.2M totalCommitted, all at hop-0.
+    ///         BASE_SALE ($1.2M): available = $1.14M, hop-0 ceiling = 70% × $1.14M = $798K.
+    ///         totalAllocUsdc = $798K < $1M = MIN_SALE → refundMode.
+    function test_refundMode_triggers_whenAllocBelowMinSale() public {
+        _allSeedsCommitFull();
+        vm.warp(crowdfund.windowEnd() + 1);
+
+        crowdfund.finalize();
+
+        assertEq(uint256(crowdfund.phase()), uint256(Phase.Finalized));
+        assertTrue(crowdfund.refundMode());
+        // In refundMode, allocations are NOT recorded
+        assertEq(crowdfund.totalAllocated(), 0);
+        assertEq(crowdfund.totalAllocatedUsdc(), 0);
+    }
+
+    /// @notice claim() reverts in refundMode
+    function test_claim_revertsInRefundMode() public {
+        _allSeedsCommitFull();
+        vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
+
+        vm.prank(seeds[0]);
+        vm.expectRevert("ArmadaCrowdfund: sale in refund mode");
+        crowdfund.claim();
+    }
+
+    /// @notice claimRefund() returns full deposited USDC in refundMode
+    function test_claimRefund_returnsFullUsdc_inRefundMode() public {
+        _allSeedsCommitFull();
+        vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
+
+        uint256 balBefore = usdc.balanceOf(seeds[0]);
+        vm.prank(seeds[0]);
+        crowdfund.claimRefund();
+        uint256 balAfter = usdc.balanceOf(seeds[0]);
+
+        assertEq(balAfter - balBefore, 15_000 * 1e6, "Should refund full committed amount");
+    }
+
+    /// @notice Double claimRefund reverts
+    function test_claimRefund_doubleCallReverts_inRefundMode() public {
+        _allSeedsCommitFull();
+        vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
+
+        vm.prank(seeds[0]);
+        crowdfund.claimRefund();
+
+        vm.prank(seeds[0]);
+        vm.expectRevert("ArmadaCrowdfund: already refunded");
+        crowdfund.claimRefund();
+    }
+
+    /// @notice All ARM is recoverable via withdrawUnallocatedArm in refundMode
+    function test_withdrawUnallocatedArm_refundMode_returnsAllArm() public {
+        _allSeedsCommitFull();
+        vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
+
+        uint256 treasuryBefore = armToken.balanceOf(treasury);
+        crowdfund.withdrawUnallocatedArm();
+        uint256 treasuryAfter = armToken.balanceOf(treasury);
+
+        assertEq(treasuryAfter - treasuryBefore, ARM_FUNDING, "All ARM should be swept");
+    }
+
+    /// @notice withdrawProceeds reverts in refundMode (no proceeds accrued)
+    function test_withdrawProceeds_revertsInRefundMode() public {
+        _allSeedsCommitFull();
+        vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
+
+        vm.expectRevert("ArmadaCrowdfund: no proceeds");
+        crowdfund.withdrawProceeds();
+    }
+
+    /// @notice getAllocation reverts in refundMode
+    function test_getAllocation_revertsInRefundMode() public {
+        _allSeedsCommitFull();
+        vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
+
+        vm.expectRevert("ArmadaCrowdfund: sale in refund mode");
+        crowdfund.getAllocation(seeds[0]);
+    }
+
+    /// @notice getAllocationAtHop reverts in refundMode
+    function test_getAllocationAtHop_revertsInRefundMode() public {
+        _allSeedsCommitFull();
+        vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
+
+        vm.expectRevert("ArmadaCrowdfund: sale in refund mode");
+        crowdfund.getAllocationAtHop(seeds[0], 0);
+    }
+
+    // ============ RefundMode cannot happen after expansion ============
+
+    /// @notice When totalCommitted >= ELASTIC_TRIGGER, MAX_SALE is used.
+    ///         Hop-0 ceiling = 70% × ($1.8M - $90K) = $1,197K > MIN_SALE.
+    ///         RefundMode cannot trigger after expansion.
+    function test_refundMode_cannotHappenAfterExpansion() public {
+        // Deploy a fresh crowdfund with 100 seeds to reach ELASTIC_TRIGGER
+        ArmadaCrowdfund cf2 = new ArmadaCrowdfund(
+            address(usdc), address(armToken), admin, treasury, admin
+        );
+        armToken.transfer(address(cf2), ARM_FUNDING);
+        cf2.loadArm();
+
+        address[] memory moreSeeds = new address[](100);
+        for (uint256 i = 0; i < 100; i++) {
+            moreSeeds[i] = address(uint160(0xF000 + i));
+        }
+        cf2.addSeeds(moreSeeds);
+        cf2.startWindow();
+
+        // 100 seeds × $15K = $1.5M = ELASTIC_TRIGGER, triggers expansion
+        for (uint256 i = 0; i < 100; i++) {
+            uint256 amount = 15_000 * 1e6;
+            usdc.mint(moreSeeds[i], amount);
+            vm.startPrank(moreSeeds[i]);
+            usdc.approve(address(cf2), amount);
+            cf2.commit(amount, 0);
+            vm.stopPrank();
+        }
+        assertEq(cf2.totalCommitted(), 1_500_000 * 1e6);
+
+        vm.warp(cf2.windowEnd() + 1);
+        cf2.finalize();
+
+        // Expansion prevents refundMode: hop-0 ceiling = $1,197K > $1M
+        assertFalse(cf2.refundMode());
+        assertTrue(cf2.totalAllocatedUsdc() >= MIN_SALE);
+    }
+
+    // ============ Fuzz: claimRefund returns exact committed amount ============
+
+    /// @notice Fuzz: in refundMode, each participant's claimRefund returns their exact deposit
+    function testFuzz_claimRefund_exactAmount(uint256 seedIdx, uint256 commitAmount) public {
+        // Only use first 100 seeds (already set up)
+        seedIdx = bound(seedIdx, 0, seeds.length - 1);
+        commitAmount = bound(commitAmount, 10 * 1e6, 15_000 * 1e6); // MIN_COMMIT to hop-0 cap
+
+        // Commit the fuzzed amount from one seed
+        usdc.mint(seeds[seedIdx], commitAmount);
+        vm.startPrank(seeds[seedIdx]);
+        usdc.approve(address(crowdfund), commitAmount);
+        crowdfund.commit(commitAmount, 0);
+        vm.stopPrank();
+
+        // Need enough total to pass MIN_SALE for finalize to not revert.
+        // Commit from remaining seeds to reach MIN_SALE.
+        uint256 totalSoFar = commitAmount;
+        for (uint256 i = 0; i < seeds.length && totalSoFar < MIN_SALE; i++) {
+            if (i == seedIdx) continue;
+            uint256 amount = 15_000 * 1e6;
+            if (totalSoFar + amount > 1_400_000 * 1e6) {
+                // Cap total at $1.4M to stay at BASE_SALE (below ELASTIC_TRIGGER)
+                // and maximize chance of refundMode
+                amount = 1_400_000 * 1e6 - totalSoFar;
+                if (amount < 10 * 1e6) break;
+            }
+            usdc.mint(seeds[i], amount);
+            vm.startPrank(seeds[i]);
+            usdc.approve(address(crowdfund), amount);
+            crowdfund.commit(amount, 0);
+            vm.stopPrank();
+            totalSoFar += amount;
+        }
+
+        vm.warp(crowdfund.windowEnd() + 1);
+
+        // Try to finalize. If refundMode triggers, verify exact refund.
+        try crowdfund.finalize() {
+            if (crowdfund.refundMode()) {
+                uint256 balBefore = usdc.balanceOf(seeds[seedIdx]);
+                vm.prank(seeds[seedIdx]);
+                crowdfund.claimRefund();
+                uint256 balAfter = usdc.balanceOf(seeds[seedIdx]);
+                assertEq(balAfter - balBefore, commitAmount, "Refund should be exact committed amount");
+            }
+        } catch {
+            // finalize reverted (below MIN_SALE) — not a refundMode scenario
+        }
+    }
+
+    // ============ Permissionless finalize ============
+
+    /// @notice Non-admin can call finalize()
+    function test_finalize_permissionless() public {
+        _allSeedsCommitFull();
+        vm.warp(crowdfund.windowEnd() + 1);
+
+        // Call from a random non-admin address
+        vm.prank(address(0xDEAD));
+        crowdfund.finalize();
+
+        assertEq(uint256(crowdfund.phase()), uint256(Phase.Finalized));
+    }
+
+    /// @notice finalize() reverts when totalCommitted < MIN_SALE
+    function test_finalize_revertsBelowMinSale() public {
+        // Only 1 seed commits $15K — way below MIN_SALE
+        uint256 amount = 15_000 * 1e6;
+        usdc.mint(seeds[0], amount);
+        vm.startPrank(seeds[0]);
+        usdc.approve(address(crowdfund), amount);
+        crowdfund.commit(amount, 0);
+        vm.stopPrank();
+
+        vm.warp(crowdfund.windowEnd() + 1);
+
+        vm.expectRevert("ArmadaCrowdfund: below minimum raise");
+        crowdfund.finalize();
+    }
+
+    // ============ Deadline fallback claimRefund path ============
+
+    /// @notice claimRefund works via deadline fallback (no finalize/cancel needed)
+    function test_claimRefund_deadlineFallback() public {
+        // Commit below MIN_SALE
+        uint256 amount = 15_000 * 1e6;
+        usdc.mint(seeds[0], amount);
+        vm.startPrank(seeds[0]);
+        usdc.approve(address(crowdfund), amount);
+        crowdfund.commit(amount, 0);
+        vm.stopPrank();
+
+        // Window expires, nobody calls finalize or cancel
+        vm.warp(crowdfund.windowEnd() + 1);
+
+        // Participant can self-serve refund
+        uint256 balBefore = usdc.balanceOf(seeds[0]);
+        vm.prank(seeds[0]);
+        crowdfund.claimRefund();
+        uint256 balAfter = usdc.balanceOf(seeds[0]);
+
+        assertEq(balAfter - balBefore, amount, "Should refund full amount via deadline fallback");
+        // Phase stays Active — this is the "zombie Active" state
+        assertEq(uint256(crowdfund.phase()), uint256(Phase.Active));
+    }
+
+    /// @notice claimRefund reverts during active window
+    function test_claimRefund_revertsDuringActiveWindow() public {
+        uint256 amount = 15_000 * 1e6;
+        usdc.mint(seeds[0], amount);
+        vm.startPrank(seeds[0]);
+        usdc.approve(address(crowdfund), amount);
+        crowdfund.commit(amount, 0);
+        vm.stopPrank();
+
+        // Still in active window
+        vm.prank(seeds[0]);
+        vm.expectRevert("ArmadaCrowdfund: refund not available");
+        crowdfund.claimRefund();
+    }
+
+    /// @notice claimRefund reverts after successful finalization (not refundMode)
+    function test_claimRefund_revertsAfterSuccessfulFinalize() public {
+        // Need demand spread across hops so totalAllocUsdc >= MIN_SALE.
+        // At BASE_SALE: hop-0 ceiling = $798K, hop-1 ceiling = $513K.
+        // 53 seeds × $15K = $795K (under hop-0 ceiling → full allocation).
+        // Plus hop-1 participants adding $210K → totalAllocUsdc = $1,005K > $1M.
+        for (uint256 i = 0; i < 53; i++) {
+            uint256 amount = 15_000 * 1e6;
+            usdc.mint(seeds[i], amount);
+            vm.startPrank(seeds[i]);
+            usdc.approve(address(crowdfund), amount);
+            crowdfund.commit(amount, 0);
+            vm.stopPrank();
+        }
+
+        // Create hop-1 participants via seed invites
+        address[] memory hop1Addrs = new address[](53);
+        for (uint256 i = 0; i < 53; i++) {
+            hop1Addrs[i] = address(uint160(0xB000 + i));
+            vm.prank(seeds[i]);
+            crowdfund.invite(hop1Addrs[i], 0);
+        }
+
+        // Hop-1 commits: 53 × $4K = $212K
+        for (uint256 i = 0; i < 53; i++) {
+            uint256 amount = 4_000 * 1e6;
+            usdc.mint(hop1Addrs[i], amount);
+            vm.startPrank(hop1Addrs[i]);
+            usdc.approve(address(crowdfund), amount);
+            crowdfund.commit(amount, 1);
+            vm.stopPrank();
+        }
+
+        vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
+
+        // Verify not in refundMode
+        assertFalse(crowdfund.refundMode());
+        assertEq(uint256(crowdfund.phase()), uint256(Phase.Finalized));
+
+        // claimRefund should revert for a seed that committed
+        vm.prank(seeds[0]);
+        vm.expectRevert("ArmadaCrowdfund: refund not available");
+        crowdfund.claimRefund();
+    }
+}

--- a/test-foundry/CrowdfundFullInvariant.t.sol
+++ b/test-foundry/CrowdfundFullInvariant.t.sol
@@ -33,6 +33,7 @@ contract CrowdfundFullHandler is Test {
     mapping(address => uint8) public ghost_hop;
     bool public ghost_finalized;
     bool public ghost_canceled;
+    bool public ghost_refundMode;
 
     constructor(
         ArmadaCrowdfund _crowdfund,
@@ -137,17 +138,15 @@ contract CrowdfundFullHandler is Test {
         vm.stopPrank();
     }
 
-    /// @dev Finalize the crowdfund
+    /// @dev Finalize the crowdfund (permissionless)
     function finalize() external {
         if (ghost_finalized || ghost_canceled) return;
 
-        vm.prank(admin);
         try crowdfund.finalize() {
             Phase p = crowdfund.phase();
             if (p == Phase.Finalized) {
                 ghost_finalized = true;
-            } else if (p == Phase.Canceled) {
-                ghost_canceled = true;
+                ghost_refundMode = crowdfund.refundMode();
             }
         } catch {}
     }
@@ -307,6 +306,7 @@ contract CrowdfundFullInvariantTest is Test {
     /// @notice After finalization, each participant's alloc + refund equals committed
     function invariant_allocPlusRefundEqualsCommitted() public view {
         if (!handler.ghost_finalized()) return;
+        if (handler.ghost_refundMode()) return; // no allocations in refundMode
 
         uint256 count = handler.getCommittersCount();
         for (uint256 i = 0; i < count; i++) {

--- a/test-foundry/CrowdfundInvariant.t.sol
+++ b/test-foundry/CrowdfundInvariant.t.sol
@@ -26,12 +26,13 @@ contract CrowdfundHandler is Test {
     uint256 public ghost_totalUsdcIn;       // USDC deposited via commit()
     uint256 public ghost_totalArmClaimed;   // ARM withdrawn via claim()
     uint256 public ghost_totalUsdcRefunded; // USDC returned via claim() refunds
-    uint256 public ghost_totalUsdcCancelRefunded; // USDC returned via refund() (canceled)
+    uint256 public ghost_totalUsdcCancelRefunded; // USDC returned via claimRefund() (canceled/refundMode)
     uint256 public ghost_proceedsWithdrawn; // USDC withdrawn via withdrawProceeds()
     uint256 public ghost_unallocArmWithdrawn; // ARM withdrawn via withdrawUnallocatedArm()
     uint256 public ghost_claimCount;        // number of successful claims
     bool public ghost_finalized;
     bool public ghost_canceled;
+    bool public ghost_refundMode;
 
     // Track per-participant committed amounts for sum verification
     mapping(address => uint256) public ghost_committed;
@@ -145,17 +146,15 @@ contract CrowdfundHandler is Test {
         vm.stopPrank();
     }
 
-    /// @dev Finalize the crowdfund (admin)
+    /// @dev Finalize the crowdfund (permissionless)
     function finalize() external {
         if (ghost_finalized || ghost_canceled) return;
 
-        vm.prank(admin);
         try crowdfund.finalize() {
             Phase p = crowdfund.phase();
             if (p == Phase.Finalized) {
                 ghost_finalized = true;
-            } else if (p == Phase.Canceled) {
-                ghost_canceled = true;
+                ghost_refundMode = crowdfund.refundMode();
             }
         } catch {}
     }
@@ -181,9 +180,9 @@ contract CrowdfundHandler is Test {
         } catch {}
     }
 
-    /// @dev Refund for a random committer (if canceled)
-    function refundCanceled(uint256 idx) external {
-        if (!ghost_canceled) return;
+    /// @dev ClaimRefund for a random committer (if canceled or refundMode)
+    function claimRefund(uint256 idx) external {
+        if (!ghost_canceled && !ghost_refundMode) return;
         if (allCommitters.length == 0) return;
         idx = bound(idx, 0, allCommitters.length - 1);
 
@@ -191,7 +190,7 @@ contract CrowdfundHandler is Test {
         uint256 usdcBefore = usdc.balanceOf(claimer);
 
         vm.prank(claimer);
-        try crowdfund.refund() {
+        try crowdfund.claimRefund() {
             uint256 usdcGained = usdc.balanceOf(claimer) - usdcBefore;
             ghost_totalUsdcCancelRefunded += usdcGained;
         } catch {}
@@ -356,6 +355,7 @@ contract CrowdfundInvariantTest is Test {
     /// @notice No participant allocation ever exceeds their commitment (in USDC value)
     function invariant_noOverAllocation() public view {
         if (!handler.ghost_finalized()) return;
+        if (handler.ghost_refundMode()) return; // no allocations in refundMode
 
         uint256 count = handler.getCommittersCount();
         for (uint256 i = 0; i < count; i++) {
@@ -403,6 +403,7 @@ contract CrowdfundInvariantTest is Test {
     /// @notice After finalization, sum of (allocUsdc + refund) for all committers equals totalCommitted
     function invariant_allocPlusRefundEqualsCommitted() public view {
         if (!handler.ghost_finalized()) return;
+        if (handler.ghost_refundMode()) return; // no allocations in refundMode
 
         uint256 count = handler.getCommittersCount();
         for (uint256 i = 0; i < count; i++) {

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -30,8 +30,11 @@ const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
 // Amount of ARM the deployer keeps for governance testing after treasury + crowdfund allocations.
 // Eligible supply ≈ DEPLOYER_KEEP + seed-claimed ARM. Quorum = 20% of eligible.
 // Deployer locks half of DEPLOYER_KEEP. That plus seed claims must exceed quorum.
-// With 1.2M keep: eligible ≈ 1.2M + ~798K claimed = ~2M, quorum = ~400K.
-// Deployer locks 600K > 400K quorum. ✓
+// With 100 seeds × $15K = $1.5M (hits ELASTIC_TRIGGER), MAX_SALE = $1.8M applies.
+// Hop-0 ceiling = 70% × ($1.8M - $90K) = $1,197K. Demand $1.5M > ceiling → pro-rata.
+// Each seed gets $1,197K / 100 = $11,970 ARM. Total claimed = 1,197,000 ARM.
+// Eligible ≈ 1.2M + ~1.197M = ~2.397M, quorum = 20% ≈ ~479K.
+// Deployer locks 600K > 479K quorum. ✓
 const DEPLOYER_KEEP = ARM(1_200_000);
 
 describe("Cross-Contract Integration (Phase 6)", function () {
@@ -59,8 +62,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     const signers = await ethers.getSigners();
     deployer = signers[0];
     treasuryAddr = signers[1];
-    seeds = signers.slice(2, 82);      // 80 seeds
-    hop1Addrs = signers.slice(82, 92); // 10 hop-1
+    seeds = signers.slice(2, 102);      // 100 seeds
+    hop1Addrs = signers.slice(102, 112); // 10 hop-1
 
     // Deploy tokens
     const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
@@ -619,7 +622,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     beforeEach(async function () {
       const signers = await ethers.getSigners();
       localDeployer = signers[0];
-      localSeeds = signers.slice(2, 82); // 80 seeds
+      localSeeds = signers.slice(2, 102); // 100 seeds
 
       // Step 1: Deploy canonical ARM token
       const ArmadaToken = await ethers.getContractFactory("ArmadaToken");

--- a/test/crowdfund_adversarial.ts
+++ b/test/crowdfund_adversarial.ts
@@ -36,6 +36,18 @@ describe("Crowdfund Adversarial", function () {
     await usdc.connect(signer).approve(await crowdfund.getAddress(), amount);
   }
 
+  // Add hop-1 demand to avoid refundMode when testing with seeds-only at hop-0.
+  // At BASE_SALE, hop-0 ceiling ($798K) < MIN_SALE ($1M). Adding 51 hop-1 at $4K
+  // pushes totalAllocUsdc to $1,002K > $1M. Hop-0 allocation math stays unchanged.
+  async function addHop1ForMinSale(seeds: SignerWithAddress[], hop1Pool: SignerWithAddress[]) {
+    const count = Math.min(51, hop1Pool.length, seeds.length);
+    for (let i = 0; i < count; i++) {
+      await crowdfund.connect(seeds[i]).invite(hop1Pool[i].address, 0);
+      await fundAndApprove(hop1Pool[i], USDC(4_000));
+      await crowdfund.connect(hop1Pool[i]).commit(USDC(4_000), 1);
+    }
+  }
+
   beforeEach(async function () {
     allSigners = await ethers.getSigners();
     deployer = allSigners[0];
@@ -172,17 +184,20 @@ describe("Crowdfund Adversarial", function () {
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
     });
 
-    it("reverts if already canceled by admin via finalize()", async function () {
+    it("permissionlessCancel still works when below MIN_SALE (no auto-cancel from finalize)", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
       await crowdfund.startWindow();
       await time.increase(THREE_WEEKS + 1);
-      await crowdfund.finalize(); // cancels (below MIN_SALE)
-      expect(await crowdfund.phase()).to.equal(Phase.Canceled);
-
-      await time.increase(THIRTY_DAYS + 1);
+      // finalize() reverts (below MIN_SALE), phase stays Active
       await expect(
-        crowdfund.connect(allSigners[2]).permissionlessCancel()
-      ).to.be.revertedWith("ArmadaCrowdfund: not in active phase");
+        crowdfund.finalize()
+      ).to.be.revertedWith("ArmadaCrowdfund: below minimum raise");
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
+
+      // permissionlessCancel still works after grace period
+      await time.increase(THIRTY_DAYS + 1);
+      await crowdfund.connect(allSigners[2]).permissionlessCancel();
+      expect(await crowdfund.phase()).to.equal(Phase.Canceled);
     });
   });
 
@@ -201,10 +216,15 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+
+      // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
+      const hop1Pool = allSigners.slice(140, 191);
+      await addHop1ForMinSale(seeds.slice(0, 51), hop1Pool);
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
-      // Verify sum of parts
+      // Verify sum of parts across all participants (seeds + hop-1)
       let sumAllocUsdc = 0n;
       let sumRefund = 0n;
       let sumAllocArm = 0n;
@@ -217,6 +237,14 @@ describe("Crowdfund Adversarial", function () {
         sumAllocUsdc += (USDC(15_000) - refund);
       }
 
+      // Also sum hop-1 allocations
+      for (let i = 0; i < 51; i++) {
+        const [alloc, refund] = await crowdfund.getAllocation(hop1Pool[i].address);
+        sumAllocArm += alloc;
+        sumRefund += refund;
+        sumAllocUsdc += (USDC(4_000) - refund);
+      }
+
       const totalCommitted = await crowdfund.totalCommitted();
       const totalAllocated = await crowdfund.totalAllocated();
       const totalAllocatedUsdc = await crowdfund.totalAllocatedUsdc();
@@ -227,11 +255,12 @@ describe("Crowdfund Adversarial", function () {
       // With lazy eval, totalAllocated/totalAllocatedUsdc are hop-level upper bounds.
       // Individual integer division truncation means sum(individual) <= hop-level total.
       // The difference is at most uniqueCommitters per oversubscribed hop (negligible dust).
+      const totalParticipants = BigInt(seeds.length + 51);
       expect(sumAllocArm).to.be.lte(totalAllocated);
-      expect(sumAllocArm).to.be.gte(totalAllocated - BigInt(seeds.length));
+      expect(sumAllocArm).to.be.gte(totalAllocated - totalParticipants);
 
       expect(sumAllocUsdc).to.be.lte(totalAllocatedUsdc);
-      expect(sumAllocUsdc).to.be.gte(totalAllocatedUsdc - BigInt(seeds.length));
+      expect(sumAllocUsdc).to.be.gte(totalAllocatedUsdc - totalParticipants);
 
       // No participant gets more than their committed amount
       for (const s of seeds) {
@@ -303,6 +332,10 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+
+      // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 191));
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -320,12 +353,20 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+
+      // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
+      const hop1Pool = allSigners.slice(140, 191);
+      await addHop1ForMinSale(seeds.slice(0, 51), hop1Pool);
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
-      // All participants claim
+      // All participants claim (seeds + hop-1)
       for (const s of seeds) {
         await crowdfund.connect(s).claim();
+      }
+      for (let i = 0; i < 51; i++) {
+        await crowdfund.connect(hop1Pool[i]).claim();
       }
 
       // Admin withdraws proceeds and unallocated ARM
@@ -399,7 +440,7 @@ describe("Crowdfund Adversarial", function () {
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
     });
 
-    it("totalCommitted 1 below MIN_SALE cancels", async function () {
+    it("totalCommitted 1 below MIN_SALE causes finalize to revert", async function () {
       // 66 seeds at $15K = $990K. 1 seed at $9,999.999999 = $999,999.999999 < $1M
       const seeds = allSigners.slice(1, 68);
       await crowdfund.addSeeds(seeds.map(s => s.address));
@@ -418,9 +459,12 @@ describe("Crowdfund Adversarial", function () {
       expect(total).to.be.lt(USDC(1_000_000));
 
       await time.increase(THREE_WEEKS + 1);
-      await crowdfund.finalize();
+      await expect(
+        crowdfund.finalize()
+      ).to.be.revertedWith("ArmadaCrowdfund: below minimum raise");
 
-      expect(await crowdfund.phase()).to.equal(Phase.Canceled);
+      // Phase stays Active — participants use claimRefund() via deadline fallback
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
     });
 
     it("totalCommitted exactly at ELASTIC_TRIGGER expands to MAX_SALE", async function () {
@@ -493,16 +537,18 @@ describe("Crowdfund Adversarial", function () {
       expect(uc2).to.equal(0);
     });
 
-    it("finalize with all whitelisted but 0 committers cancels", async function () {
+    it("finalize with all whitelisted but 0 committers reverts", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
       await crowdfund.startWindow();
 
       // Nobody commits — just fast-forward through the active window
       await time.increase(THREE_WEEKS + 1);
-      await crowdfund.finalize();
+      await expect(
+        crowdfund.finalize()
+      ).to.be.revertedWith("ArmadaCrowdfund: below minimum raise");
 
-      expect(await crowdfund.phase()).to.equal(Phase.Canceled);
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
     });
 
     it("commit below MIN_COMMIT ($10 USDC) reverts", async function () {
@@ -625,7 +671,7 @@ describe("Crowdfund Adversarial", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: seeds only during setup or week 1");
     });
 
-    it("claim when phase is Canceled reverts (should use refund)", async function () {
+    it("claim reverts when below minimum (should use claimRefund)", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
       await crowdfund.startWindow();
@@ -634,16 +680,21 @@ describe("Crowdfund Adversarial", function () {
       await crowdfund.connect(seeds[0]).commit(USDC(15_000), 0);
 
       await time.increase(THREE_WEEKS + 1);
-      await crowdfund.finalize(); // should cancel (below MIN_SALE)
+      // finalize reverts (below MIN_SALE), phase stays Active
+      await expect(
+        crowdfund.finalize()
+      ).to.be.revertedWith("ArmadaCrowdfund: below minimum raise");
 
-      expect(await crowdfund.phase()).to.equal(Phase.Canceled);
-
+      // claim() reverts because phase is Active, not Finalized
       await expect(
         crowdfund.connect(seeds[0]).claim()
       ).to.be.revertedWith("ArmadaCrowdfund: not finalized");
+
+      // claimRefund() works via deadline fallback
+      await crowdfund.connect(seeds[0]).claimRefund();
     });
 
-    it("refund when phase is Finalized reverts", async function () {
+    it("claimRefund when phase is Finalized (not refundMode) reverts", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
       await crowdfund.startWindow();
@@ -653,24 +704,32 @@ describe("Crowdfund Adversarial", function () {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
 
+      // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 191));
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
 
       await expect(
-        crowdfund.connect(seeds[0]).refund()
-      ).to.be.revertedWith("ArmadaCrowdfund: not canceled");
+        crowdfund.connect(seeds[0]).claimRefund()
+      ).to.be.revertedWith("ArmadaCrowdfund: refund not available");
     });
 
-    it("non-admin cannot finalize", async function () {
-      const seeds = allSigners.slice(1, 4);
+    it("non-admin can finalize (permissionless)", async function () {
+      const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
       await crowdfund.startWindow();
+
+      for (const s of seeds) {
+        await fundAndApprove(s, USDC(15_000));
+        await crowdfund.connect(s).commit(USDC(15_000), 0);
+      }
       await time.increase(THREE_WEEKS + 1);
 
-      await expect(
-        crowdfund.connect(allSigners[1]).finalize()
-      ).to.be.revertedWith("ArmadaCrowdfund: not admin");
+      // A random non-admin address can finalize
+      await crowdfund.connect(allSigners[71]).finalize();
+      expect(await crowdfund.phase()).to.equal(Phase.Finalized);
     });
 
     it("non-admin cannot withdrawProceeds", async function () {
@@ -699,12 +758,20 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+
+      // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
+      const hop1Pool = allSigners.slice(140, 191);
+      await addHop1ForMinSale(seeds.slice(0, 51), hop1Pool);
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       // Claims must happen before proceeds withdrawal (lazy eval)
       for (const s of seeds) {
         await crowdfund.connect(s).claim();
+      }
+      for (let i = 0; i < 51; i++) {
+        await crowdfund.connect(hop1Pool[i]).claim();
       }
 
       await crowdfund.withdrawProceeds();
@@ -768,6 +835,10 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+
+      // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 191));
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -787,6 +858,10 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(seeds[i], USDC(15_000));
         await crowdfund.connect(seeds[i]).commit(USDC(15_000), 0);
       }
+
+      // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 191));
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -855,11 +930,11 @@ describe("Crowdfund Adversarial", function () {
       expect(treasuryLeftover).to.equal(USDC(197_000));
     });
 
-    it("rollover works with zero committers at receiving hop", async function () {
-      // 68 seeds × $15K = $1.02M >= MIN_SALE, 0 hop-1 committers.
+    it("rollover works with zero committers at hop-2", async function () {
+      // 68 seeds × $15K = $1.02M. Add 51 hop-1 × $4K = $204K for MIN_SALE.
       // Hop-0 demand $1.02M > ceiling $798K → oversubscribed, no leftover from hop-0.
-      // Hop-1 eff ceiling = min($513K + $0, $342K remaining) = $342K, demand = $0 → leftover $342K
-      // Hop-2 eff ceiling = $60K floor + $342K leftover = $402K, demand = $0
+      // Hop-1 eff ceiling = min($513K + $0, $342K remaining) = $342K, demand = $204K → leftover $138K
+      // Hop-2 eff ceiling = $60K floor + $138K leftover = $198K, demand = $0
       // Rollover flows unconditionally through hops regardless of committer count.
 
       const seeds = allSigners.slice(1, 69); // 68 seeds
@@ -870,17 +945,21 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+
+      // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 191));
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
 
-      // saleSize = BASE_SALE = $1.2M (total = $1.02M < $1.5M trigger)
+      // saleSize = BASE_SALE = $1.2M (total = $1.224M < $1.5M trigger)
       // hop2Floor = $60K, available = $1.14M
       // Hop-0 ceiling = $798K, demand = $1.02M → oversubscribed, alloc = $798K, leftover = $0
       // remainingAvailable = $1.14M - $798K = $342K
-      // Hop-1 eff ceiling = min($513K + $0, $342K) = $342K, demand = $0, leftover = $342K
-      // Hop-2 eff ceiling = $60K + $342K = $402K, demand = $0
+      // Hop-1 eff ceiling = min($513K + $0, $342K) = $342K, demand = $204K, leftover = $138K
+      // Hop-2 eff ceiling = $60K + $138K = $198K, demand = $0
 
       const hop0Ceiling = await crowdfund.finalCeilings(0);
       expect(hop0Ceiling).to.equal(USDC(798_000));
@@ -889,20 +968,20 @@ describe("Crowdfund Adversarial", function () {
       expect(hop1Ceiling).to.equal(USDC(342_000));
 
       const hop2Ceiling = await crowdfund.finalCeilings(2);
-      expect(hop2Ceiling).to.equal(USDC(402_000));
+      expect(hop2Ceiling).to.equal(USDC(198_000));
 
-      // Treasury leftover = $1.2M - $798K = $402K
+      // Treasury leftover = $1.2M - ($798K + $204K) = $198K
       const treasuryLeftover = await crowdfund.treasuryLeftoverUsdc();
-      expect(treasuryLeftover).to.equal(USDC(402_000));
+      expect(treasuryLeftover).to.equal(USDC(198_000));
 
       // Key assertion: rollover flowed through hop-1 to hop-2 despite 0 committers
-      // at both hops — unconditional rollover ensures unused capacity always cascades.
+      // at hop-2 — unconditional rollover ensures unused capacity always cascades.
       expect(hop2Ceiling).to.be.gt(USDC(60_000)); // hop-2 got more than just its floor
     });
 
     it("over-subscribed hop-0 produces pro-rata with no rollover", async function () {
       // 70 seeds × $15K = $1.05M. Hop-0 ceiling = 70% of $1.14M = $798K → over-subscribed.
-      // No leftover from hop-0. Hop-1/hop-2 have zero demand.
+      // No leftover from hop-0. Add 51 hop-1 × $4K = $204K for MIN_SALE.
 
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
@@ -912,6 +991,10 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+
+      // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 191));
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -924,10 +1007,11 @@ describe("Crowdfund Adversarial", function () {
 
       // Hop-0 leftover = $0, so hop-1 gets base ceiling only
       // Hop-1 eff ceiling = min($513K + $0, $342K remaining) = $342K
-      // Hop-2 eff ceiling = $60K floor + $342K leftover = $402K
-      // No demand at hop-1/2, so treasury leftover = $1.2M - $798K = $402K
+      // Hop-1 demand = $204K < $342K → under-subscribed, leftover = $138K
+      // Hop-2 eff ceiling = $60K floor + $138K leftover = $198K
+      // Treasury leftover = $1.2M - ($798K + $204K) = $198K
       const treasuryLeftover = await crowdfund.treasuryLeftoverUsdc();
-      expect(treasuryLeftover).to.equal(USDC(402_000));
+      expect(treasuryLeftover).to.equal(USDC(198_000));
     });
 
     it("rollover preserves sum-of-parts invariant: alloc + treasury = saleSize", async function () {
@@ -987,6 +1071,10 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+
+      // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 191));
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -1001,7 +1089,7 @@ describe("Crowdfund Adversarial", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: already claimed");
     });
 
-    it("refund() is protected by nonReentrant", async function () {
+    it("claimRefund() is protected by nonReentrant", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
       await crowdfund.startWindow();
@@ -1010,14 +1098,14 @@ describe("Crowdfund Adversarial", function () {
       await crowdfund.connect(seeds[0]).commit(USDC(15_000), 0);
 
       await time.increase(THREE_WEEKS + 1);
-      await crowdfund.finalize(); // cancels (below MIN_SALE)
+      // finalize reverts (below MIN_SALE) — use deadline fallback
 
-      // Refund works
-      await crowdfund.connect(seeds[0]).refund();
+      // claimRefund works
+      await crowdfund.connect(seeds[0]).claimRefund();
 
-      // Double refund fails
+      // Double claimRefund fails
       await expect(
-        crowdfund.connect(seeds[0]).refund()
+        crowdfund.connect(seeds[0]).claimRefund()
       ).to.be.revertedWith("ArmadaCrowdfund: already refunded");
     });
 
@@ -1031,6 +1119,10 @@ describe("Crowdfund Adversarial", function () {
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+
+      // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 191));
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 

--- a/test/crowdfund_integration.ts
+++ b/test/crowdfund_integration.ts
@@ -67,6 +67,18 @@ describe("Crowdfund Integration", function () {
     await setupWithSeeds(seeds);
   }
 
+  // Add hop-1 demand to avoid refundMode when testing with seeds-only at hop-0.
+  // At BASE_SALE, hop-0 ceiling ($798K) < MIN_SALE ($1M). Adding 51 hop-1 at $4K
+  // pushes totalAllocUsdc to $1,002K > $1M. Hop-0 allocation math stays unchanged.
+  async function addHop1ForMinSale(seeds: SignerWithAddress[], hop1Pool: SignerWithAddress[]) {
+    const count = Math.min(51, hop1Pool.length, seeds.length);
+    for (let i = 0; i < count; i++) {
+      await crowdfund.connect(seeds[i]).invite(hop1Pool[i].address, 0);
+      await fundAndApprove(hop1Pool[i], USDC(4_000));
+      await crowdfund.connect(hop1Pool[i]).commit(USDC(4_000), 1);
+    }
+  }
+
   beforeEach(async function () {
     allSigners = await ethers.getSigners();
     [deployer, seed1, seed2, seed3, hop1a, hop1b, hop1c, hop2a, hop2b, treasury, outsider] = allSigners;
@@ -603,6 +615,8 @@ describe("Crowdfund Integration", function () {
       // Wait, that's only $1.02M. Need 67 more to hit $1M. Let's do 67 × $15K = $1,005,000
       // Actually 68 × 15000 = 1,020,000 which is above MIN_SALE of 1,000,000. Good.
 
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -630,6 +644,8 @@ describe("Crowdfund Integration", function () {
       for (const s of seeds.slice(0, 70)) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
 
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
@@ -664,6 +680,8 @@ describe("Crowdfund Integration", function () {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
 
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -691,6 +709,9 @@ describe("Crowdfund Integration", function () {
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -727,14 +748,17 @@ describe("Crowdfund Integration", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: already finalized");
     });
 
-    it("should cancel if below minimum raise", async function () {
+    it("should revert finalize when below minimum raise", async function () {
       await setupActive([seed1]);
       await crowdfund.connect(seed1).commit(USDC(15_000), 0); // way below $1M min
 
       await time.increase(THREE_WEEKS + 1);
-      await crowdfund.finalize();
+      await expect(
+        crowdfund.finalize()
+      ).to.be.revertedWith("ArmadaCrowdfund: below minimum raise");
 
-      expect(await crowdfund.phase()).to.equal(Phase.Canceled);
+      // Phase stays Active — participants use claimRefund() directly
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
     });
 
     it("should require ARM pre-load before window can open", async function () {
@@ -778,6 +802,7 @@ describe("Crowdfund Integration", function () {
       for (const s of seeds.slice(0, 70)) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -807,6 +832,7 @@ describe("Crowdfund Integration", function () {
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -816,27 +842,25 @@ describe("Crowdfund Integration", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: already claimed");
     });
 
-    it("should allow full refund after cancellation", async function () {
+    it("should allow full refund via deadline fallback (below min, no finalize)", async function () {
       await setupActive([seed1]);
       await crowdfund.connect(seed1).commit(USDC(10_000), 0);
 
       const usdcBefore = await usdc.balanceOf(seed1.address);
       await time.increase(THREE_WEEKS + 1);
-      await crowdfund.finalize(); // cancels (below min)
-      expect(await crowdfund.phase()).to.equal(Phase.Canceled);
-
-      await crowdfund.connect(seed1).refund();
+      // No finalize or cancel — deadline fallback path in claimRefund()
+      await crowdfund.connect(seed1).claimRefund();
       const usdcAfter = await usdc.balanceOf(seed1.address);
       expect(usdcAfter - usdcBefore).to.equal(USDC(10_000));
     });
 
-    it("should reject refund in wrong phase", async function () {
+    it("should reject claimRefund during active window", async function () {
       await setupActive([seed1]);
       await crowdfund.connect(seed1).commit(USDC(10_000), 0);
 
       await expect(
-        crowdfund.connect(seed1).refund()
-      ).to.be.revertedWith("ArmadaCrowdfund: not canceled");
+        crowdfund.connect(seed1).claimRefund()
+      ).to.be.revertedWith("ArmadaCrowdfund: refund not available");
     });
 
     it("should allow admin to withdraw USDC proceeds", async function () {
@@ -850,6 +874,7 @@ describe("Crowdfund Integration", function () {
       for (const s of committers) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -947,6 +972,7 @@ describe("Crowdfund Integration", function () {
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -1017,6 +1043,8 @@ describe("Crowdfund Integration", function () {
       }
       // 70 × $15K = $1,050,000 > MIN_SALE, < ELASTIC_TRIGGER ($1.5M)
 
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
+
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -1045,24 +1073,25 @@ describe("Crowdfund Integration", function () {
       this.skip(); // Requires more than 20 Hardhat default signers
     });
 
-    it("cancellation (below minimum)", async function () {
+    it("cancellation (below minimum) — claimRefund via deadline fallback", async function () {
       await setupActive([seed1, seed2]);
       await crowdfund.connect(seed1).commit(USDC(15_000), 0);
       await crowdfund.connect(seed2).commit(USDC(10_000), 0);
       // Total: $25K << $1M minimum
 
       await time.increase(THREE_WEEKS + 1);
-      await crowdfund.finalize();
+      // finalize() reverts (below MIN_SALE) — participants use claimRefund() directly
+      await expect(
+        crowdfund.finalize()
+      ).to.be.revertedWith("ArmadaCrowdfund: below minimum raise");
 
-      expect(await crowdfund.phase()).to.equal(Phase.Canceled);
-
-      // Both can refund
+      // Both can claimRefund via deadline fallback path
       const usdcBefore1 = await usdc.balanceOf(seed1.address);
-      await crowdfund.connect(seed1).refund();
+      await crowdfund.connect(seed1).claimRefund();
       expect(await usdc.balanceOf(seed1.address) - usdcBefore1).to.equal(USDC(15_000));
 
       const usdcBefore2 = await usdc.balanceOf(seed2.address);
-      await crowdfund.connect(seed2).refund();
+      await crowdfund.connect(seed2).claimRefund();
       expect(await usdc.balanceOf(seed2.address) - usdcBefore2).to.equal(USDC(10_000));
     });
   });
@@ -1094,6 +1123,7 @@ describe("Crowdfund Integration", function () {
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
@@ -1116,7 +1146,7 @@ describe("Crowdfund Integration", function () {
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
     });
 
-    it("refund() works for all participants after permissionless cancel", async function () {
+    it("claimRefund() works for all participants after permissionless cancel", async function () {
       await setupWithSeeds([seed1, seed2]);
       await fundAndApprove(seed1, USDC(15_000));
       await fundAndApprove(seed2, USDC(10_000));
@@ -1127,13 +1157,13 @@ describe("Crowdfund Integration", function () {
       await time.increase(THREE_WEEKS + THIRTY_DAYS + 1);
       await crowdfund.connect(outsider).permissionlessCancel();
 
-      // Both participants can refund
+      // Both participants can claimRefund
       const before1 = await usdc.balanceOf(seed1.address);
-      await crowdfund.connect(seed1).refund();
+      await crowdfund.connect(seed1).claimRefund();
       expect(await usdc.balanceOf(seed1.address) - before1).to.equal(USDC(15_000));
 
       const before2 = await usdc.balanceOf(seed2.address);
-      await crowdfund.connect(seed2).refund();
+      await crowdfund.connect(seed2).claimRefund();
       expect(await usdc.balanceOf(seed2.address) - before2).to.equal(USDC(10_000));
     });
 
@@ -1189,6 +1219,7 @@ describe("Crowdfund Integration", function () {
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
@@ -1198,26 +1229,27 @@ describe("Crowdfund Integration", function () {
       expect(armBalance).to.be.gt(0);
     });
 
-    it("refund() works while paused", async function () {
+    it("claimRefund() works while paused", async function () {
       await setupWithSeeds([seed1]);
       await fundAndApprove(seed1, USDC(1_000));
       await crowdfund.connect(seed1).commit(USDC(1_000), 0);
       await time.increase(THREE_WEEKS + 1);
-      await crowdfund.finalize(); // cancels (below MIN_SALE)
+      // finalize() reverts (below MIN_SALE) — use deadline fallback path
 
       await crowdfund.pause();
       const before = await usdc.balanceOf(seed1.address);
-      await crowdfund.connect(seed1).refund();
+      await crowdfund.connect(seed1).claimRefund();
       expect(await usdc.balanceOf(seed1.address) - before).to.equal(USDC(1_000));
     });
 
-    it("finalize() works while paused", async function () {
+    it("finalize() reverts while paused when below minimum", async function () {
       await setupWithSeeds([seed1]);
       await time.increase(THREE_WEEKS + 1);
 
       await crowdfund.pause();
-      await crowdfund.finalize();
-      expect(await crowdfund.phase()).to.equal(Phase.Canceled);
+      await expect(
+        crowdfund.finalize()
+      ).to.be.revertedWith("ArmadaCrowdfund: below minimum raise");
     });
 
     it("only admin can pause and unpause", async function () {
@@ -1249,6 +1281,7 @@ describe("Crowdfund Integration", function () {
       for (const s of seeds) {
         await crowdfund.connect(s).commit(USDC(15_000), 0);
       }
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 

--- a/test/crowdfund_multinode.ts
+++ b/test/crowdfund_multinode.ts
@@ -325,7 +325,8 @@ describe("Crowdfund Multi-Node", function () {
   // ============================================================
 
   describe("Aggregate Claim", function () {
-    // Helper: create a funded crowdfund with enough demand to finalize
+    // Helper: create a funded crowdfund with enough demand to finalize.
+    // Adds hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE at BASE_SALE).
     async function setupAndFinalize() {
       const signers = await ethers.getSigners();
       // Use many seeds to get above MIN_SALE
@@ -335,6 +336,12 @@ describe("Crowdfund Multi-Node", function () {
 
       // seed1 self-invites to hop-1
       await crowdfund.connect(seed1).invite(seed1.address, 0);
+
+      // Additional hop-1 participants to push totalAllocUsdc above MIN_SALE
+      const hop1Pool = signers.slice(140, 190);
+      for (let i = 0; i < 50; i++) {
+        await crowdfund.connect(seeds[i + 1]).invite(hop1Pool[i].address, 0);
+      }
 
       // Each seed commits $15k → 79 seeds * $15k = $1.185M
       // seed1 needs extra for hop-1 commit
@@ -346,6 +353,13 @@ describe("Crowdfund Multi-Node", function () {
 
       // seed1 also commits $4k at hop-1
       await crowdfund.connect(seed1).commit(USDC(4_000), 1);
+
+      // hop-1 participants commit $4K each → 50 × $4K = $200K
+      // totalAllocUsdc = $798K (hop-0) + $204K (hop-1) = $1,002K > MIN_SALE
+      for (const h of hop1Pool) {
+        await fundAndApprove(h, USDC(4_000));
+        await crowdfund.connect(h).commit(USDC(4_000), 1);
+      }
 
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
@@ -387,12 +401,11 @@ describe("Crowdfund Multi-Node", function () {
       await crowdfund.connect(seed1).commit(USDC(15_000), 0);
       await crowdfund.connect(seed1).commit(USDC(4_000), 1);
 
-      // Not enough total → cancel
+      // Not enough total → finalize reverts, use claimRefund deadline fallback
       await time.increase(THREE_WEEKS + 1);
-      await crowdfund.finalize(); // below MIN_SALE → Canceled
 
       const usdcBefore = await usdc.balanceOf(seed1.address);
-      await crowdfund.connect(seed1).refund();
+      await crowdfund.connect(seed1).claimRefund();
       const usdcAfter = await usdc.balanceOf(seed1.address);
 
       // Full $19k refund (both hops)

--- a/test/gas_benchmark.ts
+++ b/test/gas_benchmark.ts
@@ -44,7 +44,7 @@ describe("Gas Benchmarks", function () {
   // ============================================================
 
   describe("Crowdfund finalize() gas scaling", function () {
-    const participantCounts = [50, 100, 150]; // max 150 seeds (MAX_SEEDS cap)
+    const participantCounts = [70, 100, 150]; // min 67 for MIN_SALE, max 150 (MAX_SEEDS cap)
     const results: { count: number; gas: bigint; perParticipant: bigint }[] = [];
 
     for (const count of participantCounts) {
@@ -75,23 +75,8 @@ describe("Gas Benchmarks", function () {
         await crowdfund.startWindow();
 
         // Each seed commits $15K (max hop-0 cap)
-        // Total: count * $15K. For 50 participants = $750K (below MIN_SALE $1M, would cancel)
-        // For 50 participants, use larger amounts or accept cancellation
-        // We need >= $1M. At $15K/participant, need >= 67 participants.
-        // For count < 67, commit the max cap and it will cancel (we still measure finalize gas)
-        // Actually, for count < 67, totalCommitted < MIN_SALE so finalize() will cancel early
-        // and we won't measure the allocation loop. Instead, let's make all counts reach MIN_SALE.
-        //
-        // Strategy: for small counts, commit more per participant (up to $15K cap)
-        // 50 × $15K = $750K < $1M — not enough. Need at least 67 at $15K.
-        // For count=50, we can't reach $1M with hop-0 cap of $15K.
-        //
-        // Solution: just test counts that can hit MIN_SALE (67+)
-        // But we want to test at 50 too. So we'll skip the min-sale check by
-        // having enough total. Actually the simplest fix: commit $15K each but
-        // for count < 67 the total won't reach MIN_SALE. The finalize() will cancel immediately.
-        //
-        // Let's just measure counts >= 67 for the allocation path and note count=50 for cancel path.
+        // Total: count * $15K. Need >= $1M (MIN_SALE) for finalize() to succeed.
+        // At $15K/participant, need >= 67 participants. All test counts are >= 70.
 
         const commitAmount = USDC(15_000);
         for (const s of seeds) {
@@ -109,9 +94,7 @@ describe("Gas Benchmarks", function () {
         const gasUsed = receipt!.gasUsed;
 
         const totalCommitted = await crowdfund.totalCommitted();
-        const phase = await crowdfund.phase();
-        const minSale = USDC(1_000_000);
-        const isCanceled = totalCommitted < minSale;
+        const isRefundMode = await crowdfund.refundMode();
 
         const perParticipant = gasUsed / BigInt(count);
         results.push({ count, gas: gasUsed, perParticipant });
@@ -120,7 +103,7 @@ describe("Gas Benchmarks", function () {
           `    finalize() | ${count} participants | ` +
           `${gasUsed.toLocaleString()} gas | ` +
           `${perParticipant.toLocaleString()} gas/participant | ` +
-          `${isCanceled ? "CANCELED (below MIN_SALE)" : "FINALIZED"}`
+          `${isRefundMode ? "REFUND_MODE" : "FINALIZED"}`
         );
       });
     }
@@ -133,10 +116,8 @@ describe("Gas Benchmarks", function () {
       console.log("    Participants │ Gas Used      │ Gas/Participant │ Status");
       console.log("    ─────────────┼───────────────┼────────────────┼────────────────");
       for (const r of results) {
-        const totalCommittedUsdc = BigInt(r.count) * 15_000n;
-        const isCanceled = totalCommittedUsdc < 1_000_000n;
         console.log(
-          `    ${String(r.count).padStart(12)} │ ${r.gas.toLocaleString().padStart(13)} │ ${r.perParticipant.toLocaleString().padStart(14)} │ ${isCanceled ? "Canceled" : "Finalized"}`
+          `    ${String(r.count).padStart(12)} │ ${r.gas.toLocaleString().padStart(13)} │ ${r.perParticipant.toLocaleString().padStart(14)} │ Finalized`
         );
       }
 


### PR DESCRIPTION
## Summary

- Remove `onlyAdmin` from `finalize()` — anyone can call it once the window ends and `totalCommitted >= MIN_SALE`
- Add `refundMode` state for the edge case where post-allocation net proceeds (`totalAllocUsdc`) fall below `MIN_SALE` at `BASE_SALE` with oversubscribed hop-0
- Rename `refund()` to `claimRefund()` with three eligibility paths: `refundMode`, `Phase.Canceled`, or deadline fallback (window expired + below `MIN_SALE`)
- Fix `cf-claim` Hardhat task and frontend polling to correctly handle `refundMode`

## Test plan

- [ ] `npm run test:crowdfund` — integration tests updated for permissionless finalize and claimRefund
- [ ] `npm run test:forge` — new `ArmadaCrowdfundRefundMode.t.sol` suite (13 tests) + updated invariant/recovery tests
- [ ] Verify frontend correctly reads `refundMode` from contract and routes to `claimRefund()` when active
- [ ] Verify `cf-claim` task routes to `claimRefund()` in refundMode

🤖 Generated with [Claude Code](https://claude.com/claude-code)