### PR TITLE
feat: governor Phase 2 — classification, bond, wind-down

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/governance/TimelockController.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./ArmadaToken.sol";
 import "./IArmadaGovernance.sol";
 import "./EmergencyPausable.sol";
@@ -104,6 +105,35 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
     uint256 public quietPeriodDuration;
     uint256 public constant MAX_QUIET_PERIOD = 30 days;
 
+    // Wind-down integration: when triggered, governance permanently stops accepting new proposals.
+    // The wind-down contract is registered via one-time setter; only it can flip the flag.
+    bool public windDownActive;
+    address public windDownContract;
+    bool public windDownContractSet;
+
+    // Extended proposal classification: function selectors that force Extended type regardless
+    // of what the proposer declared. Governance can add/remove selectors via extended proposal.
+    mapping(bytes4 => bool) public extendedSelectors;
+
+    // Treasury >5% threshold for automatic extended classification of distribute() calls.
+    // The distribute selector is checked specially: if amount > 5% of treasury balance, Extended.
+    bytes4 public constant DISTRIBUTE_SELECTOR = bytes4(keccak256("distribute(address,address,uint256)"));
+    uint256 public constant TREASURY_EXTENDED_THRESHOLD_BPS = 500; // 5%
+
+    // Proposal bond: 1,000 ARM posted at proposal creation (only when ARM is transferable).
+    // Bond is always returned but with variable lock periods based on outcome.
+    uint256 public constant PROPOSAL_BOND = 1_000 * 1e18;
+    uint256 public constant BOND_LOCK_QUORUM_FAIL = 15 days;
+    uint256 public constant BOND_LOCK_VOTE_FAIL = 45 days;
+
+    struct BondInfo {
+        address depositor;
+        uint256 amount;
+        uint256 unlockTime; // 0 = immediately claimable or not yet determined
+        bool claimed;
+    }
+    mapping(uint256 => BondInfo) public proposalBonds;
+
     // ============ Events ============
 
     event ProposalCreated(
@@ -122,6 +152,12 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
     event ProposalTypeParamsUpdated(ProposalType indexed proposalType, ProposalParams params);
     event CrowdfundAddressSet(address indexed crowdfund);
     event QuietPeriodUpdated(uint256 newDuration);
+    event WindDownContractSet(address indexed windDownContract);
+    event WindDownActivated();
+    event ExtendedSelectorAdded(bytes4 indexed selector);
+    event ExtendedSelectorRemoved(bytes4 indexed selector);
+    event BondPosted(uint256 indexed proposalId, address indexed depositor, uint256 amount);
+    event BondClaimed(uint256 indexed proposalId, address indexed depositor, uint256 amount);
 
     // ============ Constructor ============
 
@@ -169,6 +205,42 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
 
         // Governance quiet period: 7 days post-crowdfund-finalization before proposals allowed
         quietPeriodDuration = 7 days;
+
+        // Register function selectors that force Extended classification.
+        // Any proposal containing a call to one of these selectors is automatically Extended
+        // regardless of what the proposer declared.
+        _registerExtendedSelectors();
+    }
+
+    /// @dev Register initial extended selectors. Separated from constructor for readability.
+    function _registerExtendedSelectors() internal {
+        // Governance parameter changes
+        extendedSelectors[this.setProposalTypeParams.selector] = true;
+        extendedSelectors[this.setWindDownContract.selector] = true;
+        extendedSelectors[this.addExtendedSelector.selector] = true;
+        extendedSelectors[this.removeExtendedSelector.selector] = true;
+
+        // Fee parameters (on privacy pool)
+        extendedSelectors[bytes4(keccak256("setShieldFee(uint120)"))] = true;
+
+        // Security Council management
+        extendedSelectors[this.setSecurityCouncil.selector] = true;
+
+        // Steward election/removal (on TreasurySteward)
+        extendedSelectors[bytes4(keccak256("electSteward(address)"))] = true;
+        extendedSelectors[bytes4(keccak256("removeSteward()"))] = true;
+
+        // ARM token transfer whitelist
+        extendedSelectors[bytes4(keccak256("addToWhitelist(address)"))] = true;
+
+        // Treasury outflow limit parameters
+        extendedSelectors[bytes4(keccak256("setOutflowWindow(address,uint256)"))] = true;
+        extendedSelectors[bytes4(keccak256("setOutflowLimitBps(address,uint256)"))] = true;
+        extendedSelectors[bytes4(keccak256("setOutflowLimitAbsolute(address,uint256)"))] = true;
+
+        // UUPS upgrade selectors
+        extendedSelectors[bytes4(keccak256("upgradeTo(address)"))] = true;
+        extendedSelectors[bytes4(keccak256("upgradeToAndCall(address,bytes)"))] = true;
     }
 
     // ============ Quorum Exclusion ============
@@ -251,6 +323,73 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         emit QuietPeriodUpdated(_duration);
     }
 
