### PR TITLE
feat: governance quiet period after crowdfund finalization

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -96,6 +96,10 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     // net proceeds fell below MIN_SALE. All USDC is refundable via claimRefund().
     bool public refundMode;
 
+    // Timestamp when finalize() was called — used by ArmadaGovernor for the
+    // 7-day governance quiet period. Set on both normal and refundMode paths.
+    uint256 public finalizedAt;
+
     // ============ Events ============
 
     event SeedAdded(address indexed seed);
@@ -400,6 +404,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         if (totalAllocUsdc_ < MIN_SALE) {
             refundMode = true;
             phase = Phase.Finalized;
+            finalizedAt = block.timestamp;
             emit SaleFinalizedRefundMode(totalCommitted, totalAllocUsdc_);
             return;
         }
@@ -409,6 +414,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         treasuryLeftoverUsdc = saleSize - totalAllocUsdc_;
         claimDeadline = block.timestamp + CLAIM_DEADLINE_DURATION;
         phase = Phase.Finalized;
+        finalizedAt = block.timestamp;
 
         // Push net proceeds to treasury atomically. Contract retains refund USDC.
         // Pro-rata division rounds each participant's allocUsdc down, making the

--- a/contracts/crowdfund/IArmadaCrowdfund.sol
+++ b/contracts/crowdfund/IArmadaCrowdfund.sol
@@ -45,3 +45,10 @@ struct HopStats {
     uint32 uniqueCommitters;    // count of unique addresses that committed > 0
     uint32 whitelistCount;      // count of whitelisted addresses at this hop
 }
+
+// ========== Interfaces ==========
+
+/// @notice Read-only interface for cross-contract queries (e.g. governor quiet period).
+interface IArmadaCrowdfundReadable {
+    function finalizedAt() external view returns (uint256);
+}

--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./IArmadaGovernance.sol";
 import "./EmergencyPausable.sol";
+import "../crowdfund/IArmadaCrowdfund.sol";
 
 /// @title ArmadaGovernor — Custom governance with typed proposals and token locking
 /// @notice Implements the Armada governance spec: proposal lifecycle, per-type quorum/timing,
@@ -91,6 +92,13 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
     // Succeeded proposals must be queued within this window or they expire
     uint256 public constant QUEUE_GRACE_PERIOD = 14 days;
 
+    // Governance quiet period — no proposals allowed for this duration after crowdfund finalization.
+    // One-time bootstrapping measure; governable (can be shortened or removed).
+    address public crowdfundAddress;
+    bool public crowdfundAddressLocked;
+    uint256 public quietPeriodDuration;
+    uint256 public constant MAX_QUIET_PERIOD = 30 days;
+
     // ============ Events ============
 
     event ProposalCreated(
@@ -106,6 +114,8 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
     event ProposalExecuted(uint256 indexed proposalId);
     event ProposalCanceled(uint256 indexed proposalId);
     event ProposalTypeParamsUpdated(ProposalType indexed proposalType, ProposalParams params);
+    event CrowdfundAddressSet(address indexed crowdfund);
+    event QuietPeriodUpdated(uint256 newDuration);
 
     // ============ Constructor ============
 
@@ -142,6 +152,9 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
             quorumBps: 2000
         });
 
+        // Governance quiet period: 7 days post-crowdfund-finalization before proposals allowed
+        quietPeriodDuration = 7 days;
+
         // Extended: 2d delay, 7d voting, 4d execution, 30% quorum
         proposalTypeParams[ProposalType.StewardElection] = ProposalParams({
             votingDelay: 2 days,
@@ -170,6 +183,19 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
     /// @notice View excluded addresses for transparency
     function getExcludedFromQuorum() external view returns (address[] memory) {
         return _excludedFromQuorum;
+    }
+
+    /// @notice One-time setter: register the crowdfund contract for quiet period checks.
+    /// Deployer-only; locks permanently after the first call.
+    function setCrowdfundAddress(address _crowdfund) external {
+        require(msg.sender == deployer, "ArmadaGovernor: not deployer");
+        require(!crowdfundAddressLocked, "ArmadaGovernor: already locked");
+        require(_crowdfund != address(0), "ArmadaGovernor: zero address");
+
+        crowdfundAddressLocked = true;
+        crowdfundAddress = _crowdfund;
+
+        emit CrowdfundAddressSet(_crowdfund);
     }
 
     // ============ Governance-Updatable Parameters ============
@@ -203,6 +229,17 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         emit ProposalTypeParamsUpdated(proposalType, params);
     }
 
+    /// @notice Update the governance quiet period duration.
+    /// @dev Only callable by the timelock (requires a governance vote).
+    ///      Setting to 0 removes the quiet period entirely.
+    function setQuietPeriodDuration(uint256 _duration) external {
+        require(msg.sender == address(timelock), "ArmadaGovernor: not timelock");
+        require(_duration <= MAX_QUIET_PERIOD, "ArmadaGovernor: exceeds max");
+
+        quietPeriodDuration = _duration;
+        emit QuietPeriodUpdated(_duration);
+    }
+
     // ============ Proposal Lifecycle ============
 
     /// @notice Create a new proposal
@@ -223,6 +260,7 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
             targets.length == values.length && targets.length == calldatas.length,
             "ArmadaGovernor: length mismatch"
         );
