### PR TITLE
feat: settlement rework — security council, atomic proceeds, claim deadline, ARM sweep

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -30,6 +30,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     uint256 public constant WINDOW_DURATION = 21 days;
     uint256 public constant LAUNCH_TEAM_INVITE_PERIOD = 7 days;
     uint256 public constant FINALIZE_GRACE_PERIOD = 30 days;
+    uint256 public constant CLAIM_DEADLINE_DURATION = 1095 days; // 3 years
     uint256 public constant MIN_COMMIT = 10 * 1e6;               // $10 USDC minimum per commit
     uint16 public constant MAX_INVITES_RECEIVED = 10;            // cap on invite stacking per (address, hop) node
     uint8 public constant MAX_SEEDS = 150;                       // max number of seeds (hop-0 participants)
@@ -48,6 +49,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     address public immutable treasury;
     /// @notice Launch team sentinel — issues predeclared invite budgets, not a participant.
     address public immutable launchTeam;
+    /// @notice Security council multisig — can cancel the sale at any pre-finalization phase.
+    address public immutable securityCouncil;
 
     // ============ State ============
     Phase public phase;
@@ -77,10 +80,10 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     uint256 public treasuryLeftoverUsdc; // USDC (6 dec) — unallocated reserve that goes to treasury
 
     // Lazy evaluation accumulators (tracked during claims)
-    uint256 public totalProceedsAccrued; // exact sum of allocUsdc from claims
     uint256 public totalArmClaimed;      // exact sum of allocArm from claims
-    uint256 public proceedsWithdrawnAmount;
-    bool public unallocatedArmWithdrawn;
+
+    // Claim deadline — set at finalization, after which unclaimed ARM is sweepable
+    uint256 public claimDeadline;
 
     // Launch team invite budget tracking
     uint8 public launchTeamHop1Used;
@@ -104,7 +107,6 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     event SaleCanceled(uint256 totalCommitted);
     event Claimed(address indexed participant, uint256 armAmount, uint256 usdcRefund);
     event Refunded(address indexed participant, uint256 amount);
-    event ProceedsWithdrawn(address indexed treasury, uint256 amount);
     event UnallocatedArmWithdrawn(address indexed treasury, uint256 amount);
     event ArmLoaded(uint256 balance);
     event SaleFinalizedRefundMode(uint256 totalCommitted, uint256 netProceeds);
@@ -123,15 +125,24 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
     // ============ Constructor ============
 