+    // ============ Extended Selector Management ============
+
+    /// @notice Register a function selector that forces Extended proposal classification.
+    /// @dev Only callable by the timelock (requires an extended governance vote, since
+    ///      this selector is itself registered as extended).
+    function addExtendedSelector(bytes4 selector) external {
+        require(msg.sender == address(timelock), "ArmadaGovernor: not timelock");
+        require(!extendedSelectors[selector], "ArmadaGovernor: selector already extended");
+
+        extendedSelectors[selector] = true;
+        emit ExtendedSelectorAdded(selector);
+    }
+
+    /// @notice Remove a function selector from the extended classification registry.
+    /// @dev Only callable by the timelock (requires an extended governance vote).
+    function removeExtendedSelector(bytes4 selector) external {
+        require(msg.sender == address(timelock), "ArmadaGovernor: not timelock");
+        require(extendedSelectors[selector], "ArmadaGovernor: selector not extended");
+
+        extendedSelectors[selector] = false;
+        emit ExtendedSelectorRemoved(selector);
+    }
+
+    // ============ Security Council ============
+
+    /// @notice Address of the Security Council multisig. address(0) means ejected/unset.
+    address public securityCouncil;
+
+    event SecurityCouncilUpdated(address indexed oldSC, address indexed newSC);
+
+    /// @notice Set or replace the Security Council address. Governance-only (timelock).
+    /// Setting to address(0) disables all SC powers (ejection state).
+    function setSecurityCouncil(address newSC) external {
+        require(msg.sender == address(timelock), "ArmadaGovernor: not timelock");
+        emit SecurityCouncilUpdated(securityCouncil, newSC);
+        securityCouncil = newSC;
+    }
+
+    // ============ Wind-Down ============
+
+    /// @notice One-time setter: register the wind-down contract address.
+    /// Callable by timelock (governance) since the wind-down contract may be deployed
+    /// after the governor and needs a governance-approved registration.
+    function setWindDownContract(address _windDownContract) external {
+        require(msg.sender == address(timelock), "ArmadaGovernor: not timelock");
+        require(!windDownContractSet, "ArmadaGovernor: wind-down contract already set");
+        require(_windDownContract != address(0), "ArmadaGovernor: zero address");
+
+        windDownContractSet = true;
+        windDownContract = _windDownContract;
+
+        emit WindDownContractSet(_windDownContract);
+    }
+
+    /// @notice Called by the wind-down contract to permanently disable governance.
+    /// Once active, no new proposals can be created. Existing proposals in flight
+    /// (Active, Succeeded, Queued) can still complete their lifecycle.
+    function setWindDownActive() external {
+        require(msg.sender == windDownContract, "ArmadaGovernor: not wind-down contract");
+        require(windDownContract != address(0), "ArmadaGovernor: wind-down contract not set");
+        require(!windDownActive, "ArmadaGovernor: wind-down already active");
+
+        windDownActive = true;
+
+        emit WindDownActivated();
+    }
+
     // ============ Proposal Lifecycle ============
 
     /// @notice Create a new proposal