+        _checkQuietPeriod();
         _checkProposalThreshold(msg.sender);
 
         uint256 proposalId = ++proposalCount;
@@ -437,5 +475,20 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
     /// @dev Unique salt per proposal for timelock deduplication
     function _proposalSalt(uint256 proposalId) internal pure returns (bytes32) {
         return bytes32(proposalId);
+    }
+
+    /// @dev Block proposals during the quiet period after crowdfund finalization.
+    ///      Reads finalizedAt from the crowdfund contract. Skips gracefully if no
+    ///      crowdfund is registered, quiet period is zero, or crowdfund isn't finalized.
+    function _checkQuietPeriod() internal view {
+        if (crowdfundAddress == address(0) || quietPeriodDuration == 0) return;
+
+        uint256 _finalizedAt = IArmadaCrowdfundReadable(crowdfundAddress).finalizedAt();
+        if (_finalizedAt == 0) return;
+
+        require(
+            block.timestamp >= _finalizedAt + quietPeriodDuration,
+            "ArmadaGovernor: quiet period active"
+        );
     }
 }

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -130,6 +130,11 @@ async function main() {
   await (await governor.setExcludedAddresses([crowdfundAddress], nm.override())).wait();
   console.log(`   Crowdfund excluded from quorum denominator`);
 
+  // 6. Register crowdfund address for governance quiet period
+  console.log("6. Registering crowdfund in governor for quiet period...");
+  await (await governor.setCrowdfundAddress(crowdfundAddress, nm.override())).wait();
+  console.log(`   Crowdfund registered for 7-day governance quiet period`);
+
   // Save deployment
   const deployment: CrowdfundDeployment = {
     chainId,

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -22,6 +22,7 @@ const Vote = { Against: 0, For: 1, Abstain: 2 };
 const ONE_DAY = 86400;
 const TWO_DAYS = 2 * ONE_DAY;
 const FIVE_DAYS = 5 * ONE_DAY;
+const SEVEN_DAYS = 7 * ONE_DAY;
 const THREE_WEEKS = 21 * ONE_DAY;
 
 const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
@@ -124,6 +125,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     await timelockController.grantRole(PROPOSER_ROLE, await governor.getAddress());
     await timelockController.grantRole(EXECUTOR_ROLE, await governor.getAddress());
 
+    // Register crowdfund for governance quiet period
+    await governor.setCrowdfundAddress(await crowdfund.getAddress());
+
     // Deploy TreasuryGov (holds ARM for governance distributions)
     // Owner is set to timelock at deployment and is immutable — governance controls the treasury
     const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
@@ -178,6 +182,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       expect(seed0Arm).to.be.gt(0);
 
       // === GOVERNANCE PHASE ===
+
+      // 6b. Skip past 7-day governance quiet period
+      await time.increase(SEVEN_DAYS + 1);
 
       // 7. Deployer needs voting power to propose AND reach quorum.
       // Deployer kept DEPLOYER_KEEP ARM. Lock most of it.
@@ -267,6 +274,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       for (const seed of seeds) {
         await crowdfund.connect(seed).claim();
       }
+
+      // Skip past 7-day governance quiet period
+      await time.increase(SEVEN_DAYS + 1);
     }
 
     it("ARM total supply is constant after crowdfund distribution", async function () {
@@ -370,6 +380,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       for (let i = 0; i < 10; i++) {
         await crowdfund.connect(seeds[i]).claim();
       }
+
+      // Skip past 7-day governance quiet period
+      await time.increase(SEVEN_DAYS + 1);
 
       // Deployer locks enough to propose AND contribute to quorum
       const deployerLock = DEPLOYER_KEEP / 2n;
@@ -563,6 +576,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
+      // Skip past 7-day governance quiet period
+      await time.increase(SEVEN_DAYS + 1);
+
       // DON'T claim — seeds have 0 ARM balance
       expect(await armToken.balanceOf(seeds[0].address)).to.equal(0);
 
@@ -691,8 +707,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await localArmToken.transfer(await localCrowdfund.getAddress(), CROWDFUND_ALLOCATION);
       await localCrowdfund.loadArm();
 
-      // Step 6: Register crowdfund in quorum exclusion
+      // Step 6: Register crowdfund in quorum exclusion and quiet period
       await localGovernor.setExcludedAddresses([await localCrowdfund.getAddress()]);
+      await localGovernor.setCrowdfundAddress(await localCrowdfund.getAddress());
     });
 
     it("all ARM balances sum to total supply", async function () {
@@ -756,6 +773,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       await time.increase(THREE_WEEKS + 1);
       await localCrowdfund.finalize();
+
+      // Skip quiet period so governance proposals can proceed
+      await time.increase(SEVEN_DAYS + 1);
 
       // Before any claims: crowdfund still holds all ARM
       const crowdfundArmBefore = await localArmToken.balanceOf(await localCrowdfund.getAddress());
@@ -876,6 +896,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       for (const seed of claimedSeeds) {
         await localCrowdfund.connect(seed).claim();
       }
+
+      // Skip past 7-day governance quiet period
+      await time.increase(SEVEN_DAYS + 1);
 
       // Deployer locks enough to propose and exceed quorum
       // Quorum = 20% of (supply - treasury - crowdfund) = 20% of deployer remainder

--- a/test/governance_quiet_period.ts
+++ b/test/governance_quiet_period.ts
@@ -1,0 +1,353 @@
+// ABOUTME: Tests the 7-day governance quiet period after crowdfund finalization.
+// ABOUTME: Covers proposal blocking, boundary conditions, governable duration, and access control.
+
+/**
+ * Governance Quiet Period Tests (T6.1)
+ *
+ * After crowdfund finalization, a 7-day quiet period blocks all governance proposals.
+ * This gives participants time to claim ARM and delegate before governance begins.
+ * The quiet period is governable — governance can shorten, extend, or remove it.
+ */
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
+import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+
+const ProposalType = { ParameterChange: 0, Treasury: 1, StewardElection: 2 };
+const ONE_DAY = 86400;
+const SEVEN_DAYS = 7 * ONE_DAY;
+const THREE_WEEKS = 21 * ONE_DAY;
+
+const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
+const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
+
+describe("Governance Quiet Period (T6.1)", function () {
+  let armToken: any;
+  let usdc: any;
+  let crowdfund: any;
+  let votingLocker: any;
+  let timelockController: any;
+  let governor: any;
+  let treasury: any;
+
+  let deployer: SignerWithAddress;
+  let treasuryAddr: SignerWithAddress;
+  let seeds: SignerWithAddress[];
+  let nonDeployer: SignerWithAddress;
+
+  const PROPOSER_ROLE = ethers.keccak256(ethers.toUtf8Bytes("PROPOSER_ROLE"));
+  const EXECUTOR_ROLE = ethers.keccak256(ethers.toUtf8Bytes("EXECUTOR_ROLE"));
+
+  // Helper: deploy full stack (tokens, crowdfund, governance)
+  async function deployStack() {
+    const signers = await ethers.getSigners();
+    deployer = signers[0];
+    treasuryAddr = signers[1];
+    nonDeployer = signers[2];
+    seeds = signers.slice(3, 103); // 100 seeds
+
+    // Deploy tokens
+    const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+    armToken = await ArmadaToken.deploy(deployer.address);
+    await armToken.waitForDeployment();
+
+    const MockUSDCV2 = await ethers.getContractFactory("MockUSDCV2");
+    usdc = await MockUSDCV2.deploy("Mock USDC", "USDC");
+    await usdc.waitForDeployment();
+
+    // Deploy crowdfund
+    const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+    crowdfund = await ArmadaCrowdfund.deploy(
+      await usdc.getAddress(),
+      await armToken.getAddress(),
+      deployer.address,
+      treasuryAddr.address,
+      deployer.address,
+      deployer.address // securityCouncil
+    );
+    await crowdfund.waitForDeployment();
+
+    // Fund ARM to crowdfund (1.8M for MAX_SALE)
+    await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
+    await crowdfund.loadArm();
+
+    // Deploy governance
+    const MAX_PAUSE_DURATION = 14 * ONE_DAY;
+
+    const TimelockController = await ethers.getContractFactory("TimelockController");
+    timelockController = await TimelockController.deploy(
+      ONE_DAY,
+      [deployer.address],
+      [deployer.address],
+      deployer.address
+    );
+    await timelockController.waitForDeployment();
+    const timelockAddr = await timelockController.getAddress();
+
+    const VotingLocker = await ethers.getContractFactory("VotingLocker");
+    votingLocker = await VotingLocker.deploy(
+      await armToken.getAddress(), deployer.address, MAX_PAUSE_DURATION, timelockAddr
+    );
+    await votingLocker.waitForDeployment();
+
+    const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
+    governor = await ArmadaGovernor.deploy(
+      await votingLocker.getAddress(),
+      await armToken.getAddress(),
+      timelockAddr,
+      treasuryAddr.address,
+      deployer.address,
+      MAX_PAUSE_DURATION
+    );
+    await governor.waitForDeployment();
+
+    // Grant governor roles on timelock
+    await timelockController.grantRole(PROPOSER_ROLE, await governor.getAddress());
+    await timelockController.grantRole(EXECUTOR_ROLE, await governor.getAddress());
+
+    // Deploy treasury for dummy calldata target
+    const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+    treasury = await ArmadaTreasuryGov.deploy(timelockAddr, deployer.address, MAX_PAUSE_DURATION);
+    await treasury.waitForDeployment();
+  }
+
+  // Helper: lock ARM for proposer threshold
+  async function lockArmForProposal(amount: bigint = ARM(200_000)) {
+    await armToken.approve(await votingLocker.getAddress(), amount);
+    await votingLocker.lock(amount);
+    await mine(1);
+  }
+
+  // Helper: create a basic proposal (async — resolves treasury address)
+  async function propose(description = "Test proposal") {
+    const treasuryAddress = await treasury.getAddress();
+    const calldata = treasury.interface.encodeFunctionData("setSteward", [deployer.address]);
+    return governor.propose(
+      ProposalType.ParameterChange,
+      [treasuryAddress],
+      [0],
+      [calldata],
+      description
+    );
+  }
+
+  // Helper: call setQuietPeriodDuration through the timelock (the only authorized caller)
+  async function setQuietPeriodViaTImelock(duration: number) {
+    const calldata = governor.interface.encodeFunctionData("setQuietPeriodDuration", [duration]);
+    const governorAddr = await governor.getAddress();
+    const salt = ethers.id(`set-quiet-period-${duration}`);
+    await timelockController.schedule(governorAddr, 0, calldata, ethers.ZeroHash, salt, ONE_DAY);
+    await time.increase(ONE_DAY + 1);
+    await timelockController.execute(governorAddr, 0, calldata, ethers.ZeroHash, salt);
+  }
+
+  // Helper: run crowdfund to finalization (normal path — above MIN_SALE)
+  async function finalizeCrowdfund() {
+    await crowdfund.addSeeds(seeds.map(s => s.address));
+    await crowdfund.startWindow();
+
+    for (const seed of seeds) {
+      const amount = USDC(15_000);
+      await usdc.mint(seed.address, amount);
+      await usdc.connect(seed).approve(await crowdfund.getAddress(), amount);
+      await crowdfund.connect(seed).commit(amount, 0);
+    }
+
+    await time.increase(THREE_WEEKS + 1);
+    await crowdfund.finalize();
+  }
+
+  beforeEach(async function () {
+    await deployStack();
+  });
+
+  // ============ Core quiet period behavior ============
+
+  describe("Proposal blocking during quiet period", function () {
+    it("propose reverts during quiet period (day 1-6 post-finalization)", async function () {
+      await governor.setCrowdfundAddress(await crowdfund.getAddress());
+      await finalizeCrowdfund();
+      await lockArmForProposal();
+
+      // Day 3 — well within 7-day quiet period
+      await time.increase(3 * ONE_DAY);
+
+      await expect(propose()).to.be.revertedWith("ArmadaGovernor: quiet period active");
+    });
+
+    it("propose succeeds after quiet period (day 8+)", async function () {
+      await governor.setCrowdfundAddress(await crowdfund.getAddress());
+      await finalizeCrowdfund();
+      await lockArmForProposal();
+
+      await time.increase(SEVEN_DAYS + 1);
+
+      await expect(propose()).to.not.be.reverted;
+    });
+
+    it("propose succeeds at exactly finalizedAt + 7 days", async function () {
+      await governor.setCrowdfundAddress(await crowdfund.getAddress());
+      await finalizeCrowdfund();
+
+      const finalizedAt = await crowdfund.finalizedAt();
+
+      await lockArmForProposal();
+
+      // Move to exactly finalizedAt + 7 days. The lock/mine above advanced time
+      // slightly, so compute the remaining offset.
+      const currentTime = BigInt(await time.latest());
+      const target = finalizedAt + BigInt(SEVEN_DAYS);
+      if (currentTime < target) {
+        await time.increaseTo(target);
+      }
+
+      await expect(propose()).to.not.be.reverted;
+    });
+  });
+
+  // ============ Edge cases: no crowdfund / not finalized ============
+
+  describe("Edge cases — no crowdfund or not finalized", function () {
+    it("propose succeeds if crowdfund not yet finalized (finalizedAt == 0)", async function () {
+      await governor.setCrowdfundAddress(await crowdfund.getAddress());
+
+      // Crowdfund exists but not finalized — finalizedAt == 0
+      expect(await crowdfund.finalizedAt()).to.equal(0);
+
+      await lockArmForProposal();
+      await expect(propose()).to.not.be.reverted;
+    });
+
+    it("propose succeeds if no crowdfund registered (crowdfundAddress == 0)", async function () {
+      // Don't call setCrowdfundAddress — crowdfundAddress remains address(0)
+      expect(await governor.crowdfundAddress()).to.equal(ethers.ZeroAddress);
+
+      await lockArmForProposal();
+      await expect(propose()).to.not.be.reverted;
+    });
+  });
+
+  // ============ Governable quiet period duration ============
+
+  describe("Governable quiet period duration", function () {
+    it("governance can set quietPeriodDuration to 0 to remove it", async function () {
+      await governor.setCrowdfundAddress(await crowdfund.getAddress());
+      await finalizeCrowdfund();
+      await lockArmForProposal();
+
+      // Quiet period active — proposal should revert
+      await expect(propose("before removal")).to.be.revertedWith("ArmadaGovernor: quiet period active");
+
+      // Governance (timelock) sets quiet period to 0
+      await setQuietPeriodViaTImelock(0);
+
+      // Now proposal succeeds during what would have been the quiet period
+      await expect(propose("after removal")).to.not.be.reverted;
+    });
+
+    it("governance can extend quiet period — propose at day 8 reverts if extended to 14 days", async function () {
+      await governor.setCrowdfundAddress(await crowdfund.getAddress());
+
+      // Extend quiet period to 14 days via timelock BEFORE finalization
+      // (so we don't have to time-travel through the quiet period to execute the timelock op)
+      await setQuietPeriodViaTImelock(14 * ONE_DAY);
+
+      await finalizeCrowdfund();
+      await lockArmForProposal();
+
+      // Day 8 — would succeed with 7-day period, but now reverts with 14-day
+      await time.increase(8 * ONE_DAY);
+      await expect(propose()).to.be.revertedWith("ArmadaGovernor: quiet period active");
+
+      // Day 15 (from finalization) — succeeds after extended period
+      await time.increase(7 * ONE_DAY);
+      await expect(propose()).to.not.be.reverted;
+    });
+  });
+
+  // ============ Access control ============
+
+  describe("Access control", function () {
+    it("setQuietPeriodDuration by non-timelock reverts", async function () {
+      await expect(
+        governor.connect(nonDeployer).setQuietPeriodDuration(0)
+      ).to.be.revertedWith("ArmadaGovernor: not timelock");
+    });
+
+    it("setQuietPeriodDuration above MAX_QUIET_PERIOD reverts", async function () {
+      const MAX_QUIET_PERIOD = 30 * ONE_DAY;
+      const calldata = governor.interface.encodeFunctionData(
+        "setQuietPeriodDuration", [MAX_QUIET_PERIOD + 1]
+      );
+      const governorAddr = await governor.getAddress();
+      const salt = ethers.id("exceeds-max-quiet");
+      await timelockController.schedule(governorAddr, 0, calldata, ethers.ZeroHash, salt, ONE_DAY);
+      await time.increase(ONE_DAY + 1);
+      await expect(
+        timelockController.execute(governorAddr, 0, calldata, ethers.ZeroHash, salt)
+      ).to.be.revertedWith("TimelockController: underlying transaction reverted");
+    });
+
+    it("setCrowdfundAddress is one-time only (second call reverts)", async function () {
+      await governor.setCrowdfundAddress(await crowdfund.getAddress());
+
+      await expect(
+        governor.setCrowdfundAddress(await crowdfund.getAddress())
+      ).to.be.revertedWith("ArmadaGovernor: already locked");
+    });
+
+    it("setCrowdfundAddress by non-deployer reverts", async function () {
+      await expect(
+        governor.connect(nonDeployer).setCrowdfundAddress(await crowdfund.getAddress())
+      ).to.be.revertedWith("ArmadaGovernor: not deployer");
+    });
+
+    it("setCrowdfundAddress with zero address reverts", async function () {
+      await expect(
+        governor.setCrowdfundAddress(ethers.ZeroAddress)
+      ).to.be.revertedWith("ArmadaGovernor: zero address");
+    });
+  });
+
+  // ============ RefundMode ============
+
+  describe("RefundMode finalization", function () {
+    it("quiet period applies even when finalized in refundMode", async function () {
+      await governor.setCrowdfundAddress(await crowdfund.getAddress());
+
+      // To trigger refundMode: totalCommitted >= MIN_SALE ($1M) but totalAllocUsdc < MIN_SALE.
+      // Must stay below ELASTIC_TRIGGER ($1.5M) to keep saleSize at BASE_SALE ($1.2M).
+      // 70 seeds × $15K = $1.05M committed (≥ $1M, < $1.5M → BASE_SALE).
+      // Hop-0 ceiling = 70% × $1.2M = $840K. Demand $1.05M > $840K → pro-rata $840K.
+      // No hop-1/2 participants → totalAllocUsdc = $840K < $1M → refundMode. ✓
+      const refundSeeds = seeds.slice(0, 70);
+      await crowdfund.addSeeds(refundSeeds.map(s => s.address));
+      await crowdfund.startWindow();
+
+      for (const seed of refundSeeds) {
+        const amount = USDC(15_000);
+        await usdc.mint(seed.address, amount);
+        await usdc.connect(seed).approve(await crowdfund.getAddress(), amount);
+        await crowdfund.connect(seed).commit(amount, 0);
+      }
+
+      await time.increase(THREE_WEEKS + 1);
+      await crowdfund.finalize();
+
+      // Verify refundMode was triggered
+      expect(await crowdfund.refundMode()).to.be.true;
+      expect(await crowdfund.finalizedAt()).to.be.gt(0);
+
+      await lockArmForProposal();
+
+      // Quiet period should be active even in refundMode
+      await time.increase(3 * ONE_DAY);
+      await expect(propose()).to.be.revertedWith("ArmadaGovernor: quiet period active");
+
+      // After quiet period, proposal succeeds
+      await time.increase(5 * ONE_DAY);
+      await expect(propose()).to.not.be.reverted;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a 7-day governance quiet period after crowdfund finalization, blocking all proposals until participants have time to claim ARM and delegate
- Quiet period is governable via timelock — can be shortened, extended, or removed entirely (0 disables it, max 30 days)
- `setCrowdfundAddress()` is a deployer-only, one-time setter that permanently locks after the first call
- New `IArmadaCrowdfundReadable` interface for cross-contract `finalizedAt` reads

## Test plan
- [x] Dedicated test suite (`governance_quiet_period.ts`) covering:
  - Proposal blocking during quiet period (days 1–6)
  - Success after quiet period expires
  - Exact boundary condition at `finalizedAt + 7 days`
  - Edge cases: no crowdfund registered, crowdfund not yet finalized
  - Governable duration: set to 0 (remove), extend to 14 days
  - Access control on `setCrowdfundAddress` and `setQuietPeriodDuration`
  - Quiet period applies after refundMode finalization
- [x] Existing `cross_contract_integration.ts` updated to account for quiet period

🤖 Generated with [Claude Code](https://claude.com/claude-code)