### PR TITLE
feat: SC veto mechanism with ratification votes (Task 4.3)

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -134,6 +134,18 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
     }
     mapping(uint256 => BondInfo) public proposalBonds;
 
+    // ============ Veto & Ratification ============
+
+    /// @notice Calldata hashes of proposals where community denied the SC's veto.
+    /// Prevents the SC from vetoing identical proposal content twice.
+    mapping(bytes32 => bool) public vetoDeniedHashes;
+
+    /// @notice Maps ratification proposalId → original vetoed proposalId
+    mapping(uint256 => uint256) public ratificationOf;
+
+    /// @notice Maps vetoed proposalId → ratification proposalId (reverse lookup)
+    mapping(uint256 => uint256) public vetoRatificationId;
+
     // ============ Events ============
 
     event ProposalCreated(
@@ -158,6 +170,9 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
     event ExtendedSelectorRemoved(bytes4 indexed selector);
     event BondPosted(uint256 indexed proposalId, address indexed depositor, uint256 amount);
     event BondClaimed(uint256 indexed proposalId, address indexed depositor, uint256 amount);
+    event ProposalVetoed(uint256 indexed proposalId, bytes32 rationaleHash, uint256 ratificationId);
+    event RatificationResolved(uint256 indexed ratificationId, bool vetoUpheld);
+    event SecurityCouncilEjected(uint256 indexed ratificationId);
 
     // ============ Constructor ============
 
@@ -361,6 +376,137 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         securityCouncil = newSC;
     }
 
+    // ============ Veto Mechanism ============
+
+    /// @notice Security Council vetoes a queued proposal, triggering a ratification vote.
+    /// @param proposalId The queued proposal to veto
+    /// @param rationaleHash Off-chain rationale hash for verifiability
+    function veto(uint256 proposalId, bytes32 rationaleHash) external {
+        require(msg.sender == securityCouncil, "ArmadaGovernor: not security council");
+        require(securityCouncil != address(0), "ArmadaGovernor: SC ejected");
+        require(state(proposalId) == ProposalState.Queued, "ArmadaGovernor: not queued");
+
+        // Double-veto prevention: community denied a veto on identical calldata
+        bytes32 calldataHash = _proposalCalldataHash(proposalId);
+        require(!vetoDeniedHashes[calldataHash], "ArmadaGovernor: community overrode, no double veto");
+
+        Proposal storage p = _proposals[proposalId];
+
+        // Cancel the original proposal
+        p.canceled = true;
+
+        // Cancel the timelock operation
+        bytes32 timelockId = timelock.hashOperationBatch(
+            p.targets, p.values, p.calldatas, 0, _proposalSalt(proposalId)
+        );
+        timelock.cancel(timelockId);
+
+        // Auto-create ratification vote
+        uint256 ratId = _createRatificationProposal(proposalId, rationaleHash);
+
+        emit ProposalVetoed(proposalId, rationaleHash, ratId);
+    }
+
+    /// @notice Resolve a veto ratification vote after voting ends.
+    /// FOR or quorum-not-met = veto upheld. AGAINST with quorum = SC ejected.
+    /// @param ratificationId The ratification proposal to resolve
+    function resolveRatification(uint256 ratificationId) external {
+        uint256 vetoedId = ratificationOf[ratificationId];
+        require(vetoedId != 0, "ArmadaGovernor: not a ratification proposal");
+
+        Proposal storage p = _proposals[ratificationId];
+        require(block.timestamp > p.voteEnd, "ArmadaGovernor: voting not ended");
+        require(!p.executed, "ArmadaGovernor: already resolved");
+
+        p.executed = true;
+
+        // Evaluate outcome: does the community uphold or deny the veto?
+        bool quorumMet = _quorumReached(ratificationId);
+        bool majorityAgainst = quorumMet && !_voteSucceeded(ratificationId);
+
+        if (majorityAgainst) {
+            // Community denies the veto → eject SC, store calldata hash
+            address oldSC = securityCouncil;
+            securityCouncil = address(0);
+
+            vetoDeniedHashes[_proposalCalldataHash(vetoedId)] = true;
+
+            emit SecurityCouncilEjected(ratificationId);
+            emit SecurityCouncilUpdated(oldSC, address(0));
+            emit RatificationResolved(ratificationId, false);
+        } else {
+            // FOR wins or quorum not met → veto stands
+            emit RatificationResolved(ratificationId, true);
+        }
+    }
+
+    /// @dev Create a ratification proposal internally (bypasses propose() guards).
+    function _createRatificationProposal(
+        uint256 vetoedProposalId,
+        bytes32 rationaleHash
+    ) internal returns (uint256) {
+        uint256 ratId = ++proposalCount;
+
+        // Build description for on-chain verifiability
+        string memory desc = string(abi.encodePacked(
+            "Veto ratification for proposal #",
+            _uint2str(vetoedProposalId),
+            " | rationale: ",
+            _bytes32ToHex(rationaleHash)
+        ));
+
+        _initProposal(ratId, ProposalType.VetoRatification, desc);
+
+        // Ratification has no execution calldata — consequences handled by resolveRatification()
+        // (targets, values, calldatas arrays remain empty/default)
+
+        // Store bidirectional mappings
+        ratificationOf[ratId] = vetoedProposalId;
+        vetoRatificationId[vetoedProposalId] = ratId;
+
+        Proposal storage p = _proposals[ratId];
+        emit ProposalCreated(
+            ratId, msg.sender, ProposalType.VetoRatification,
+            p.voteStart, p.voteEnd, desc
+        );
+
+        return ratId;
+    }
+
+    /// @dev Compute a deterministic hash of a proposal's calldata for double-veto prevention.
+    function _proposalCalldataHash(uint256 proposalId) internal view returns (bytes32) {
+        Proposal storage p = _proposals[proposalId];
+        return keccak256(abi.encode(p.targets, p.values, p.calldatas));
+    }
+
+    /// @dev Convert uint to decimal string for ratification description.
+    function _uint2str(uint256 value) internal pure returns (string memory) {
+        if (value == 0) return "0";
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) { digits++; temp /= 10; }
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits--;
+            buffer[digits] = bytes1(uint8(48 + value % 10));
+            value /= 10;
+        }
+        return string(buffer);
+    }
+
+    /// @dev Convert bytes32 to hex string (0x-prefixed) for ratification description.
+    function _bytes32ToHex(bytes32 value) internal pure returns (string memory) {
+        bytes memory hexChars = "0123456789abcdef";
+        bytes memory str = new bytes(66); // "0x" + 64 hex chars
+        str[0] = "0";
+        str[1] = "x";
+        for (uint256 i = 0; i < 32; i++) {
+            str[2 + i * 2] = hexChars[uint8(value[i] >> 4)];
+            str[3 + i * 2] = hexChars[uint8(value[i] & 0x0f)];
+        }
+        return string(str);
+    }
+
     // ============ Wind-Down ============
 
     /// @notice One-time setter: register the wind-down contract address.
@@ -558,6 +704,7 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         require(state(proposalId) == ProposalState.Succeeded, "ArmadaGovernor: not succeeded");
 
         Proposal storage p = _proposals[proposalId];