@@ -266,6 +405,7 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         bytes[] memory calldatas,
         string memory description
     ) external returns (uint256) {
+        require(!windDownActive, "ArmadaGovernor: governance ended");
         require(targets.length > 0, "ArmadaGovernor: empty proposal");
         require(
             targets.length == values.length && targets.length == calldatas.length,
@@ -278,16 +418,38 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         _checkQuietPeriod();
         _checkProposalThreshold(msg.sender);
 
+        // Mechanical classification: if any calldata triggers extended, override to Extended.
+        // Proposers can opt into Extended voluntarily, but cannot downgrade to Standard
+        // when calldata contains extended-classified function calls.
+        ProposalType effectiveType = _classifyProposal(proposalType, targets, calldatas);
+
         uint256 proposalId = ++proposalCount;
-        _initProposal(proposalId, proposalType, description);
+        _initProposal(proposalId, effectiveType, description);
 
         Proposal storage p = _proposals[proposalId];
         p.targets = targets;
         p.values = values;
         p.calldatas = calldatas;
 
+        // Bond: required only when ARM is transferable (post-transfer-unlock).
+        // Pre-transfer-unlock, bonds are economically meaningless and technically impossible
+        // for non-whitelisted holders, so governance operates on threshold only.
+        if (armToken.transferable()) {
+            require(
+                armToken.transferFrom(msg.sender, address(this), PROPOSAL_BOND),
+                "ArmadaGovernor: bond transfer failed"
+            );
+            proposalBonds[proposalId] = BondInfo({
+                depositor: msg.sender,
+                amount: PROPOSAL_BOND,
+                unlockTime: 0,
+                claimed: false
+            });
+            emit BondPosted(proposalId, msg.sender, PROPOSAL_BOND);
+        }
+
         emit ProposalCreated(
-            proposalId, msg.sender, proposalType,
+            proposalId, msg.sender, effectiveType,
             p.voteStart, p.voteEnd, description
         );
         return proposalId;
@@ -440,6 +602,48 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         emit ProposalCanceled(proposalId);
     }
 
+    /// @notice Claim a proposal bond after the lock period has elapsed.
+    /// Bond is always returned — lock periods vary by defeat reason.
+    function claimBond(uint256 proposalId) external nonReentrant {
+        BondInfo storage bond = proposalBonds[proposalId];
+        require(bond.amount > 0, "ArmadaGovernor: no bond");
+        require(!bond.claimed, "ArmadaGovernor: bond already claimed");
+
+        ProposalState currentState = state(proposalId);
+        Proposal storage p = _proposals[proposalId];
+
+        uint256 unlockTime;
+
+        if (currentState == ProposalState.Executed) {
+            // Passed and executed: immediately claimable
+            unlockTime = 0;
+        } else if (currentState == ProposalState.Canceled) {
+            // Proposer self-cancelled during Pending: immediately claimable
+            unlockTime = 0;
+        } else if (currentState == ProposalState.Defeated) {
+            // Determine defeat reason: quorum not met vs majority against
+            bool quorumMet = _quorumReached(proposalId);
+            if (!quorumMet) {
+                unlockTime = p.voteEnd + BOND_LOCK_QUORUM_FAIL;
+            } else {
+                // Quorum met but majority against (or expired grace period)
+                unlockTime = p.voteEnd + BOND_LOCK_VOTE_FAIL;
+            }
+        } else {
+            revert("ArmadaGovernor: proposal not in terminal state");
+        }
+
+        require(block.timestamp >= unlockTime, "ArmadaGovernor: bond still locked");
+
+        bond.claimed = true;
+        require(
+            armToken.transfer(bond.depositor, bond.amount),
+            "ArmadaGovernor: bond return failed"
+        );
+
+        emit BondClaimed(proposalId, bond.depositor, bond.amount);
+    }
+
     // ============ View Functions ============
 
     /// @notice Get current state of a proposal
@@ -529,6 +733,54 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
     /// @dev Unique salt per proposal for timelock deduplication
     function _proposalSalt(uint256 proposalId) internal pure returns (bytes32) {
         return bytes32(proposalId);
+    }
+
+    /// @dev Classify a proposal based on its calldata. If any action targets a function
+    ///      in the extended selector registry, force Extended. If a distribute() call would
+    ///      move >5% of the treasury's balance of that token, force Extended.
+    ///      The proposer's declared type is respected only if it's already Extended.
+    function _classifyProposal(
+        ProposalType declaredType,
+        address[] memory, /* targets — reserved for future target-specific checks */
+        bytes[] memory calldatas
+    ) internal view returns (ProposalType) {
+        // If already Extended, no need to check further
+        if (declaredType == ProposalType.Extended) return ProposalType.Extended;
+
+        for (uint256 i = 0; i < calldatas.length; i++) {
+            if (calldatas[i].length < 4) continue;
+
+            bytes4 selector;
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                // calldatas[i] is a bytes memory; its data starts at offset 0x20
+                let dataPtr := mload(add(add(calldatas, 0x20), mul(i, 0x20)))
+                selector := mload(add(dataPtr, 0x20))
+            }
+
+            // Check registered extended selectors
+            if (extendedSelectors[selector]) return ProposalType.Extended;
+
+            // Special case: distribute() calls exceeding 5% of treasury balance
+            if (selector == DISTRIBUTE_SELECTOR && calldatas[i].length >= 100) {
+                // Decode: distribute(address token, address recipient, uint256 amount)
+                // token is at bytes 4..35, amount is at bytes 68..99
+                address token;
+                uint256 amount;
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let dataPtr := mload(add(add(calldatas, 0x20), mul(i, 0x20)))
+                    token := mload(add(dataPtr, 0x24))  // skip 4-byte selector + 32 bytes but token is at offset 4
+                    amount := mload(add(dataPtr, 0x64)) // offset 4 + 32 + 32 = 68
+                }
+                uint256 treasuryBalance = IERC20(token).balanceOf(treasuryAddress);
+                if (treasuryBalance > 0 && amount > (treasuryBalance * TREASURY_EXTENDED_THRESHOLD_BPS) / 10000) {
+                    return ProposalType.Extended;
+                }
+            }
+        }
+
+        return declaredType;
     }
 
     /// @dev Block proposals during the quiet period after crowdfund finalization.

--- a/test-foundry/GovernorClassificationBondWindDown.t.sol
+++ b/test-foundry/GovernorClassificationBondWindDown.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// ABOUTME: Foundry tests for Phase 2 governor features: extended classification, bond, wind-down.
-// ABOUTME: Covers Tasks 2.5 (mechanical classification), 2.6 (proposal bond), 2.7 (wind-down integration).
+// ABOUTME: Foundry tests for governor extended classification, proposal bond, and wind-down features.
+// ABOUTME: Covers mechanical selector-based classification, ARM bond lifecycle, and wind-down governance shutdown.
 pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
