### PR TITLE
feat: restructure ProposalType (Standard/Extended/VetoRatification)

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -141,30 +141,34 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         deployer = msg.sender;
 
         // Standard proposals: 2d delay, 7d voting, 2d execution, 20% quorum
-        proposalTypeParams[ProposalType.ParameterChange] = ProposalParams({
+        proposalTypeParams[ProposalType.Standard] = ProposalParams({
             votingDelay: 2 days,
             votingPeriod: 7 days,
             executionDelay: 2 days,
             quorumBps: 2000
         });
 
-        proposalTypeParams[ProposalType.Treasury] = ProposalParams({
-            votingDelay: 2 days,
-            votingPeriod: 7 days,
-            executionDelay: 2 days,
-            quorumBps: 2000
-        });
-
-        // Governance quiet period: 7 days post-crowdfund-finalization before proposals allowed
-        quietPeriodDuration = 7 days;
-
-        // Extended: 2d delay, 14d voting, 7d execution, 30% quorum
-        proposalTypeParams[ProposalType.StewardElection] = ProposalParams({
+        // Extended proposals: 2d delay, 14d voting, 7d execution, 30% quorum
+        proposalTypeParams[ProposalType.Extended] = ProposalParams({
             votingDelay: 2 days,
             votingPeriod: 14 days,
             executionDelay: 7 days,
             quorumBps: 3000
         });
+
+        // VetoRatification: immediate voting, 7d period, no execution delay, 20% quorum.
+        // These params bypass setProposalTypeParams() bounds (MIN_VOTING_DELAY=1d,
+        // MIN_EXECUTION_DELAY=1d), making VetoRatification timing effectively immutable
+        // via governance. Only the veto mechanism (Phase 4) can create these proposals.
+        proposalTypeParams[ProposalType.VetoRatification] = ProposalParams({
+            votingDelay: 0,
+            votingPeriod: 7 days,
+            executionDelay: 0,
+            quorumBps: 2000
+        });
+
+        // Governance quiet period: 7 days post-crowdfund-finalization before proposals allowed
+        quietPeriodDuration = 7 days;
     }
 
     // ============ Quorum Exclusion ============
@@ -211,6 +215,10 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         ProposalParams calldata params
     ) external {
         require(msg.sender == address(timelock), "ArmadaGovernor: not timelock");
+        require(
+            proposalType != ProposalType.VetoRatification,
+            "ArmadaGovernor: VetoRatification immutable"
+        );
         require(
             params.votingDelay >= MIN_VOTING_DELAY && params.votingDelay <= MAX_VOTING_DELAY,
             "ArmadaGovernor: votingDelay out of bounds"
@@ -262,6 +270,10 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         require(
             targets.length == values.length && targets.length == calldatas.length,
             "ArmadaGovernor: length mismatch"
+        );
+        require(
+            proposalType != ProposalType.VetoRatification,
+            "ArmadaGovernor: auto-created only"
         );
         _checkQuietPeriod();
         _checkProposalThreshold(msg.sender);

--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -159,7 +159,7 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         // VetoRatification: immediate voting, 7d period, no execution delay, 20% quorum.
         // These params bypass setProposalTypeParams() bounds (MIN_VOTING_DELAY=1d,
         // MIN_EXECUTION_DELAY=1d), making VetoRatification timing effectively immutable
-        // via governance. Only the veto mechanism (Phase 4) can create these proposals.
+        // via governance. Only the veto mechanism can create these proposals.
         proposalTypeParams[ProposalType.VetoRatification] = ProposalParams({
             votingDelay: 0,
             votingPeriod: 7 days,

--- a/contracts/governance/IArmadaGovernance.sol
+++ b/contracts/governance/IArmadaGovernance.sol
@@ -6,9 +6,9 @@ pragma solidity ^0.8.17;
 // ========== Enums ==========
 
 enum ProposalType {
-    ParameterChange,   // Fee tiers, volume thresholds, yield fee rate, etc.
-    Treasury,          // Allocations, grants, partnerships
-    StewardElection    // Elect/replace treasury steward
+    Standard,          // 0 — 7d voting, 48h execution, 20% quorum
+    Extended,          // 1 — 14d voting, 7d execution, 30% quorum
+    VetoRatification   // 2 — 7d voting, no delay, 20% quorum (auto-created only)
 }
 
 enum ProposalState {

--- a/contracts/governance/TreasurySteward.sol
+++ b/contracts/governance/TreasurySteward.sol
@@ -9,7 +9,7 @@ import "./IArmadaGovernance.sol";
 import "./EmergencyPausable.sol";
 
 /// @title TreasurySteward — Elected steward with action queue and veto mechanism
-/// @notice Steward is elected via governance (StewardElection proposal). Has limited powers:
+/// @notice Steward is elected via governance (Extended proposal). Has limited powers:
 ///         can propose and execute actions on whitelisted target contracts, but tokenholders
 ///         can veto actions via governance proposals before they are executed.
 ///         The action delay is enforced to be >= 120% of the fastest governance veto cycle,
@@ -219,10 +219,10 @@ contract TreasurySteward is ReentrancyGuard, EmergencyPausable {
     // ============ View Functions ============
 
     /// @notice Minimum action delay derived from governor timing: 120% of the fastest governance cycle
-    /// @dev Fastest cycle is ParameterChange: votingDelay + votingPeriod + executionDelay
+    /// @dev Fastest cycle is Standard: votingDelay + votingPeriod + executionDelay
     function minActionDelay() public view returns (uint256) {
         (uint256 votingDelay, uint256 votingPeriod, uint256 executionDelay,) =
-            IArmadaGovernorTiming(governor).proposalTypeParams(ProposalType.ParameterChange);
+            IArmadaGovernorTiming(governor).proposalTypeParams(ProposalType.Standard);
         uint256 governanceCycle = votingDelay + votingPeriod + executionDelay;
         return (governanceCycle * DELAY_SAFETY_MARGIN_BPS) / BPS_DENOMINATOR;
     }

--- a/governance-ui/src/components/CreateProposalForm.tsx
+++ b/governance-ui/src/components/CreateProposalForm.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Form for creating governance proposals with calldata template builders.
-// ABOUTME: Supports Treasury (distribute/claim), StewardElection, and ParameterChange types.
+// ABOUTME: Supports Standard (distribute/claim), Extended (steward election), and manual calldata types.
 
 import { useState } from 'react'
 import { ethers } from 'ethers'
@@ -17,7 +17,7 @@ type TreasuryAction = 'distribute' | 'createClaim'
 
 export function CreateProposalForm({ contracts, wallet, onCreated }: CreateProposalFormProps) {
   const [isOpen, setIsOpen] = useState(false)
-  const [proposalType, setProposalType] = useState<ProposalType>(ProposalType.Treasury)
+  const [proposalType, setProposalType] = useState<ProposalType>(ProposalType.Standard)
   const [description, setDescription] = useState('')
   const [txStatus, setTxStatus] = useState<string | null>(null)
   const [txError, setTxError] = useState<string | null>(null)
@@ -28,10 +28,10 @@ export function CreateProposalForm({ contracts, wallet, onCreated }: CreatePropo
   const [treasuryRecipient, setTreasuryRecipient] = useState('')
   const [treasuryAmount, setTreasuryAmount] = useState('')
 
-  // StewardElection template fields
+  // Extended (steward election) template fields
   const [stewardAddress, setStewardAddress] = useState('')
 
-  // ParameterChange manual fields
+  // Manual calldata fields (for VetoRatification or advanced use)
   const [manualTarget, setManualTarget] = useState('')
   const [manualCalldata, setManualCalldata] = useState('')
   const [manualValue, setManualValue] = useState('0')
@@ -41,7 +41,7 @@ export function CreateProposalForm({ contracts, wallet, onCreated }: CreatePropo
   const buildActions = (): { targets: string[]; values: bigint[]; calldatas: string[] } | null => {
     if (!deployment) return null
 
-    if (proposalType === ProposalType.Treasury) {
+    if (proposalType === ProposalType.Standard) {
       const tokenAddr = treasuryToken === 'arm'
         ? deployment.contracts.armToken
         : contracts.usdcAddress ?? ''
@@ -65,7 +65,7 @@ export function CreateProposalForm({ contracts, wallet, onCreated }: CreatePropo
       }
     }
 
-    if (proposalType === ProposalType.StewardElection) {
+    if (proposalType === ProposalType.Extended) {
       if (!stewardAddress) return null
 
       const stewardIface = new ethers.Interface([
@@ -89,7 +89,7 @@ export function CreateProposalForm({ contracts, wallet, onCreated }: CreatePropo
       }
     }
 
-    // ParameterChange — manual
+    // Fallback manual calldata path
     if (!manualTarget || !manualCalldata) return null
     return {
       targets: [manualTarget],
@@ -173,7 +173,7 @@ export function CreateProposalForm({ contracts, wallet, onCreated }: CreatePropo
       <div className="mt-3">
         <label className="text-xs text-neutral-500">Type</label>
         <div className="mt-1 flex gap-2">
-          {[ProposalType.Treasury, ProposalType.StewardElection, ProposalType.ParameterChange].map((t) => (
+          {[ProposalType.Standard, ProposalType.Extended].map((t) => (
             <button
               key={t}
               onClick={() => setProposalType(t)}
@@ -201,8 +201,8 @@ export function CreateProposalForm({ contracts, wallet, onCreated }: CreatePropo
         />
       </div>
 
-      {/* Treasury Template */}
-      {proposalType === ProposalType.Treasury && (
+      {/* Standard Template */}
+      {proposalType === ProposalType.Standard && (
         <div className="mt-3 space-y-2">
           <div className="flex gap-2">
             <button
@@ -245,8 +245,8 @@ export function CreateProposalForm({ contracts, wallet, onCreated }: CreatePropo
         </div>
       )}
 
-      {/* StewardElection Template */}
-      {proposalType === ProposalType.StewardElection && (
+      {/* Extended Template */}
+      {proposalType === ProposalType.Extended && (
         <div className="mt-3">
           <input
             type="text"
@@ -261,8 +261,8 @@ export function CreateProposalForm({ contracts, wallet, onCreated }: CreatePropo
         </div>
       )}
 
-      {/* ParameterChange Manual */}
-      {proposalType === ProposalType.ParameterChange && (
+      {/* VetoRatification Manual Calldata — not shown in selector, kept for completeness */}
+      {proposalType === ProposalType.VetoRatification && (
         <div className="mt-3 space-y-2">
           <input
             type="text"

--- a/governance-ui/src/components/ProposalsPanel.tsx
+++ b/governance-ui/src/components/ProposalsPanel.tsx
@@ -57,11 +57,11 @@ export function ProposalsPanel({ contracts, wallet, govData }: ProposalsPanelPro
             <p className="mt-0.5 font-mono text-neutral-200">{fmtArm(eligible)} ARM</p>
           </div>
           <div>
-            <p className="text-neutral-500">Treasury/Param Quorum (20%)</p>
+            <p className="text-neutral-500">Standard Quorum (20%)</p>
             <p className="mt-0.5 font-mono text-neutral-200">{fmtArm(quorum20)} ARM</p>
           </div>
           <div>
-            <p className="text-neutral-500">Steward Election Quorum (30%)</p>
+            <p className="text-neutral-500">Extended Quorum (30%)</p>
             <p className="mt-0.5 font-mono text-neutral-200">{fmtArm(quorum30)} ARM</p>
           </div>
         </div>

--- a/governance-ui/src/governance-types.ts
+++ b/governance-ui/src/governance-types.ts
@@ -14,9 +14,9 @@ export enum ProposalState {
 
 /** Matches IArmadaGovernance.ProposalType enum */
 export enum ProposalType {
-  ParameterChange = 0,
-  Treasury = 1,
-  StewardElection = 2,
+  Standard = 0,
+  Extended = 1,
+  VetoRatification = 2,
 }
 
 /** Vote support values: 0=Against, 1=For, 2=Abstain */
@@ -69,9 +69,9 @@ export interface StewardActionData {
 
 /** Labels for proposal types */
 export const PROPOSAL_TYPE_LABELS: Record<ProposalType, string> = {
-  [ProposalType.ParameterChange]: 'Parameter Change',
-  [ProposalType.Treasury]: 'Treasury',
-  [ProposalType.StewardElection]: 'Steward Election',
+  [ProposalType.Standard]: 'Standard',
+  [ProposalType.Extended]: 'Extended',
+  [ProposalType.VetoRatification]: 'Veto Ratification',
 }
 
 /** Labels for proposal states */

--- a/mcp-server/src/tools/contract-state.ts
+++ b/mcp-server/src/tools/contract-state.ts
@@ -144,7 +144,7 @@ async function queryGovernance(env: DeployEnv): Promise<ContractQueryResult> {
   const gov = deployments.hub.governance.contracts;
   const usdcAddr = deployments.hub.cctp?.contracts.usdc;
 
-  // ProposalType enum: 0 = Treasury, 1 = Constitutional
+  // ProposalType enum: 0 = Standard, 1 = Extended, 2 = VetoRatification
   const [
     proposalThreshold,
     treasuryParams,

--- a/scripts/full_lifecycle_demo.ts
+++ b/scripts/full_lifecycle_demo.ts
@@ -56,7 +56,7 @@ const STEWARD_ACTION_DELAY = Math.ceil((TWO_DAYS + FIVE_DAYS + TWO_DAYS) * 12000
 const TIMELOCK_MIN_DELAY   = TWO_DAYS;
 
 // Governance enums
-const ProposalType = { ParameterChange: 0, Treasury: 1, StewardElection: 2 };
+const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 const Vote = { Against: 0, For: 1, Abstain: 2 };
 const PhaseNames  = ["SETUP", "ACTIVE", "FINALIZED", "CANCELED"];
 const StateNames  = ["PENDING", "ACTIVE", "DEFEATED", "SUCCEEDED", "QUEUED", "EXECUTED", "CANCELED"];
@@ -438,9 +438,9 @@ async function main() {
   const totalLocked = deployerLockAmt + totalSeedLocked;
   const proposalThreshold = await armToken.totalSupply() / 10000n * 10n; // 0.1%
 
-  log("QUORUM", `Treasury/ParameterChange (20%): ${fmtArm(quorum20pct)}`);
+  log("QUORUM", `Standard (20%): ${fmtArm(quorum20pct)}`);
   log("QUORUM", `  Deployer alone: ${fmtArm(deployerLockAmt)} ${deployerLockAmt >= quorum20pct ? "\u2713 SUFFICIENT" : "\u2717 INSUFFICIENT"}`);
-  log("QUORUM", `StewardElection (30%):          ${fmtArm(quorum30pct)}`);
+  log("QUORUM", `Extended (30%):          ${fmtArm(quorum30pct)}`);
   log("QUORUM", `  Deployer alone: ${fmtArm(deployerLockAmt)} ${deployerLockAmt >= quorum30pct ? "\u2713 SUFFICIENT" : "\u2717 INSUFFICIENT"}`);
   log("QUORUM", `  Deployer + seeds: ${fmtArm(totalLocked)} ${totalLocked >= quorum30pct ? "\u2713 SUFFICIENT" : "\u2717 INSUFFICIENT"}`);
 
@@ -451,7 +451,7 @@ async function main() {
   log("THRESHOLD", `Proposal threshold (0.1%): ${fmtArm(proposalThreshold)}`);
   verify("Deployer exceeds proposal threshold", deployerLockAmt >= proposalThreshold);
   verify("Treasury quorum reachable", totalLocked >= quorum20pct);
-  verify("StewardElection quorum reachable", totalLocked >= quorum30pct);
+  verify("Extended quorum reachable", totalLocked >= quorum30pct);
 
   // ================================================================
   //  PHASE 5: TREASURY PROPOSAL
@@ -467,7 +467,7 @@ async function main() {
   ])];
 
   await governor.connect(deployer).propose(
-    ProposalType.Treasury, targets5, values5, calldatas5,
+    ProposalType.Standard, targets5, values5, calldatas5,
     `Distribute ${DISTRIBUTE_AMOUNT} USDC to community grant recipient`
   );
   const pid1 = Number(await governor.proposalCount());
@@ -540,12 +540,12 @@ async function main() {
   ];
 
   await governor.connect(deployer).propose(
-    ProposalType.StewardElection, electTargets, electValues, electCalldatas,
+    ProposalType.Extended, electTargets, electValues, electCalldatas,
     "Elect treasury steward"
   );
   const pid2 = Number(await governor.proposalCount());
   log("PROPOSE", `Proposal #${pid2}: "Elect treasury steward"`);
-  log("PROPOSE", `Type: StewardElection (2d delay, 7d voting, 4d execution, 30% quorum)`);
+  log("PROPOSE", `Type: Extended (2d delay, 7d voting, 4d execution, 30% quorum)`);
   log("STATE", `Proposal #${pid2}: ${StateNames[Number(await governor.state(pid2))]}`);
 
   await fastForward(TWO_DAYS, "2 days (voting delay)");

--- a/scripts/governance_demo.ts
+++ b/scripts/governance_demo.ts
@@ -15,7 +15,7 @@
 
 import { ethers, network } from "hardhat";
 
-const ProposalType = { ParameterChange: 0, Treasury: 1, StewardElection: 2 };
+const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 const Vote = { Against: 0, For: 1, Abstain: 2 };
 const StateNames = ["PENDING", "ACTIVE", "DEFEATED", "SUCCEEDED", "QUEUED", "EXECUTED", "CANCELED"];
 
@@ -144,7 +144,7 @@ async function main() {
   ])];
 
   await governor.connect(alice).propose(
-    ProposalType.Treasury, targets1, values1, calldatas1, "Pay Carol 500 USDC"
+    ProposalType.Standard, targets1, values1, calldatas1, "Pay Carol 500 USDC"
   );
   const pid1 = Number(await governor.proposalCount());
   log("PROPOSE", `Alice creates Treasury proposal #${pid1}: "Pay Carol 500 USDC"`);
@@ -199,11 +199,11 @@ async function main() {
   ];
 
   await governor.connect(alice).propose(
-    ProposalType.StewardElection, electTargets, electValues, electCalldatas,
+    ProposalType.Extended, electTargets, electValues, electCalldatas,
     "Elect Dave as steward"
   );
   const pid2 = Number(await governor.proposalCount());
-  log("PROPOSE", `Alice creates StewardElection proposal #${pid2}: "Elect Dave as steward"`);
+  log("PROPOSE", `Alice creates Extended proposal #${pid2}: "Elect Dave as steward"`);
 
   await fastForward(TWO_DAYS, "2 days (voting delay)");
   await governor.connect(alice).castVote(pid2, Vote.For);
@@ -244,7 +244,7 @@ async function main() {
   ];
 
   await governor.connect(alice).propose(
-    ProposalType.ParameterChange, vetoTargets, vetoValues, vetoCalldatas,
+    ProposalType.Standard, vetoTargets, vetoValues, vetoCalldatas,
     "Remove Dave as steward"
   );
   const pid3 = Number(await governor.proposalCount());

--- a/test-foundry/GovernorInvariant.t.sol
+++ b/test-foundry/GovernorInvariant.t.sol
@@ -166,7 +166,7 @@ contract GovernorHandler is Test {
 
         vm.prank(actor);
         try governor.propose(
-            ProposalType.ParameterChange,
+            ProposalType.Standard,
             targets,
             values,
             calldatas,

--- a/test-foundry/StewardSecurity.t.sol
+++ b/test-foundry/StewardSecurity.t.sol
@@ -29,7 +29,7 @@ contract StewardSecurityTest is Test {
     address public stewardPerson = address(0xDA7E);
     address public attacker = address(0xBAD);
 
-    // Governor ParameterChange timing: 2d + 5d + 2d = 9 days
+    // Governor Standard proposal timing: 2d + 5d + 2d = 9 days
     // Min delay = 9 days * 120% = 10.8 days = 933120 seconds
     uint256 constant EXPECTED_MIN_DELAY = (2 days + 7 days + 2 days) * 12000 / 10000;
     // Use exactly the min delay for test setup
@@ -129,7 +129,7 @@ contract StewardSecurityTest is Test {
 
     function test_minActionDelay_derivedFromGovernor() public view {
         uint256 minDelay = steward.minActionDelay();
-        // ParameterChange: 2d voting delay + 5d voting period + 2d execution delay = 9d
+        // Standard: 2d voting delay + 5d voting period + 2d execution delay = 9d
         // 9 days * 120% = 10.8 days
         assertEq(minDelay, EXPECTED_MIN_DELAY);
     }

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -12,7 +12,7 @@ import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
-const ProposalType = { ParameterChange: 0, Treasury: 1, StewardElection: 2 };
+const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 const ProposalState = {
   Pending: 0, Active: 1, Defeated: 2, Succeeded: 3,
   Queued: 4, Executed: 5, Canceled: 6,
@@ -198,7 +198,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       // 9. Create a governance proposal (treasury owner is already the timelock from deployment)
       const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
       const proposalTx = await governor.propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await treasuryGov.getAddress()],
         [0],
         [dummyCalldata],
@@ -288,7 +288,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       // Create proposal to check quorum
       const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
       await governor.propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await treasuryGov.getAddress()],
         [0],
         [dummyCalldata],
@@ -341,7 +341,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
       await expect(
         governor.connect(pooledSeed).propose(
-          ProposalType.ParameterChange,
+          ProposalType.Standard,
           [await treasuryGov.getAddress()],
           [0],
           [dummyCalldata],
@@ -392,7 +392,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await mine(1);
       const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
       await governor.propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await treasuryGov.getAddress()],
         [0],
         [dummyCalldata],
@@ -443,7 +443,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       );
 
       await governor.propose(
-        ProposalType.Treasury,
+        ProposalType.Standard,
         [await crowdfund.getAddress()],
         [0],
         [sweepCalldata],
@@ -483,7 +483,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       // At snapshot: Alice has voting power, Bob does not
       const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
       await governor.propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await treasuryGov.getAddress()],
         [0],
         [dummyCalldata],
@@ -523,7 +523,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
       await governor.propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await treasuryGov.getAddress()],
         [0],
         [dummyCalldata],
@@ -565,7 +565,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
       await governor.propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await treasuryGov.getAddress()],
         [0],
         [dummyCalldata],
@@ -709,7 +709,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       // Create a proposal to get quorum value
       const dummyCalldata = localTreasury.interface.encodeFunctionData("setSteward", [localDeployer.address]);
       await localGovernor.propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await localTreasury.getAddress()],
         [0],
         [dummyCalldata],
@@ -756,7 +756,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       // Create proposal before claims
       const dummyCalldata = localTreasury.interface.encodeFunctionData("setSteward", [localDeployer.address]);
       await localGovernor.propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await localTreasury.getAddress()],
         [0],
         [dummyCalldata],
@@ -775,7 +775,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       // Create another proposal after claims
       await mine(1);
       await localGovernor.propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await localTreasury.getAddress()],
         [0],
         [dummyCalldata],
@@ -880,7 +880,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       // Propose: set treasury steward (demo governance action)
       const dummyCalldata = localTreasury.interface.encodeFunctionData("setSteward", [localDeployer.address]);
       await localGovernor.propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await localTreasury.getAddress()],
         [0],
         [dummyCalldata],

--- a/test/gas_benchmark.ts
+++ b/test/gas_benchmark.ts
@@ -395,7 +395,7 @@ describe("Gas Benchmarks", function () {
       // Create a proposal
       await mine(1);
       const proposeTx = await governor.propose(
-        0, // ParameterChange
+        0, // Standard
         [deployer.address],
         [0],
         [ethers.hexlify(ethers.toUtf8Bytes(""))],

--- a/test/governance_adversarial.ts
+++ b/test/governance_adversarial.ts
@@ -14,7 +14,7 @@ import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
-const ProposalType = { ParameterChange: 0, Treasury: 1, StewardElection: 2 };
+const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 const ProposalState = {
   Pending: 0, Active: 1, Defeated: 2, Succeeded: 3,
   Queued: 4, Executed: 5, Canceled: 6,
@@ -57,7 +57,7 @@ describe("Governance Adversarial", function () {
   // Helper: create a simple proposal
   async function createProposal(
     proposer: SignerWithAddress,
-    proposalType: number = ProposalType.ParameterChange,
+    proposalType: number = ProposalType.Standard,
     description: string = "Test proposal"
   ): Promise<number> {
     // Dummy target: call a view function (harmless)
@@ -622,7 +622,7 @@ describe("Governance Adversarial", function () {
 
     it("concurrent proposals have independent quorum snapshots", async function () {
       // Create proposal 1
-      const proposalId1 = await createProposal(alice, ProposalType.ParameterChange, "Proposal 1");
+      const proposalId1 = await createProposal(alice, ProposalType.Standard, "Proposal 1");
       const quorum1 = await governor.quorum(proposalId1);
 
       // Transfer 5% of supply worth of alice's ARM to treasury, changing the balance
@@ -631,7 +631,7 @@ describe("Governance Adversarial", function () {
       await mineBlock();
 
       // Create proposal 2 with different treasury balance
-      const proposalId2 = await createProposal(alice, ProposalType.ParameterChange, "Proposal 2");
+      const proposalId2 = await createProposal(alice, ProposalType.Standard, "Proposal 2");
       const quorum2 = await governor.quorum(proposalId2);
 
       // Proposal 1 quorum should reflect original treasury balance (65% excluded)
@@ -648,13 +648,13 @@ describe("Governance Adversarial", function () {
   });
 
   // ============================================================
-  // 6. StewardElection Extended Timing
+  // 6. Extended Proposal Timing
   // ============================================================
 
-  describe("Steward Election Timing", function () {
-    it("StewardElection uses 14d voting and 7d execution delay", async function () {
-      // Create a StewardElection proposal
-      const proposalId = await createProposal(alice, ProposalType.StewardElection, "Elect steward");
+  describe("Extended Proposal Timing", function () {
+    it("Extended proposal uses 14d voting and 7d execution delay", async function () {
+      // Create an Extended proposal
+      const proposalId = await createProposal(alice, ProposalType.Extended, "Elect steward");
 
       await time.increase(TWO_DAYS + 1);
 
@@ -671,10 +671,10 @@ describe("Governance Adversarial", function () {
       expect(await governor.state(proposalId)).to.equal(ProposalState.Succeeded);
     });
 
-    it("StewardElection requires 30% quorum", async function () {
+    it("Extended proposal requires 30% quorum", async function () {
       // Eligible = 35% of supply. 30% quorum = 10.5% of supply.
       // Bob (15% of supply) exceeds quorum.
-      const proposalId = await createProposal(alice, ProposalType.StewardElection);
+      const proposalId = await createProposal(alice, ProposalType.Extended);
 
       await time.increase(TWO_DAYS + 1);
 
@@ -686,13 +686,13 @@ describe("Governance Adversarial", function () {
       expect(await governor.state(proposalId)).to.equal(ProposalState.Succeeded);
     });
 
-    it("StewardElection defeated if 30% quorum not reached", async function () {
+    it("Extended proposal defeated if 30% quorum not reached", async function () {
       // Eligible = 35% of supply. 30% quorum = 10.5% of supply.
       // Transfer half of alice's tokens to reduce her voting power (10% of supply < 10.5% quorum).
       await armToken.connect(alice).transfer(carol.address, ALICE_AMOUNT / 2n);
       await mineBlock();
 
-      const proposalId = await createProposal(alice, ProposalType.StewardElection);
+      const proposalId = await createProposal(alice, ProposalType.Extended);
 
       await time.increase(TWO_DAYS + 1);
 

--- a/test/governance_emergency_pause.ts
+++ b/test/governance_emergency_pause.ts
@@ -14,7 +14,7 @@ import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
-const ProposalType = { ParameterChange: 0, Treasury: 1, StewardElection: 2 };
+const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 const Vote = { Against: 0, For: 1, Abstain: 2 };
 
 const ONE_DAY = 86400;
@@ -75,11 +75,11 @@ describe("Governance Emergency Pause", function () {
       await governor.connect(v.signer).castVote(proposalId, v.support);
     }
 
-    const votingPeriod = proposalType === ProposalType.StewardElection ? EXTENDED_VOTING_PERIOD : STANDARD_VOTING_PERIOD;
+    const votingPeriod = proposalType === ProposalType.Extended ? EXTENDED_VOTING_PERIOD : STANDARD_VOTING_PERIOD;
     await time.increase(votingPeriod + 1);
     await governor.queue(proposalId);
 
-    const executionDelay = proposalType === ProposalType.StewardElection ? EXTENDED_EXECUTION_DELAY : STANDARD_EXECUTION_DELAY;
+    const executionDelay = proposalType === ProposalType.Extended ? EXTENDED_EXECUTION_DELAY : STANDARD_EXECUTION_DELAY;
     await time.increase(executionDelay + 1);
 
     return proposalId;
@@ -591,7 +591,7 @@ describe("Governance Emergency Pause", function () {
       await standaloneGovernor.connect(guardian).emergencyPause();
 
       await standaloneGovernor.connect(alice).propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await standaloneGovernor.getAddress()],
         [0n],
         [standaloneGovernor.interface.encodeFunctionData("proposalCount")],
@@ -603,7 +603,7 @@ describe("Governance Emergency Pause", function () {
     it("castVote still works when paused", async function () {
       // Create a proposal first
       await standaloneGovernor.connect(alice).propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await standaloneGovernor.getAddress()],
         [0n],
         [standaloneGovernor.interface.encodeFunctionData("proposalCount")],
@@ -622,7 +622,7 @@ describe("Governance Emergency Pause", function () {
     it("execute reverts when paused", async function () {
       // Create and advance a proposal to Queued state
       await standaloneGovernor.connect(alice).propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await standaloneGovernor.getAddress()],
         [0n],
         [standaloneGovernor.interface.encodeFunctionData("proposalCount")],

--- a/test/governance_integration.ts
+++ b/test/governance_integration.ts
@@ -15,7 +15,7 @@ import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
 // Proposal types (must match IArmadaGovernance.sol enum order)
-const ProposalType = { ParameterChange: 0, Treasury: 1, StewardElection: 2 };
+const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 // Proposal states
 const ProposalState = {
   Pending: 0, Active: 1, Defeated: 2, Succeeded: 3,
@@ -94,14 +94,14 @@ describe("Governance Integration", function () {
     }
 
     // Fast-forward past voting period
-    const votingPeriod = proposalType === ProposalType.StewardElection ? EXTENDED_VOTING_PERIOD : STANDARD_VOTING_PERIOD;
+    const votingPeriod = proposalType === ProposalType.Extended ? EXTENDED_VOTING_PERIOD : STANDARD_VOTING_PERIOD;
     await time.increase(votingPeriod + 1);
 
     // Queue
     await governor.queue(proposalId);
 
     // Fast-forward past execution delay
-    const executionDelay = proposalType === ProposalType.StewardElection ? EXTENDED_EXECUTION_DELAY : STANDARD_EXECUTION_DELAY;
+    const executionDelay = proposalType === ProposalType.Extended ? EXTENDED_EXECUTION_DELAY : STANDARD_EXECUTION_DELAY;
     await time.increase(executionDelay + 1);
 
     // Execute
@@ -229,10 +229,10 @@ describe("Governance Integration", function () {
   });
 
   // ============================================================
-  // 3. Proposal Lifecycle — Parameter Change
+  // 3. Proposal Lifecycle — Standard
   // ============================================================
 
-  describe("Proposal Lifecycle - ParameterChange", function () {
+  describe("Proposal Lifecycle - Standard", function () {
     it("should create proposal with sufficient voting power", async function () {
       const targets = [await treasury.getAddress()];
       const values = [0n];
@@ -241,7 +241,7 @@ describe("Governance Integration", function () {
       ])];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas,
+        ProposalType.Standard, targets, values, calldatas,
         "Test parameter change"
       );
 
@@ -257,7 +257,7 @@ describe("Governance Integration", function () {
 
       await expect(
         governor.connect(carol).propose(
-          ProposalType.ParameterChange, targets, values, calldatas, "Should fail"
+          ProposalType.Standard, targets, values, calldatas, "Should fail"
         )
       ).to.be.revertedWith("ArmadaGovernor: below proposal threshold");
     });
@@ -270,7 +270,7 @@ describe("Governance Integration", function () {
       ])];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Lifecycle test"
+        ProposalType.Standard, targets, values, calldatas, "Lifecycle test"
       );
 
       // Pending
@@ -297,7 +297,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "No votes"
+        ProposalType.Standard, targets, values, calldatas, "No votes"
       );
 
       await time.increase(TWO_DAYS + 1);
@@ -313,7 +313,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Majority against"
+        ProposalType.Standard, targets, values, calldatas, "Majority against"
       );
 
       await time.increase(TWO_DAYS + 1);
@@ -336,7 +336,7 @@ describe("Governance Integration", function () {
       ])];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Execute test"
+        ProposalType.Standard, targets, values, calldatas, "Execute test"
       );
 
       await time.increase(TWO_DAYS + 1);
@@ -368,7 +368,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Timing test"
+        ProposalType.Standard, targets, values, calldatas, "Timing test"
       );
 
       const [,, voteStart, voteEnd] = await governor.getProposal(1);
@@ -382,10 +382,10 @@ describe("Governance Integration", function () {
   });
 
   // ============================================================
-  // 4. Proposal Lifecycle — Treasury
+  // 4. Proposal Lifecycle — Standard (Treasury Target)
   // ============================================================
 
-  describe("Proposal Lifecycle - Treasury", function () {
+  describe("Proposal Lifecycle - Standard (Treasury Target)", function () {
     it("should pay USDC to an address via treasury proposal", async function () {
       const payAmount = ethers.parseUnits("500", USDC_DECIMALS);
       const targets = [await treasury.getAddress()];
@@ -397,7 +397,7 @@ describe("Governance Integration", function () {
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Treasury, targets, values, calldatas,
+        ProposalType.Standard, targets, values, calldatas,
         "Pay Carol 500 USDC"
       );
 
@@ -413,7 +413,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.Treasury, targets, values, calldatas, "Quorum test"
+        ProposalType.Standard, targets, values, calldatas, "Quorum test"
       );
 
       await time.increase(TWO_DAYS + 1);
@@ -434,7 +434,7 @@ describe("Governance Integration", function () {
       const values = [0n];
       const calldatas = ["0x"];
       await governor.connect(alice).propose(
-        ProposalType.Treasury, targets, values, calldatas, "Quorum calc test"
+        ProposalType.Standard, targets, values, calldatas, "Quorum calc test"
       );
 
       const actualQuorum = await governor.quorum(1);
@@ -451,7 +451,7 @@ describe("Governance Integration", function () {
       const values = [0n];
       const calldatas = ["0x"];
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Quorum floor test"
+        ProposalType.Standard, targets, values, calldatas, "Quorum floor test"
       );
 
       const QUORUM_FLOOR = ethers.parseUnits("100000", ARM_DECIMALS);
@@ -466,7 +466,7 @@ describe("Governance Integration", function () {
       const values = [0n];
       const calldatas = ["0x"];
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Percentage quorum test"
+        ProposalType.Standard, targets, values, calldatas, "Percentage quorum test"
       );
 
       const expectedEligible = TOTAL_SUPPLY - TREASURY_AMOUNT;
@@ -486,7 +486,7 @@ describe("Governance Integration", function () {
       const values = [0n];
       const calldatas = ["0x"];
       await governor.connect(alice).propose(
-        ProposalType.StewardElection, targets, values, calldatas, "Extended quorum floor test"
+        ProposalType.Extended, targets, values, calldatas, "Extended quorum floor test"
       );
 
       const QUORUM_FLOOR = ethers.parseUnits("100000", ARM_DECIMALS);
@@ -495,10 +495,10 @@ describe("Governance Integration", function () {
   });
 
   // ============================================================
-  // 5. Proposal Lifecycle — Steward Election
+  // 5. Proposal Lifecycle — Extended
   // ============================================================
 
-  describe("Proposal Lifecycle - StewardElection", function () {
+  describe("Proposal Lifecycle - Extended", function () {
     it("should elect steward via proposal with extended timing", async function () {
       const targets = [
         await stewardContract.getAddress(),
@@ -515,7 +515,7 @@ describe("Governance Integration", function () {
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.StewardElection, targets, values, calldatas,
+        ProposalType.Extended, targets, values, calldatas,
         "Elect Dave as steward"
       );
 
@@ -524,7 +524,7 @@ describe("Governance Integration", function () {
       expect(await treasury.steward()).to.equal(await stewardContract.getAddress());
     });
 
-    it("should use 30% quorum for steward elections", async function () {
+    it("should use 30% quorum for Extended proposals", async function () {
       // 30% of eligible (35% of supply) = 10.5% of total supply
       // Bob (15% of supply) should meet this
       const targets = [await stewardContract.getAddress()];
@@ -534,7 +534,7 @@ describe("Governance Integration", function () {
       ];
 
       await governor.connect(alice).propose(
-        ProposalType.StewardElection, targets, values, calldatas, "30% quorum test"
+        ProposalType.Extended, targets, values, calldatas, "30% quorum test"
       );
 
       const expectedQuorum = ((TOTAL_SUPPLY - TREASURY_AMOUNT) * 3000n) / 10000n;
@@ -549,7 +549,7 @@ describe("Governance Integration", function () {
       ];
 
       await governor.connect(alice).propose(
-        ProposalType.StewardElection, targets, values, calldatas, "Extended timing"
+        ProposalType.Extended, targets, values, calldatas, "Extended timing"
       );
 
       const [,, voteStart, voteEnd] = await governor.getProposal(1);
@@ -576,7 +576,7 @@ describe("Governance Integration", function () {
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Treasury, targets, values, calldatas,
+        ProposalType.Standard, targets, values, calldatas,
         "Create claim for Carol"
       );
 
@@ -600,7 +600,7 @@ describe("Governance Integration", function () {
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Treasury, targets, values, calldatas,
+        ProposalType.Standard, targets, values, calldatas,
         "Partial claim test"
       );
 
@@ -623,7 +623,7 @@ describe("Governance Integration", function () {
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Treasury, targets, values, calldatas,
+        ProposalType.Standard, targets, values, calldatas,
         "Non-beneficiary test"
       );
 
@@ -655,7 +655,7 @@ describe("Governance Integration", function () {
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.StewardElection, targets, values, calldatas,
+        ProposalType.Extended, targets, values, calldatas,
         "Elect Dave"
       );
     }
@@ -745,7 +745,7 @@ describe("Governance Integration", function () {
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.ParameterChange, vetoTargets, vetoValues, vetoCalldatas,
+        ProposalType.Standard, vetoTargets, vetoValues, vetoCalldatas,
         "Veto steward action #1"
       );
 
@@ -804,7 +804,7 @@ describe("Governance Integration", function () {
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.StewardElection, targets, values, calldatas,
+        ProposalType.Extended, targets, values, calldatas,
         "Elect Carol as steward"
       );
       expect(await stewardContract.currentSteward()).to.equal(carol.address);
@@ -869,7 +869,7 @@ describe("Governance Integration", function () {
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.StewardElection, targets, values, calldatas,
+        ProposalType.Extended, targets, values, calldatas,
         "Elect Carol as steward"
       );
 
@@ -902,7 +902,7 @@ describe("Governance Integration", function () {
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.StewardElection, targets, values, calldatas,
+        ProposalType.Extended, targets, values, calldatas,
         "Re-elect Dave"
       );
 
@@ -932,7 +932,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Vote test"
+        ProposalType.Standard, targets, values, calldatas, "Vote test"
       );
 
       await time.increase(TWO_DAYS + 1);
@@ -954,7 +954,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "No power test"
+        ProposalType.Standard, targets, values, calldatas, "No power test"
       );
 
       await time.increase(TWO_DAYS + 1);
@@ -971,7 +971,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Vote switch test"
+        ProposalType.Standard, targets, values, calldatas, "Vote switch test"
       );
 
       await time.increase(TWO_DAYS + 1);
@@ -999,7 +999,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Switch test 2"
+        ProposalType.Standard, targets, values, calldatas, "Switch test 2"
       );
 
       await time.increase(TWO_DAYS + 1);
@@ -1018,7 +1018,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Same vote test"
+        ProposalType.Standard, targets, values, calldatas, "Same vote test"
       );
 
       await time.increase(TWO_DAYS + 1);
@@ -1035,7 +1035,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Quorum conservation test"
+        ProposalType.Standard, targets, values, calldatas, "Quorum conservation test"
       );
 
       await time.increase(TWO_DAYS + 1);
@@ -1061,7 +1061,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Multi-switch test"
+        ProposalType.Standard, targets, values, calldatas, "Multi-switch test"
       );
 
       await time.increase(TWO_DAYS + 1);
@@ -1084,7 +1084,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Re-delegation test"
+        ProposalType.Standard, targets, values, calldatas, "Re-delegation test"
       );
 
       await time.increase(TWO_DAYS + 1);
@@ -1111,7 +1111,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Cancel test"
+        ProposalType.Standard, targets, values, calldatas, "Cancel test"
       );
 
       await governor.connect(alice).cancel(1);
@@ -1124,7 +1124,7 @@ describe("Governance Integration", function () {
       const calldatas = ["0x"];
 
       await governor.connect(alice).propose(
-        ProposalType.ParameterChange, targets, values, calldatas, "Cancel auth test"
+        ProposalType.Standard, targets, values, calldatas, "Cancel auth test"
       );
 
       await expect(
@@ -1134,7 +1134,73 @@ describe("Governance Integration", function () {
   });
 
   // ============================================================
-  // 10. Full End-to-End Flow
+  // 10. Proposal Types
+  // ============================================================
+
+  describe("Proposal Types", function () {
+    it("should have correct Standard proposal params", async function () {
+      const [votingDelay, votingPeriod, executionDelay, quorumBps] =
+        await governor.proposalTypeParams(ProposalType.Standard);
+      expect(votingDelay).to.equal(TWO_DAYS);
+      expect(votingPeriod).to.equal(SEVEN_DAYS);
+      expect(executionDelay).to.equal(TWO_DAYS);
+      expect(quorumBps).to.equal(2000);
+    });
+
+    it("should have correct Extended proposal params", async function () {
+      const [votingDelay, votingPeriod, executionDelay, quorumBps] =
+        await governor.proposalTypeParams(ProposalType.Extended);
+      expect(votingDelay).to.equal(TWO_DAYS);
+      expect(votingPeriod).to.equal(FOURTEEN_DAYS);
+      expect(executionDelay).to.equal(SEVEN_DAYS);
+      expect(quorumBps).to.equal(3000);
+    });
+
+    it("should have correct VetoRatification proposal params", async function () {
+      const [votingDelay, votingPeriod, executionDelay, quorumBps] =
+        await governor.proposalTypeParams(ProposalType.VetoRatification);
+      expect(votingDelay).to.equal(0);
+      expect(votingPeriod).to.equal(SEVEN_DAYS);
+      expect(executionDelay).to.equal(0);
+      expect(quorumBps).to.equal(2000);
+    });
+
+    it("should reject manual creation of VetoRatification proposals", async function () {
+      const targets = [await treasury.getAddress()];
+      const values = [0n];
+      const calldatas = ["0x"];
+
+      await expect(
+        governor.connect(alice).propose(
+          ProposalType.VetoRatification, targets, values, calldatas, "Manual veto test"
+        )
+      ).to.be.revertedWith("ArmadaGovernor: auto-created only");
+    });
+
+    it("should reject governance updates to VetoRatification params", async function () {
+      // VetoRatification params are immutable — setProposalTypeParams reverts.
+      // We need to call through the timelock. Use passProposal to test this.
+      // But since the revert happens inside the timelock execution, we test directly
+      // by impersonating the timelock.
+      const timelockAddr = await governor.timelock();
+      await ethers.provider.send("hardhat_impersonateAccount", [timelockAddr]);
+      // Fund the timelock to send transactions
+      await alice.sendTransaction({ to: timelockAddr, value: ethers.parseEther("1") });
+      const timelockSigner = await ethers.getSigner(timelockAddr);
+
+      await expect(
+        governor.connect(timelockSigner).setProposalTypeParams(
+          ProposalType.VetoRatification,
+          { votingDelay: 0, votingPeriod: SEVEN_DAYS, executionDelay: 0, quorumBps: 2000 }
+        )
+      ).to.be.revertedWith("ArmadaGovernor: VetoRatification immutable");
+
+      await ethers.provider.send("hardhat_stopImpersonatingAccount", [timelockAddr]);
+    });
+  });
+
+  // ============================================================
+  // 11. Full End-to-End Flow
   // ============================================================
 
   describe("Full Flow", function () {
@@ -1149,7 +1215,7 @@ describe("Governance Integration", function () {
 
       // Propose
       await governor.connect(alice).propose(
-        ProposalType.Treasury, targets, values, calldatas, "Pay Carol 2500 USDC"
+        ProposalType.Standard, targets, values, calldatas, "Pay Carol 2500 USDC"
       );
       expect(await governor.state(1)).to.equal(ProposalState.Pending);
 

--- a/test/governance_param_updates.ts
+++ b/test/governance_param_updates.ts
@@ -4,7 +4,7 @@
  * Tests the ability to update proposal type parameters via governance:
  * - Timelock-only access control
  * - Bounded parameter validation (min/max for all fields)
- * - Full governance lifecycle to change params via ParameterChange proposal
+ * - Full governance lifecycle to change params via Standard proposal
  * - Quorum snapshotting: in-flight proposals unaffected by param changes
  * - TreasurySteward.minActionDelay() reflects updated governor timing
  */
@@ -14,7 +14,7 @@ import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
-const ProposalType = { ParameterChange: 0, Treasury: 1, StewardElection: 2 };
+const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 const ProposalState = {
   Pending: 0, Active: 1, Defeated: 2, Succeeded: 3,
   Queued: 4, Executed: 5, Canceled: 6,
@@ -75,11 +75,11 @@ describe("Governance Parameter Updates", function () {
       await governor.connect(v.signer).castVote(proposalId, v.support);
     }
 
-    const votingPeriod = proposalType === ProposalType.StewardElection ? EXTENDED_VOTING_PERIOD : STANDARD_VOTING_PERIOD;
+    const votingPeriod = proposalType === ProposalType.Extended ? EXTENDED_VOTING_PERIOD : STANDARD_VOTING_PERIOD;
     await time.increase(votingPeriod + 1);
     await governor.queue(proposalId);
 
-    const executionDelay = proposalType === ProposalType.StewardElection ? EXTENDED_EXECUTION_DELAY : TWO_DAYS;
+    const executionDelay = proposalType === ProposalType.Extended ? EXTENDED_EXECUTION_DELAY : TWO_DAYS;
     await time.increase(executionDelay + 1);
     await governor.execute(proposalId);
 
@@ -107,11 +107,11 @@ describe("Governance Parameter Updates", function () {
       await governor.connect(v.signer).castVote(proposalId, v.support);
     }
 
-    const votingPeriod = proposalType === ProposalType.StewardElection ? EXTENDED_VOTING_PERIOD : STANDARD_VOTING_PERIOD;
+    const votingPeriod = proposalType === ProposalType.Extended ? EXTENDED_VOTING_PERIOD : STANDARD_VOTING_PERIOD;
     await time.increase(votingPeriod + 1);
     await governor.queue(proposalId);
 
-    const executionDelay = proposalType === ProposalType.StewardElection ? EXTENDED_EXECUTION_DELAY : TWO_DAYS;
+    const executionDelay = proposalType === ProposalType.Extended ? EXTENDED_EXECUTION_DELAY : TWO_DAYS;
     await time.increase(executionDelay + 1);
 
     return proposalId;
@@ -195,7 +195,7 @@ describe("Governance Parameter Updates", function () {
         quorumBps: 2500,
       };
       await expect(
-        governor.connect(alice).setProposalTypeParams(ProposalType.ParameterChange, newParams)
+        governor.connect(alice).setProposalTypeParams(ProposalType.Standard, newParams)
       ).to.be.revertedWith("ArmadaGovernor: not timelock");
     });
 
@@ -207,7 +207,7 @@ describe("Governance Parameter Updates", function () {
         quorumBps: 2500,
       };
       await expect(
-        governor.connect(deployer).setProposalTypeParams(ProposalType.ParameterChange, newParams)
+        governor.connect(deployer).setProposalTypeParams(ProposalType.Standard, newParams)
       ).to.be.revertedWith("ArmadaGovernor: not timelock");
     });
   });
@@ -239,8 +239,8 @@ describe("Governance Parameter Updates", function () {
     };
 
     it("accepts valid params within bounds", async function () {
-      await standaloneGovernor.setProposalTypeParams(ProposalType.ParameterChange, validParams);
-      const [delay, period, execDelay, quorum] = await standaloneGovernor.proposalTypeParams(ProposalType.ParameterChange);
+      await standaloneGovernor.setProposalTypeParams(ProposalType.Standard, validParams);
+      const [delay, period, execDelay, quorum] = await standaloneGovernor.proposalTypeParams(ProposalType.Standard);
       expect(delay).to.equal(validParams.votingDelay);
       expect(period).to.equal(validParams.votingPeriod);
       expect(execDelay).to.equal(validParams.executionDelay);
@@ -254,8 +254,8 @@ describe("Governance Parameter Updates", function () {
         executionDelay: 1 * ONE_DAY,
         quorumBps: 500,
       };
-      await standaloneGovernor.setProposalTypeParams(ProposalType.Treasury, minParams);
-      const [delay, period, execDelay, quorum] = await standaloneGovernor.proposalTypeParams(ProposalType.Treasury);
+      await standaloneGovernor.setProposalTypeParams(ProposalType.Standard, minParams);
+      const [delay, period, execDelay, quorum] = await standaloneGovernor.proposalTypeParams(ProposalType.Standard);
       expect(delay).to.equal(minParams.votingDelay);
       expect(period).to.equal(minParams.votingPeriod);
       expect(execDelay).to.equal(minParams.executionDelay);
@@ -269,14 +269,14 @@ describe("Governance Parameter Updates", function () {
         executionDelay: 14 * ONE_DAY,
         quorumBps: 5000,
       };
-      await standaloneGovernor.setProposalTypeParams(ProposalType.Treasury, maxParams);
-      const [delay, period, execDelay, quorum] = await standaloneGovernor.proposalTypeParams(ProposalType.Treasury);
+      await standaloneGovernor.setProposalTypeParams(ProposalType.Standard, maxParams);
+      const [delay, period, execDelay, quorum] = await standaloneGovernor.proposalTypeParams(ProposalType.Standard);
       expect(quorum).to.equal(maxParams.quorumBps);
     });
 
     it("rejects votingDelay below minimum", async function () {
       await expect(
-        standaloneGovernor.setProposalTypeParams(ProposalType.ParameterChange, {
+        standaloneGovernor.setProposalTypeParams(ProposalType.Standard, {
           ...validParams, votingDelay: ONE_DAY - 1,
         })
       ).to.be.revertedWith("ArmadaGovernor: votingDelay out of bounds");
@@ -284,7 +284,7 @@ describe("Governance Parameter Updates", function () {
 
     it("rejects votingDelay above maximum", async function () {
       await expect(
-        standaloneGovernor.setProposalTypeParams(ProposalType.ParameterChange, {
+        standaloneGovernor.setProposalTypeParams(ProposalType.Standard, {
           ...validParams, votingDelay: 14 * ONE_DAY + 1,
         })
       ).to.be.revertedWith("ArmadaGovernor: votingDelay out of bounds");
@@ -292,7 +292,7 @@ describe("Governance Parameter Updates", function () {
 
     it("rejects votingPeriod below minimum", async function () {
       await expect(
-        standaloneGovernor.setProposalTypeParams(ProposalType.ParameterChange, {
+        standaloneGovernor.setProposalTypeParams(ProposalType.Standard, {
           ...validParams, votingPeriod: ONE_DAY - 1,
         })
       ).to.be.revertedWith("ArmadaGovernor: votingPeriod out of bounds");
@@ -300,7 +300,7 @@ describe("Governance Parameter Updates", function () {
 
     it("rejects votingPeriod above maximum", async function () {
       await expect(
-        standaloneGovernor.setProposalTypeParams(ProposalType.ParameterChange, {
+        standaloneGovernor.setProposalTypeParams(ProposalType.Standard, {
           ...validParams, votingPeriod: 30 * ONE_DAY + 1,
         })
       ).to.be.revertedWith("ArmadaGovernor: votingPeriod out of bounds");
@@ -308,7 +308,7 @@ describe("Governance Parameter Updates", function () {
 
     it("rejects executionDelay below minimum", async function () {
       await expect(
-        standaloneGovernor.setProposalTypeParams(ProposalType.ParameterChange, {
+        standaloneGovernor.setProposalTypeParams(ProposalType.Standard, {
           ...validParams, executionDelay: ONE_DAY - 1,
         })
       ).to.be.revertedWith("ArmadaGovernor: executionDelay out of bounds");
@@ -316,7 +316,7 @@ describe("Governance Parameter Updates", function () {
 
     it("rejects executionDelay above maximum", async function () {
       await expect(
-        standaloneGovernor.setProposalTypeParams(ProposalType.ParameterChange, {
+        standaloneGovernor.setProposalTypeParams(ProposalType.Standard, {
           ...validParams, executionDelay: 14 * ONE_DAY + 1,
         })
       ).to.be.revertedWith("ArmadaGovernor: executionDelay out of bounds");
@@ -324,7 +324,7 @@ describe("Governance Parameter Updates", function () {
 
     it("rejects quorumBps below minimum", async function () {
       await expect(
-        standaloneGovernor.setProposalTypeParams(ProposalType.ParameterChange, {
+        standaloneGovernor.setProposalTypeParams(ProposalType.Standard, {
           ...validParams, quorumBps: 499,
         })
       ).to.be.revertedWith("ArmadaGovernor: quorumBps out of bounds");
@@ -332,7 +332,7 @@ describe("Governance Parameter Updates", function () {
 
     it("rejects quorumBps above maximum", async function () {
       await expect(
-        standaloneGovernor.setProposalTypeParams(ProposalType.ParameterChange, {
+        standaloneGovernor.setProposalTypeParams(ProposalType.Standard, {
           ...validParams, quorumBps: 5001,
         })
       ).to.be.revertedWith("ArmadaGovernor: quorumBps out of bounds");
@@ -340,7 +340,7 @@ describe("Governance Parameter Updates", function () {
 
     it("emits ProposalTypeParamsUpdated event", async function () {
       await expect(
-        standaloneGovernor.setProposalTypeParams(ProposalType.ParameterChange, validParams)
+        standaloneGovernor.setProposalTypeParams(ProposalType.Standard, validParams)
       ).to.emit(standaloneGovernor, "ProposalTypeParamsUpdated");
     });
   });
@@ -384,7 +384,7 @@ describe("Governance Parameter Updates", function () {
     it("quorum uses snapshotted quorumBps, not current params", async function () {
       // Create a proposal with current quorumBps (2000 = 20%)
       await standaloneGovernor.connect(alice).propose(
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await standaloneGovernor.getAddress()],
         [0n],
         [standaloneGovernor.interface.encodeFunctionData("proposalCount")],
@@ -405,7 +405,7 @@ describe("Governance Parameter Updates", function () {
       };
       const calldata = standaloneGovernor.interface.encodeFunctionData(
         "setProposalTypeParams",
-        [ProposalType.ParameterChange, newParams]
+        [ProposalType.Standard, newParams]
       );
 
       const salt = ethers.id("change-quorum");
@@ -418,7 +418,7 @@ describe("Governance Parameter Updates", function () {
       );
 
       // Verify params actually changed
-      const [,,, newQuorumBps] = await standaloneGovernor.proposalTypeParams(ProposalType.ParameterChange);
+      const [,,, newQuorumBps] = await standaloneGovernor.proposalTypeParams(ProposalType.Standard);
       expect(newQuorumBps).to.equal(3000);
 
       // The existing proposal's quorum should still use the snapshotted value (20%)
@@ -432,7 +432,7 @@ describe("Governance Parameter Updates", function () {
   // ============================================================
 
   describe("Full Lifecycle: Change Params via Governance", function () {
-    it("governance can update ParameterChange params", async function () {
+    it("governance can update Standard params", async function () {
       const newParams = {
         votingDelay: 3 * ONE_DAY,
         votingPeriod: 7 * ONE_DAY,
@@ -441,27 +441,27 @@ describe("Governance Parameter Updates", function () {
       };
       const calldata = governor.interface.encodeFunctionData(
         "setProposalTypeParams",
-        [ProposalType.ParameterChange, newParams]
+        [ProposalType.Standard, newParams]
       );
 
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await governor.getAddress()],
         [0n],
         [calldata],
-        "Update ParameterChange timing to 3d/7d/3d and 25% quorum"
+        "Update Standard timing to 3d/7d/3d and 25% quorum"
       );
 
-      const [delay, period, execDelay, quorum] = await governor.proposalTypeParams(ProposalType.ParameterChange);
+      const [delay, period, execDelay, quorum] = await governor.proposalTypeParams(ProposalType.Standard);
       expect(delay).to.equal(newParams.votingDelay);
       expect(period).to.equal(newParams.votingPeriod);
       expect(execDelay).to.equal(newParams.executionDelay);
       expect(quorum).to.equal(newParams.quorumBps);
     });
 
-    it("governance can update StewardElection params", async function () {
+    it("governance can update Extended params", async function () {
       const newParams = {
         votingDelay: 3 * ONE_DAY,
         votingPeriod: 10 * ONE_DAY,
@@ -470,20 +470,20 @@ describe("Governance Parameter Updates", function () {
       };
       const calldata = governor.interface.encodeFunctionData(
         "setProposalTypeParams",
-        [ProposalType.StewardElection, newParams]
+        [ProposalType.Extended, newParams]
       );
 
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await governor.getAddress()],
         [0n],
         [calldata],
-        "Update StewardElection timing"
+        "Update Extended timing"
       );
 
-      const [delay, period, execDelay, quorum] = await governor.proposalTypeParams(ProposalType.StewardElection);
+      const [delay, period, execDelay, quorum] = await governor.proposalTypeParams(ProposalType.Extended);
       expect(delay).to.equal(newParams.votingDelay);
       expect(period).to.equal(newParams.votingPeriod);
       expect(execDelay).to.equal(newParams.executionDelay);
@@ -499,7 +499,7 @@ describe("Governance Parameter Updates", function () {
     it("steward minActionDelay reflects updated governor timing", async function () {
       const minDelayBefore = await stewardContract.minActionDelay();
 
-      // Shorten the ParameterChange cycle: 1d + 3d + 1d = 5d → 120% = 6d
+      // Shorten the Standard proposal cycle: 1d + 3d + 1d = 5d → 120% = 6d
       const newParams = {
         votingDelay: 1 * ONE_DAY,
         votingPeriod: 3 * ONE_DAY,
@@ -508,17 +508,17 @@ describe("Governance Parameter Updates", function () {
       };
       const calldata = governor.interface.encodeFunctionData(
         "setProposalTypeParams",
-        [ProposalType.ParameterChange, newParams]
+        [ProposalType.Standard, newParams]
       );
 
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.ParameterChange,
+        ProposalType.Standard,
         [await governor.getAddress()],
         [0n],
         [calldata],
-        "Shorten ParameterChange cycle"
+        "Shorten Standard proposal cycle"
       );
 
       const minDelayAfter = await stewardContract.minActionDelay();

--- a/test/governance_quiet_period.ts
+++ b/test/governance_quiet_period.ts
@@ -14,7 +14,7 @@ import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
-const ProposalType = { ParameterChange: 0, Treasury: 1, StewardElection: 2 };
+const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 const ONE_DAY = 86400;
 const SEVEN_DAYS = 7 * ONE_DAY;
 const THREE_WEEKS = 21 * ONE_DAY;
@@ -119,7 +119,7 @@ describe("Governance Quiet Period (T6.1)", function () {
     const treasuryAddress = await treasury.getAddress();
     const calldata = treasury.interface.encodeFunctionData("setSteward", [deployer.address]);
     return governor.propose(
-      ProposalType.ParameterChange,
+      ProposalType.Standard,
       [treasuryAddress],
       [0],
       [calldata],


### PR DESCRIPTION
## Summary
- **Replaces** `ParameterChange/Treasury/StewardElection` enum with spec-aligned `Standard/Extended/VetoRatification` (Task 2.4)
- **Standard** (0): 7d voting, 48h execution, 20% quorum — covers all proposals that aren't mechanically classified as extended
- **Extended** (1): 14d voting, 7d execution, 30% quorum — steward elections, fee changes, SC seat changes, etc.
- **VetoRatification** (2): 7d voting, no delay, 20% quorum — auto-created only (Phase 4 veto mechanism)
- VetoRatification is **locked down**: `propose()` rejects manual creation, `setProposalTypeParams()` rejects modifications, and constructor params bypass min bounds making timing effectively immutable
- Updates all 18 files across contracts, tests, Foundry invariants, scripts, and governance UI

## Test plan
- [x] 47 governance integration tests (5 new for proposal type params + VetoRatification guards)
- [x] 18 param update tests (consolidated Standard/Extended, VetoRatification immutability)
- [x] 48 adversarial tests (describe blocks renamed Standard/Extended)
- [x] 18 cross-contract integration tests
- [x] 63 emergency pause + quiet period + gas benchmark tests
- [x] 6 Foundry invariant tests (INV-G1 through INV-G6)
- [x] `forge build` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)