+        require(p.proposalType != ProposalType.VetoRatification, "ArmadaGovernor: use resolveRatification");
         p.queued = true;
 
         bytes32 timelockId = timelock.hashOperationBatch(
@@ -579,6 +726,7 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         require(state(proposalId) == ProposalState.Queued, "ArmadaGovernor: not queued");
 
         Proposal storage p = _proposals[proposalId];
+        require(p.proposalType != ProposalType.VetoRatification, "ArmadaGovernor: use resolveRatification");
         p.executed = true;
 
         timelock.executeBatch{value: msg.value}(
@@ -618,8 +766,17 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
             // Passed and executed: immediately claimable
             unlockTime = 0;
         } else if (currentState == ProposalState.Canceled) {
-            // Proposer self-cancelled during Pending: immediately claimable
-            unlockTime = 0;
+            uint256 ratId = vetoRatificationId[proposalId];
+            if (ratId != 0) {
+                // Vetoed proposal: bond deferred until ratification resolves.
+                // Proposer did nothing wrong — proposal passed on merit — so no penalty.
+                Proposal storage rat = _proposals[ratId];
+                require(rat.executed, "ArmadaGovernor: ratification not resolved");
+                unlockTime = 0;
+            } else {
+                // Proposer self-cancelled during Pending: immediately claimable
+                unlockTime = 0;
+            }
         } else if (currentState == ProposalState.Defeated) {
             // Determine defeat reason: quorum not met vs majority against
             bool quorumMet = _quorumReached(proposalId);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "deploy:governance": "hardhat run scripts/deploy_governance.ts --network hub",
     "deploy:crowdfund": "hardhat run scripts/deploy_crowdfund.ts --network hub",
     "test": "hardhat test test/privacy_pool_integration.ts",
-    "test:governance": "hardhat test test/governance_integration.ts test/governance_adversarial.ts",
+    "test:governance": "hardhat test test/governance_integration.ts test/governance_adversarial.ts test/governance_veto.ts",
     "test:crowdfund": "hardhat test test/crowdfund_integration.ts test/crowdfund_adversarial.ts",
     "test:all": "hardhat test",
     "test:mcp": "npx mocha --require ts-node/register mcp-server/test/unit.test.ts",

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -160,6 +160,9 @@ async function main() {
   console.log("   Granted PROPOSER_ROLE to governor");
   await (await timelock.grantRole(EXECUTOR_ROLE, governorAddress, nm.override())).wait();
   console.log("   Granted EXECUTOR_ROLE to governor");
+  const CANCELLER_ROLE = await timelock.CANCELLER_ROLE();
+  await (await timelock.grantRole(CANCELLER_ROLE, governorAddress, nm.override())).wait();
+  console.log("   Granted CANCELLER_ROLE to governor (for SC veto)");
 
   // 8. Configure ARM token (one-time setters)
   console.log("8. Configuring ARM token...");

--- a/test-foundry/GovernorVeto.t.sol
+++ b/test-foundry/GovernorVeto.t.sol
@@ -1,0 +1,717 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Foundry tests for Security Council veto mechanism and ratification votes.
+// ABOUTME: Covers veto lifecycle, SC ejection, double-veto prevention, and bond deferral.
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/ArmadaGovernor.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/governance/ArmadaTreasuryGov.sol";
+import "../contracts/governance/IArmadaGovernance.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+
+/// @title GovernorVetoTest — Tests for SC veto, ratification, ejection, and double-veto prevention
+contract GovernorVetoTest is Test {
+    // Mirror events from governor for expectEmit
+    event ProposalVetoed(uint256 indexed proposalId, bytes32 rationaleHash, uint256 ratificationId);
+    event RatificationResolved(uint256 indexed ratificationId, bool vetoUpheld);
+    event SecurityCouncilEjected(uint256 indexed ratificationId);
+    event SecurityCouncilUpdated(address indexed oldSC, address indexed newSC);
+    event ProposalCreated(
+        uint256 indexed proposalId,
+        address indexed proposer,
+        ProposalType proposalType,
+        uint256 voteStart,
+        uint256 voteEnd,
+        string description
+    );
+    event ProposalCanceled(uint256 indexed proposalId);
+    event BondClaimed(uint256 indexed proposalId, address indexed depositor, uint256 amount);
+
+    ArmadaGovernor public governor;
+    ArmadaToken public armToken;
+    TimelockController public timelock;
+    ArmadaTreasuryGov public treasury;
+
+    address public deployer = address(this);
+    address public alice = address(0xA11CE);
+    address public bob = address(0xB0B);
+    address public carol = address(0xCA201);
+    address public sc = address(0x5C5C);       // Security Council
+    address public windDown = address(0xD00D);
+
+    uint256 constant TOTAL_SUPPLY = 12_000_000 * 1e18;
+    uint256 constant BOND_AMOUNT = 1_000 * 1e18;
+    uint256 constant TWO_DAYS = 2 days;
+    uint256 constant SEVEN_DAYS = 7 days;
+    uint256 constant FOURTEEN_DAYS = 14 days;
+    uint256 constant MAX_PAUSE = 14 days;
+
+    function setUp() public {
+        // Deploy timelock
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        timelock = new TimelockController(TWO_DAYS, proposers, executors, deployer);
+
+        // Deploy ARM token
+        armToken = new ArmadaToken(deployer, address(timelock));
+
+        // Deploy treasury
+        treasury = new ArmadaTreasuryGov(address(timelock), deployer, MAX_PAUSE);
+
+        // Deploy governor
+        governor = new ArmadaGovernor(
+            address(armToken),
+            payable(address(timelock)),
+            address(treasury),
+            deployer,
+            MAX_PAUSE
+        );
+
+        // Whitelist participants
+        address[] memory whitelist = new address[](4);
+        whitelist[0] = deployer;
+        whitelist[1] = alice;
+        whitelist[2] = bob;
+        whitelist[3] = address(governor);
+        armToken.initWhitelist(whitelist);
+
+        // Distribute tokens: alice 20%, bob 15%, treasury 50%, deployer keeps 15%
+        armToken.transfer(alice, TOTAL_SUPPLY * 20 / 100);
+        armToken.transfer(bob, TOTAL_SUPPLY * 15 / 100);
+        armToken.transfer(address(treasury), TOTAL_SUPPLY * 50 / 100);
+
+        // Delegate to activate voting power
+        vm.prank(alice);
+        armToken.delegate(alice);
+        vm.prank(bob);
+        armToken.delegate(bob);
+
+        // Advance block so checkpoints are available
+        vm.roll(block.number + 1);
+
+        // Grant timelock roles to governor (PROPOSER, EXECUTOR, CANCELLER)
+        timelock.grantRole(timelock.PROPOSER_ROLE(), address(governor));
+        timelock.grantRole(timelock.EXECUTOR_ROLE(), address(governor));
+        timelock.grantRole(timelock.CANCELLER_ROLE(), address(governor));
+
+        // Set Security Council on governor (via timelock)
+        vm.prank(address(timelock));
+        governor.setSecurityCouncil(sc);
+    }
+
+    // ======== Helpers ========
+
+    /// @dev Enable ARM transfers and approve governor for bond
+    function _enableTransfersAndApproveBond(address proposer) internal {
+        armToken.setWindDownContract(windDown);
+        vm.prank(windDown);
+        armToken.setTransferable(true);
+
+        vm.prank(proposer);
+        armToken.approve(address(governor), BOND_AMOUNT);
+    }
+
+    /// @dev Create a standard proposal and advance it to Queued state
+    function _createAndQueueProposal(address proposer) internal returns (uint256) {
+        address[] memory targets = new address[](1);
+        targets[0] = address(governor);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("proposalCount()");
+
+        vm.prank(proposer);
+        uint256 proposalId = governor.propose(ProposalType.Standard, targets, values, calldatas, "test proposal");
+
+        // Advance past voting delay (2 days)
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+
+        // Vote FOR with alice and bob (35% of supply, exceeds 20% quorum)
+        vm.prank(alice);
+        governor.castVote(proposalId, 1); // FOR
+        vm.prank(bob);
+        governor.castVote(proposalId, 1); // FOR
+
+        // Advance past voting period (7 days for Standard)
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        // Queue
+        governor.queue(proposalId);
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Queued));
+
+        return proposalId;
+    }
+
+    /// @dev Create a standard proposal with specific calldata and advance to Queued state
+    function _createAndQueueProposalWithCalldata(
+        address proposer,
+        address target,
+        bytes memory data,
+        string memory desc
+    ) internal returns (uint256) {
+        address[] memory targets = new address[](1);
+        targets[0] = target;
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = data;
+
+        vm.prank(proposer);
+        uint256 proposalId = governor.propose(ProposalType.Standard, targets, values, calldatas, desc);
+
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+
+        vm.prank(alice);
+        governor.castVote(proposalId, 1);
+        vm.prank(bob);
+        governor.castVote(proposalId, 1);
+
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        governor.queue(proposalId);
+        return proposalId;
+    }
+
+    // ======== Veto Core ========
+
+    function test_veto_scCanVetoQueuedProposal() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+        bytes32 rationaleHash = keccak256("Security risk identified");
+
+        vm.prank(sc);
+        governor.veto(proposalId, rationaleHash);
+
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Canceled));
+    }
+
+    function test_veto_createsRatificationProposal() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+        bytes32 rationaleHash = keccak256("Security risk");
+
+        uint256 countBefore = governor.proposalCount();
+
+        vm.prank(sc);
+        governor.veto(proposalId, rationaleHash);
+
+        uint256 ratId = governor.proposalCount();
+        assertEq(ratId, countBefore + 1);
+        assertEq(governor.ratificationOf(ratId), proposalId);
+        assertEq(governor.vetoRatificationId(proposalId), ratId);
+    }
+
+    function test_veto_ratificationHasCorrectParams() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+
+        uint256 ratId = governor.proposalCount();
+
+        (
+            address proposer,
+            ProposalType pType,
+            uint256 voteStart,
+            uint256 voteEnd,
+            , , , ,
+        ) = governor.getProposal(ratId);
+
+        assertEq(proposer, sc, "proposer should be SC");
+        assertEq(uint256(pType), uint256(ProposalType.VetoRatification));
+        // VetoRatification has 0 voting delay, so voting starts immediately
+        assertEq(voteStart, block.timestamp, "voting should start immediately");
+        assertEq(voteEnd, block.timestamp + SEVEN_DAYS, "voting period should be 7 days");
+    }
+
+    function test_veto_ratificationVotingStartsImmediately() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+
+        uint256 ratId = governor.proposalCount();
+
+        // Should be Active immediately (0 voting delay)
+        assertEq(uint256(governor.state(ratId)), uint256(ProposalState.Active));
+
+        // Can vote immediately
+        vm.prank(alice);
+        governor.castVote(ratId, 1); // FOR
+    }
+
+    function test_veto_emitsProposalVetoedEvent() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+        bytes32 rationaleHash = keccak256("Security risk");
+
+        vm.expectEmit(true, false, false, true);
+        emit ProposalVetoed(proposalId, rationaleHash, proposalId + 1);
+
+        vm.prank(sc);
+        governor.veto(proposalId, rationaleHash);
+    }
+
+    function test_veto_cancelsTimelockOperation() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        // Get the timelock operation ID before veto
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
+            governor.getProposalActions(proposalId);
+        bytes32 timelockId = timelock.hashOperationBatch(
+            targets, values, calldatas, 0, bytes32(proposalId)
+        );
+
+        // Verify operation is pending in timelock
+        assertTrue(timelock.isOperationPending(timelockId));
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+
+        // Verify operation is no longer pending
+        assertFalse(timelock.isOperationPending(timelockId));
+    }
+
+    // ======== Veto Access Control ========
+
+    function test_veto_revertsIfNotSC() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("ArmadaGovernor: not security council");
+        governor.veto(proposalId, keccak256("rationale"));
+    }
+
+    function test_veto_revertsIfSCEjected() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        // Eject SC
+        vm.prank(address(timelock));
+        governor.setSecurityCouncil(address(0));
+
+        vm.prank(address(0));
+        vm.expectRevert("ArmadaGovernor: SC ejected");
+        governor.veto(proposalId, keccak256("rationale"));
+    }
+
+    function test_veto_revertsIfNotQueued() public {
+        // Create proposal but don't queue it
+        address[] memory targets = new address[](1);
+        targets[0] = address(governor);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("proposalCount()");
+
+        vm.prank(alice);
+        uint256 proposalId = governor.propose(ProposalType.Standard, targets, values, calldatas, "test");
+
+        // Still Pending
+        vm.prank(sc);
+        vm.expectRevert("ArmadaGovernor: not queued");
+        governor.veto(proposalId, keccak256("rationale"));
+
+        // Advance to Active
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+        vm.prank(sc);
+        vm.expectRevert("ArmadaGovernor: not queued");
+        governor.veto(proposalId, keccak256("rationale"));
+    }
+
+    // ======== Ratification Resolution ========
+
+    function test_resolve_forWinsVetoUpheld() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+        uint256 ratId = governor.proposalCount();
+
+        // Vote FOR (uphold veto) — alice and bob
+        vm.prank(alice);
+        governor.castVote(ratId, 1); // FOR
+        vm.prank(bob);
+        governor.castVote(ratId, 1); // FOR
+
+        // Advance past voting period (7 days)
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        vm.expectEmit(true, false, false, true);
+        emit RatificationResolved(ratId, true);
+
+        governor.resolveRatification(ratId);
+
+        // SC retains seat
+        assertEq(governor.securityCouncil(), sc);
+        // Original proposal stays cancelled
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Canceled));
+    }
+
+    function test_resolve_quorumNotMetVetoStands() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+        uint256 ratId = governor.proposalCount();
+
+        // No one votes — quorum not met
+
+        // Advance past voting period
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        vm.expectEmit(true, false, false, true);
+        emit RatificationResolved(ratId, true);
+
+        governor.resolveRatification(ratId);
+
+        // SC retains seat
+        assertEq(governor.securityCouncil(), sc);
+    }
+
+    function test_resolve_againstWinsSCEjected() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+        uint256 ratId = governor.proposalCount();
+
+        // Vote AGAINST (deny veto) — alice and bob
+        vm.prank(alice);
+        governor.castVote(ratId, 0); // AGAINST
+        vm.prank(bob);
+        governor.castVote(ratId, 0); // AGAINST
+
+        // Advance past voting period
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        vm.expectEmit(true, false, false, false);
+        emit SecurityCouncilEjected(ratId);
+        vm.expectEmit(true, true, false, false);
+        emit SecurityCouncilUpdated(sc, address(0));
+        vm.expectEmit(true, false, false, true);
+        emit RatificationResolved(ratId, false);
+
+        governor.resolveRatification(ratId);
+
+        // SC ejected
+        assertEq(governor.securityCouncil(), address(0));
+    }
+
+    function test_resolve_againstStoresCalldataHash() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        // Compute expected calldata hash
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
+            governor.getProposalActions(proposalId);
+        bytes32 expectedHash = keccak256(abi.encode(targets, values, calldatas));
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+        uint256 ratId = governor.proposalCount();
+
+        // Vote AGAINST
+        vm.prank(alice);
+        governor.castVote(ratId, 0);
+        vm.prank(bob);
+        governor.castVote(ratId, 0);
+
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+        governor.resolveRatification(ratId);
+
+        // Calldata hash should be stored
+        assertTrue(governor.vetoDeniedHashes(expectedHash));
+    }
+
+    function test_resolve_revertsBeforeVotingEnds() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+        uint256 ratId = governor.proposalCount();
+
+        // Try to resolve immediately (voting still active)
+        vm.expectRevert("ArmadaGovernor: voting not ended");
+        governor.resolveRatification(ratId);
+    }
+
+    function test_resolve_revertsIfNotRatification() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        vm.expectRevert("ArmadaGovernor: not a ratification proposal");
+        governor.resolveRatification(proposalId);
+    }
+
+    function test_resolve_revertsIfAlreadyResolved() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+        uint256 ratId = governor.proposalCount();
+
+        // Vote FOR
+        vm.prank(alice);
+        governor.castVote(ratId, 1);
+
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+        governor.resolveRatification(ratId);
+
+        // Try again
+        vm.expectRevert("ArmadaGovernor: already resolved");
+        governor.resolveRatification(ratId);
+    }
+
+    // ======== Double-Veto Prevention ========
+
+    function test_doubleVeto_identicalCalldataReverts() public {
+        // First proposal: create, queue, veto, community AGAINST → deny veto
+        uint256 proposalId1 = _createAndQueueProposalWithCalldata(
+            alice, address(governor), abi.encodeWithSignature("proposalCount()"), "first attempt"
+        );
+
+        vm.prank(sc);
+        governor.veto(proposalId1, keccak256("rationale"));
+        uint256 ratId1 = governor.proposalCount();
+
+        vm.prank(alice);
+        governor.castVote(ratId1, 0); // AGAINST
+        vm.prank(bob);
+        governor.castVote(ratId1, 0); // AGAINST
+
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+        governor.resolveRatification(ratId1);
+
+        // SC ejected, set new SC
+        assertEq(governor.securityCouncil(), address(0));
+        address newSC = address(0x5C5C2);
+        vm.prank(address(timelock));
+        governor.setSecurityCouncil(newSC);
+
+        // Second proposal with identical calldata: create, queue
+        uint256 proposalId2 = _createAndQueueProposalWithCalldata(
+            alice, address(governor), abi.encodeWithSignature("proposalCount()"), "second attempt"
+        );
+
+        // New SC tries to veto — should revert
+        vm.prank(newSC);
+        vm.expectRevert("ArmadaGovernor: community overrode, no double veto");
+        governor.veto(proposalId2, keccak256("rationale2"));
+    }
+
+    function test_doubleVeto_modifiedCalldataAllowed() public {
+        // First: veto denied
+        uint256 proposalId1 = _createAndQueueProposalWithCalldata(
+            alice, address(governor), abi.encodeWithSignature("proposalCount()"), "first"
+        );
+
+        vm.prank(sc);
+        governor.veto(proposalId1, keccak256("rationale"));
+        uint256 ratId1 = governor.proposalCount();
+
+        vm.prank(alice);
+        governor.castVote(ratId1, 0);
+        vm.prank(bob);
+        governor.castVote(ratId1, 0);
+
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+        governor.resolveRatification(ratId1);
+
+        // Set new SC
+        address newSC = address(0x5C5C2);
+        vm.prank(address(timelock));
+        governor.setSecurityCouncil(newSC);
+
+        // Second proposal with DIFFERENT calldata
+        uint256 proposalId2 = _createAndQueueProposalWithCalldata(
+            alice, address(governor), abi.encodeWithSignature("proposalThreshold()"), "different calldata"
+        );
+
+        // New SC can veto — different calldata hash
+        vm.prank(newSC);
+        governor.veto(proposalId2, keccak256("rationale2"));
+
+        // Veto succeeds
+        assertEq(uint256(governor.state(proposalId2)), uint256(ProposalState.Canceled));
+    }
+
+    // ======== Queue/Execute Guards ========
+
+    function test_queue_revertsForRatification() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+        uint256 ratId = governor.proposalCount();
+
+        // Vote FOR so it would be "Succeeded"
+        vm.prank(alice);
+        governor.castVote(ratId, 1);
+        vm.prank(bob);
+        governor.castVote(ratId, 1);
+
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        // Try to queue — should revert
+        vm.expectRevert("ArmadaGovernor: use resolveRatification");
+        governor.queue(ratId);
+    }
+
+    // ======== Post-Ejection ========
+
+    function test_postEjection_cannotVeto() public {
+        uint256 proposalId1 = _createAndQueueProposal(alice);
+
+        // Veto → community AGAINST → SC ejected
+        vm.prank(sc);
+        governor.veto(proposalId1, keccak256("rationale"));
+        uint256 ratId = governor.proposalCount();
+
+        vm.prank(alice);
+        governor.castVote(ratId, 0);
+        vm.prank(bob);
+        governor.castVote(ratId, 0);
+
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+        governor.resolveRatification(ratId);
+
+        assertEq(governor.securityCouncil(), address(0));
+
+        // Create a new proposal and queue it
+        uint256 proposalId2 = _createAndQueueProposal(alice);
+
+        // Ejected SC tries to veto
+        vm.prank(sc);
+        vm.expectRevert("ArmadaGovernor: not security council");
+        governor.veto(proposalId2, keccak256("rationale"));
+    }
+
+    function test_postEjection_governanceCanSetNewSC() public {
+        // Eject SC
+        vm.prank(address(timelock));
+        governor.setSecurityCouncil(address(0));
+
+        assertEq(governor.securityCouncil(), address(0));
+
+        // Set new SC via governance (simulated as timelock)
+        address newSC = address(0x5C5C2);
+        vm.prank(address(timelock));
+        governor.setSecurityCouncil(newSC);
+
+        assertEq(governor.securityCouncil(), newSC);
+    }
+
+    // ======== Bond Integration ========
+
+    function test_bond_vetoedProposalDeferredUntilRatificationResolves() public {
+        _enableTransfersAndApproveBond(alice);
+        uint256 aliceBalanceBefore = armToken.balanceOf(alice);
+
+        // Create, queue, veto
+        uint256 proposalId = _createAndQueueProposal(alice);
+        uint256 ratId = governor.proposalCount() + 1; // will be next
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+        ratId = governor.proposalCount();
+
+        // Try to claim bond while ratification in progress — should revert
+        vm.expectRevert("ArmadaGovernor: ratification not resolved");
+        governor.claimBond(proposalId);
+
+        // Vote FOR (uphold veto) and resolve
+        vm.prank(alice);
+        governor.castVote(ratId, 1);
+        vm.prank(bob);
+        governor.castVote(ratId, 1);
+
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+        governor.resolveRatification(ratId);
+
+        // Now bond should be claimable
+        governor.claimBond(proposalId);
+
+        // Bond returned
+        assertEq(armToken.balanceOf(alice), aliceBalanceBefore);
+    }
+
+    function test_bond_vetoedProposalClaimableAfterAgainstResolution() public {
+        _enableTransfersAndApproveBond(alice);
+
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+        uint256 ratId = governor.proposalCount();
+
+        // Vote AGAINST → SC ejected
+        vm.prank(alice);
+        governor.castVote(ratId, 0);
+        vm.prank(bob);
+        governor.castVote(ratId, 0);
+
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+        governor.resolveRatification(ratId);
+
+        // Bond still claimable (proposer not penalized even if veto was denied)
+        governor.claimBond(proposalId);
+    }
+
+    // ======== Full Lifecycle Integration ========
+
+    function test_fullLifecycle_vetoUpheld() public {
+        // 1. Create and queue a proposal
+        uint256 proposalId = _createAndQueueProposal(alice);
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Queued));
+
+        // 2. SC vetoes
+        bytes32 rationaleHash = keccak256("Potential reentrancy vulnerability");
+        vm.prank(sc);
+        governor.veto(proposalId, rationaleHash);
+
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Canceled));
+
+        // 3. Ratification vote begins immediately
+        uint256 ratId = governor.proposalCount();
+        assertEq(uint256(governor.state(ratId)), uint256(ProposalState.Active));
+
+        // 4. Community votes FOR (uphold veto)
+        vm.prank(alice);
+        governor.castVote(ratId, 1);
+        vm.prank(bob);
+        governor.castVote(ratId, 1);
+
+        // 5. Voting ends
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        // 6. Resolve
+        governor.resolveRatification(ratId);
+
+        // 7. Verify final state
+        assertEq(governor.securityCouncil(), sc, "SC should retain seat");
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Canceled));
+        assertEq(uint256(governor.state(ratId)), uint256(ProposalState.Executed));
+    }
+
+    function test_fullLifecycle_vetoDeniedSCEjected() public {
+        // 1. Create and queue
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        // 2. SC vetoes
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("False alarm"));
+
+        // 3. Community votes AGAINST (deny veto)
+        uint256 ratId = governor.proposalCount();
+        vm.prank(alice);
+        governor.castVote(ratId, 0);
+        vm.prank(bob);
+        governor.castVote(ratId, 0);
+
+        // 4. Resolve
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+        governor.resolveRatification(ratId);
+
+        // 5. SC ejected
+        assertEq(governor.securityCouncil(), address(0));
+
+        // 6. Calldata hash stored — identical proposal cannot be vetoed again
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
+            governor.getProposalActions(proposalId);
+        bytes32 calldataHash = keccak256(abi.encode(targets, values, calldatas));
+        assertTrue(governor.vetoDeniedHashes(calldataHash));
+    }
+}