@@ -20,8 +20,8 @@ contract MockUSDC is ERC20 {
     }
 }
 
-/// @title GovernorPhase2Test — Tests for extended classification, bond mechanism, and wind-down
-contract GovernorPhase2Test is Test {
+/// @title GovernorClassificationBondWindDownTest — Tests for extended classification, bond mechanism, and wind-down
+contract GovernorClassificationBondWindDownTest is Test {
     // Mirror events from governor for expectEmit
     event WindDownActivated();
 
@@ -134,7 +134,7 @@ contract GovernorPhase2Test is Test {
     }
 
     // ═══════════════════════════════════════════════════════════════
-    // TASK 2.7: WIND-DOWN INTEGRATION
+    // WIND-DOWN INTEGRATION
     // ═══════════════════════════════════════════════════════════════
 
     function test_windDown_proposeRevertsWhenActive() public {
@@ -229,7 +229,7 @@ contract GovernorPhase2Test is Test {
     }
 
     // ═══════════════════════════════════════════════════════════════
-    // TASK 2.5: MECHANICAL EXTENDED PROPOSAL CLASSIFICATION
+    // MECHANICAL EXTENDED PROPOSAL CLASSIFICATION
     // ═══════════════════════════════════════════════════════════════
 
     function test_classify_registeredSelectorForcesExtended() public {
@@ -370,7 +370,7 @@ contract GovernorPhase2Test is Test {
     }
 
     // ═══════════════════════════════════════════════════════════════
-    // TASK 2.5: SECURITY COUNCIL STATE
+    // SECURITY COUNCIL STATE
     // ═══════════════════════════════════════════════════════════════
 
     function test_securityCouncil_setByTimelock() public {
@@ -395,7 +395,7 @@ contract GovernorPhase2Test is Test {
     }
 
     // ═══════════════════════════════════════════════════════════════
-    // TASK 2.6: PROPOSAL BOND
+    // PROPOSAL BOND
     // ═══════════════════════════════════════════════════════════════
 
     function test_bond_notRequiredWhenNonTransferable() public {

--- a/test-foundry/GovernorPhase2.t.sol
+++ b/test-foundry/GovernorPhase2.t.sol
@@ -1,0 +1,564 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Foundry tests for Phase 2 governor features: extended classification, bond, wind-down.
+// ABOUTME: Covers Tasks 2.5 (mechanical classification), 2.6 (proposal bond), 2.7 (wind-down integration).
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/ArmadaGovernor.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/governance/ArmadaTreasuryGov.sol";
+import "../contracts/governance/IArmadaGovernance.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @dev Minimal mock ERC20 for treasury balance checks in classification tests
+contract MockUSDC is ERC20 {
+    constructor() ERC20("Mock USDC", "USDC") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/// @title GovernorPhase2Test — Tests for extended classification, bond mechanism, and wind-down
+contract GovernorPhase2Test is Test {
+    // Mirror events from governor for expectEmit
+    event WindDownActivated();
+
+    ArmadaGovernor public governor;
+    ArmadaToken public armToken;
+    TimelockController public timelock;
+    ArmadaTreasuryGov public treasury;
+    MockUSDC public usdc;
+
+    address public deployer = address(this);
+    address public alice = address(0xA11CE);
+    address public bob = address(0xB0B);
+    address public windDown = address(0xD00D);
+    address public securityCouncil = address(0x5C5C);
+
+    uint256 constant TOTAL_SUPPLY = 12_000_000 * 1e18;
+    uint256 constant BOND_AMOUNT = 1_000 * 1e18;
+    uint256 constant TWO_DAYS = 2 days;
+    uint256 constant SEVEN_DAYS = 7 days;
+    uint256 constant FOURTEEN_DAYS = 14 days;
+    uint256 constant MAX_PAUSE = 14 days;
+
+    function setUp() public {
+        // Deploy timelock
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        timelock = new TimelockController(TWO_DAYS, proposers, executors, deployer);
+
+        // Deploy ARM token
+        armToken = new ArmadaToken(deployer, address(timelock));
+
+        // Deploy treasury
+        treasury = new ArmadaTreasuryGov(address(timelock), deployer, MAX_PAUSE);
+
+        // Deploy governor
+        governor = new ArmadaGovernor(
+            address(armToken),
+            payable(address(timelock)),
+            address(treasury),
+            deployer,
+            MAX_PAUSE
+        );
+
+        // Setup: whitelist deployer so they can transfer tokens
+        address[] memory whitelist = new address[](3);
+        whitelist[0] = deployer;
+        whitelist[1] = alice;
+        whitelist[2] = address(governor);
+        armToken.initWhitelist(whitelist);
+
+        // Distribute tokens: alice gets 20%, bob gets 15%, treasury gets rest
+        armToken.transfer(alice, TOTAL_SUPPLY * 20 / 100);
+        armToken.transfer(bob, TOTAL_SUPPLY * 15 / 100);
+        armToken.transfer(address(treasury), TOTAL_SUPPLY * 50 / 100);
+
+        // Delegate to activate voting power
+        vm.prank(alice);
+        armToken.delegate(alice);
+        vm.prank(bob);
+        armToken.delegate(bob);
+
+        // Advance block so checkpoints are available
+        vm.roll(block.number + 1);
+
+        // Deploy mock USDC for treasury balance tests
+        usdc = new MockUSDC();
+
+        // Grant timelock roles to governor
+        timelock.grantRole(timelock.PROPOSER_ROLE(), address(governor));
+        timelock.grantRole(timelock.EXECUTOR_ROLE(), address(governor));
+    }
+
+    // ======== Helpers ========
+
+    /// @dev Enable ARM transfers and approve governor for bond on behalf of proposer
+    function _enableTransfersAndApproveBond(address proposer) internal {
+        armToken.setWindDownContract(windDown);
+        vm.prank(windDown);
+        armToken.setTransferable(true);
+
+        vm.prank(proposer);
+        armToken.approve(address(governor), BOND_AMOUNT);
+    }
+
+    function _proposeStandard(address proposer) internal returns (uint256) {
+        address[] memory targets = new address[](1);
+        targets[0] = address(governor);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("proposalCount()");
+
+        vm.prank(proposer);
+        return governor.propose(ProposalType.Standard, targets, values, calldatas, "test");
+    }
+
+    function _proposeWithCalldata(
+        address proposer,
+        ProposalType pType,
+        address target,
+        bytes memory data
+    ) internal returns (uint256) {
+        address[] memory targets = new address[](1);
+        targets[0] = target;
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = data;
+
+        vm.prank(proposer);
+        return governor.propose(pType, targets, values, calldatas, "test");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // TASK 2.7: WIND-DOWN INTEGRATION
+    // ═══════════════════════════════════════════════════════════════
+
+    function test_windDown_proposeRevertsWhenActive() public {
+        // Register wind-down contract via timelock
+        vm.prank(address(timelock));
+        governor.setWindDownContract(windDown);
+
+        // Activate wind-down
+        vm.prank(windDown);
+        governor.setWindDownActive();
+
+        assertTrue(governor.windDownActive());
+
+        // Proposing should revert
+        vm.expectRevert("ArmadaGovernor: governance ended");
+        _proposeStandard(alice);
+    }
+
+    function test_windDown_onlyWindDownContractCanActivate() public {
+        vm.prank(address(timelock));
+        governor.setWindDownContract(windDown);
+
+        vm.prank(alice);
+        vm.expectRevert("ArmadaGovernor: not wind-down contract");
+        governor.setWindDownActive();
+    }
+
+    function test_windDown_cannotActivateBeforeSet() public {
+        // windDownContract is address(0); random caller should fail
+        vm.prank(alice);
+        vm.expectRevert("ArmadaGovernor: not wind-down contract");
+        governor.setWindDownActive();
+    }
+
+    function test_windDown_cannotSetContractTwice() public {
+        vm.prank(address(timelock));
+        governor.setWindDownContract(windDown);
+
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaGovernor: wind-down contract already set");
+        governor.setWindDownContract(address(0x999));
+    }
+
+    function test_windDown_onlyTimelockCanSetContract() public {
+        vm.prank(alice);
+        vm.expectRevert("ArmadaGovernor: not timelock");
+        governor.setWindDownContract(windDown);
+    }
+
+    function test_windDown_cannotActivateTwice() public {
+        vm.prank(address(timelock));
+        governor.setWindDownContract(windDown);
+
+        vm.prank(windDown);
+        governor.setWindDownActive();
+
+        vm.prank(windDown);
+        vm.expectRevert("ArmadaGovernor: wind-down already active");
+        governor.setWindDownActive();
+    }
+
+    function test_windDown_existingProposalsContinue() public {
+        // Create a proposal before wind-down
+        uint256 proposalId = _proposeStandard(alice);
+
+        // Activate wind-down
+        vm.prank(address(timelock));
+        governor.setWindDownContract(windDown);
+        vm.prank(windDown);
+        governor.setWindDownActive();
+
+        // The existing proposal should still be in Pending state and voteable
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Pending));
+
+        // Advance to voting period
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Active));
+
+        // Alice can still vote
+        vm.prank(alice);
+        governor.castVote(proposalId, 1); // FOR
+    }
+
+    function test_windDown_emitsEvent() public {
+        vm.prank(address(timelock));
+        governor.setWindDownContract(windDown);
+
+        vm.prank(windDown);
+        vm.expectEmit(true, true, true, true);
+        emit WindDownActivated();
+        governor.setWindDownActive();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // TASK 2.5: MECHANICAL EXTENDED PROPOSAL CLASSIFICATION
+    // ═══════════════════════════════════════════════════════════════
+
+    function test_classify_registeredSelectorForcesExtended() public {
+        // setProposalTypeParams is registered as extended in constructor
+        bytes memory data = abi.encodeWithSelector(
+            governor.setProposalTypeParams.selector,
+            ProposalType.Standard,
+            ProposalParams(2 days, 7 days, 2 days, 2000)
+        );
+
+        uint256 proposalId = _proposeWithCalldata(alice, ProposalType.Standard, address(governor), data);
+
+        // Check it was classified as Extended
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Extended));
+    }
+
+    function test_classify_unregisteredSelectorStaysStandard() public {
+        // proposalCount() is not registered as extended
+        bytes memory data = abi.encodeWithSignature("proposalCount()");
+        uint256 proposalId = _proposeWithCalldata(alice, ProposalType.Standard, address(governor), data);
+
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Standard));
+    }
+
+    function test_classify_voluntaryExtendedPreserved() public {
+        // Proposer declares Extended voluntarily with standard calldata
+        bytes memory data = abi.encodeWithSignature("proposalCount()");
+        uint256 proposalId = _proposeWithCalldata(alice, ProposalType.Extended, address(governor), data);
+
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Extended));
+    }
+
+    function test_classify_mixedCalldataExtendedWins() public {
+        // One standard call + one extended call → Extended
+        address[] memory targets = new address[](2);
+        targets[0] = address(governor);
+        targets[1] = address(governor);
+        uint256[] memory values = new uint256[](2);
+        bytes[] memory calldatas = new bytes[](2);
+        calldatas[0] = abi.encodeWithSignature("proposalCount()"); // standard
+        calldatas[1] = abi.encodeWithSelector( // extended (governance param change)
+            governor.setProposalTypeParams.selector,
+            ProposalType.Standard,
+            ProposalParams(2 days, 7 days, 2 days, 2000)
+        );
+
+        vm.prank(alice);
+        uint256 proposalId = governor.propose(ProposalType.Standard, targets, values, calldatas, "mixed");
+
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Extended));
+    }
+
+    function test_classify_addExtendedSelector() public {
+        bytes4 newSelector = bytes4(keccak256("someNewFunction(uint256)"));
+
+        // Not extended yet
+        assertFalse(governor.extendedSelectors(newSelector));
+
+        // Add via timelock
+        vm.prank(address(timelock));
+        governor.addExtendedSelector(newSelector);
+
+        assertTrue(governor.extendedSelectors(newSelector));
+
+        // Now proposals with this selector should be Extended
+        bytes memory data = abi.encodeWithSelector(newSelector, uint256(42));
+        uint256 proposalId = _proposeWithCalldata(alice, ProposalType.Standard, address(governor), data);
+
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Extended));
+    }
+
+    function test_classify_removeExtendedSelector() public {
+        // setProposalTypeParams is registered; remove it
+        vm.prank(address(timelock));
+        governor.removeExtendedSelector(governor.setProposalTypeParams.selector);
+
+        assertFalse(governor.extendedSelectors(governor.setProposalTypeParams.selector));
+    }
+
+    function test_classify_onlyTimelockCanAddSelector() public {
+        bytes4 selector = bytes4(keccak256("test()"));
+        vm.prank(alice);
+        vm.expectRevert("ArmadaGovernor: not timelock");
+        governor.addExtendedSelector(selector);
+    }
+
+    function test_classify_onlyTimelockCanRemoveSelector() public {
+        vm.prank(alice);
+        vm.expectRevert("ArmadaGovernor: not timelock");
+        governor.removeExtendedSelector(governor.setProposalTypeParams.selector);
+    }
+
+    function test_classify_addExtendedSelectorIsItself_Extended() public {
+        // addExtendedSelector's own selector is registered as extended in constructor
+        assertTrue(governor.extendedSelectors(governor.addExtendedSelector.selector));
+    }
+
+    function test_classify_securityCouncilSelectorIsExtended() public {
+        assertTrue(governor.extendedSelectors(governor.setSecurityCouncil.selector));
+    }
+
+    function test_classify_distributeLargeAmountForcesExtended() public {
+        // Put USDC in treasury so we can test the 5% check
+        usdc.mint(address(treasury), 1_000_000e6); // $1M in treasury
+
+        // Distribute 60,000 USDC (6% > 5% threshold) → Extended
+        bytes memory data = abi.encodeWithSelector(
+            bytes4(keccak256("distribute(address,address,uint256)")),
+            address(usdc),
+            alice,
+            60_000e6
+        );
+        uint256 proposalId = _proposeWithCalldata(alice, ProposalType.Standard, address(treasury), data);
+
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Extended));
+    }
+
+    function test_classify_distributeSmallAmountStaysStandard() public {
+        usdc.mint(address(treasury), 1_000_000e6);
+
+        // Distribute 40,000 USDC (4% < 5% threshold) → Standard
+        bytes memory data = abi.encodeWithSelector(
+            bytes4(keccak256("distribute(address,address,uint256)")),
+            address(usdc),
+            alice,
+            40_000e6
+        );
+        uint256 proposalId = _proposeWithCalldata(alice, ProposalType.Standard, address(treasury), data);
+
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Standard));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // TASK 2.5: SECURITY COUNCIL STATE
+    // ═══════════════════════════════════════════════════════════════
+
+    function test_securityCouncil_setByTimelock() public {
+        vm.prank(address(timelock));
+        governor.setSecurityCouncil(securityCouncil);
+        assertEq(governor.securityCouncil(), securityCouncil);
+    }
+
+    function test_securityCouncil_onlyTimelockCanSet() public {
+        vm.prank(alice);
+        vm.expectRevert("ArmadaGovernor: not timelock");
+        governor.setSecurityCouncil(securityCouncil);
+    }
+
+    function test_securityCouncil_canSetToZeroForEjection() public {
+        vm.prank(address(timelock));
+        governor.setSecurityCouncil(securityCouncil);
+
+        vm.prank(address(timelock));
+        governor.setSecurityCouncil(address(0));
+        assertEq(governor.securityCouncil(), address(0));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // TASK 2.6: PROPOSAL BOND
+    // ═══════════════════════════════════════════════════════════════
+
+    function test_bond_notRequiredWhenNonTransferable() public {
+        // ARM is non-transferable by default — propose should work without bond
+        uint256 proposalId = _proposeStandard(alice);
+        assertGt(proposalId, 0);
+
+        // No bond recorded
+        (address depositor, uint256 amount,,) = governor.proposalBonds(proposalId);
+        assertEq(depositor, address(0));
+        assertEq(amount, 0);
+    }
+
+    function test_bond_requiredWhenTransferable() public {
+        _enableTransfersAndApproveBond(alice);
+
+        uint256 aliceBalBefore = armToken.balanceOf(alice);
+        uint256 proposalId = _proposeStandard(alice);
+
+        // Bond was taken
+        uint256 aliceBalAfter = armToken.balanceOf(alice);
+        assertEq(aliceBalBefore - aliceBalAfter, BOND_AMOUNT);
+
+        // Bond info recorded
+        (address depositor, uint256 amount,,) = governor.proposalBonds(proposalId);
+        assertEq(depositor, alice);
+        assertEq(amount, BOND_AMOUNT);
+    }
+
+    function test_bond_revertsWithoutApproval() public {
+        armToken.setWindDownContract(windDown);
+        vm.prank(windDown);
+        armToken.setTransferable(true);
+
+        // Alice does NOT approve governor
+        vm.expectRevert(); // ERC20: insufficient allowance
+        _proposeStandard(alice);
+    }
+
+    function test_bond_claimAfterExecution() public {
+        _enableTransfersAndApproveBond(alice);
+
+        uint256 proposalId = _proposeStandard(alice);
+
+        // Fast-forward through voting delay
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+
+        // Vote FOR
+        vm.prank(alice);
+        governor.castVote(proposalId, 1);
+        vm.prank(bob);
+        governor.castVote(proposalId, 1);
+
+        // Fast-forward past voting period
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        // Queue
+        governor.queue(proposalId);
+
+        // Fast-forward past execution delay
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+
+        // Execute
+        governor.execute(proposalId);
+
+        // Claim bond — should be immediately available
+        uint256 aliceBalBefore = armToken.balanceOf(alice);
+        governor.claimBond(proposalId);
+        uint256 aliceBalAfter = armToken.balanceOf(alice);
+        assertEq(aliceBalAfter - aliceBalBefore, BOND_AMOUNT);
+    }
+
+    function test_bond_claimAfterCancel() public {
+        _enableTransfersAndApproveBond(alice);
+
+        uint256 proposalId = _proposeStandard(alice);
+
+        // Cancel during Pending
+        vm.prank(alice);
+        governor.cancel(proposalId);
+
+        // Claim bond — immediately available
+        uint256 aliceBalBefore = armToken.balanceOf(alice);
+        governor.claimBond(proposalId);
+        assertEq(armToken.balanceOf(alice) - aliceBalBefore, BOND_AMOUNT);
+    }
+
+    function test_bond_lockedOnQuorumFail() public {
+        _enableTransfersAndApproveBond(alice);
+
+        uint256 proposalId = _proposeStandard(alice);
+
+        // Fast-forward past voting delay + voting period with NO votes → quorum not met
+        vm.warp(block.timestamp + TWO_DAYS + SEVEN_DAYS + 1);
+
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Defeated));
+
+        // Try to claim immediately → should revert (locked 15 days)
+        vm.expectRevert("ArmadaGovernor: bond still locked");
+        governor.claimBond(proposalId);
+
+        // Fast-forward 15 days → now claimable
+        vm.warp(block.timestamp + 15 days);
+        governor.claimBond(proposalId);
+    }
+
+    function test_bond_lockedOnVoteDown() public {
+        _enableTransfersAndApproveBond(alice);
+
+        uint256 proposalId = _proposeStandard(alice);
+
+        // Fast-forward past voting delay
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+
+        // Vote AGAINST with enough to reach quorum
+        vm.prank(alice);
+        governor.castVote(proposalId, 0); // AGAINST
+        vm.prank(bob);
+        governor.castVote(proposalId, 0); // AGAINST
+
+        // Fast-forward past voting period
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Defeated));
+
+        // Try to claim immediately → locked 45 days
+        vm.expectRevert("ArmadaGovernor: bond still locked");
+        governor.claimBond(proposalId);
+
+        // Fast-forward 45 days → now claimable
+        vm.warp(block.timestamp + 45 days);
+        governor.claimBond(proposalId);
+    }
+
+    function test_bond_cannotClaimTwice() public {
+        _enableTransfersAndApproveBond(alice);
+
+        uint256 proposalId = _proposeStandard(alice);
+
+        vm.prank(alice);
+        governor.cancel(proposalId);
+
+        governor.claimBond(proposalId);
+
+        vm.expectRevert("ArmadaGovernor: bond already claimed");
+        governor.claimBond(proposalId);
+    }
+
+    function test_bond_cannotClaimActiveProposal() public {
+        _enableTransfersAndApproveBond(alice);
+
+        uint256 proposalId = _proposeStandard(alice);
+
+        // Still Pending — not terminal
+        vm.expectRevert("ArmadaGovernor: proposal not in terminal state");
+        governor.claimBond(proposalId);
+    }
+
+    function test_bond_noBondReverts() public {
+        // Propose without bond (non-transferable)
+        uint256 proposalId = _proposeStandard(alice);
+
+        vm.expectRevert("ArmadaGovernor: no bond");
+        governor.claimBond(proposalId);
+    }
+}

