### PR TITLE
feat: multi-hop crowdfund UI with per-hop allocations and refund mode

### DIFF
--- a/crowdfund-frontend/src/atoms/crowdfund.ts
+++ b/crowdfund-frontend/src/atoms/crowdfund.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Jotai atoms for crowdfund contract state (phase, stats, participants).
 // ABOUTME: Updated by the useCrowdfund hook; consumed by UI components.
 import { atom } from 'jotai'
-import type { Phase, HopStats, Participant, CrowdfundEvent, CrowdfundDeployment } from '@/types/crowdfund'
+import type { Phase, HopStats, Participant, CrowdfundEvent, CrowdfundDeployment, UserHopData, UserHopAllocation } from '@/types/crowdfund'
 
 export interface CrowdfundState {
   // Contract phase and timing
@@ -19,7 +19,12 @@ export interface CrowdfundState {
   saleSize: bigint
   hopStats: [HopStats, HopStats, HopStats] | null
   participantCount: number
-  // Current user's data (for the user's active hop)
+  // Current user's data — all hops where whitelisted
+  userHops: UserHopData[]
+  selectedHop: number
+  userHopAllocations: UserHopAllocation[]
+  claimDeadline: bigint
+  // Convenience fields derived from selectedHop for direct component access
   currentHop: number
   currentParticipant: Participant | null
   currentInvitesRemaining: number
@@ -48,6 +53,10 @@ const DEFAULT_STATE: CrowdfundState = {
   saleSize: 0n,
   hopStats: null,
   participantCount: 0,
+  userHops: [],
+  selectedHop: 0,
+  userHopAllocations: [],
+  claimDeadline: 0n,
   currentHop: 0,
   currentParticipant: null,
   currentInvitesRemaining: 0,

--- a/crowdfund-frontend/src/components/ParticipantPanel.tsx
+++ b/crowdfund-frontend/src/components/ParticipantPanel.tsx
@@ -8,7 +8,7 @@ import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
 import { Badge } from '@/components/ui/badge'
 import { UserPlus, DollarSign, Gift, Undo2 } from 'lucide-react'
-import { Phase, CROWDFUND_CONSTANTS } from '@/types/crowdfund'
+import { Phase } from '@/types/crowdfund'
 import { formatUsdc, formatArm, hopLabel, parseUsdcInput } from '@/utils/format'
 import type { CrowdfundState } from '@/atoms/crowdfund'
 import type { useCrowdfund } from '@/hooks/useCrowdfund'
@@ -30,9 +30,20 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
   const isWhitelisted = participant?.isWhitelisted ?? false
   const hop = state.currentHop
   const committed = participant?.committed ?? 0n
-  const invitesReceived = BigInt(participant?.invitesReceived ?? 1)
-  const cap = invitesReceived * (CROWDFUND_CONSTANTS.HOP_CAPS[hop] ?? CROWDFUND_CONSTANTS.HOP_CAPS[0])
+
+  // Use effectiveCap from contract (handles invite stacking correctly)
+  const hopData = state.userHops.find((h) => h.hop === hop)
+  const cap = hopData?.effectiveCap ?? 0n
   const remaining = cap - committed
+
+  // Aggregate committed across all hops (for refund display)
+  const totalUserCommitted = state.userHops.reduce(
+    (sum, h) => sum + h.participant.committed,
+    0n,
+  )
+
+  // Check if any hop has been claimed (claim() is aggregate across all hops)
+  const anyClaimed = state.userHops.some((h) => h.participant.claimed)
 
   // Use chain block timestamp (not Date.now()) — EVM time diverges from wall clock in local mode
   const now = state.blockTimestamp || Math.floor(Date.now() / 1000)
@@ -73,7 +84,7 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
 
   const handleRefund = async () => {
     setIsSubmitting(true)
-    await crowdfund.claimRefund()
+    await crowdfund.refund()
     setIsSubmitting(false)
   }
 
@@ -83,6 +94,31 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
         <CardTitle className="text-base">Participant</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
+        {/* Hop Selector — only shown when whitelisted at multiple hops */}
+        {state.userHops.length > 1 && (
+          <div className="space-y-1">
+            <Label className="text-xs text-muted-foreground">Active Hop</Label>
+            <div className="flex gap-1">
+              {state.userHops.map((h) => (
+                <Button
+                  key={h.hop}
+                  variant={h.hop === hop ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => crowdfund.setSelectedHop(h.hop)}
+                  className="text-xs"
+                >
+                  {hopLabel(h.hop)}
+                  {h.participant.committed > 0n && (
+                    <span className="ml-1 opacity-70">
+                      ({formatUsdc(h.participant.committed)})
+                    </span>
+                  )}
+                </Button>
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* My Status */}
         <div className="grid grid-cols-2 gap-2 text-sm">
           <div className="text-muted-foreground">Status</div>
@@ -103,6 +139,12 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
               <div>{formatUsdc(remaining)}</div>
               <div className="text-muted-foreground">Invites Left</div>
               <div>{state.currentInvitesRemaining}</div>
+              {state.userHops.length > 1 && (
+                <>
+                  <div className="text-muted-foreground">Total (all hops)</div>
+                  <div className="font-medium">{formatUsdc(totalUserCommitted)}</div>
+                </>
+              )}
             </>
           )}
         </div>
@@ -178,8 +220,8 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
           </>
         )}
 
-        {/* Claim Section (Finalized) */}
-        {phase === Phase.Finalized && committed > 0n && (
+        {/* Claim Section (Finalized, normal — not refundMode) */}
+        {phase === Phase.Finalized && !state.refundMode && totalUserCommitted > 0n && (
           <>
             <Separator />
             <div className="space-y-2">
@@ -187,6 +229,18 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
                 <Gift className="h-3.5 w-3.5" />
                 Claim Allocation
               </Label>
+              {/* Per-hop breakdown (only if multiple hops have allocations) */}
+              {state.userHopAllocations.length > 1 && (
+                <div className="text-xs space-y-1 bg-muted/30 rounded-md p-2">
+                  {state.userHopAllocations.map((a) => (
+                    <div key={a.hop} className="flex justify-between">
+                      <span className="text-muted-foreground">{hopLabel(a.hop)}:</span>
+                      <span>{formatArm(a.allocation)} ARM / {formatUsdc(a.refund)} refund</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {/* Aggregate totals */}
               {state.currentAllocation && (
                 <div className="grid grid-cols-2 gap-1 text-sm bg-muted/50 rounded-md p-2">
                   <span className="text-muted-foreground">ARM tokens:</span>
@@ -197,17 +251,48 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
               )}
               <Button
                 onClick={handleClaim}
-                disabled={isSubmitting || state.currentAllocation?.claimed === true}
+                disabled={isSubmitting || anyClaimed}
                 className="w-full"
               >
-                {state.currentAllocation?.claimed ? 'Already Claimed' : 'Claim'}
+                {anyClaimed ? 'Already Claimed' : 'Claim'}
+              </Button>
+              {/* Claim deadline */}
+              {state.claimDeadline > 0n && !anyClaimed && (
+                <p className="text-xs text-muted-foreground">
+                  Claim by: {new Date(Number(state.claimDeadline) * 1000).toLocaleDateString()}
+                </p>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Refund Section (Finalized + refundMode) */}
+        {phase === Phase.Finalized && state.refundMode && totalUserCommitted > 0n && (
+          <>
+            <Separator />
+            <div className="space-y-2">
+              <Label className="flex items-center gap-1.5">
+                <Undo2 className="h-3.5 w-3.5" />
+                Refund (Sale Below Minimum)
+              </Label>
+              <p className="text-sm">
+                Sale did not reach minimum. Full refund available:{' '}
+                <span className="font-medium">{formatUsdc(totalUserCommitted)}</span>
+              </p>
+              <Button
+                onClick={handleRefund}
+                disabled={isSubmitting || anyClaimed}
+                className="w-full"
+                variant="destructive"
+              >
+                {anyClaimed ? 'Already Refunded' : 'Claim Refund'}
               </Button>
             </div>
           </>
         )}
 
         {/* Refund Section (Canceled) */}
-        {phase === Phase.Canceled && committed > 0n && (
+        {phase === Phase.Canceled && totalUserCommitted > 0n && (
           <>
             <Separator />
             <div className="space-y-2">
@@ -215,14 +300,14 @@ export function ParticipantPanel({ state, crowdfund }: ParticipantPanelProps) {
                 <Undo2 className="h-3.5 w-3.5" />
                 Refund
               </Label>
-              <p className="text-sm">Full refund: <span className="font-medium">{formatUsdc(committed)}</span></p>
+              <p className="text-sm">Full refund: <span className="font-medium">{formatUsdc(totalUserCommitted)}</span></p>
               <Button
                 onClick={handleRefund}
-                disabled={isSubmitting || participant?.claimed === true}
+                disabled={isSubmitting || anyClaimed}
                 className="w-full"
                 variant="destructive"
               >
-                {participant?.claimed ? 'Already Refunded' : 'Claim Refund'}
+                {anyClaimed ? 'Already Refunded' : 'Claim Refund'}
               </Button>
             </div>
           </>

--- a/crowdfund-frontend/src/components/ParticipantsTable.tsx
+++ b/crowdfund-frontend/src/components/ParticipantsTable.tsx
@@ -35,6 +35,7 @@ export function ParticipantsTable({ state, crowdfund }: ParticipantsTableProps) 
   }, [state.participantCount]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const isFinalized = state.phase === Phase.Finalized || state.phase === Phase.Canceled
+  const isRefundMode = state.refundMode || state.phase === Phase.Canceled
 
   return (
     <Card>
@@ -68,11 +69,17 @@ export function ParticipantsTable({ state, crowdfund }: ParticipantsTableProps) 
                   <TableHead>Hop</TableHead>
                   <TableHead className="text-right">Committed</TableHead>
                   <TableHead className="text-right">Invites Sent</TableHead>
-                  {isFinalized && (
+                  {isFinalized && !isRefundMode && (
                     <>
                       <TableHead className="text-right">Allocation</TableHead>
                       <TableHead className="text-right">Refund</TableHead>
                       <TableHead>Claimed</TableHead>
+                    </>
+                  )}
+                  {isFinalized && isRefundMode && (
+                    <>
+                      <TableHead className="text-right">Refund</TableHead>
+                      <TableHead>Refunded</TableHead>
                     </>
                   )}
                 </TableRow>
@@ -96,7 +103,7 @@ export function ParticipantsTable({ state, crowdfund }: ParticipantsTableProps) 
                     <TableCell className="text-right">
                       {row.participant.invitesSent}
                     </TableCell>
-                    {isFinalized && (
+                    {isFinalized && !isRefundMode && (
                       <>
                         <TableCell className="text-right">
                           {row.participant.allocation > 0n
@@ -106,6 +113,22 @@ export function ParticipantsTable({ state, crowdfund }: ParticipantsTableProps) 
                         <TableCell className="text-right">
                           {row.participant.refund > 0n
                             ? formatUsdc(row.participant.refund)
+                            : '-'}
+                        </TableCell>
+                        <TableCell>
+                          {row.participant.claimed ? (
+                            <Badge variant="outline" className="border-success text-success text-xs">Yes</Badge>
+                          ) : (
+                            <span className="text-muted-foreground text-xs">No</span>
+                          )}
+                        </TableCell>
+                      </>
+                    )}
+                    {isFinalized && isRefundMode && (
+                      <>
+                        <TableCell className="text-right">
+                          {row.participant.committed > 0n
+                            ? formatUsdc(row.participant.committed)
                             : '-'}
                         </TableCell>
                         <TableCell>

--- a/crowdfund-frontend/src/hooks/useCrowdfund.ts
+++ b/crowdfund-frontend/src/hooks/useCrowdfund.ts
@@ -17,7 +17,7 @@ import { loadDeployment } from '@/config/deployments'
 import { POLL_INTERVAL_MS, isLocalMode } from '@/config/network'
 import { getCrowdfundContract, getUsdcContract, getArmContract } from '@/services/contract'
 import { fetchPastEvents, subscribeToEvents } from '@/services/events'
-import type { CrowdfundDeployment, HopStats, Participant, Phase } from '@/types/crowdfund'
+import type { CrowdfundDeployment, Phase, UserHopData, UserHopAllocation } from '@/types/crowdfund'
 import { formatUsdc } from '@/utils/format'
 import { parseParticipant, parseHopStats } from '@/utils/crowdfund-parse'
 
@@ -29,6 +29,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
   const setParticipantList = useSetAtom(participantListAtom)
   const setParticipantListLoading = useSetAtom(participantListLoadingAtom)
   const unsubRef = useRef<(() => void) | null>(null)
+  const selectedHopRef = useRef(0)
 
   // Load deployment on mount
   useEffect(() => {
@@ -70,6 +71,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
         armBalance,
         usdcAllowance,
         isRefundMode,
+        claimDeadline,
       ] = await Promise.all([
         contract.phase(),
         contract.admin(),
@@ -87,42 +89,81 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
         arm.balanceOf(currentAddress),
         usdc.allowance(currentAddress, deployment.contracts.crowdfund),
         contract.refundMode(),
+        contract.claimDeadline(),
       ])
 
       const parsedPhase = Number(phase) as Phase
 
-      // Determine user's active hop by checking all hops for whitelist status.
-      // Use the lowest whitelisted hop as the "active" hop for UI display.
+      // Determine which hops the user is whitelisted in (may be multiple)
       const hopChecks = await Promise.all(
         [0, 1, 2].map((h) => contract.isWhitelisted(currentAddress, h)),
       )
-      let activeHop = 0
-      for (let h = 0; h < hopChecks.length; h++) {
-        if (hopChecks[h]) {
-          activeHop = h
-          break
-        }
-      }
+      const whitelistedHops = [0, 1, 2].filter((_, i) => hopChecks[i])
 
-      // Fetch participant data and invites remaining for the active hop
-      const [participantData, invitesRemaining] = await Promise.all([
-        contract.participants(currentAddress, activeHop),
-        contract.getInvitesRemaining(currentAddress, activeHop),
-      ])
-      const parsedParticipant = parseParticipant(participantData)
-
-      // Fetch allocation if finalized (and not in refund mode) and participant has committed
-      let currentAllocation = null
-      if (parsedPhase === 2 && !isRefundMode && parsedParticipant.committed > 0n) {
-        try {
-          const allocResult = await contract.getAllocation(currentAddress)
-          currentAllocation = {
-            allocation: BigInt(allocResult[0]),
-            refund: BigInt(allocResult[1]),
-            claimed: allocResult[2] as boolean,
+      // Fetch participant data, effective cap, and invites remaining for ALL whitelisted hops
+      const userHops: UserHopData[] = await Promise.all(
+        whitelistedHops.map(async (hop) => {
+          const [participantData, effectiveCap, invitesRemaining] = await Promise.all([
+            contract.participants(currentAddress, hop),
+            contract.getEffectiveCap(currentAddress, hop),
+            contract.getInvitesRemaining(currentAddress, hop),
+          ])
+          return {
+            hop,
+            participant: parseParticipant(participantData),
+            effectiveCap: BigInt(effectiveCap),
+            invitesRemaining: Number(invitesRemaining),
           }
-        } catch {
-          // getAllocation may fail if not finalized
+        }),
+      )
+
+      // Use previous selectedHop if still whitelisted, else fall back to lowest whitelisted hop
+      const prevSelectedHop = selectedHopRef.current
+      const selectedHop = whitelistedHops.includes(prevSelectedHop)
+        ? prevSelectedHop
+        : (whitelistedHops[0] ?? 0)
+      selectedHopRef.current = selectedHop
+      const selectedHopData = userHops.find((h) => h.hop === selectedHop)
+      const currentParticipant = selectedHopData?.participant ?? null
+      const currentInvitesRemaining = selectedHopData?.invitesRemaining ?? 0
+
+      // Fetch aggregate allocation if finalized and not in refund mode
+      let currentAllocation = null
+      let userHopAllocations: UserHopAllocation[] = []
+      if (parsedPhase === 2 && !isRefundMode) {
+        // Aggregate allocation for the claim button
+        const hasCommitted = userHops.some((h) => h.participant.committed > 0n)
+        if (hasCommitted) {
+          try {
+            const allocResult = await contract.getAllocation(currentAddress)
+            currentAllocation = {
+              allocation: BigInt(allocResult[0]),
+              refund: BigInt(allocResult[1]),
+              claimed: allocResult[2] as boolean,
+            }
+          } catch {
+            // getAllocation may fail if not finalized
+          }
+
+          // Per-hop allocation breakdown
+          const hopsWithCommitments = userHops.filter((h) => h.participant.committed > 0n)
+          userHopAllocations = (
+            await Promise.all(
+              hopsWithCommitments.map(async (h) => {
+                try {
+                  const res = await contract.getAllocationAtHop(currentAddress, h.hop)
+                  return {
+                    hop: h.hop,
+                    allocation: BigInt(res[0]),
+                    refund: BigInt(res[1]),
+                    claimed: res[2] as boolean,
+                  }
+                } catch {
+                  return null
+                }
+              }),
+            )
+          ).filter((a): a is UserHopAllocation => a !== null)
         }
       }
 
@@ -141,9 +182,13 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
           parseHopStats(hop2Stats),
         ],
         participantCount: Number(participantCount),
-        currentHop: activeHop,
-        currentParticipant: parsedParticipant,
-        currentInvitesRemaining: Number(invitesRemaining),
+        userHops,
+        selectedHop,
+        userHopAllocations,
+        claimDeadline: BigInt(claimDeadline),
+        currentHop: selectedHop,
+        currentParticipant,
+        currentInvitesRemaining,
         currentAllocation,
         usdcBalance: BigInt(usdcBalance),
         armBalance: BigInt(armBalance),
@@ -173,6 +218,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
       const count = Number(await contract.getParticipantCount())
       const phase = Number(await contract.phase())
       const isFinalized = phase === 2 // Phase.Finalized
+      const isRefundMode = isFinalized ? (await contract.refundMode()) as boolean : false
       const rows: ParticipantRow[] = []
 
       // Fetch in batches of 20. participantNodes returns (address, hop) tuples.
@@ -194,9 +240,9 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
           addressesAndHops.map(({ addr, hop }) => contract.participants(addr, hop)),
         )
 
-        // After finalization, fetch computed allocations via getAllocationAtHop()
-        // since the struct only stores allocation/refund after claim().
-        const allocations = isFinalized
+        // After finalization, fetch computed allocations via getAllocationAtHop().
+        // In refundMode, allocations are meaningless — committed amount IS the refund.
+        const allocations = isFinalized && !isRefundMode
           ? await Promise.all(
               addressesAndHops.map(({ addr, hop }) =>
                 contract.getAllocationAtHop(addr, hop).catch(() => null),
@@ -212,6 +258,10 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
             parsed.allocation = BigInt(allocations[j][0])
             parsed.refund = BigInt(allocations[j][1])
             parsed.claimed = allocations[j][2] as boolean
+          } else if (isRefundMode) {
+            // In refundMode, full committed amount is refundable
+            parsed.allocation = 0n
+            parsed.refund = parsed.committed
           }
 
           rows.push({
@@ -260,6 +310,26 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
       unsubRef.current = null
     }
   }, [deployment, provider, setEvents])
+
+  // =========== Hop Selection ===========
+
+  const setSelectedHop = useCallback(
+    (hop: number) => {
+      selectedHopRef.current = hop
+      setState((prev) => {
+        const hopData = prev.userHops.find((h) => h.hop === hop)
+        if (!hopData) return prev
+        return {
+          ...prev,
+          selectedHop: hop,
+          currentHop: hop,
+          currentParticipant: hopData.participant,
+          currentInvitesRemaining: hopData.invitesRemaining,
+        }
+      })
+    },
+    [setState],
+  )
 
   // =========== Write Operations ===========
 
@@ -463,6 +533,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
     deployment,
     refreshState,
     refreshParticipantList,
+    setSelectedHop,
     // Write operations
     addSeeds,
     loadArm,

--- a/crowdfund-frontend/src/types/crowdfund.ts
+++ b/crowdfund-frontend/src/types/crowdfund.ts
@@ -33,6 +33,22 @@ export interface AllocationInfo {
   claimed: boolean
 }
 
+/** Per-hop data for the connected user */
+export interface UserHopData {
+  hop: number
+  participant: Participant
+  effectiveCap: bigint
+  invitesRemaining: number
+}
+
+/** Per-hop allocation (post-finalization, non-refundMode only) */
+export interface UserHopAllocation {
+  hop: number
+  allocation: bigint
+  refund: bigint
+  claimed: boolean
+}
+
 export interface CrowdfundDeployment {
   chainId: number
   deployer: string

--- a/scripts/full_lifecycle_demo.ts
+++ b/scripts/full_lifecycle_demo.ts
@@ -257,7 +257,7 @@ async function main() {
   let hop1Count = 0;
   for (let i = 0; i < NUM_SEED_INVITERS; i++) {
     for (let j = 0; j < INVITES_PER_SEED && hop1Count < hop1Addrs.length; j++) {
-      await crowdfund.connect(seeds[i]).invite(hop1Addrs[hop1Count].address);
+      await crowdfund.connect(seeds[i]).invite(hop1Addrs[hop1Count].address, 0);
       hop1Count++;
     }
     log("INVITE", `Seed-${String.fromCharCode(65 + i)} invites ${INVITES_PER_SEED} \u2192 hop 1`);
@@ -266,7 +266,7 @@ async function main() {
   let hop2Count = 0;
   for (let i = 0; i < hop1Addrs.length; i++) {
     for (let j = 0; j < INVITES_PER_HOP1 && hop2Count < hop2Addrs.length; j++) {
-      await crowdfund.connect(hop1Addrs[i]).invite(hop2Addrs[hop2Count].address);
+      await crowdfund.connect(hop1Addrs[i]).invite(hop2Addrs[hop2Count].address, 1);
       hop2Count++;
     }
   }
@@ -284,7 +284,7 @@ async function main() {
     const amount = ethers.parseUnits(SEED_CAP, 6);
     await usdc.mint(s.address, amount);
     await usdc.connect(s).approve(await crowdfund.getAddress(), amount);
-    await crowdfund.connect(s).commit(amount);
+    await crowdfund.connect(s).commit(amount, 0);
   }
   log("COMMIT", `${seeds.length} seeds commit $${SEED_CAP} each = ${fmtUsdc(ethers.parseUnits(SEED_CAP, 6) * BigInt(seeds.length))}`);
 
@@ -293,7 +293,7 @@ async function main() {
     const amount = ethers.parseUnits(HOP1_CAP, 6);
     await usdc.mint(hop1Addrs[i].address, amount);
     await usdc.connect(hop1Addrs[i]).approve(await crowdfund.getAddress(), amount);
-    await crowdfund.connect(hop1Addrs[i]).commit(amount);
+    await crowdfund.connect(hop1Addrs[i]).commit(amount, 1);
   }
   log("COMMIT", `${hop1Count} hop-1 commit $${HOP1_CAP} each = ${fmtUsdc(ethers.parseUnits(HOP1_CAP, 6) * BigInt(hop1Count))}`);
 
@@ -302,7 +302,7 @@ async function main() {
     const amount = ethers.parseUnits(HOP2_CAP, 6);
     await usdc.mint(hop2Addrs[i].address, amount);
     await usdc.connect(hop2Addrs[i]).approve(await crowdfund.getAddress(), amount);
-    await crowdfund.connect(hop2Addrs[i]).commit(amount);
+    await crowdfund.connect(hop2Addrs[i]).commit(amount, 2);
   }
   log("COMMIT", `${hop2Count} hop-2 commit $${HOP2_CAP} each = ${fmtUsdc(ethers.parseUnits(HOP2_CAP, 6) * BigInt(hop2Count))}`);
 


### PR DESCRIPTION
## Summary
- Support users whitelisted at multiple hops: hop selector, per-hop allocation breakdown, aggregate totals
- Handle refund mode (sale below minimum) as a distinct UI state in both ParticipantPanel and ParticipantsTable
- Fix stale closure bug where `refreshState` poll would revert the user's hop selection via `selectedHopRef`
- Update demo script to pass explicit hop parameters to `invite()` and `commit()` matching updated contract ABI

## Test plan
- [ ] Start local environment (`npm run chains && npm run setup`)
- [ ] Open crowdfund UI (`npm run crowdfund-ui`), connect wallet whitelisted at multiple hops
- [ ] Verify hop selector appears and switching hops updates committed/cap/invites display
- [ ] Verify hop selection persists across poll cycles (no revert after ~5s)
- [ ] Finalize a crowdfund and verify per-hop allocation breakdown displays correctly
- [ ] Test refund mode: finalize with total below minimum, verify refund UI appears instead of claim
- [ ] Test canceled state: verify refund section shows aggregate committed across all hops
- [ ] Run `npm run crowdfund:populate` / full lifecycle demo to verify script updates work

🤖 Generated with [Claude Code](https://claude.com/claude-code)