--- a/test/governance_veto.ts
+++ b/test/governance_veto.ts
@@ -1,0 +1,712 @@
+// ABOUTME: Hardhat integration tests for SC veto mechanism, ratification votes, and bond deferral.
+// ABOUTME: Covers veto lifecycle, SC ejection, double-veto prevention, queue/execute guards, and post-ejection behavior.
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
+import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+
+// Proposal types (must match IArmadaGovernance.sol enum order)
+const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
+// Proposal states
+const ProposalState = {
+  Pending: 0, Active: 1, Defeated: 2, Succeeded: 3,
+  Queued: 4, Executed: 5, Canceled: 6,
+};
+// Vote support values
+const Vote = { Against: 0, For: 1, Abstain: 2 };
+
+// Time constants
+const ONE_DAY = 86400;
+const TWO_DAYS = 2 * ONE_DAY;
+const SEVEN_DAYS = 7 * ONE_DAY;
+const FOURTEEN_DAYS = 14 * ONE_DAY;
+
+// Spec-aligned timing
+const STANDARD_VOTING_PERIOD = SEVEN_DAYS;
+const STANDARD_EXECUTION_DELAY = TWO_DAYS;
+
+describe("Governance Veto", function () {
+  // Contracts
+  let armToken: any;
+  let timelockController: any;
+  let governor: any;
+  let treasury: any;
+
+  // Signers
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let carol: SignerWithAddress; // used as Security Council
+  let dave: SignerWithAddress;
+
+  // Constants
+  const ARM_DECIMALS = 18;
+  const TOTAL_SUPPLY = ethers.parseUnits("12000000", ARM_DECIMALS);
+  const TREASURY_AMOUNT = TOTAL_SUPPLY * 65n / 100n;
+  const ALICE_AMOUNT = TOTAL_SUPPLY * 20n / 100n;
+  const BOB_AMOUNT = TOTAL_SUPPLY * 15n / 100n;
+
+  // Helper: mine a block so checkpoint reads work
+  async function mineBlock() {
+    await mine(1);
+  }
+
+  // Helper: impersonate timelock to call governor functions that require timelock caller
+  async function asTimelock(): Promise<SignerWithAddress> {
+    const timelockAddr = await timelockController.getAddress();
+    await ethers.provider.send("hardhat_impersonateAccount", [timelockAddr]);
+    await deployer.sendTransaction({ to: timelockAddr, value: ethers.parseEther("1") });
+    return await ethers.getSigner(timelockAddr) as unknown as SignerWithAddress;
+  }
+
+  async function stopImpersonatingTimelock() {
+    const timelockAddr = await timelockController.getAddress();
+    await ethers.provider.send("hardhat_stopImpersonatingAccount", [timelockAddr]);
+  }
+
+  // Helper: create a Standard proposal, vote it through, and queue it
+  async function createAndQueueProposal(
+    proposer: SignerWithAddress,
+    targets?: string[],
+    calldatas?: string[],
+    description?: string,
+  ): Promise<number> {
+    const govAddr = await governor.getAddress();
+    const _targets = targets ?? [govAddr];
+    const _values = [0n];
+    const _calldatas = calldatas ?? [governor.interface.encodeFunctionData("proposalCount")];
+    const _description = description ?? "Test proposal";
+
+    await governor.connect(proposer).propose(
+      ProposalType.Standard, _targets, _values, _calldatas, _description
+    );
+    const proposalId = Number(await governor.proposalCount());
+
+    // Advance past voting delay (2 days)
+    await time.increase(TWO_DAYS + 1);
+
+    // Vote FOR with alice and bob (35% combined, exceeds 20% quorum)
+    await governor.connect(alice).castVote(proposalId, Vote.For);
+    await governor.connect(bob).castVote(proposalId, Vote.For);
+
+    // Advance past voting period (7 days for Standard)
+    await time.increase(STANDARD_VOTING_PERIOD + 1);
+
+    // Queue
+    await governor.queue(proposalId);
+    expect(await governor.state(proposalId)).to.equal(ProposalState.Queued);
+
+    return proposalId;
+  }
+
+  // Helper: veto a queued proposal as SC, return the ratification proposal ID
+  async function vetoProposal(proposalId: number, rationaleHash?: string): Promise<number> {
+    const hash = rationaleHash ?? ethers.keccak256(ethers.toUtf8Bytes("Security risk identified"));
+
+    await governor.connect(carol).veto(proposalId, hash);
+    return Number(await governor.proposalCount());
+  }
+
+  beforeEach(async function () {
+    [deployer, alice, bob, carol, dave] = await ethers.getSigners();
+
+    // 1. Deploy TimelockController (minDelay = 2 days)
+    const TimelockController = await ethers.getContractFactory("TimelockController");
+    timelockController = await TimelockController.deploy(
+      TWO_DAYS, [], [], deployer.address
+    );
+    await timelockController.waitForDeployment();
+    const timelockAddr = await timelockController.getAddress();
+    const MAX_PAUSE_DURATION = 14 * ONE_DAY;
+
+    // 2. Deploy ARM token
+    const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+    armToken = await ArmadaToken.deploy(deployer.address, timelockAddr);
+    await armToken.waitForDeployment();
+
+    // 3. Deploy Treasury
+    const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+    treasury = await ArmadaTreasuryGov.deploy(
+      timelockAddr, deployer.address, MAX_PAUSE_DURATION
+    );
+    await treasury.waitForDeployment();
+
+    // 4. Deploy Governor
+    const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
+    governor = await ArmadaGovernor.deploy(
+      await armToken.getAddress(),
+      timelockAddr,
+      await treasury.getAddress(),
+      deployer.address, MAX_PAUSE_DURATION
+    );
+    await governor.waitForDeployment();
+
+    // 5. Configure timelock roles: PROPOSER, EXECUTOR, and CANCELLER for governor
+    const PROPOSER_ROLE = await timelockController.PROPOSER_ROLE();
+    const EXECUTOR_ROLE = await timelockController.EXECUTOR_ROLE();
+    const CANCELLER_ROLE = await timelockController.CANCELLER_ROLE();
+    const ADMIN_ROLE = await timelockController.TIMELOCK_ADMIN_ROLE();
+    const govAddr = await governor.getAddress();
+
+    await timelockController.grantRole(PROPOSER_ROLE, govAddr);
+    await timelockController.grantRole(EXECUTOR_ROLE, govAddr);
+    await timelockController.grantRole(CANCELLER_ROLE, govAddr);
+
+    // 6. Set Security Council (carol) via timelock impersonation
+    const timelockSigner = await asTimelock();
+    await governor.connect(timelockSigner).setSecurityCouncil(carol.address);
+    await stopImpersonatingTimelock();
+
+    // 7. Renounce deployer admin role on timelock
+    await timelockController.renounceRole(ADMIN_ROLE, deployer.address);
+
+    // 8. Configure ARM token
+    await armToken.setNoDelegation(await treasury.getAddress());
+    await armToken.initWhitelist([
+      deployer.address,
+      await treasury.getAddress(),
+      alice.address,
+      bob.address,
+      govAddr,
+    ]);
+
+    // 9. Distribute ARM tokens
+    await armToken.transfer(await treasury.getAddress(), TREASURY_AMOUNT);
+    await armToken.transfer(alice.address, ALICE_AMOUNT);
+    await armToken.transfer(bob.address, BOB_AMOUNT);
+
+    // 10. Delegate tokens for voting power
+    await armToken.connect(alice).delegate(alice.address);
+    await armToken.connect(bob).delegate(bob.address);
+
+    await mineBlock();
+  });
+
+  // ======== Veto Core ========
+
+  describe("Veto Core", function () {
+    it("should cancel a queued proposal when SC vetoes", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+
+      await governor.connect(carol).veto(
+        proposalId, ethers.keccak256(ethers.toUtf8Bytes("Security risk"))
+      );
+
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Canceled);
+    });
+
+    it("should create a ratification proposal on veto", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+      const countBefore = Number(await governor.proposalCount());
+
+      const ratId = await vetoProposal(proposalId);
+
+      expect(ratId).to.equal(countBefore + 1);
+      expect(await governor.ratificationOf(ratId)).to.equal(proposalId);
+      expect(await governor.vetoRatificationId(proposalId)).to.equal(ratId);
+    });
+
+    it("should create ratification with correct VetoRatification params", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+      const ratId = await vetoProposal(proposalId);
+
+      const [proposer, proposalType, voteStart, voteEnd] = await governor.getProposal(ratId);
+
+      expect(proposer).to.equal(carol.address); // SC is the proposer
+      expect(proposalType).to.equal(ProposalType.VetoRatification);
+
+      // VetoRatification has 0 voting delay — voting starts at creation time
+      // voteEnd should be voteStart + 7 days
+      expect(voteEnd - voteStart).to.equal(SEVEN_DAYS);
+    });
+
+    it("should start ratification voting immediately (Active state)", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+      const ratId = await vetoProposal(proposalId);
+
+      // Should be Active immediately (0 voting delay)
+      expect(await governor.state(ratId)).to.equal(ProposalState.Active);
+
+      // Can vote immediately
+      await governor.connect(alice).castVote(ratId, Vote.For);
+    });
+
+    it("should emit ProposalVetoed event", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+      const rationaleHash = ethers.keccak256(ethers.toUtf8Bytes("Security risk"));
+      const expectedRatId = Number(await governor.proposalCount()) + 1;
+
+      await expect(
+        governor.connect(carol).veto(proposalId, rationaleHash)
+      ).to.emit(governor, "ProposalVetoed").withArgs(
+        proposalId, rationaleHash, expectedRatId
+      );
+    });
+
+    it("should cancel the timelock operation on veto", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+
+      // Get the timelock operation ID before veto.
+      // ethers v6 returns readonly Result objects — convert to plain arrays for contract calls.
+      const result = await governor.getProposalActions(proposalId);
+      const targets = Array.from(result[0]);
+      const values = Array.from(result[1]);
+      const calldatas = Array.from(result[2]);
+      const salt = ethers.zeroPadValue(ethers.toBeHex(proposalId), 32);
+      const timelockId = await timelockController.hashOperationBatch(
+        targets, values, calldatas, ethers.ZeroHash, salt
+      );
+
+      // Verify operation is pending in timelock
+      expect(await timelockController.isOperationPending(timelockId)).to.be.true;
+
+      await vetoProposal(proposalId);
+
+      // Verify operation is no longer pending
+      expect(await timelockController.isOperationPending(timelockId)).to.be.false;
+    });
+  });
+
+  // ======== Veto Access Control ========
+
+  describe("Veto Access Control", function () {
+    it("should revert if caller is not SC", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+
+      await expect(
+        governor.connect(alice).veto(
+          proposalId, ethers.keccak256(ethers.toUtf8Bytes("rationale"))
+        )
+      ).to.be.revertedWith("ArmadaGovernor: not security council");
+    });
+
+    it("should revert if SC has been ejected", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+
+      // Eject SC via timelock
+      const timelockSigner = await asTimelock();
+      await governor.connect(timelockSigner).setSecurityCouncil(ethers.ZeroAddress);
+      await stopImpersonatingTimelock();
+
+      await expect(
+        governor.connect(carol).veto(
+          proposalId, ethers.keccak256(ethers.toUtf8Bytes("rationale"))
+        )
+      ).to.be.revertedWith("ArmadaGovernor: not security council");
+    });
+
+    it("should revert if proposal is not Queued", async function () {
+      // Create proposal but don't queue it
+      const govAddr = await governor.getAddress();
+      await governor.connect(alice).propose(
+        ProposalType.Standard,
+        [govAddr], [0n],
+        [governor.interface.encodeFunctionData("proposalCount")],
+        "Test proposal"
+      );
+      const proposalId = Number(await governor.proposalCount());
+
+      // Still Pending
+      await expect(
+        governor.connect(carol).veto(
+          proposalId, ethers.keccak256(ethers.toUtf8Bytes("rationale"))
+        )
+      ).to.be.revertedWith("ArmadaGovernor: not queued");
+
+      // Advance to Active
+      await time.increase(TWO_DAYS + 1);
+      await expect(
+        governor.connect(carol).veto(
+          proposalId, ethers.keccak256(ethers.toUtf8Bytes("rationale"))
+        )
+      ).to.be.revertedWith("ArmadaGovernor: not queued");
+    });
+  });
+
+  // ======== Ratification Resolution ========
+
+  describe("Ratification Resolution", function () {
+    it("should uphold veto when FOR wins", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+      const ratId = await vetoProposal(proposalId);
+
+      // Vote FOR (uphold veto)
+      await governor.connect(alice).castVote(ratId, Vote.For);
+      await governor.connect(bob).castVote(ratId, Vote.For);
+
+      // Advance past voting period (7 days)
+      await time.increase(SEVEN_DAYS + 1);
+
+      await expect(governor.resolveRatification(ratId))
+        .to.emit(governor, "RatificationResolved")
+        .withArgs(ratId, true);
+
+      // SC retains seat
+      expect(await governor.securityCouncil()).to.equal(carol.address);
+      // Original proposal stays canceled
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Canceled);
+    });
+
+    it("should uphold veto when quorum is not met", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+      const ratId = await vetoProposal(proposalId);
+
+      // No one votes — quorum not met
+
+      // Advance past voting period
+      await time.increase(SEVEN_DAYS + 1);
+
+      await expect(governor.resolveRatification(ratId))
+        .to.emit(governor, "RatificationResolved")
+        .withArgs(ratId, true);
+
+      // SC retains seat
+      expect(await governor.securityCouncil()).to.equal(carol.address);
+    });
+
+    it("should eject SC when AGAINST wins with quorum", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+      const ratId = await vetoProposal(proposalId);
+
+      // Vote AGAINST (deny veto)
+      await governor.connect(alice).castVote(ratId, Vote.Against);
+      await governor.connect(bob).castVote(ratId, Vote.Against);
+
+      // Advance past voting period
+      await time.increase(SEVEN_DAYS + 1);
+
+      const tx = governor.resolveRatification(ratId);
+      await expect(tx).to.emit(governor, "SecurityCouncilEjected").withArgs(ratId);
+      await expect(tx).to.emit(governor, "SecurityCouncilUpdated").withArgs(carol.address, ethers.ZeroAddress);
+      await expect(tx).to.emit(governor, "RatificationResolved").withArgs(ratId, false);
+
+      // SC ejected
+      expect(await governor.securityCouncil()).to.equal(ethers.ZeroAddress);
+    });
+
+    it("should store calldata hash when veto is denied", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+
+      // Compute expected calldata hash
+      const [targets, values, calldatas] = await governor.getProposalActions(proposalId);
+      const expectedHash = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ["address[]", "uint256[]", "bytes[]"],
+          [targets, values, calldatas]
+        )
+      );
+
+      const ratId = await vetoProposal(proposalId);
+
+      // Vote AGAINST
+      await governor.connect(alice).castVote(ratId, Vote.Against);
+      await governor.connect(bob).castVote(ratId, Vote.Against);
+
+      await time.increase(SEVEN_DAYS + 1);
+      await governor.resolveRatification(ratId);
+
+      expect(await governor.vetoDeniedHashes(expectedHash)).to.be.true;
+    });
+
+    it("should revert if voting hasn't ended", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+      const ratId = await vetoProposal(proposalId);
+
+      await expect(
+        governor.resolveRatification(ratId)
+      ).to.be.revertedWith("ArmadaGovernor: voting not ended");
+    });
+
+    it("should revert if not a ratification proposal", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+
+      await expect(
+        governor.resolveRatification(proposalId)
+      ).to.be.revertedWith("ArmadaGovernor: not a ratification proposal");
+    });
+
+    it("should revert if already resolved", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+      const ratId = await vetoProposal(proposalId);
+
+      await governor.connect(alice).castVote(ratId, Vote.For);
+      await time.increase(SEVEN_DAYS + 1);
+      await governor.resolveRatification(ratId);
+
+      await expect(
+        governor.resolveRatification(ratId)
+      ).to.be.revertedWith("ArmadaGovernor: already resolved");
+    });
+  });
+
+  // ======== Double-Veto Prevention ========
+
+  describe("Double-Veto Prevention", function () {
+    it("should block veto on identical calldata after community denial", async function () {
+      // First proposal: create, queue, veto, community AGAINST → deny veto
+      const proposalId1 = await createAndQueueProposal(alice);
+      const ratId1 = await vetoProposal(proposalId1);
+
+      await governor.connect(alice).castVote(ratId1, Vote.Against);
+      await governor.connect(bob).castVote(ratId1, Vote.Against);
+      await time.increase(SEVEN_DAYS + 1);
+      await governor.resolveRatification(ratId1);
+
+      // SC ejected, set new SC (dave)
+      expect(await governor.securityCouncil()).to.equal(ethers.ZeroAddress);
+      const timelockSigner = await asTimelock();
+      await governor.connect(timelockSigner).setSecurityCouncil(dave.address);
+      await stopImpersonatingTimelock();
+
+      // Second proposal with identical calldata
+      const proposalId2 = await createAndQueueProposal(
+        alice,
+        undefined, // same targets (governor)
+        undefined, // same calldatas (proposalCount)
+        "second attempt"
+      );
+
+      // New SC tries to veto — should revert
+      await expect(
+        governor.connect(dave).veto(
+          proposalId2, ethers.keccak256(ethers.toUtf8Bytes("rationale2"))
+        )
+      ).to.be.revertedWith("ArmadaGovernor: community overrode, no double veto");
+    });
+
+    it("should allow veto on modified calldata", async function () {
+      // First: veto denied
+      const proposalId1 = await createAndQueueProposal(alice);
+      const ratId1 = await vetoProposal(proposalId1);
+
+      await governor.connect(alice).castVote(ratId1, Vote.Against);
+      await governor.connect(bob).castVote(ratId1, Vote.Against);
+      await time.increase(SEVEN_DAYS + 1);
+      await governor.resolveRatification(ratId1);
+
+      // Set new SC (dave)
+      const timelockSigner = await asTimelock();
+      await governor.connect(timelockSigner).setSecurityCouncil(dave.address);
+      await stopImpersonatingTimelock();
+
+      // Second proposal with DIFFERENT calldata
+      const govAddr = await governor.getAddress();
+      const proposalId2 = await createAndQueueProposal(
+        alice,
+        [govAddr],
+        [governor.interface.encodeFunctionData("proposalThreshold")],
+        "different calldata"
+      );
+
+      // New SC can veto — different calldata hash
+      await governor.connect(dave).veto(
+        proposalId2, ethers.keccak256(ethers.toUtf8Bytes("rationale2"))
+      );
+
+      expect(await governor.state(proposalId2)).to.equal(ProposalState.Canceled);
+    });
+  });
+
+  // ======== Queue/Execute Guards ========
+
+  describe("Queue/Execute Guards", function () {
+    it("should revert queue() for ratification proposals", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+      const ratId = await vetoProposal(proposalId);
+
+      // Vote FOR so it would be "Succeeded"
+      await governor.connect(alice).castVote(ratId, Vote.For);
+      await governor.connect(bob).castVote(ratId, Vote.For);
+      await time.increase(SEVEN_DAYS + 1);
+
+      await expect(
+        governor.queue(ratId)
+      ).to.be.revertedWith("ArmadaGovernor: use resolveRatification");
+    });
+
+    it("should revert execute() for ratification proposals", async function () {
+      const proposalId = await createAndQueueProposal(alice);
+      const ratId = await vetoProposal(proposalId);
+
+      // Vote FOR
+      await governor.connect(alice).castVote(ratId, Vote.For);
+      await governor.connect(bob).castVote(ratId, Vote.For);
+      await time.increase(SEVEN_DAYS + 1);
+
+      // Ratification proposals are never queued (they bypass normal execution path),
+      // so execute() reverts at the Queued state check before reaching the type guard.
+      await expect(
+        governor.execute(ratId)
+      ).to.be.revertedWith("ArmadaGovernor: not queued");
+    });
+  });
+
+  // ======== Post-Ejection ========
+
+  describe("Post-Ejection", function () {
+    it("should prevent ejected SC from vetoing", async function () {
+      const proposalId1 = await createAndQueueProposal(alice);
+
+      // Veto → community AGAINST → SC ejected
+      const ratId = await vetoProposal(proposalId1);
+      await governor.connect(alice).castVote(ratId, Vote.Against);
+      await governor.connect(bob).castVote(ratId, Vote.Against);
+      await time.increase(SEVEN_DAYS + 1);
+      await governor.resolveRatification(ratId);
+
+      expect(await governor.securityCouncil()).to.equal(ethers.ZeroAddress);
+
+      // Create a new proposal and queue it
+      const proposalId2 = await createAndQueueProposal(alice);
+
+      // Ejected SC tries to veto — carol is no longer SC
+      await expect(
+        governor.connect(carol).veto(
+          proposalId2, ethers.keccak256(ethers.toUtf8Bytes("rationale"))
+        )
+      ).to.be.revertedWith("ArmadaGovernor: not security council");
+    });
+
+    it("should allow governance to set a new SC after ejection", async function () {
+      // Eject SC via timelock
+      const timelockSigner = await asTimelock();
+      await governor.connect(timelockSigner).setSecurityCouncil(ethers.ZeroAddress);
+
+      expect(await governor.securityCouncil()).to.equal(ethers.ZeroAddress);
+
+      // Set new SC (dave) via governance
+      await governor.connect(timelockSigner).setSecurityCouncil(dave.address);
+      await stopImpersonatingTimelock();
+
+      expect(await governor.securityCouncil()).to.equal(dave.address);
+    });
+  });
+
+  // ======== Bond Deferral ========
+
+  describe("Bond Deferral", function () {
+    // Helper: enable ARM transfers and approve bond for proposer
+    async function enableTransfersAndApproveBond(proposer: SignerWithAddress) {
+      // ARM token requires windDown contract to enable transfers
+      await armToken.setWindDownContract(dave.address);
+      await armToken.connect(dave).setTransferable(true);
+
+      const bondAmount = ethers.parseUnits("1000", ARM_DECIMALS);
+      await armToken.connect(proposer).approve(await governor.getAddress(), bondAmount);
+    }
+
+    it("should defer bond claim until ratification resolves", async function () {
+      await enableTransfersAndApproveBond(alice);
+      const balanceBefore = await armToken.balanceOf(alice.address);
+
+      const proposalId = await createAndQueueProposal(alice);
+      const ratId = await vetoProposal(proposalId);
+
+      // Try to claim bond while ratification in progress — should revert
+      await expect(
+        governor.claimBond(proposalId)
+      ).to.be.revertedWith("ArmadaGovernor: ratification not resolved");
+
+      // Vote FOR (uphold veto) and resolve
+      await governor.connect(alice).castVote(ratId, Vote.For);
+      await governor.connect(bob).castVote(ratId, Vote.For);
+      await time.increase(SEVEN_DAYS + 1);
+      await governor.resolveRatification(ratId);
+
+      // Now bond should be claimable
+      await governor.claimBond(proposalId);
+
+      // Bond returned — balance restored
+      expect(await armToken.balanceOf(alice.address)).to.equal(balanceBefore);
+    });
+
+    it("should allow bond claim after AGAINST resolution (no penalty to proposer)", async function () {
+      await enableTransfersAndApproveBond(alice);
+
+      const proposalId = await createAndQueueProposal(alice);
+      const ratId = await vetoProposal(proposalId);
+
+      // Vote AGAINST → SC ejected
+      await governor.connect(alice).castVote(ratId, Vote.Against);
+      await governor.connect(bob).castVote(ratId, Vote.Against);
+      await time.increase(SEVEN_DAYS + 1);
+      await governor.resolveRatification(ratId);
+
+      // Bond still claimable (proposer not penalized even if veto was denied)
+      await expect(governor.claimBond(proposalId)).to.not.be.reverted;
+    });
+  });
+
+  // ======== Full Lifecycle Integration ========
+
+  describe("Full Lifecycle", function () {
+    it("should complete veto-upheld lifecycle: propose → vote → queue → veto → FOR → upheld", async function () {
+      // 1. Create and queue a proposal
+      const proposalId = await createAndQueueProposal(alice);
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Queued);
+
+      // 2. SC vetoes
+      const rationaleHash = ethers.keccak256(ethers.toUtf8Bytes("Potential reentrancy vulnerability"));
+      await governor.connect(carol).veto(proposalId, rationaleHash);
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Canceled);
+
+      // 3. Ratification vote begins immediately
+      const ratId = Number(await governor.proposalCount());
+      expect(await governor.state(ratId)).to.equal(ProposalState.Active);
+
+      // 4. Community votes FOR (uphold veto)
+      await governor.connect(alice).castVote(ratId, Vote.For);
+      await governor.connect(bob).castVote(ratId, Vote.For);
+
+      // 5. Voting ends
+      await time.increase(SEVEN_DAYS + 1);
+
+      // 6. Resolve
+      await governor.resolveRatification(ratId);
+
+      // 7. Verify final state
+      expect(await governor.securityCouncil()).to.equal(carol.address);
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Canceled);
+      expect(await governor.state(ratId)).to.equal(ProposalState.Executed);
+    });
+
+    it("should complete veto-denied lifecycle: propose → vote → queue → veto → AGAINST → SC ejected → new SC set", async function () {
+      // 1. Create and queue
+      const proposalId = await createAndQueueProposal(alice);
+
+      // 2. SC vetoes
+      await governor.connect(carol).veto(
+        proposalId, ethers.keccak256(ethers.toUtf8Bytes("False alarm"))
+      );
+
+      // 3. Community votes AGAINST (deny veto)
+      const ratId = Number(await governor.proposalCount());
+      await governor.connect(alice).castVote(ratId, Vote.Against);
+      await governor.connect(bob).castVote(ratId, Vote.Against);
+
+      // 4. Resolve
+      await time.increase(SEVEN_DAYS + 1);
+      await governor.resolveRatification(ratId);
+
+      // 5. SC ejected
+      expect(await governor.securityCouncil()).to.equal(ethers.ZeroAddress);
+
+      // 6. Calldata hash stored
+      const [targets, values, calldatas] = await governor.getProposalActions(proposalId);
+      const calldataHash = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ["address[]", "uint256[]", "bytes[]"],
+          [targets, values, calldatas]
+        )
+      );
+      expect(await governor.vetoDeniedHashes(calldataHash)).to.be.true;
+
+      // 7. Governance can set new SC
+      const timelockSigner = await asTimelock();
+      await governor.connect(timelockSigner).setSecurityCouncil(dave.address);
+      await stopImpersonatingTimelock();
+      expect(await governor.securityCouncil()).to.equal(dave.address);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **SC veto**: `veto(proposalId, rationaleHash)` cancels a queued proposal and its timelock operation, auto-creates a 7-day ratification vote
- **Ratification resolution**: `resolveRatification()` — FOR/quorum-not-met upholds veto; AGAINST with quorum ejects SC (`address(0)`) and stores calldata hash
- **Double-veto prevention**: `vetoDeniedHashes` mapping blocks re-vetoing identical proposal calldata after community denial
- **Bond deferral**: vetoed proposal bonds held until ratification resolves, then immediately claimable
- **Deploy script**: grants `CANCELLER_ROLE` to governor on timelock
- **Closes**: GAP 4.3 (veto mechanism), completes GAP 2.5 (VetoRatification)

## Test plan

- [ ] 25 new Foundry tests in `GovernorVeto.t.sol` — all pass
- [ ] All 217 existing Foundry tests pass (no regressions)
- [ ] All 610 Hardhat tests pass (no regressions)
- [ ] Verify veto lifecycle: propose → vote → queue → veto → ratification vote → resolve
- [ ] Verify SC ejection path: AGAINST majority → `securityCouncil = address(0)`
- [ ] Verify double-veto: identical calldata blocked, modified calldata allowed
- [ ] Verify bond deferral: claim reverts during ratification, succeeds after resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)