--- a/test/governance_param_updates.ts
+++ b/test/governance_param_updates.ts
@@ -4,7 +4,7 @@
  * Tests the ability to update proposal type parameters via governance:
  * - Timelock-only access control
  * - Bounded parameter validation (min/max for all fields)
- * - Full governance lifecycle to change params via Standard proposal
+ * - Full governance lifecycle to change params (auto-classified as Extended)
  * - Quorum snapshotting: in-flight proposals unaffected by param changes
  * - TreasurySteward.minActionDelay() reflects updated governor timing
  */
@@ -444,10 +444,12 @@ describe("Governance Parameter Updates", function () {
         [ProposalType.Standard, newParams]
       );
 
+      // setProposalTypeParams is an extended selector, so auto-classification
+      // upgrades this to Extended regardless of declared type
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Standard,
+        ProposalType.Extended,
         [await governor.getAddress()],
         [0n],
         [calldata],
@@ -473,10 +475,12 @@ describe("Governance Parameter Updates", function () {
         [ProposalType.Extended, newParams]
       );
 
+      // setProposalTypeParams is an extended selector, so auto-classification
+      // upgrades this to Extended regardless of declared type
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Standard,
+        ProposalType.Extended,
         [await governor.getAddress()],
         [0n],
         [calldata],
@@ -511,10 +515,12 @@ describe("Governance Parameter Updates", function () {
         [ProposalType.Standard, newParams]
       );
 
+      // setProposalTypeParams is an extended selector, so auto-classification
+      // upgrades this to Extended regardless of declared type
       await passProposal(
         alice,
         [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Standard,
+        ProposalType.Extended,
         [await governor.getAddress()],
         [0n],
         [calldata],


### PR DESCRIPTION
## Summary

- **Mechanical extended classification** (Task 2.5): Proposals containing calldata for governance-sensitive functions (fee changes, SC management, UUPS upgrades, steward election, etc.) are automatically classified as Extended. Includes a `distribute()` >5% treasury balance check. Registry of extended selectors is governance-manageable.
- **Proposal bond** (Task 2.6): 1,000 ARM bond required post-transfer-unlock. Lock periods: immediate return on execution/cancel, 15 days on quorum failure, 45 days on vote-down. No bond pre-transfer-unlock (threshold-only mode).
- **Wind-down integration** (Task 2.7): `setWindDownActive()` permanently disables `propose()`. Existing in-flight proposals complete normally.
- **Security Council state** (Task 4.1): `securityCouncil` address + `setSecurityCouncil()` with ejection support (`address(0)`).

Completes Phase 2 of the governance spec compliance work, unblocking Phases 4, 5, and 7.

## Test plan

- [x] 33 new Foundry tests in `GovernorPhase2.t.sol` — all pass
- [x] 95 existing Hardhat governance tests — all pass (no regressions)
- [x] 76 existing Foundry governance tests (invariant + steward security) — all pass
- [x] `forge test` full suite (174 tests) — 0 failures
- [ ] Manual review of inline assembly in `_classifyProposal` for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)