### PR TITLE
feat: per-hop invite-received caps

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -31,7 +31,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     uint256 public constant LAUNCH_TEAM_INVITE_PERIOD = 7 days;
     uint256 public constant CLAIM_DEADLINE_DURATION = 1095 days; // 3 years
     uint256 public constant MIN_COMMIT = 10 * 1e6;               // $10 USDC minimum per commit
-    uint16 public constant MAX_INVITES_RECEIVED = 10;            // cap on invite stacking per (address, hop) node
+    // Per-hop invite stacking caps are stored in hopConfigs[].maxInvitesReceived (1, 10, 20)
     uint8 public constant MAX_SEEDS = 150;                       // max number of seeds (hop-0 participants)
     uint8 public constant LAUNCH_TEAM_HOP1_BUDGET = 60;          // launch team direct hop-1 invite slots
     uint8 public constant LAUNCH_TEAM_HOP2_BUDGET = 60;          // launch team direct hop-2 invite slots
@@ -148,9 +148,9 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         securityCouncil = _securityCouncil;
         phase = Phase.Setup;
 
-        hopConfigs[0] = HopConfig({ ceilingBps: 7000, capUsdc: 15_000 * 1e6, maxInvites: 3 });
-        hopConfigs[1] = HopConfig({ ceilingBps: 4500, capUsdc: 4_000 * 1e6,  maxInvites: 2 });
-        hopConfigs[2] = HopConfig({ ceilingBps: 0,    capUsdc: 1_000 * 1e6,  maxInvites: 0 });
+        hopConfigs[0] = HopConfig({ ceilingBps: 7000, capUsdc: 15_000 * 1e6, maxInvites: 3, maxInvitesReceived: 1 });
+        hopConfigs[1] = HopConfig({ ceilingBps: 4500, capUsdc: 4_000 * 1e6,  maxInvites: 2, maxInvitesReceived: 10 });
+        hopConfigs[2] = HopConfig({ ceilingBps: 0,    capUsdc: 1_000 * 1e6,  maxInvites: 0, maxInvitesReceived: 20 });
     }
 
     // ============ Setup Phase ============