-    constructor(address _usdc, address _armToken, address _admin, address _treasury, address _launchTeam) {
+    constructor(
+        address _usdc,
+        address _armToken,
+        address _admin,
+        address _treasury,
+        address _launchTeam,
+        address _securityCouncil
+    ) {
         require(_admin != address(0), "ArmadaCrowdfund: zero admin");
         require(_treasury != address(0), "ArmadaCrowdfund: zero treasury");
         require(_launchTeam != address(0), "ArmadaCrowdfund: zero launchTeam");
+        require(_securityCouncil != address(0), "ArmadaCrowdfund: zero securityCouncil");
         usdc = IERC20(_usdc);
         armToken = IERC20(_armToken);
         admin = _admin;
         treasury = _treasury;
         launchTeam = _launchTeam;
+        securityCouncil = _securityCouncil;
         phase = Phase.Setup;
 
         hopConfigs[0] = HopConfig({ ceilingBps: 7000, capUsdc: 15_000 * 1e6, maxInvites: 3 });
@@ -334,8 +345,18 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
     // ============ Finalization ============
 
-    /// @notice Anyone can cancel the sale if admin hasn't finalized within the grace period
-    /// @dev Prevents permanent fund lockup if admin key is lost or admin is unresponsive
+    /// @notice Security council emergency cancel. Immediate and irreversible.
+    ///         Available at any pre-finalization phase (Setup, Active, or post-window).
+    function cancel() external {
+        require(msg.sender == securityCouncil, "ArmadaCrowdfund: not security council");
+        require(phase != Phase.Finalized, "ArmadaCrowdfund: already finalized");
+        require(phase != Phase.Canceled, "ArmadaCrowdfund: already canceled");
+        phase = Phase.Canceled;
+        emit SaleCanceled(totalCommitted);
+    }
+
+    /// @notice Anyone can cancel the sale if nobody has finalized within the grace period
+    /// @dev Prevents permanent fund lockup if admin key is lost or nobody calls finalize()
     function permissionlessCancel() external {
         require(phase == Phase.Active, "ArmadaCrowdfund: not in active phase");
         require(
@@ -386,7 +407,20 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         totalAllocatedUsdc = totalAllocUsdc_;
         totalAllocated = totalAllocArm_;
         treasuryLeftoverUsdc = saleSize - totalAllocUsdc_;
+        claimDeadline = block.timestamp + CLAIM_DEADLINE_DURATION;
         phase = Phase.Finalized;
+
+        // Push net proceeds to treasury atomically. Contract retains refund USDC.
+        // Pro-rata division rounds each participant's allocUsdc down, making the
+        // sum of individual refunds slightly larger than (totalCommitted - totalAllocUsdc).
+        // Retain a small rounding buffer (1 unit per participant node) so the contract
+        // never runs short on refund payouts. Residual dust (< $0.01) remains
+        // in the contract as the cost of rounding safety.
+        uint256 roundingBuffer = participantNodes.length;
+        uint256 proceedsPush = totalAllocUsdc_ > roundingBuffer
+            ? totalAllocUsdc_ - roundingBuffer
+            : 0;
+        usdc.safeTransfer(treasury, proceedsPush);
 
         emit SaleFinalized(saleSize, totalAllocUsdc_, totalAllocArm_, treasuryLeftoverUsdc);
     }
@@ -395,13 +429,15 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
     /// @notice Claim ARM allocation and USDC refund after finalization.
     ///         Aggregates across all hops where the caller has committed.
+    ///         Proceeds (allocated USDC) are pushed to treasury at finalization, so
+    ///         participants only receive ARM + their pro-rata USDC refund.
     /// @dev Allocation is computed lazily from stored hop-level reserves/demands
     function claim() external nonReentrant {
         require(phase == Phase.Finalized, "ArmadaCrowdfund: not finalized");
         require(!refundMode, "ArmadaCrowdfund: sale in refund mode");
+        require(block.timestamp <= claimDeadline, "ArmadaCrowdfund: claim deadline passed");
 
         uint256 totalAllocArm = 0;
-        uint256 totalAllocUsdc = 0;
         uint256 totalRefundUsdc = 0;
         bool hasCommitment = false;
 
@@ -412,20 +448,18 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
             hasCommitment = true;
             require(!p.claimed, "ArmadaCrowdfund: already claimed");
 
-            (uint256 allocArm, uint256 allocUsdc, uint256 refundUsdc) = _computeAllocation(p.committed, h);
+            (uint256 allocArm, , uint256 refundUsdc) = _computeAllocation(p.committed, h);
 
             p.claimed = true;
             p.allocation = allocArm;    // store for record-keeping
             p.refund = refundUsdc;      // store for record-keeping
 
             totalAllocArm += allocArm;
-            totalAllocUsdc += allocUsdc;
             totalRefundUsdc += refundUsdc;
         }
 
         require(hasCommitment, "ArmadaCrowdfund: no commitment");
 
-        totalProceedsAccrued += totalAllocUsdc;
         totalArmClaimed += totalAllocArm;
 
         if (totalAllocArm > 0) {
@@ -473,40 +507,32 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         emit Refunded(msg.sender, totalAmount);
     }
 
-    /// @notice Admin withdraws USDC sale proceeds to treasury
-    /// @dev Proceeds accrue as participants claim. Can be called multiple times.
-    function withdrawProceeds() external onlyAdmin nonReentrant {
-        require(phase == Phase.Finalized, "ArmadaCrowdfund: not finalized");
-
-        uint256 available = totalProceedsAccrued - proceedsWithdrawnAmount;
-        require(available > 0, "ArmadaCrowdfund: no proceeds");
-
-        proceedsWithdrawnAmount += available;
-        usdc.safeTransfer(treasury, available);
-
-        emit ProceedsWithdrawn(treasury, available);
-    }
-
-    /// @notice Admin withdraws unallocated ARM tokens to treasury
-    /// @dev Uses hop-level totalAllocated (upper bound) minus claimed ARM to compute unallocated.
-    ///      Safe: unallocated = initialFunding - totalAllocated_upper >= 0.
-    function withdrawUnallocatedArm() external onlyAdmin nonReentrant {
+    /// @notice Sweep unallocated or unclaimed ARM to treasury. Permissionless. Callable
+    ///         multiple times — no idempotency flag. Three sweep windows:
+    ///         1. Post-finalization: sweeps unsold ARM immediately (MAX_SALE - totalAllocated)
+    ///         2. Post-claim-deadline: sweeps all remaining ARM (unclaimed participant ARM)
+    ///         3. Post-cancel/refundMode: sweeps all ARM (nothing owed)
+    function withdrawUnallocatedArm() external nonReentrant {
         require(
             phase == Phase.Finalized || phase == Phase.Canceled,
             "ArmadaCrowdfund: not finalized or canceled"
         );
-        require(!unallocatedArmWithdrawn, "ArmadaCrowdfund: already withdrawn");
 
-        unallocatedArmWithdrawn = true;
         uint256 armBalance = armToken.balanceOf(address(this));
-        uint256 armStillOwed = totalAllocated - totalArmClaimed;
-        uint256 unallocated = armBalance - armStillOwed;
-
-        if (unallocated > 0) {
-            armToken.safeTransfer(treasury, unallocated);
+        uint256 armStillOwed;
+        if (phase == Phase.Canceled || refundMode) {
+            armStillOwed = 0;
+        } else if (block.timestamp > claimDeadline) {
+            armStillOwed = 0;
+        } else {
+            armStillOwed = totalAllocated - totalArmClaimed;
         }
+        uint256 sweepable = armBalance - armStillOwed;
+        require(sweepable > 0, "ArmadaCrowdfund: nothing to sweep");
 
-        emit UnallocatedArmWithdrawn(treasury, unallocated);
+        armToken.safeTransfer(treasury, sweepable);
+
+        emit UnallocatedArmWithdrawn(treasury, sweepable);
     }
 
     // ============ Emergency Pause ============

--- a/crowdfund-frontend/src/components/AdminPanel.tsx
+++ b/crowdfund-frontend/src/components/AdminPanel.tsx
@@ -7,7 +7,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
-import { ShieldCheck, Play, Flag, Banknote, Coins, Zap } from 'lucide-react'
+import { ShieldCheck, ShieldAlert, Play, Flag, Coins, Zap } from 'lucide-react'
 import { Phase } from '@/types/crowdfund'
 import type { CrowdfundState } from '@/atoms/crowdfund'
 import type { useCrowdfund } from '@/hooks/useCrowdfund'
@@ -114,9 +114,9 @@ export function AdminPanel({ state, crowdfund }: AdminPanelProps) {
     setIsSubmitting(false)
   }
 
-  const handleWithdrawProceeds = async () => {
+  const handleCancelSale = async () => {
     setIsSubmitting(true)
-    await crowdfund.withdrawProceeds()
+    await crowdfund.cancelSale()
     setIsSubmitting(false)
   }
 
@@ -214,6 +214,19 @@ export function AdminPanel({ state, crowdfund }: AdminPanelProps) {
             {state.armLoaded && state.hopStats && state.hopStats[0].whitelistCount === 0 && (
               <p className="text-xs text-muted-foreground">Add at least one seed first</p>
             )}
+
+            <Separator />
+
+            <Button
+              onClick={handleCancelSale}
+              disabled={isSubmitting}
+              size="sm"
+              variant="destructive"
+              className="w-full gap-2"
+            >
+              <ShieldAlert className="h-4 w-4" />
+              Cancel Sale (Security Council)
+            </Button>
           </>
         )}
 
@@ -232,6 +245,19 @@ export function AdminPanel({ state, crowdfund }: AdminPanelProps) {
             <p className="text-xs text-muted-foreground">
               Only works after the 3-week window has ended.
             </p>
+
+            <Separator />
+
+            <Button
+              onClick={handleCancelSale}
+              disabled={isSubmitting}
+              size="sm"
+              variant="destructive"
+              className="w-full gap-2"
+            >
+              <ShieldAlert className="h-4 w-4" />
+              Cancel Sale (Security Council)
+            </Button>
           </div>
         )}
 
@@ -263,25 +289,19 @@ export function AdminPanel({ state, crowdfund }: AdminPanelProps) {
 
             <div className="flex gap-2">
               <Button
-                onClick={handleWithdrawProceeds}
-                disabled={isSubmitting}
-                size="sm"
-                className="flex-1 gap-1.5"
-              >
-                <Banknote className="h-3.5 w-3.5" />
-                Withdraw Proceeds
-              </Button>
-              <Button
                 onClick={handleWithdrawArm}
                 disabled={isSubmitting}
                 size="sm"
-                variant="outline"
                 className="flex-1 gap-1.5"
               >
                 <Coins className="h-3.5 w-3.5" />
-                Withdraw ARM
+                Sweep Unallocated ARM
               </Button>
             </div>
+
+            <p className="text-xs text-muted-foreground">
+              Proceeds are pushed to treasury at finalization.
+            </p>
           </>
         )}
 

--- a/crowdfund-frontend/src/config/abi.ts
+++ b/crowdfund-frontend/src/config/abi.ts
@@ -8,7 +8,7 @@ export const CROWDFUND_ABI = [
   'function loadArm() external',
   'function startWindow() external',
   'function finalize() external',
-  'function withdrawProceeds() external',
+  'function cancel() external',
   'function withdrawUnallocatedArm() external',
   'function pause() external',
   'function unpause() external',
@@ -42,10 +42,9 @@ export const CROWDFUND_ABI = [
   'function hopConfigs(uint256) view returns (uint16 ceilingBps, uint256 capUsdc, uint8 maxInvites)',
   'function finalCeilings(uint256) view returns (uint256)',
   'function finalDemands(uint256) view returns (uint256)',
-  'function totalProceedsAccrued() view returns (uint256)',
   'function totalArmClaimed() view returns (uint256)',
-  'function proceedsWithdrawnAmount() view returns (uint256)',
-  'function unallocatedArmWithdrawn() view returns (bool)',
+  'function claimDeadline() view returns (uint256)',
+  'function securityCouncil() view returns (address)',
   'function treasuryLeftoverUsdc() view returns (uint256)',
 
   // View functions
@@ -72,7 +71,6 @@ export const CROWDFUND_ABI = [
   'event SaleCanceled(uint256 totalCommitted)',
   'event Claimed(address indexed participant, uint256 armAmount, uint256 usdcRefund)',
   'event Refunded(address indexed participant, uint256 amount)',
-  'event ProceedsWithdrawn(address indexed treasury, uint256 amount)',
   'event UnallocatedArmWithdrawn(address indexed treasury, uint256 amount)',
   'event ArmLoaded(uint256 balance)',
 ] as const

--- a/crowdfund-frontend/src/hooks/useCrowdfund.ts
+++ b/crowdfund-frontend/src/hooks/useCrowdfund.ts
@@ -383,11 +383,11 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
     [executeTx],
   )
 
-  const withdrawProceeds = useCallback(
+  const cancelSale = useCallback(
     () =>
-      executeTx('Withdrawing proceeds', (signer, dep) => {
+      executeTx('Security council cancel', (signer, dep) => {
         const contract = getCrowdfundContract(dep, signer)
-        return contract.withdrawProceeds()
+        return contract.cancel()
       }),
     [executeTx],
   )
@@ -472,7 +472,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
     finalize,
     claim,
     refund,
-    withdrawProceeds,
+    cancelSale,
     withdrawUnallocatedArm,
     // Faucet
     mintUsdc,

--- a/scripts/crowdfund_demo.ts
+++ b/scripts/crowdfund_demo.ts
@@ -79,7 +79,8 @@ async function main() {
     await armToken.getAddress(),
     deployer.address,
     treasuryAddr.address,
-    deployer.address
+    deployer.address,
+    deployer.address        // securityCouncil (demo)
   );
   await crowdfund.waitForDeployment();
 
@@ -207,7 +208,8 @@ async function main() {
     await armToken.getAddress(),
     deployer.address,
     treasuryAddr.address,
-    deployer.address
+    deployer.address,
+    deployer.address        // securityCouncil (demo)
   );
   await cf2.waitForDeployment();
 

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -99,7 +99,7 @@ async function main() {
   console.log("3. Deploying ArmadaCrowdfund...");
   const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
   const crowdfund = await ArmadaCrowdfund.deploy(
-    usdcAddress, armTokenAddress, deployer.address, treasuryAddress, deployer.address, nm.override()
+    usdcAddress, armTokenAddress, deployer.address, treasuryAddress, deployer.address, deployer.address, nm.override()
   );
   await crowdfund.deploymentTransaction()!.wait();
   const crowdfundAddress = await crowdfund.getAddress();

--- a/scripts/full_lifecycle_demo.ts
+++ b/scripts/full_lifecycle_demo.ts
@@ -192,7 +192,8 @@ async function main() {
     await armToken.getAddress(),
     deployer.address,       // admin
     await treasury.getAddress(),  // immutable treasury destination
-    deployer.address        // launchTeam
+    deployer.address,       // launchTeam
+    deployer.address        // securityCouncil (demo: deployer acts as council)
   );
   await crowdfund.waitForDeployment();
   log("DEPLOY", `ArmadaCrowdfund: ${await crowdfund.getAddress()}`);
@@ -373,21 +374,16 @@ async function main() {
   //  PHASE 3: TREASURY RECLAIM
   // ================================================================
 
-  section("PHASE 3: Treasury Reclaim \u2014 Proceeds + Unallocated ARM");
+  section("PHASE 3: Treasury Reclaim \u2014 Unallocated ARM");
 
   const treasuryUsdcBefore = await usdc.balanceOf(await treasury.getAddress());
   const treasuryArmBefore  = await armToken.balanceOf(await treasury.getAddress());
-  log("BEFORE", `Treasury USDC: ${fmtUsdc(treasuryUsdcBefore)}`);
+  log("BEFORE", `Treasury USDC: ${fmtUsdc(treasuryUsdcBefore)} (proceeds pushed at finalization)`);
   log("BEFORE", `Treasury ARM:  ${fmtArm(treasuryArmBefore)}`);
 
-  // Withdraw USDC proceeds (accrued from claims above)
-  await crowdfund.withdrawProceeds();
-  const proceedsAccrued = await crowdfund.totalProceedsAccrued();
-  log("WITHDRAW", `USDC proceeds withdrawn: ${fmtUsdc(proceedsAccrued)} \u2192 treasury`);
-
-  // Withdraw unallocated ARM
+  // Sweep unallocated ARM (permissionless)
   await crowdfund.withdrawUnallocatedArm();
-  log("WITHDRAW", "Unallocated ARM withdrawn \u2192 treasury");
+  log("WITHDRAW", "Unallocated ARM swept \u2192 treasury");
 
   const treasuryUsdcAfter = await usdc.balanceOf(await treasury.getAddress());
   const treasuryArmAfter  = await armToken.balanceOf(await treasury.getAddress());

--- a/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
+++ b/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
@@ -31,7 +31,8 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
             address(armToken),
             admin,
             treasury,
-            admin
+            admin,
+            admin   // securityCouncil
         );
 
         // Fund ARM tokens and verify pre-load
@@ -67,26 +68,25 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
 
         assertEq(treasuryAfter - treasuryBefore, ARM_FUNDING, "treasury should receive all ARM");
         assertEq(armToken.balanceOf(address(crowdfund)), 0, "crowdfund should have zero ARM");
-        assertTrue(crowdfund.unallocatedArmWithdrawn(), "flag should be set");
     }
 
-    /// @notice Double-call reverts even in Canceled phase
+    /// @notice Double-call reverts when nothing left to sweep
     function test_withdrawUnallocatedArm_canceled_doubleCallReverts() public {
         _cancelViaTooFewCommitments();
 
         crowdfund.withdrawUnallocatedArm();
 
-        vm.expectRevert("ArmadaCrowdfund: already withdrawn");
+        vm.expectRevert("ArmadaCrowdfund: nothing to sweep");
         crowdfund.withdrawUnallocatedArm();
     }
 
-    /// @notice Non-admin cannot call withdrawUnallocatedArm in Canceled phase
-    function test_withdrawUnallocatedArm_canceled_nonAdminReverts() public {
+    /// @notice Anyone can call withdrawUnallocatedArm (permissionless)
+    function test_withdrawUnallocatedArm_canceled_permissionless() public {
         _cancelViaTooFewCommitments();
 
         vm.prank(address(0xBEEF));
-        vm.expectRevert("ArmadaCrowdfund: not admin");
         crowdfund.withdrawUnallocatedArm();
+        assertEq(armToken.balanceOf(address(crowdfund)), 0, "all ARM swept");
     }
 
     // ============ Phase guards: still reverts in pre-finalization phases ============
@@ -99,7 +99,8 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
             address(armToken),
             admin,
             treasury,
-            admin
+            admin,
+            admin   // securityCouncil
         );
 
         vm.expectRevert("ArmadaCrowdfund: not finalized or canceled");
@@ -136,7 +137,8 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
             address(armToken),
             admin,
             treasury,
-            admin
+            admin,
+            admin   // securityCouncil
         );
         armToken.transfer(address(fuzzCrowdfund), funding);
         fuzzCrowdfund.loadArm();

--- a/test-foundry/ArmadaCrowdfundCancel.t.sol
+++ b/test-foundry/ArmadaCrowdfundCancel.t.sol
@@ -30,7 +30,8 @@ contract ArmadaCrowdfundCancelTest is Test {
             address(armToken),
             admin,
             address(0xCAFE), // treasury
-            admin
+            admin,
+            admin             // securityCouncil
         );
 
         // Fund ARM for MAX_SALE and verify pre-load

--- a/test-foundry/ArmadaCrowdfundRefundMode.t.sol
+++ b/test-foundry/ArmadaCrowdfundRefundMode.t.sol
@@ -34,7 +34,8 @@ contract ArmadaCrowdfundRefundModeTest is Test {
             address(armToken),
             admin,
             treasury,
-            admin
+            admin,
+            admin   // securityCouncil
         );
 
         armToken.transfer(address(crowdfund), ARM_FUNDING);
@@ -132,14 +133,17 @@ contract ArmadaCrowdfundRefundModeTest is Test {
         assertEq(treasuryAfter - treasuryBefore, ARM_FUNDING, "All ARM should be swept");
     }
 
-    /// @notice withdrawProceeds reverts in refundMode (no proceeds accrued)
-    function test_withdrawProceeds_revertsInRefundMode() public {
+    /// @notice In refundMode, withdrawUnallocatedArm sweeps all ARM (nothing owed)
+    function test_withdrawUnallocatedArm_sweepsAllInRefundMode() public {
         _allSeedsCommitFull();
         vm.warp(crowdfund.windowEnd() + 1);
         crowdfund.finalize();
 
-        vm.expectRevert("ArmadaCrowdfund: no proceeds");
-        crowdfund.withdrawProceeds();
+        assertTrue(crowdfund.refundMode(), "should be in refund mode");
+        uint256 treasuryBefore = armToken.balanceOf(treasury);
+        crowdfund.withdrawUnallocatedArm();
+        uint256 treasuryAfter = armToken.balanceOf(treasury);
+        assertEq(treasuryAfter - treasuryBefore, ARM_FUNDING, "All ARM should be swept");
     }
 
     /// @notice getAllocation reverts in refundMode
@@ -170,7 +174,7 @@ contract ArmadaCrowdfundRefundModeTest is Test {
     function test_refundMode_cannotHappenAfterExpansion() public {
         // Deploy a fresh crowdfund with 100 seeds to reach ELASTIC_TRIGGER
         ArmadaCrowdfund cf2 = new ArmadaCrowdfund(
-            address(usdc), address(armToken), admin, treasury, admin
+            address(usdc), address(armToken), admin, treasury, admin, admin
         );
         armToken.transfer(address(cf2), ARM_FUNDING);
         cf2.loadArm();

--- a/test-foundry/CrowdfundFullInvariant.t.sol
+++ b/test-foundry/CrowdfundFullInvariant.t.sol
@@ -188,7 +188,8 @@ contract CrowdfundFullInvariantTest is Test {
             address(armToken),
             admin,
             address(0xBEEF), // treasury
-            admin
+            admin,
+            admin             // securityCouncil
         );
 
         // Fund ARM to crowdfund and verify pre-load

--- a/test-foundry/CrowdfundInvariant.t.sol
+++ b/test-foundry/CrowdfundInvariant.t.sol
@@ -27,7 +27,7 @@ contract CrowdfundHandler is Test {
     uint256 public ghost_totalArmClaimed;   // ARM withdrawn via claim()
     uint256 public ghost_totalUsdcRefunded; // USDC returned via claim() refunds
     uint256 public ghost_totalUsdcCancelRefunded; // USDC returned via claimRefund() (canceled/refundMode)
-    uint256 public ghost_proceedsWithdrawn; // USDC withdrawn via withdrawProceeds()
+    uint256 public ghost_proceedsPushed;    // USDC pushed to treasury at finalization
     uint256 public ghost_unallocArmWithdrawn; // ARM withdrawn via withdrawUnallocatedArm()
     uint256 public ghost_claimCount;        // number of successful claims
     bool public ghost_finalized;
@@ -146,15 +146,22 @@ contract CrowdfundHandler is Test {
         vm.stopPrank();
     }
 
-    /// @dev Finalize the crowdfund (permissionless)
+    /// @dev Finalize the crowdfund (permissionless).
+    ///      Proceeds are pushed to treasury atomically at finalization.
     function finalize() external {
         if (ghost_finalized || ghost_canceled) return;
+
+        address treasury = address(0xBEEF);
+        uint256 usdcBefore = usdc.balanceOf(treasury);
 
         try crowdfund.finalize() {
             Phase p = crowdfund.phase();
             if (p == Phase.Finalized) {
                 ghost_finalized = true;
                 ghost_refundMode = crowdfund.refundMode();
+                // Track proceeds pushed at finalization
+                uint256 usdcGained = usdc.balanceOf(treasury) - usdcBefore;
+                ghost_proceedsPushed += usdcGained;
             }
         } catch {}
     }
@@ -196,26 +203,12 @@ contract CrowdfundHandler is Test {
         } catch {}
     }
 
-    /// @dev Withdraw proceeds (admin)
-    function withdrawProceeds() external {
-        if (!ghost_finalized) return;
-        address treasury = address(0xBEEF);
-        uint256 usdcBefore = usdc.balanceOf(treasury);
-
-        vm.prank(admin);
-        try crowdfund.withdrawProceeds() {
-            uint256 gained = usdc.balanceOf(treasury) - usdcBefore;
-            ghost_proceedsWithdrawn += gained;
-        } catch {}
-    }
-
-    /// @dev Withdraw unallocated ARM (admin)
+    /// @dev Sweep unallocated ARM (permissionless)
     function withdrawUnallocatedArm() external {
-        if (!ghost_finalized) return;
+        if (!ghost_finalized && !ghost_canceled) return;
         address treasury = address(0xBEEF);
         uint256 armBefore = armToken.balanceOf(treasury);
 
-        vm.prank(admin);
         try crowdfund.withdrawUnallocatedArm() {
             uint256 gained = armToken.balanceOf(treasury) - armBefore;
             ghost_unallocArmWithdrawn += gained;
@@ -260,7 +253,8 @@ contract CrowdfundInvariantTest is Test {
             address(armToken),
             admin,
             address(0xBEEF), // treasury
-            admin
+            admin,
+            admin             // securityCouncil
         );
 
         // Fund ARM to crowdfund and verify pre-load
@@ -333,12 +327,12 @@ contract CrowdfundInvariantTest is Test {
 
     // ============ Invariants ============
 
-    /// @notice USDC conservation: contract balance = totalCommitted - claimed refunds - proceeds - cancel refunds
+    /// @notice USDC conservation: contract balance = totalCommitted - claimed refunds - proceeds pushed - cancel refunds
     function invariant_usdcConservation() public view {
         uint256 contractUsdc = usdc.balanceOf(address(crowdfund));
         uint256 expectedUsdc = handler.ghost_totalUsdcIn()
             - handler.ghost_totalUsdcRefunded()
-            - handler.ghost_proceedsWithdrawn()
+            - handler.ghost_proceedsPushed()
             - handler.ghost_totalUsdcCancelRefunded();
         assertEq(contractUsdc, expectedUsdc, "USDC conservation violated");
     }

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -82,7 +82,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await armToken.getAddress(),
       deployer.address,
       treasuryAddr.address,
-      deployer.address
+      deployer.address,
+      deployer.address        // securityCouncil
     );
     await crowdfund.waitForDeployment();
 
@@ -426,12 +427,11 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       expect(await governor.hasVoted(proposalId, alice.address)).to.be.true;
     });
 
-    it("governance proposal calling crowdfund.withdrawProceeds via timelock requires admin role", async function () {
+    it("governance proposal can call permissionless withdrawUnallocatedArm via timelock", async function () {
       await setupCrowdfundAndGovernance();
 
-      // The crowdfund admin is the deployer, NOT the timelock.
-      // A governance proposal that tries to call withdrawProceeds via timelock should fail
-      // because timelock is not the crowdfund admin.
+      // withdrawUnallocatedArm is permissionless, so governance can call it
+      // even though timelock is not the crowdfund admin.
 
       // Seeds lock to create voting power
       for (let i = 0; i < 10; i++) {
@@ -441,17 +441,17 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       }
       await mine(1);
 
-      // Create proposal to withdraw crowdfund proceeds via timelock
-      const withdrawCalldata = crowdfund.interface.encodeFunctionData(
-        "withdrawProceeds"
+      // Create proposal to sweep unallocated ARM via timelock
+      const sweepCalldata = crowdfund.interface.encodeFunctionData(
+        "withdrawUnallocatedArm"
       );
 
       await governor.propose(
         ProposalType.Treasury,
         [await crowdfund.getAddress()],
         [0],
-        [withdrawCalldata],
-        "Attempt to withdraw crowdfund proceeds via governance"
+        [sweepCalldata],
+        "Sweep unallocated ARM to treasury via governance"
       );
       const proposalId = 1;
 
@@ -467,10 +467,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await governor.queue(proposalId);
       await time.increase(TWO_DAYS + 1);
 
-      // Execute should revert because timelock is not the crowdfund admin
-      await expect(
-        governor.execute(proposalId)
-      ).to.be.reverted; // TimelockController will revert because the underlying call fails
+      // Execute succeeds — withdrawUnallocatedArm is permissionless
+      await governor.execute(proposalId);
     });
 
     it("voting power reflects lock state at proposal snapshot, not current state", async function () {
@@ -684,7 +682,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         await localArmToken.getAddress(),
         localDeployer.address,
         await localTreasury.getAddress(),
-        localDeployer.address
+        localDeployer.address,
+        localDeployer.address   // securityCouncil
       );
       await localCrowdfund.waitForDeployment();
 
@@ -802,7 +801,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       expect(quorumAfter).to.be.gt(quorumBefore);
     });
 
-    it("withdrawProceeds sends USDC to treasury contract", async function () {
+    it("finalize pushes USDC proceeds to treasury contract", async function () {
       // Run crowdfund
       await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
       await localCrowdfund.startWindow();
@@ -823,16 +822,13 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       }
 
       const treasuryAddress = await localTreasury.getAddress();
-      const usdcBefore = await localUsdc.balanceOf(treasuryAddress);
 
-      await localCrowdfund.withdrawProceeds();
-
-      const usdcAfter = await localUsdc.balanceOf(treasuryAddress);
-      expect(usdcAfter).to.be.gt(usdcBefore);
-
-      // Proceeds should equal totalProceedsAccrued
-      const proceeds = await localCrowdfund.totalProceedsAccrued();
-      expect(usdcAfter - usdcBefore).to.equal(proceeds);
+      // Proceeds are pushed to treasury at finalization (minus small rounding buffer)
+      const treasuryUsdc = await localUsdc.balanceOf(treasuryAddress);
+      const totalAllocUsdc = await localCrowdfund.totalAllocatedUsdc();
+      // Treasury receives proceeds minus rounding buffer (at most ~participantCount units)
+      expect(treasuryUsdc).to.be.gte(totalAllocUsdc - 500n);
+      expect(treasuryUsdc).to.be.lte(totalAllocUsdc);
     });
 
     it("withdrawUnallocatedArm sends ARM to treasury contract", async function () {

--- a/test/crowdfund_adversarial.ts
+++ b/test/crowdfund_adversarial.ts
@@ -67,7 +67,8 @@ describe("Crowdfund Adversarial", function () {
       await armToken.getAddress(),
       deployer.address,
       treasuryAddr.address,
-      deployer.address
+      deployer.address,
+      deployer.address        // securityCouncil
     );
     await crowdfund.waitForDeployment();
 
@@ -318,9 +319,9 @@ describe("Crowdfund Adversarial", function () {
 
       expect(sumAllocUsdc + sumRefund).to.equal(totalCommitted);
 
-      // Contract USDC balance should cover all refunds + proceeds
+      // Contract USDC balance covers all refunds (plus rounding buffer from proceeds push)
       const contractUsdc = await usdc.balanceOf(await crowdfund.getAddress());
-      expect(contractUsdc).to.equal(totalCommitted);
+      expect(contractUsdc).to.be.gte(sumRefund);
     });
 
     it("contract ARM balance covers all allocations after finalization", async function () {
@@ -369,8 +370,8 @@ describe("Crowdfund Adversarial", function () {
         await crowdfund.connect(hop1Pool[i]).claim();
       }
 
-      // Admin withdraws proceeds and unallocated ARM
-      await crowdfund.withdrawProceeds();
+      // Proceeds already pushed to treasury at finalization.
+      // Sweep unallocated ARM (permissionless).
       await crowdfund.withdrawUnallocatedArm();
 
       // Contract should have ~0 of both tokens (rounding dust at most)
@@ -732,7 +733,7 @@ describe("Crowdfund Adversarial", function () {
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
     });
 
-    it("non-admin cannot withdrawProceeds", async function () {
+    it("non-admin can sweep unallocated ARM (permissionless)", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
       await crowdfund.startWindow();
@@ -744,12 +745,11 @@ describe("Crowdfund Adversarial", function () {
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
-      await expect(
-        crowdfund.connect(allSigners[1]).withdrawProceeds()
-      ).to.be.revertedWith("ArmadaCrowdfund: not admin");
+      // withdrawUnallocatedArm is permissionless — non-admin can call
+      await crowdfund.connect(allSigners[1]).withdrawUnallocatedArm();
     });
 
-    it("double withdrawProceeds reverts after all proceeds withdrawn", async function () {
+    it("withdrawUnallocatedArm second call reverts when nothing to sweep", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
       await crowdfund.startWindow();
@@ -766,38 +766,13 @@ describe("Crowdfund Adversarial", function () {
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
-      // Claims must happen before proceeds withdrawal (lazy eval)
-      for (const s of seeds) {
-        await crowdfund.connect(s).claim();
-      }
-      for (let i = 0; i < 51; i++) {
-        await crowdfund.connect(hop1Pool[i]).claim();
-      }
-
-      await crowdfund.withdrawProceeds();
-
-      await expect(
-        crowdfund.withdrawProceeds()
-      ).to.be.revertedWith("ArmadaCrowdfund: no proceeds");
-    });
-
-    it("double withdrawUnallocatedArm reverts", async function () {
-      const seeds = allSigners.slice(1, 71);
-      await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
-
-      for (const s of seeds) {
-        await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
-      }
-      await time.increase(THREE_WEEKS + 1);
-      await crowdfund.finalize();
-
+      // First sweep: unsold ARM goes to treasury
       await crowdfund.withdrawUnallocatedArm();
 
+      // Second sweep: nothing left (unclaimed ARM still owed)
       await expect(
         crowdfund.withdrawUnallocatedArm()
-      ).to.be.revertedWith("ArmadaCrowdfund: already withdrawn");
+      ).to.be.revertedWith("ArmadaCrowdfund: nothing to sweep");
     });
 
     it("constructor rejects zero admin address", async function () {
@@ -808,6 +783,7 @@ describe("Crowdfund Adversarial", function () {
           await armToken.getAddress(),
           ethers.ZeroAddress,
           treasuryAddr.address,
+          deployer.address,
           deployer.address
         )
       ).to.be.revertedWith("ArmadaCrowdfund: zero admin");
@@ -821,9 +797,24 @@ describe("Crowdfund Adversarial", function () {
           await armToken.getAddress(),
           deployer.address,
           ethers.ZeroAddress,
+          deployer.address,
           deployer.address
         )
       ).to.be.revertedWith("ArmadaCrowdfund: zero treasury");
+    });
+
+    it("constructor rejects zero securityCouncil address", async function () {
+      const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      await expect(
+        ArmadaCrowdfund.deploy(
+          await usdc.getAddress(),
+          await armToken.getAddress(),
+          deployer.address,
+          treasuryAddr.address,
+          deployer.address,
+          ethers.ZeroAddress
+        )
+      ).to.be.revertedWith("ArmadaCrowdfund: zero securityCouncil");
     });
 
     it("non-participant cannot claim", async function () {
@@ -1126,16 +1117,10 @@ describe("Crowdfund Adversarial", function () {
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
-      // Claim some so proceeds accrue
-      await crowdfund.connect(seeds[0]).claim();
-
-      // First withdrawal works
-      await crowdfund.withdrawProceeds();
-
-      // Second withdrawal reverts (no proceeds left)
-      await expect(
-        crowdfund.withdrawProceeds()
-      ).to.be.revertedWith("ArmadaCrowdfund: no proceeds");
+      // Proceeds already pushed at finalization — no withdrawProceeds() needed
+      // Verify treasury received proceeds
+      const treasuryUsdc = await usdc.balanceOf(treasuryAddr.address);
+      expect(treasuryUsdc).to.be.gt(0);
     });
 
     it("withdrawUnallocatedArm() is protected by nonReentrant", async function () {
@@ -1157,7 +1142,7 @@ describe("Crowdfund Adversarial", function () {
       // Second withdrawal reverts
       await expect(
         crowdfund.withdrawUnallocatedArm()
-      ).to.be.revertedWith("ArmadaCrowdfund: already withdrawn");
+      ).to.be.revertedWith("ArmadaCrowdfund: nothing to sweep");
     });
 
     it("commit() is protected by nonReentrant", async function () {

--- a/test/crowdfund_integration.ts
+++ b/test/crowdfund_integration.ts
@@ -100,7 +100,8 @@ describe("Crowdfund Integration", function () {
       await armToken.getAddress(),
       deployer.address,
       treasury.address,
-      deployer.address
+      deployer.address,
+      deployer.address        // securityCouncil
     );
     await crowdfund.waitForDeployment();
 
@@ -211,7 +212,8 @@ describe("Crowdfund Integration", function () {
         await freshArmToken.getAddress(),
         deployer.address,
         treasury.address,
-        deployer.address
+        deployer.address,
+        deployer.address        // securityCouncil
       );
       await freshCrowdfund.waitForDeployment();
     });
@@ -769,7 +771,8 @@ describe("Crowdfund Integration", function () {
         await armToken.getAddress(),
         deployer.address,
         treasury.address,
-        deployer.address
+        deployer.address,
+        deployer.address        // securityCouncil
       );
       await unfundedCrowdfund.waitForDeployment();
 
@@ -863,7 +866,39 @@ describe("Crowdfund Integration", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: refund not available");
     });
 
-    it("should allow admin to withdraw USDC proceeds", async function () {
+    it("should push USDC proceeds to treasury at finalization", async function () {
+      const seeds = allSigners.slice(1, 80);
+      const committers = seeds.slice(0, 68);
+      for (const s of seeds) {
+        await fundAndApprove(s, USDC(15_000));
+      }
+      await crowdfund.addSeeds(seeds.map(s => s.address));
+      await crowdfund.startWindow();
+      for (const s of committers) {
+        await crowdfund.connect(s).commit(USDC(15_000), 0);
+      }
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
+      await time.increase(THREE_WEEKS + 1);
+
+      const treasuryBefore = await usdc.balanceOf(treasury.address);
+      await crowdfund.finalize();
+      const treasuryAfter = await usdc.balanceOf(treasury.address);
+
+      // Proceeds pushed atomically at finalization (minus small rounding buffer)
+      const totalAllocUsdc = await crowdfund.totalAllocatedUsdc();
+      const pushed = treasuryAfter - treasuryBefore;
+      expect(totalAllocUsdc).to.be.gt(0);
+      expect(pushed).to.be.lte(totalAllocUsdc);
+      expect(pushed).to.be.gte(totalAllocUsdc - 500n);
+
+      // Contract retains refund USDC (plus rounding buffer)
+      const contractUsdc = await usdc.balanceOf(await crowdfund.getAddress());
+      const totalCommitted = await crowdfund.totalCommitted();
+      expect(contractUsdc).to.be.gte(totalCommitted - totalAllocUsdc);
+      expect(contractUsdc).to.be.lte(totalCommitted - totalAllocUsdc + 500n);
+    });
+
+    it("should allow anyone to sweep unallocated ARM", async function () {
       const seeds = allSigners.slice(1, 80);
       const committers = seeds.slice(0, 68);
       for (const s of seeds) {
@@ -878,42 +913,15 @@ describe("Crowdfund Integration", function () {
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
-      // Proceeds accrue as participants claim (lazy evaluation)
-      for (const s of committers) {
-        await crowdfund.connect(s).claim();
-      }
-
-      const totalProceeds = await crowdfund.totalProceedsAccrued();
-      expect(totalProceeds).to.be.gt(0);
-      const treasuryBefore = await usdc.balanceOf(treasury.address);
-      await crowdfund.withdrawProceeds();
-      const treasuryAfter = await usdc.balanceOf(treasury.address);
-
-      expect(treasuryAfter - treasuryBefore).to.equal(totalProceeds);
-    });
-
-    it("should allow admin to withdraw unallocated ARM", async function () {
-      const seeds = allSigners.slice(1, 80);
-      const committers = seeds.slice(0, 68);
-      for (const s of seeds) {
-        await fundAndApprove(s, USDC(15_000));
-      }
-      await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
-      for (const s of committers) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
-      }
-      await time.increase(THREE_WEEKS + 1);
-      await crowdfund.finalize();
-
       // totalAllocated is hop-level upper bound, totalArmClaimed tracks claims
       const totalAlloc = await crowdfund.totalAllocated();
       const armInContract = await armToken.balanceOf(await crowdfund.getAddress());
       // Before claims: armStillOwed = totalAlloc - 0 = totalAlloc
       const expectedUnalloc = armInContract - totalAlloc;
 
+      // Permissionless — called by a random non-admin signer
       const treasuryBefore = await armToken.balanceOf(treasury.address);
-      await crowdfund.withdrawUnallocatedArm();
+      await crowdfund.connect(seed1).withdrawUnallocatedArm();
       const treasuryAfter = await armToken.balanceOf(treasury.address);
 
       expect(treasuryAfter - treasuryBefore).to.equal(expectedUnalloc);

--- a/test/crowdfund_launch_team.ts
+++ b/test/crowdfund_launch_team.ts
@@ -60,7 +60,8 @@ describe("Launch Team & Seed Cap", function () {
       await armToken.getAddress(),
       deployer.address,   // admin
       treasury.address,   // treasury
-      deployer.address    // launchTeam (same as admin for local testing)
+      deployer.address,   // launchTeam (same as admin for local testing)
+      deployer.address    // securityCouncil
     );
     await crowdfund.waitForDeployment();
 
@@ -158,7 +159,8 @@ describe("Launch Team & Seed Cap", function () {
         await armToken.getAddress(),
         deployer.address,
         treasury.address,
-        deployer.address
+        deployer.address,
+        deployer.address        // securityCouncil
       );
       await expect(
         freshCrowdfund.launchTeamInvite(invitee1.address, 1)
@@ -321,7 +323,8 @@ describe("Launch Team & Seed Cap", function () {
         await armToken.getAddress(),
         deployer.address,
         treasury.address,
-        ltSigner.address  // separate launch team
+        ltSigner.address,  // separate launch team
+        deployer.address   // securityCouncil
       );
       await cf.waitForDeployment();
 
@@ -417,7 +420,8 @@ describe("Launch Team & Seed Cap", function () {
           await armToken.getAddress(),
           deployer.address,
           treasury.address,
-          ethers.ZeroAddress
+          ethers.ZeroAddress,
+          deployer.address
         )
       ).to.be.revertedWith("ArmadaCrowdfund: zero launchTeam");
     });

--- a/test/crowdfund_multinode.ts
+++ b/test/crowdfund_multinode.ts
@@ -55,7 +55,8 @@ describe("Crowdfund Multi-Node", function () {
       await armToken.getAddress(),
       deployer.address,
       treasury.address,
-      deployer.address
+      deployer.address,
+      deployer.address        // securityCouncil
     );
     await crowdfund.waitForDeployment();
 

--- a/test/crowdfund_settlement.ts
+++ b/test/crowdfund_settlement.ts
@@ -1,0 +1,463 @@
+// ABOUTME: Tests for crowdfund settlement: security council cancel, proceeds push,
+// ABOUTME: claim deadline, and multi-window ARM sweep.
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+const Phase = { Setup: 0, Active: 1, Finalized: 2, Canceled: 3 };
+
+const USDC = (n: number) => BigInt(n) * 1_000_000n;
+const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
+const THREE_WEEKS = 21 * 24 * 60 * 60;
+const THREE_YEARS = 1095 * 24 * 60 * 60;
+
+describe("Crowdfund Settlement Rework", function () {
+  let deployer: HardhatEthersSigner;
+  let treasury: HardhatEthersSigner;
+  let securityCouncil: HardhatEthersSigner;
+  let allSigners: HardhatEthersSigner[];
+  let usdc: any;
+  let armToken: any;
+  let crowdfund: any;
+
+  async function fundAndApprove(signer: HardhatEthersSigner, amount: bigint) {
+    await usdc.mint(signer.address, amount);
+    await usdc.connect(signer).approve(await crowdfund.getAddress(), amount);
+  }
+
+  // Helper: set up a crowdfund with seeds committed to reach successful finalization.
+  // Always adds hop-1 demand to ensure totalAllocUsdc > MIN_SALE (avoids refundMode).
+  async function setupAndFinalize(seedCount: number, commitUsdc: bigint) {
+    const seeds = allSigners.slice(5, 5 + seedCount);
+    for (const s of seeds) {
+      await fundAndApprove(s, commitUsdc);
+    }
+    await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
+    await crowdfund.startWindow();
+    for (const s of seeds) {
+      await crowdfund.connect(s).commit(commitUsdc, 0);
+    }
+
+    // Add hop-1 demand to ensure net proceeds > MIN_SALE.
+    // Hop-0 ceiling at BASE_SALE ≈ $798K, so we need ~$210K+ from hop-1.
+    const hop1Pool = allSigners.slice(140, 195);
+    const inviterCount = Math.min(seeds.length, 18); // 18 × 3 = 54 hop-1 × $4K = $216K
+    for (let i = 0; i < inviterCount; i++) {
+      for (let j = 0; j < 3 && (i * 3 + j) < hop1Pool.length; j++) {
+        const hop1Idx = i * 3 + j;
+        await crowdfund.connect(seeds[i]).invite(hop1Pool[hop1Idx].address, 0);
+        await fundAndApprove(hop1Pool[hop1Idx], USDC(4_000));
+        await crowdfund.connect(hop1Pool[hop1Idx]).commit(USDC(4_000), 1);
+      }
+    }
+
+    await time.increase(THREE_WEEKS + 1);
+    await crowdfund.finalize();
+    expect(await crowdfund.refundMode()).to.be.false;
+    return seeds;
+  }
+
+  beforeEach(async function () {
+    allSigners = await ethers.getSigners();
+    deployer = allSigners[0];
+    treasury = allSigners[1];
+    securityCouncil = allSigners[2];
+
+    const MockUSDCV2 = await ethers.getContractFactory("MockUSDCV2");
+    usdc = await MockUSDCV2.deploy("Mock USDC", "USDC");
+    await usdc.waitForDeployment();
+
+    const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+    armToken = await ArmadaToken.deploy(deployer.address);
+    await armToken.waitForDeployment();
+
+    const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+    crowdfund = await ArmadaCrowdfund.deploy(
+      await usdc.getAddress(),
+      await armToken.getAddress(),
+      deployer.address,
+      treasury.address,
+      deployer.address,         // launchTeam
+      securityCouncil.address   // securityCouncil
+    );
+    await crowdfund.waitForDeployment();
+
+    await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
+    await crowdfund.loadArm();
+  });
+
+  // ============================================================
+  // T4.5 — Security Council cancel()
+  // ============================================================
+
+  describe("Security Council Cancel (T4.5)", function () {
+    it("security council can cancel during Setup phase", async function () {
+      expect(await crowdfund.phase()).to.equal(Phase.Setup);
+      await crowdfund.connect(securityCouncil).cancel();
+      expect(await crowdfund.phase()).to.equal(Phase.Canceled);
+    });
+
+    it("security council can cancel during Active phase", async function () {
+      await crowdfund.addSeeds([allSigners[5].address]);
+      await crowdfund.startWindow();
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
+
+      await crowdfund.connect(securityCouncil).cancel();
+      expect(await crowdfund.phase()).to.equal(Phase.Canceled);
+    });
+
+    it("security council can cancel after window but before finalize", async function () {
+      await crowdfund.addSeeds([allSigners[5].address]);
+      await crowdfund.startWindow();
+      await time.increase(THREE_WEEKS + 1);
+
+      // Window ended, but still Active phase
+      await crowdfund.connect(securityCouncil).cancel();
+      expect(await crowdfund.phase()).to.equal(Phase.Canceled);
+    });
+
+    it("cancel after finalize reverts", async function () {
+      await setupAndFinalize(80, USDC(15_000));
+      expect(await crowdfund.phase()).to.equal(Phase.Finalized);
+
+      await expect(
+        crowdfund.connect(securityCouncil).cancel()
+      ).to.be.revertedWith("ArmadaCrowdfund: already finalized");
+    });
+
+    it("cancel when already canceled reverts", async function () {
+      await crowdfund.connect(securityCouncil).cancel();
+      await expect(
+        crowdfund.connect(securityCouncil).cancel()
+      ).to.be.revertedWith("ArmadaCrowdfund: already canceled");
+    });
+
+    it("non-security-council address reverts", async function () {
+      await expect(
+        crowdfund.connect(deployer).cancel()
+      ).to.be.revertedWith("ArmadaCrowdfund: not security council");
+    });
+
+    it("after cancel: commit reverts", async function () {
+      await crowdfund.addSeeds([allSigners[5].address]);
+      await crowdfund.startWindow();
+      await fundAndApprove(allSigners[5], USDC(15_000));
+
+      await crowdfund.connect(securityCouncil).cancel();
+
+      await expect(
+        crowdfund.connect(allSigners[5]).commit(USDC(10_000), 0)
+      ).to.be.revertedWith("ArmadaCrowdfund: not active");
+    });
+
+    it("after cancel: finalize reverts", async function () {
+      await crowdfund.addSeeds([allSigners[5].address]);
+      await crowdfund.startWindow();
+      await time.increase(THREE_WEEKS + 1);
+
+      await crowdfund.connect(securityCouncil).cancel();
+
+      await expect(
+        crowdfund.finalize()
+      ).to.be.revertedWith("ArmadaCrowdfund: already finalized");
+    });
+
+    it("after cancel: claimRefund works", async function () {
+      await crowdfund.addSeeds([allSigners[5].address]);
+      await crowdfund.startWindow();
+      await fundAndApprove(allSigners[5], USDC(10_000));
+      await crowdfund.connect(allSigners[5]).commit(USDC(10_000), 0);
+
+      const usdcBefore = await usdc.balanceOf(allSigners[5].address);
+      await crowdfund.connect(securityCouncil).cancel();
+      await crowdfund.connect(allSigners[5]).claimRefund();
+      const usdcAfter = await usdc.balanceOf(allSigners[5].address);
+
+      expect(usdcAfter - usdcBefore).to.equal(USDC(10_000));
+    });
+
+    it("after cancel: ARM is recoverable", async function () {
+      await crowdfund.connect(securityCouncil).cancel();
+
+      const treasuryBefore = await armToken.balanceOf(treasury.address);
+      await crowdfund.withdrawUnallocatedArm();
+      const treasuryAfter = await armToken.balanceOf(treasury.address);
+
+      expect(treasuryAfter - treasuryBefore).to.equal(ARM(1_800_000));
+    });
+
+    it("emits SaleCanceled event", async function () {
+      await crowdfund.addSeeds([allSigners[5].address]);
+      await crowdfund.startWindow();
+      await fundAndApprove(allSigners[5], USDC(10_000));
+      await crowdfund.connect(allSigners[5]).commit(USDC(10_000), 0);
+
+      await expect(crowdfund.connect(securityCouncil).cancel())
+        .to.emit(crowdfund, "SaleCanceled")
+        .withArgs(USDC(10_000));
+    });
+
+    it("securityCouncil immutable is set correctly", async function () {
+      expect(await crowdfund.securityCouncil()).to.equal(securityCouncil.address);
+    });
+  });
+
+  // ============================================================
+  // T4.6 — Proceeds pushed at finalization
+  // ============================================================
+
+  describe("Proceeds Pushed at Finalization (T4.6)", function () {
+    it("treasury receives proceeds in the same tx as finalize", async function () {
+      const treasuryBefore = await usdc.balanceOf(treasury.address);
+      await setupAndFinalize(80, USDC(15_000));
+      const treasuryAfter = await usdc.balanceOf(treasury.address);
+
+      const totalAllocUsdc = await crowdfund.totalAllocatedUsdc();
+      const pushed = treasuryAfter - treasuryBefore;
+      expect(totalAllocUsdc).to.be.gt(0);
+      // Proceeds pushed = totalAllocUsdc minus a small rounding buffer (1 per participant node)
+      expect(pushed).to.be.lte(totalAllocUsdc);
+      expect(pushed).to.be.gte(totalAllocUsdc - 500n); // at most ~500 participants' worth of buffer
+    });
+
+    it("contract balance after finalize covers all refunds", async function () {
+      await setupAndFinalize(80, USDC(15_000));
+
+      const contractUsdc = await usdc.balanceOf(await crowdfund.getAddress());
+      const totalCommitted = await crowdfund.totalCommitted();
+      const totalAllocUsdc = await crowdfund.totalAllocatedUsdc();
+
+      // Contract retains slightly more than (totalCommitted - totalAllocUsdc) due to rounding buffer
+      expect(contractUsdc).to.be.gte(totalCommitted - totalAllocUsdc);
+      expect(contractUsdc).to.be.lte(totalCommitted - totalAllocUsdc + 500n);
+    });
+
+    it("all participants can still claim after proceeds push", async function () {
+      const seeds = await setupAndFinalize(80, USDC(15_000));
+
+      // All seeds claim
+      for (const s of seeds) {
+        await crowdfund.connect(s).claim();
+      }
+
+      // Contract should have minimal USDC left (dust from rounding)
+      const contractUsdc = await usdc.balanceOf(await crowdfund.getAddress());
+      expect(contractUsdc).to.be.lte(USDC(1));
+    });
+
+    it("refundMode does NOT push proceeds (no proceeds to push)", async function () {
+      // 80 seeds at hop-0 only → enters refundMode (hop-0 ceiling < MIN_SALE)
+      const seeds = allSigners.slice(5, 85);
+      for (const s of seeds) {
+        await fundAndApprove(s, USDC(15_000));
+      }
+      await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
+      await crowdfund.startWindow();
+      for (const s of seeds) {
+        await crowdfund.connect(s).commit(USDC(15_000), 0);
+      }
+      await time.increase(THREE_WEEKS + 1);
+
+      const treasuryBefore = await usdc.balanceOf(treasury.address);
+      await crowdfund.finalize();
+      const treasuryAfter = await usdc.balanceOf(treasury.address);
+
+      expect(await crowdfund.refundMode()).to.be.true;
+      // No USDC pushed in refundMode
+      expect(treasuryAfter - treasuryBefore).to.equal(0);
+    });
+  });
+
+  // ============================================================
+  // T4.7 — 3-Year Claim Deadline
+  // ============================================================
+
+  describe("Claim Deadline (T4.7)", function () {
+    it("claimDeadline is set at finalization", async function () {
+      await setupAndFinalize(80, USDC(15_000));
+
+      const deadline = await crowdfund.claimDeadline();
+      expect(deadline).to.be.gt(0);
+    });
+
+    it("claim just before deadline succeeds", async function () {
+      const seeds = await setupAndFinalize(80, USDC(15_000));
+
+      const deadline = await crowdfund.claimDeadline();
+      // increaseTo sets next block timestamp; claim tx executes in the block after that
+      await time.increaseTo(deadline - 2n);
+
+      // Should succeed (block.timestamp <= claimDeadline)
+      await crowdfund.connect(seeds[0]).claim();
+    });
+
+    it("claim after deadline reverts", async function () {
+      const seeds = await setupAndFinalize(80, USDC(15_000));
+
+      const deadline = await crowdfund.claimDeadline();
+      await time.increaseTo(deadline);
+
+      await expect(
+        crowdfund.connect(seeds[0]).claim()
+      ).to.be.revertedWith("ArmadaCrowdfund: claim deadline passed");
+    });
+
+    it("claimRefund after claim deadline still succeeds (USDC has no expiry)", async function () {
+      // Create a refundMode scenario
+      const seeds = allSigners.slice(5, 85);
+      for (const s of seeds) {
+        await fundAndApprove(s, USDC(15_000));
+      }
+      await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
+      await crowdfund.startWindow();
+      for (const s of seeds) {
+        await crowdfund.connect(s).commit(USDC(15_000), 0);
+      }
+      await time.increase(THREE_WEEKS + 1);
+      await crowdfund.finalize();
+      expect(await crowdfund.refundMode()).to.be.true;
+
+      // Warp far into the future
+      await time.increase(THREE_YEARS + 1);
+
+      // Refund still works
+      const usdcBefore = await usdc.balanceOf(seeds[0].address);
+      await crowdfund.connect(seeds[0]).claimRefund();
+      const usdcAfter = await usdc.balanceOf(seeds[0].address);
+      expect(usdcAfter - usdcBefore).to.equal(USDC(15_000));
+    });
+
+    it("claimDeadline is 0 in refundMode", async function () {
+      const seeds = allSigners.slice(5, 85);
+      for (const s of seeds) {
+        await fundAndApprove(s, USDC(15_000));
+      }
+      await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
+      await crowdfund.startWindow();
+      for (const s of seeds) {
+        await crowdfund.connect(s).commit(USDC(15_000), 0);
+      }
+      await time.increase(THREE_WEEKS + 1);
+      await crowdfund.finalize();
+
+      expect(await crowdfund.refundMode()).to.be.true;
+      expect(await crowdfund.claimDeadline()).to.equal(0);
+    });
+
+    it("CLAIM_DEADLINE_DURATION is 1095 days (3 years)", async function () {
+      expect(await crowdfund.CLAIM_DEADLINE_DURATION()).to.equal(1095 * 24 * 60 * 60);
+    });
+  });
+
+  // ============================================================
+  // T4.8 — Multi-Window withdrawUnallocatedArm
+  // ============================================================
+
+  describe("Multi-Window ARM Sweep (T4.8)", function () {
+    it("post-finalization base sale: sweeps unsold ARM immediately", async function () {
+      // 68 seeds × $15K = $1.02M at BASE_SALE
+      const seeds = await setupAndFinalize(68, USDC(15_000));
+
+      const totalAlloc = await crowdfund.totalAllocated();
+      const armInContract = await armToken.balanceOf(await crowdfund.getAddress());
+      const expectedSweep = armInContract - totalAlloc;
+      expect(expectedSweep).to.be.gt(0);
+
+      const treasuryBefore = await armToken.balanceOf(treasury.address);
+      await crowdfund.withdrawUnallocatedArm();
+      const treasuryAfter = await armToken.balanceOf(treasury.address);
+
+      expect(treasuryAfter - treasuryBefore).to.equal(expectedSweep);
+    });
+
+    it("second sweep after first: reverts (nothing to sweep until claims or deadline)", async function () {
+      await setupAndFinalize(68, USDC(15_000));
+
+      await crowdfund.withdrawUnallocatedArm();
+
+      await expect(
+        crowdfund.withdrawUnallocatedArm()
+      ).to.be.revertedWith("ArmadaCrowdfund: nothing to sweep");
+    });
+
+    it("after some claims: sweep sees reduced armStillOwed", async function () {
+      const seeds = await setupAndFinalize(68, USDC(15_000));
+
+      // First sweep: unsold ARM
+      const totalAlloc = await crowdfund.totalAllocated();
+      const armBalance = await armToken.balanceOf(await crowdfund.getAddress());
+      const expectedFirstSweep = armBalance - totalAlloc;
+      expect(expectedFirstSweep).to.be.gt(0);
+      await crowdfund.withdrawUnallocatedArm();
+
+      // Half the seeds claim — reduces armStillOwed
+      for (let i = 0; i < 34; i++) {
+        await crowdfund.connect(seeds[i]).claim();
+      }
+
+      // armStillOwed decreased, but no new unsold ARM. Balance = totalAlloc - claimed.
+      // Nothing new to sweep unless there's rounding dust.
+      const armAfterClaims = await armToken.balanceOf(await crowdfund.getAddress());
+      const totalArmClaimed = await crowdfund.totalArmClaimed();
+      // Contract should have exactly totalAlloc - totalArmClaimed
+      expect(armAfterClaims).to.equal(totalAlloc - totalArmClaimed);
+    });
+
+    it("after 3-year deadline: sweeps all remaining ARM (unclaimed)", async function () {
+      const seeds = await setupAndFinalize(68, USDC(15_000));
+
+      // First sweep: unsold ARM
+      await crowdfund.withdrawUnallocatedArm();
+
+      // Only 1 of 68 seeds claims
+      await crowdfund.connect(seeds[0]).claim();
+
+      // Before deadline: can't sweep unclaimed
+      await expect(
+        crowdfund.withdrawUnallocatedArm()
+      ).to.be.revertedWith("ArmadaCrowdfund: nothing to sweep");
+
+      // Warp past deadline
+      const deadline = await crowdfund.claimDeadline();
+      await time.increaseTo(deadline + 1n);
+
+      // Now all unclaimed ARM is sweepable
+      const armBalance = await armToken.balanceOf(await crowdfund.getAddress());
+      expect(armBalance).to.be.gt(0);
+
+      const treasuryBefore = await armToken.balanceOf(treasury.address);
+      await crowdfund.withdrawUnallocatedArm();
+      const treasuryAfter = await armToken.balanceOf(treasury.address);
+
+      expect(treasuryAfter - treasuryBefore).to.equal(armBalance);
+      expect(await armToken.balanceOf(await crowdfund.getAddress())).to.equal(0);
+    });
+
+    it("after cancel: sweeps all ARM", async function () {
+      await crowdfund.addSeeds([allSigners[5].address]);
+      await crowdfund.startWindow();
+
+      await crowdfund.connect(securityCouncil).cancel();
+
+      const treasuryBefore = await armToken.balanceOf(treasury.address);
+      await crowdfund.withdrawUnallocatedArm();
+      const treasuryAfter = await armToken.balanceOf(treasury.address);
+
+      expect(treasuryAfter - treasuryBefore).to.equal(ARM(1_800_000));
+    });
+
+    it("permissionless: any address can call", async function () {
+      await setupAndFinalize(80, USDC(15_000));
+
+      // Random non-admin signer calls
+      const rando = allSigners[199];
+      const treasuryBefore = await armToken.balanceOf(treasury.address);
+      await crowdfund.connect(rando).withdrawUnallocatedArm();
+      const treasuryAfter = await armToken.balanceOf(treasury.address);
+
+      expect(treasuryAfter).to.be.gt(treasuryBefore);
+    });
+  });
+});

--- a/test/gas_benchmark.ts
+++ b/test/gas_benchmark.ts
@@ -62,7 +62,8 @@ describe("Gas Benchmarks", function () {
           await armToken.getAddress(),
           deployer.address,
           deployer.address, // treasury
-          deployer.address  // launchTeam
+          deployer.address, // launchTeam
+          deployer.address  // securityCouncil
         );
 
         // Fund ARM for MAX_SALE
@@ -166,7 +167,8 @@ describe("Gas Benchmarks", function () {
           await armToken.getAddress(),
           deployer.address,
           deployer.address, // treasury
-          deployer.address  // launchTeam
+          deployer.address, // launchTeam
+          deployer.address  // securityCouncil
         );
 
         const seeds = allSigners.slice(1, batchSize + 1);
@@ -203,7 +205,8 @@ describe("Gas Benchmarks", function () {
         await armToken.getAddress(),
         deployer.address,
         deployer.address, // treasury
-        deployer.address  // launchTeam
+        deployer.address, // launchTeam
+        deployer.address  // securityCouncil
       );
 
       await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
@@ -466,7 +469,8 @@ describe("Gas Benchmarks", function () {
         await armToken.getAddress(),
         deployer.address,
         deployer.address, // treasury
-        deployer.address  // launchTeam
+        deployer.address, // launchTeam
+        deployer.address  // securityCouncil
       );
 
       await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));


### PR DESCRIPTION
## Summary

- **Security council cancel**: New `securityCouncil` immutable role with `cancel()` for emergency pre-finalization cancellation at any phase (Setup, Active, post-window)
- **Atomic proceeds push**: Removes lazy `withdrawProceeds()` — proceeds are pushed to treasury atomically during `finalize()` with a rounding buffer to ensure refund solvency
- **3-year claim deadline**: After `CLAIM_DEADLINE_DURATION` (1095 days), unclaimed ARM becomes sweepable; USDC refunds have no expiry
- **Multi-window ARM sweep**: `withdrawUnallocatedArm()` is now permissionless and callable multiple times across three windows: post-finalization (unsold), post-deadline (unclaimed), post-cancel/refundMode (all)

## Test plan

- [x] New `test/crowdfund_settlement.ts` with 25 tests across 4 describe blocks (T4.5–T4.8)
- [ ] Run `npm run test:crowdfund` — all Hardhat crowdfund tests pass
- [ ] Run `npm run test:forge` — all Foundry fuzz/invariant tests pass
- [ ] Verify frontend cancel button renders in Setup and Active phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>