@@ -246,10 +246,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
             emit Invited(msg.sender, invitee, inviteeHop);
         } else {
             // Subsequent invite — increment counter (scales cap + outgoing budget)
-            // TODO: MAX_INVITES_RECEIVED = 10 is a placeholder — revisit after modeling
-            // expected invite patterns and desired cap concentration limits.
             require(
-                inviteeNode.invitesReceived < MAX_INVITES_RECEIVED,
+                inviteeNode.invitesReceived < hopConfigs[inviteeHop].maxInvitesReceived,
                 "ArmadaCrowdfund: max invites received"
             );
             inviteeNode.invitesReceived++;
@@ -295,7 +293,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
             emit Invited(msg.sender, invitee, hop);
         } else {
             require(
-                inviteeNode.invitesReceived < MAX_INVITES_RECEIVED,
+                inviteeNode.invitesReceived < hopConfigs[hop].maxInvitesReceived,
                 "ArmadaCrowdfund: max invites received"
             );
             inviteeNode.invitesReceived++;

--- a/contracts/crowdfund/IArmadaCrowdfund.sol
+++ b/contracts/crowdfund/IArmadaCrowdfund.sol
@@ -18,9 +18,10 @@ enum Phase {
 // ========== Structs ==========
 
 struct HopConfig {
-    uint16 ceilingBps;      // Ceiling as basis points — overlapping (7000, 4500, 0). Hop-2 uses floor+rollover instead.
-    uint256 capUsdc;        // Max individual commitment in USDC (6 decimals)
-    uint8 maxInvites;       // How many addresses this hop can invite (3, 2, 0)
+    uint16 ceilingBps;          // Ceiling as basis points — overlapping (7000, 4500, 0). Hop-2 uses floor+rollover instead.
+    uint256 capUsdc;            // Max individual commitment in USDC (6 decimals)
+    uint8 maxInvites;           // How many addresses this hop can invite (3, 2, 0)
+    uint16 maxInvitesReceived;  // Cap on invite stacking per (address, hop) node
 }
 
 struct Participant {

--- a/crowdfund-frontend/src/config/abi.ts
+++ b/crowdfund-frontend/src/config/abi.ts
@@ -42,7 +42,7 @@ export const CROWDFUND_ABI = [
   'function participants(address, uint8) view returns (bool isWhitelisted, uint16 invitesReceived, uint256 committed, uint256 allocation, uint256 refund, bool claimed, address invitedBy, uint16 invitesSent)',
   'function participantNodes(uint256) view returns (address addr, uint8 hop)',
   'function hopStats(uint256) view returns (uint256 totalCommitted, uint32 uniqueCommitters, uint32 whitelistCount)',
-  'function hopConfigs(uint256) view returns (uint16 ceilingBps, uint256 capUsdc, uint8 maxInvites)',
+  'function hopConfigs(uint256) view returns (uint16 ceilingBps, uint256 capUsdc, uint8 maxInvites, uint16 maxInvitesReceived)',
   'function finalCeilings(uint256) view returns (uint256)',
   'function finalDemands(uint256) view returns (uint256)',
   'function totalArmClaimed() view returns (uint256)',

--- a/test-foundry/CrowdfundFullInvariant.t.sol
+++ b/test-foundry/CrowdfundFullInvariant.t.sol
@@ -260,9 +260,9 @@ contract CrowdfundFullInvariantTest is Test {
 
     /// @notice Hop ceiling basis points match spec: 7000/4500/0 (hop-2 uses floor+rollover, not BPS)
     function invariant_ceilingBpsAreValid() public view {
-        (uint16 bps0, , ) = crowdfund.hopConfigs(0);
-        (uint16 bps1, , ) = crowdfund.hopConfigs(1);
-        (uint16 bps2, , ) = crowdfund.hopConfigs(2);
+        (uint16 bps0, , , ) = crowdfund.hopConfigs(0);
+        (uint16 bps1, , , ) = crowdfund.hopConfigs(1);
+        (uint16 bps2, , , ) = crowdfund.hopConfigs(2);
         assertEq(bps0, 7000, "INV-C2: Hop 0 ceiling should be 7000");
         assertEq(bps1, 4500, "INV-C2: Hop 1 ceiling should be 4500");
         assertEq(bps2, 0, "INV-C2: Hop 2 ceiling should be 0 (uses floor+rollover)");

--- a/test/crowdfund_launch_team.ts
+++ b/test/crowdfund_launch_team.ts
@@ -396,8 +396,8 @@ describe("Launch Team & Seed Cap", function () {
       expect(await crowdfund.getInvitesRemaining(invitee.address, 1)).to.equal(4); // 2 × 2
     });
 
-    it("re-invite capped at MAX_INVITES_RECEIVED", async function () {
-      // Invite 10 times (uses 10 budget slots)
+    it("re-invite capped at per-hop maxInvitesReceived (hop-1 = 10)", async function () {
+      // Hop-1 cap is 10 — invite 10 times (uses 10 budget slots)
       for (let i = 0; i < 10; i++) {
         await crowdfund.launchTeamInvite(invitee.address, 1);
       }
@@ -406,6 +406,19 @@ describe("Launch Team & Seed Cap", function () {
       // 11th re-invite should revert
       await expect(
         crowdfund.launchTeamInvite(invitee.address, 1)
+      ).to.be.revertedWith("ArmadaCrowdfund: max invites received");
+    });
+
+    it("re-invite capped at per-hop maxInvitesReceived (hop-2 = 20)", async function () {
+      // Hop-2 cap is 20 — invite 20 times (uses 20 budget slots)
+      for (let i = 0; i < 20; i++) {
+        await crowdfund.launchTeamInvite(invitee.address, 2);
+      }
+      expect(await crowdfund.getInvitesReceived(invitee.address, 2)).to.equal(20);
+
+      // 21st re-invite should revert
+      await expect(
+        crowdfund.launchTeamInvite(invitee.address, 2)
       ).to.be.revertedWith("ArmadaCrowdfund: max invites received");
     });
 

--- a/test/crowdfund_multinode.ts
+++ b/test/crowdfund_multinode.ts
@@ -235,6 +235,87 @@ describe("Crowdfund Multi-Node", function () {
   });
 
   // ============================================================
+  // Per-Hop Invite-Received Caps
+  // ============================================================
+
+  describe("Per-Hop Invite-Received Caps", function () {
+    it("hop-1 maxInvitesReceived is 10", async function () {
+      // Need 10 seeds to send 10 invites to the same hop-1 address
+      const signers = await ethers.getSigners();
+      const seeds = signers.slice(10, 20);
+      await setupWithSeeds(seeds);
+
+      // All 10 seeds invite alice to hop-1
+      for (let i = 0; i < 10; i++) {
+        await crowdfund.connect(seeds[i]).invite(alice.address, 0);
+      }
+      expect(await crowdfund.getInvitesReceived(alice.address, 1)).to.equal(10);
+
+      // Need an 11th seed to attempt the overflow
+      const extraSeed = signers[20];
+      await crowdfund.addSeeds([extraSeed.address]);
+      await expect(
+        crowdfund.connect(extraSeed).invite(alice.address, 0)
+      ).to.be.revertedWith("ArmadaCrowdfund: max invites received");
+    });
+
+    it("hop-2 maxInvitesReceived is 20", async function () {
+      // Need 20 hop-1 addresses to send 20 invites to the same hop-2 address
+      const signers = await ethers.getSigners();
+      const seeds = signers.slice(10, 17); // 7 seeds, each with 3 outgoing invites = 21 hop-1 addresses
+      await setupWithSeeds(seeds);
+
+      // Create 21 hop-1 addresses
+      const hop1Addrs: any[] = [];
+      for (let i = 0; i < seeds.length; i++) {
+        for (let j = 0; j < 3; j++) {
+          const idx = 20 + i * 3 + j;
+          if (idx < signers.length) {
+            await crowdfund.connect(seeds[i]).invite(signers[idx].address, 0);
+            hop1Addrs.push(signers[idx]);
+          }
+        }
+      }
+
+      // First 20 hop-1 addresses invite alice to hop-2
+      for (let i = 0; i < 20; i++) {
+        await crowdfund.connect(hop1Addrs[i]).invite(alice.address, 1);
+      }
+      expect(await crowdfund.getInvitesReceived(alice.address, 2)).to.equal(20);
+
+      // 21st should revert
+      await expect(
+        crowdfund.connect(hop1Addrs[20]).invite(alice.address, 1)
+      ).to.be.revertedWith("ArmadaCrowdfund: max invites received");
+    });
+
+    it("different hops enforce different caps", async function () {
+      // Hop-1 cap is 10, hop-2 cap is 20 — verify they're independent
+      const signers = await ethers.getSigners();
+      const seeds = signers.slice(10, 21); // 11 seeds
+      await setupWithSeeds(seeds);
+
+      // 10 invites to alice at hop-1 succeed, 11th fails
+      for (let i = 0; i < 10; i++) {
+        await crowdfund.connect(seeds[i]).invite(alice.address, 0);
+      }
+      await expect(
+        crowdfund.connect(seeds[10]).invite(alice.address, 0)
+      ).to.be.revertedWith("ArmadaCrowdfund: max invites received");
+
+      // Meanwhile alice can still receive invites at hop-2 (different node)
+      // Use two of the seeds' hop-1 invitees to invite alice at hop-2
+      const bob = signers[25];
+      const carol = signers[26];
+      await crowdfund.connect(seeds[0]).invite(bob.address, 0);
+      await crowdfund.connect(seeds[1]).invite(carol.address, 0);
+      await crowdfund.connect(bob).invite(alice.address, 1);
+      await crowdfund.connect(carol).invite(alice.address, 1);
+      expect(await crowdfund.getInvitesReceived(alice.address, 2)).to.equal(2);
+    });
+  });
+
+  // ============================================================
   // Full Recursive Self-Fill ($33k)
   // ============================================================
 


### PR DESCRIPTION
## Summary
- Replace flat `MAX_INVITES_RECEIVED = 10` constant with per-hop caps stored in `hopConfigs[].maxInvitesReceived`
- Hop 0 (seeds): cap 1 — prevents accidental duplicate seed additions
- Hop 1: cap 10 — moderate invite stacking (effective cap up to $40K)
- Hop 2: cap 20 — higher tolerance at smallest individual tier ($1K cap, effective up to $20K)

## Changes
- `IArmadaCrowdfund.sol`: add `maxInvitesReceived` field to `HopConfig` struct
- `ArmadaCrowdfund.sol`: remove `MAX_INVITES_RECEIVED` constant, update `invite()` and `launchTeamInvite()` to check `hopConfigs[hop].maxInvitesReceived`
- Frontend ABI updated for new `hopConfigs` return type
- Foundry invariant test updated for 4-field `hopConfigs` destructuring

## Test plan
- [x] `npm run test:all` — 533 Hardhat tests passing
- [x] `npm run test:forge` — 165 Foundry tests passing
- New tests: hop-1 cap at 10, hop-2 cap at 20, independent per-hop enforcement (via both `invite()` and `launchTeamInvite()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)