### PR TITLE
feat: steward pass-by-default proposals (GAPs 5.1-5.3)

### DIFF
--- a/config/local.env
+++ b/config/local.env
@@ -35,9 +35,6 @@ export AAVE_YIELD_BPS=5000000
 
 # Governance config
 export TIMELOCK_DELAY=172800
-# Must be >= 120% of governance cycle (2d+5d+2d=9d). Default: 933120s (10.8d)
-export STEWARD_DELAY=933120
-
 # CCTP finality mode: "fast" (1000, ~8-20s, 1-1.3 bps fee) or "standard" (2000, ~15-19 min, free)
 export CCTP_FINALITY_MODE=fast
 

--- a/config/networks.ts
+++ b/config/networks.ts
@@ -57,8 +57,6 @@ export interface NetworkConfig {
   aaveYieldBps: number;
   /** Governance timelock delay in seconds */
   timelockDelay: number;
-  /** Treasury steward action delay in seconds */
-  stewardDelay: number;
   /** Relayer HTTP API port */
   relayerPort: number;
   /** Hardcoded ETH/USDC price for fee calculation */
@@ -194,9 +192,6 @@ export function getNetworkConfig(): NetworkConfig {
     },
     aaveYieldBps: numEnv("AAVE_YIELD_BPS", 5000000),
     timelockDelay: numEnv("TIMELOCK_DELAY", 172800),
-    // Steward action delay must be >= 120% of governance cycle (2d + 7d + 2d = 11d = 950400s)
-    // Default: 1140480s = 13.2 days (exactly 120% of 11-day cycle)
-    stewardDelay: numEnv("STEWARD_DELAY", 1140480),
     relayerPort: numEnv("RELAYER_PORT", 3001),
     ethUsdcPrice: numEnv("ETH_USDC_PRICE", 2000),
     treasuryAddress: process.env.TREASURY_ADDRESS ?? "",

--- a/config/sepolia.env
+++ b/config/sepolia.env
@@ -71,8 +71,6 @@ export AAVE_YIELD_BPS=50000
 # Governance Config (shortened for testnet iteration speed)
 # ============================================================================
 export TIMELOCK_DELAY=60
-# Must be >= 120% of governance cycle (2d+5d+2d=9d). Min: 933120s (10.8d)
-export STEWARD_DELAY=933120
 
 # ============================================================================
 # CCTP Finality Mode

--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -111,6 +111,11 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
     address public windDownContract;
     bool public windDownContractSet;
 
+    // Steward contract: registered via one-time setter. The governor calls it to verify
+    // that msg.sender is the elected steward when creating steward proposals.
+    address public stewardContract;
+    bool public stewardContractLocked;
+
     // Extended proposal classification: function selectors that force Extended type regardless
     // of what the proposer declared. Governance can add/remove selectors via extended proposal.
     mapping(bytes4 => bool) public extendedSelectors;
@@ -170,6 +175,7 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
     event ExtendedSelectorRemoved(bytes4 indexed selector);
     event BondPosted(uint256 indexed proposalId, address indexed depositor, uint256 amount);
     event BondClaimed(uint256 indexed proposalId, address indexed depositor, uint256 amount);
+    event StewardContractSet(address indexed steward);
     event ProposalVetoed(uint256 indexed proposalId, bytes32 rationaleHash, uint256 ratificationId);
     event RatificationResolved(uint256 indexed ratificationId, bool vetoUpheld);
     event SecurityCouncilEjected(uint256 indexed ratificationId);
@@ -218,6 +224,17 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
             quorumBps: 2000
         });
 
+        // Steward: immediate voting, 7d review window, 2d timelock, 20% quorum.
+        // Pass-by-default: passes unless quorum met AND majority votes AGAINST.
+        // These params bypass setProposalTypeParams() bounds, making Steward timing
+        // effectively immutable via governance. Only proposeStewardAction() creates these.
+        proposalTypeParams[ProposalType.Steward] = ProposalParams({
+            votingDelay: 0,
+            votingPeriod: 7 days,
+            executionDelay: 2 days,
+            quorumBps: 2000
+        });
+
         // Governance quiet period: 7 days post-crowdfund-finalization before proposals allowed
         quietPeriodDuration = 7 days;
 
@@ -244,6 +261,11 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         // Steward election/removal (on TreasurySteward)
         extendedSelectors[bytes4(keccak256("electSteward(address)"))] = true;
         extendedSelectors[bytes4(keccak256("removeSteward()"))] = true;
+
+        // Steward budget management (on ArmadaTreasuryGov)
+        extendedSelectors[bytes4(keccak256("addStewardBudgetToken(address,uint256,uint256)"))] = true;
+        extendedSelectors[bytes4(keccak256("updateStewardBudgetToken(address,uint256,uint256)"))] = true;
+        extendedSelectors[bytes4(keccak256("removeStewardBudgetToken(address)"))] = true;
 
         // ARM token transfer whitelist
         extendedSelectors[bytes4(keccak256("addToWhitelist(address)"))] = true;
@@ -292,6 +314,19 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         emit CrowdfundAddressSet(_crowdfund);
     }
 
+    /// @notice One-time setter: register the TreasurySteward contract.
+    /// Deployer-only; locks permanently after the first call.
+    function setStewardContract(address _steward) external {
+        require(msg.sender == deployer, "ArmadaGovernor: not deployer");
+        require(!stewardContractLocked, "ArmadaGovernor: already locked");
+        require(_steward != address(0), "ArmadaGovernor: zero address");
+
+        stewardContractLocked = true;
+        stewardContract = _steward;
+
+        emit StewardContractSet(_steward);
+    }
+
     // ============ Governance-Updatable Parameters ============
 
     /// @notice Update proposal type parameters (timing and quorum).
@@ -303,8 +338,8 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
     ) external {
         require(msg.sender == address(timelock), "ArmadaGovernor: not timelock");
         require(
-            proposalType != ProposalType.VetoRatification,
-            "ArmadaGovernor: VetoRatification immutable"
+            proposalType != ProposalType.VetoRatification && proposalType != ProposalType.Steward,
+            "ArmadaGovernor: immutable proposal type"
         );
         require(
             params.votingDelay >= MIN_VOTING_DELAY && params.votingDelay <= MAX_VOTING_DELAY,
@@ -507,6 +542,100 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         return string(str);
     }
 
+    // ============ Steward Proposals ============
+
+    /// @notice Create a steward proposal (pass-by-default governance proposal).
+    /// Only callable by the elected steward via the registered TreasurySteward contract.
+    /// Steward proposals do not require a proposal threshold (authority comes from election).
+    /// @param targets Target addresses for execution
+    /// @param values ETH values for each call
+    /// @param calldatas Encoded function calls
+    /// @param description Human-readable description
+    function proposeStewardAction(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description
+    ) external returns (uint256) {
+        require(!windDownActive, "ArmadaGovernor: governance ended");
+        require(stewardContract != address(0), "ArmadaGovernor: steward contract not set");
+        require(
+            msg.sender == ITreasurySteward(stewardContract).currentSteward(),
+            "ArmadaGovernor: not current steward"
+        );
+        require(
+            ITreasurySteward(stewardContract).isStewardActive(),
+            "ArmadaGovernor: steward not active"
+        );
+        require(targets.length > 0, "ArmadaGovernor: empty proposal");
+        require(
+            targets.length == values.length && targets.length == calldatas.length,
+            "ArmadaGovernor: length mismatch"
+        );
+        _checkQuietPeriod();
+        _checkSelfPayment(msg.sender, calldatas);
+
+        uint256 proposalId = ++proposalCount;
+        _initProposal(proposalId, ProposalType.Steward, description);
+
+        Proposal storage p = _proposals[proposalId];
+        p.targets = targets;
+        p.values = values;
+        p.calldatas = calldatas;
+
+        // Bond: required only when ARM is transferable (same as regular proposals)
+        if (armToken.transferable()) {
+            require(
+                armToken.transferFrom(msg.sender, address(this), PROPOSAL_BOND),
+                "ArmadaGovernor: bond transfer failed"
+            );
+            proposalBonds[proposalId] = BondInfo({
+                depositor: msg.sender,
+                amount: PROPOSAL_BOND,
+                unlockTime: 0,
+                claimed: false
+            });
+            emit BondPosted(proposalId, msg.sender, PROPOSAL_BOND);
+        }
+
+        emit ProposalCreated(
+            proposalId, msg.sender, ProposalType.Steward,
+            p.voteStart, p.voteEnd, description
+        );
+        return proposalId;
+    }
+
+    /// @dev Prevent steward proposals from paying the steward's own address.
+    /// Checks stewardSpend and distribute calldatas for the recipient parameter.
+    function _checkSelfPayment(address stewardAddr, bytes[] memory calldatas) internal pure {
+        bytes4 stewardSpendSelector = bytes4(keccak256("stewardSpend(address,address,uint256)"));
+        bytes4 distributeSelector = bytes4(keccak256("distribute(address,address,uint256)"));
+
+        for (uint256 i = 0; i < calldatas.length; i++) {
+            if (calldatas[i].length < 4) continue;
+
+            bytes4 selector;
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                let dataPtr := mload(add(add(calldatas, 0x20), mul(i, 0x20)))
+                selector := mload(add(dataPtr, 0x20))
+            }
+
+            if (selector == stewardSpendSelector || selector == distributeSelector) {
+                // Both signatures: fn(address token, address recipient, uint256 amount)
+                // Recipient is the 2nd parameter at ABI offset 36 (4 + 32)
+                require(calldatas[i].length >= 68, "ArmadaGovernor: calldata too short");
+                address recipient;
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let dataPtr := mload(add(add(calldatas, 0x20), mul(i, 0x20)))
+                    recipient := mload(add(dataPtr, 0x44)) // 0x20 (length) + 0x04 (selector) + 0x20 (1st param)
+                }
+                require(recipient != stewardAddr, "ArmadaGovernor: self-payment not allowed");
+            }
+        }
+    }
+
     // ============ Wind-Down ============
 
     /// @notice One-time setter: register the wind-down contract address.
@@ -558,7 +687,7 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
             "ArmadaGovernor: length mismatch"
         );
         require(
-            proposalType != ProposalType.VetoRatification,
+            proposalType != ProposalType.VetoRatification && proposalType != ProposalType.Steward,
             "ArmadaGovernor: auto-created only"
         );
         _checkQuietPeriod();
@@ -814,8 +943,15 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         if (block.timestamp <= p.voteEnd) return ProposalState.Active;
 
         // After voting ends: check quorum and majority
-        if (!_quorumReached(proposalId) || !_voteSucceeded(proposalId)) {
-            return ProposalState.Defeated;
+        if (p.proposalType == ProposalType.Steward) {
+            // Pass-by-default: defeated ONLY if quorum met AND majority votes against
+            if (_quorumReached(proposalId) && !_voteSucceeded(proposalId)) {
+                return ProposalState.Defeated;
+            }
+        } else {
+            if (!_quorumReached(proposalId) || !_voteSucceeded(proposalId)) {
+                return ProposalState.Defeated;
+            }
         }
 
         if (p.queued) return ProposalState.Queued;

--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -227,7 +227,7 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
         // Steward: immediate voting, 7d review window, 2d timelock, 20% quorum.
         // Pass-by-default: passes unless quorum met AND majority votes AGAINST.
         // These params bypass setProposalTypeParams() bounds, making Steward timing
-        // effectively immutable via governance. Only proposeStewardAction() creates these.
+        // effectively immutable via governance. Only proposeStewardSpend() creates these.
         proposalTypeParams[ProposalType.Steward] = ProposalParams({
             votingDelay: 0,
             votingPeriod: 7 days,
@@ -544,17 +544,18 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
 
     // ============ Steward Proposals ============
 
-    /// @notice Create a steward proposal (pass-by-default governance proposal).
+    /// @notice Create a steward spend proposal (pass-by-default governance proposal).
     /// Only callable by the elected steward via the registered TreasurySteward contract.
-    /// Steward proposals do not require a proposal threshold (authority comes from election).
-    /// @param targets Target addresses for execution
-    /// @param values ETH values for each call
-    /// @param calldatas Encoded function calls
+    /// The governor constructs stewardSpend calldata internally — the steward cannot
+    /// submit arbitrary targets or calldata, only structured spend requests.
+    /// @param tokens Token addresses to spend (must be authorized in treasury budget table)
+    /// @param recipients Recipient addresses for each spend
+    /// @param amounts Amounts to spend for each entry
     /// @param description Human-readable description
-    function proposeStewardAction(
-        address[] memory targets,
-        uint256[] memory values,
-        bytes[] memory calldatas,
+    function proposeStewardSpend(
+        address[] memory tokens,
+        address[] memory recipients,
+        uint256[] memory amounts,
         string memory description
     ) external returns (uint256) {
         require(!windDownActive, "ArmadaGovernor: governance ended");
@@ -567,13 +568,29 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
             ITreasurySteward(stewardContract).isStewardActive(),
             "ArmadaGovernor: steward not active"
         );
-        require(targets.length > 0, "ArmadaGovernor: empty proposal");
+        require(tokens.length > 0, "ArmadaGovernor: empty proposal");
         require(
-            targets.length == values.length && targets.length == calldatas.length,
+            tokens.length == recipients.length && tokens.length == amounts.length,
             "ArmadaGovernor: length mismatch"
         );
         _checkQuietPeriod();
-        _checkSelfPayment(msg.sender, calldatas);
+
+        // Self-payment check: steward cannot be a recipient in any spend
+        for (uint256 i = 0; i < recipients.length; i++) {
+            require(recipients[i] != msg.sender, "ArmadaGovernor: self-payment not allowed");
+        }
+
+        // Governor constructs the calldata — steward only provides structured spend params
+        address[] memory targets = new address[](tokens.length);
+        uint256[] memory values = new uint256[](tokens.length);
+        bytes[] memory calldatas = new bytes[](tokens.length);
+        for (uint256 i = 0; i < tokens.length; i++) {
+            targets[i] = treasuryAddress;
+            calldatas[i] = abi.encodeWithSignature(
+                "stewardSpend(address,address,uint256)",
+                tokens[i], recipients[i], amounts[i]
+            );
+        }
 
         uint256 proposalId = ++proposalCount;
         _initProposal(proposalId, ProposalType.Steward, description);
@@ -603,37 +620,6 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
             p.voteStart, p.voteEnd, description
         );
         return proposalId;
-    }
-
-    /// @dev Prevent steward proposals from paying the steward's own address.
-    /// Checks stewardSpend and distribute calldatas for the recipient parameter.
-    function _checkSelfPayment(address stewardAddr, bytes[] memory calldatas) internal pure {
-        bytes4 stewardSpendSelector = bytes4(keccak256("stewardSpend(address,address,uint256)"));
-        bytes4 distributeSelector = bytes4(keccak256("distribute(address,address,uint256)"));
-
-        for (uint256 i = 0; i < calldatas.length; i++) {
-            if (calldatas[i].length < 4) continue;
-
-            bytes4 selector;
-            // solhint-disable-next-line no-inline-assembly
-            assembly {
-                let dataPtr := mload(add(add(calldatas, 0x20), mul(i, 0x20)))
-                selector := mload(add(dataPtr, 0x20))
-            }
-
-            if (selector == stewardSpendSelector || selector == distributeSelector) {
-                // Both signatures: fn(address token, address recipient, uint256 amount)
-                // Recipient is the 2nd parameter at ABI offset 36 (4 + 32)
-                require(calldatas[i].length >= 68, "ArmadaGovernor: calldata too short");
-                address recipient;
-                // solhint-disable-next-line no-inline-assembly
-                assembly {
-                    let dataPtr := mload(add(add(calldatas, 0x20), mul(i, 0x20)))
-                    recipient := mload(add(dataPtr, 0x44)) // 0x20 (length) + 0x04 (selector) + 0x20 (1st param)
-                }
-                require(recipient != stewardAddr, "ArmadaGovernor: self-payment not allowed");
-            }
-        }
     }
 
     // ============ Wind-Down ============

--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -930,8 +930,8 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
 
         // After voting ends: check quorum and majority
         if (p.proposalType == ProposalType.Steward) {
-            // Pass-by-default: defeated ONLY if quorum met AND majority votes against
-            if (_quorumReached(proposalId) && !_voteSucceeded(proposalId)) {
+            // Pass-by-default: defeated ONLY if quorum met AND strict majority votes against
+            if (_quorumReached(proposalId) && p.againstVotes > p.forVotes) {
                 return ProposalState.Defeated;
             }
         } else {

--- a/contracts/governance/ArmadaTreasuryGov.sol
+++ b/contracts/governance/ArmadaTreasuryGov.sol
@@ -45,28 +45,23 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
     // ============ State ============
 
     address public immutable owner; // TimelockController address (set once at deployment, cannot be changed)
-    address public steward; // Treasury steward (limited powers)
-
     // Claims system
     uint256 public claimCount;
     mapping(uint256 => Claim) public claims;
     mapping(address => uint256[]) private _beneficiaryClaims;
 
-    // Steward budget tracking (per token)
-    //
-    // The steward can spend up to 1% of the treasury balance per 30-day period.
-    // The budget basis (treasury balance used for the 1% calculation) is snapshotted
-    // once at the start of each period and held constant for the full 30 days.
-    // This prevents mid-period balance changes from shifting the budget.
-    //
-    // The 30-day period starts on the steward's first spend after the previous period
-    // expires (not on a fixed calendar schedule). Changing the steward does not reset
-    // the budget window or the amount already spent.
-    uint256 public constant STEWARD_BUDGET_BPS = 100; // 1%
-    uint256 public constant BUDGET_PERIOD = 30 days;
-    mapping(address => uint256) public budgetSpentThisPeriod; // cumulative spend in current period
-    mapping(address => uint256) public lastBudgetReset; // timestamp when current period started
-    mapping(address => uint256) public budgetBasis; // treasury balance snapshotted at period start
+    // Per-token steward budget table (governance-managed via Extended proposals).
+    // Each authorized token has an absolute spending limit per rolling window.
+    // Unused budget does not carry over between windows.
+    struct StewardBudget {
+        uint256 limit;         // max spend per window in token units
+        uint256 window;        // window duration in seconds
+        bool authorized;       // whether steward can spend this token
+    }
+
+    mapping(address => StewardBudget) public stewardBudgets;
+    mapping(address => uint256) public stewardBudgetSpent;
+    mapping(address => uint256) public stewardBudgetWindowStart;
 
     // Aggregate outflow rate limits (per token)
     //
@@ -82,8 +77,10 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
     event DirectDistribution(address indexed token, address indexed recipient, uint256 amount);
     event ClaimCreated(uint256 indexed claimId, address indexed beneficiary, address token, uint256 amount);
     event ClaimExercised(uint256 indexed claimId, address indexed beneficiary, uint256 amount);
-    event StewardUpdated(address indexed oldSteward, address indexed newSteward);
     event StewardSpent(address indexed token, address indexed recipient, uint256 amount, uint256 budgetRemaining);
+    event StewardBudgetTokenAdded(address indexed token, uint256 limit, uint256 window);
+    event StewardBudgetTokenUpdated(address indexed token, uint256 limit, uint256 window);
+    event StewardBudgetTokenRemoved(address indexed token);
     event OutflowConfigInitialized(address indexed token, uint256 windowDuration, uint256 limitBps, uint256 limitAbsolute, uint256 floorAbsolute);
     event OutflowWindowUpdated(address indexed token, uint256 newWindow);
     event OutflowLimitBpsUpdated(address indexed token, uint256 newBps);
@@ -93,11 +90,6 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
 
     modifier onlyOwner() {
         require(msg.sender == owner, "ArmadaTreasuryGov: not owner");
-        _;
-    }
-
-    modifier onlySteward() {
-        require(msg.sender == steward, "ArmadaTreasuryGov: not steward");
         _;
     }
 
@@ -148,14 +140,6 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
         return claimId;
     }
 
-    /// @notice Set the treasury steward (governance only).
-    /// @dev Does not reset the budget window or spending. The new steward inherits the
-    /// current period's remaining budget and timing.
-    function setSteward(address _steward) external onlyOwner {
-        emit StewardUpdated(steward, _steward);
-        steward = _steward;
-    }
-
     // ============ Claim Functions ============
 
     /// @notice Exercise a claim — beneficiary receives tokens at their discretion
@@ -174,37 +158,83 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
         emit ClaimExercised(claimId, c.beneficiary, amount);
     }
 
-    // ============ Steward Functions ============
+    // ============ Steward Spending (executed by timelock via governor) ============
 
-    /// @notice Steward: spend from operational budget
-    /// @dev The budget is 1% of the treasury balance snapshotted at the start of each 30-day period.
-    /// The period starts on the first spend after the previous period expires. Mid-period balance
-    /// changes (deposits, governance distributions) do not affect the current period's budget.
-    function stewardSpend(address token, address recipient, uint256 amount) external onlySteward whenNotPaused {
+    /// @notice Execute a steward spend from the per-token budget.
+    /// @dev Called by the timelock after a steward proposal passes through governance.
+    /// Budget enforcement uses an absolute per-token limit over a rolling window,
+    /// configured via addStewardBudgetToken/updateStewardBudgetToken.
+    function stewardSpend(address token, address recipient, uint256 amount) external onlyOwner whenNotPaused {
         require(recipient != address(0), "ArmadaTreasuryGov: zero address");
         require(amount > 0, "ArmadaTreasuryGov: zero amount");
 
-        // Start a new budget period if the previous one has expired.
-        // Snapshot the treasury balance as the basis for this period's 1% cap.
-        if (block.timestamp >= lastBudgetReset[token] + BUDGET_PERIOD) {
-            budgetSpentThisPeriod[token] = 0;
-            lastBudgetReset[token] = block.timestamp;
-            budgetBasis[token] = IERC20(token).balanceOf(address(this));
+        StewardBudget storage budget = stewardBudgets[token];
+        require(budget.authorized, "ArmadaTreasuryGov: token not authorized for steward");
+
+        // Reset window if expired
+        if (block.timestamp >= stewardBudgetWindowStart[token] + budget.window) {
+            stewardBudgetSpent[token] = 0;
+            stewardBudgetWindowStart[token] = block.timestamp;
         }
 
-        // Budget for this period: 1% of the snapshotted balance
-        uint256 monthlyBudget = (budgetBasis[token] * STEWARD_BUDGET_BPS) / 10000;
         require(
-            budgetSpentThisPeriod[token] + amount <= monthlyBudget,
-            "ArmadaTreasuryGov: exceeds monthly budget"
+            stewardBudgetSpent[token] + amount <= budget.limit,
+            "ArmadaTreasuryGov: exceeds steward budget"
         );
 
-        budgetSpentThisPeriod[token] += amount;
+        stewardBudgetSpent[token] += amount;
         _checkAndRecordOutflow(token, amount);
         IERC20(token).safeTransfer(recipient, amount);
 
-        uint256 remaining = monthlyBudget - budgetSpentThisPeriod[token];
+        uint256 remaining = budget.limit - stewardBudgetSpent[token];
         emit StewardSpent(token, recipient, amount, remaining);
+    }
+
+    // ============ Steward Budget Management (owner = timelock) ============
+
+    /// @notice Add a new token to the steward budget table.
+    /// @param token Token address to authorize for steward spending
+    /// @param limit Maximum spend per window in token units
+    /// @param window Window duration in seconds (minimum 1 day)
+    function addStewardBudgetToken(address token, uint256 limit, uint256 window) external onlyOwner {
+        require(!stewardBudgets[token].authorized, "ArmadaTreasuryGov: token already authorized");
+        require(limit > 0, "ArmadaTreasuryGov: zero limit");
+        require(window >= 1 days, "ArmadaTreasuryGov: window too short");
+
+        stewardBudgets[token] = StewardBudget({
+            limit: limit,
+            window: window,
+            authorized: true
+        });
+
+        emit StewardBudgetTokenAdded(token, limit, window);
+    }
+
+    /// @notice Update an existing steward budget token's parameters.
+    /// @param token Token address (must already be authorized)
+    /// @param limit New maximum spend per window in token units
+    /// @param window New window duration in seconds (minimum 1 day)
+    function updateStewardBudgetToken(address token, uint256 limit, uint256 window) external onlyOwner {
+        require(stewardBudgets[token].authorized, "ArmadaTreasuryGov: token not authorized");
+        require(limit > 0, "ArmadaTreasuryGov: zero limit");
+        require(window >= 1 days, "ArmadaTreasuryGov: window too short");
+
+        stewardBudgets[token].limit = limit;
+        stewardBudgets[token].window = window;
+
+        emit StewardBudgetTokenUpdated(token, limit, window);
+    }
+
+    /// @notice Remove a token from the steward budget table, disabling steward spending.
+    /// @param token Token address to deauthorize
+    function removeStewardBudgetToken(address token) external onlyOwner {
+        require(stewardBudgets[token].authorized, "ArmadaTreasuryGov: token not authorized");
+
+        delete stewardBudgets[token];
+        stewardBudgetSpent[token] = 0;
+        stewardBudgetWindowStart[token] = 0;
+
+        emit StewardBudgetTokenRemoved(token);
     }
 
     // ============ Outflow Rate Limit Management (owner = timelock) ============
@@ -325,19 +355,16 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
     }
 
     /// @notice View the steward's current budget status for a token
-    /// @dev If the period has expired, returns what the budget *would* be if a new period
-    /// started now (based on current balance). During an active period, returns the
-    /// snapshotted budget basis.
     function getStewardBudget(address token) external view returns (uint256 budget, uint256 spent, uint256 remaining) {
-        if (block.timestamp >= lastBudgetReset[token] + BUDGET_PERIOD) {
-            // Period expired — show what the next period's budget would be
-            uint256 treasuryBalance = IERC20(token).balanceOf(address(this));
-            budget = (treasuryBalance * STEWARD_BUDGET_BPS) / 10000;
+        StewardBudget storage b = stewardBudgets[token];
+        if (!b.authorized) return (0, 0, 0);
+
+        budget = b.limit;
+        if (block.timestamp >= stewardBudgetWindowStart[token] + b.window) {
+            // Window expired — full budget available
             spent = 0;
         } else {
-            // Active period — use snapshotted basis
-            budget = (budgetBasis[token] * STEWARD_BUDGET_BPS) / 10000;
-            spent = budgetSpentThisPeriod[token];
+            spent = stewardBudgetSpent[token];
         }
         remaining = budget > spent ? budget - spent : 0;
     }

--- a/contracts/governance/IArmadaGovernance.sol
+++ b/contracts/governance/IArmadaGovernance.sol
@@ -8,7 +8,8 @@ pragma solidity ^0.8.17;
 enum ProposalType {
     Standard,          // 0 — 7d voting, 48h execution, 20% quorum
     Extended,          // 1 — 14d voting, 7d execution, 30% quorum
-    VetoRatification   // 2 — 7d voting, no delay, 20% quorum (auto-created only)
+    VetoRatification,  // 2 — 7d voting, no delay, 20% quorum (auto-created only)
+    Steward            // 3 — 7d voting, 2d execution, 20% quorum (pass-by-default, auto-created only)
 }
 
 enum ProposalState {
@@ -30,21 +31,15 @@ struct ProposalParams {
     uint256 quorumBps;       // quorum in basis points of eligible supply
 }
 
-struct StewardAction {
-    uint256 id;
-    address target;
-    bytes data;
-    uint256 value;
-    uint256 timestamp;
-    bool executed;
-    bool vetoed;
-    address proposedBy;
-}
-
 // ========== Interfaces ==========
 
 interface IArmadaGovernorTiming {
     function proposalTypeParams(ProposalType proposalType) external view returns (
         uint256 votingDelay, uint256 votingPeriod, uint256 executionDelay, uint256 quorumBps
     );
+}
+
+interface ITreasurySteward {
+    function currentSteward() external view returns (address);
+    function isStewardActive() external view returns (bool);
 }

--- a/contracts/governance/IArmadaGovernance.sol
+++ b/contracts/governance/IArmadaGovernance.sol
@@ -1,3 +1,6 @@
+// ABOUTME: Shared types, enums, and interfaces for the Armada governance system.
+// ABOUTME: Defines ProposalType, ProposalState, ProposalParams, and contract interfaces (governor, steward, token).
+
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 

--- a/contracts/governance/TreasurySteward.sol
+++ b/contracts/governance/TreasurySteward.sol
@@ -9,7 +9,7 @@ import "./EmergencyPausable.sol";
 
 /// @title TreasurySteward — Steward identity management
 /// @notice Steward is elected via governance (Extended proposal). The steward submits
-///         spending proposals through ArmadaGovernor.proposeStewardAction(), which creates
+///         spending proposals through ArmadaGovernor.proposeStewardSpend(), which creates
 ///         pass-by-default governance proposals. This contract tracks steward identity only:
 ///         election, term duration, removal, and active status.
 contract TreasurySteward is EmergencyPausable {

--- a/contracts/governance/TreasurySteward.sol
+++ b/contracts/governance/TreasurySteward.sol
@@ -1,58 +1,31 @@
-// ABOUTME: Treasury steward contract with action queue, veto mechanism, and target whitelist.
-// ABOUTME: Steward proposes actions targeting whitelisted contracts; governance can veto before execution.
+// ABOUTME: Treasury steward identity management contract (election, term tracking, removal).
+// ABOUTME: Steward proposals flow through ArmadaGovernor as pass-by-default governance proposals.
 
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./IArmadaGovernance.sol";
 import "./EmergencyPausable.sol";
 
-/// @title TreasurySteward — Elected steward with action queue and veto mechanism
-/// @notice Steward is elected via governance (Extended proposal). Has limited powers:
-///         can propose and execute actions on whitelisted target contracts, but tokenholders
-///         can veto actions via governance proposals before they are executed.
-///         The action delay is enforced to be >= 120% of the fastest governance veto cycle,
-///         ensuring governance always has time to veto before execution.
-contract TreasurySteward is ReentrancyGuard, EmergencyPausable {
-
-    // ============ Constants ============
-
-    /// @notice Safety margin for action delay over governance cycle (120% = 12000 bps)
-    uint256 private constant DELAY_SAFETY_MARGIN_BPS = 12000;
-    uint256 private constant BPS_DENOMINATOR = 10000;
+/// @title TreasurySteward — Steward identity management
+/// @notice Steward is elected via governance (Extended proposal). The steward submits
+///         spending proposals through ArmadaGovernor.proposeStewardAction(), which creates
+///         pass-by-default governance proposals. This contract tracks steward identity only:
+///         election, term duration, removal, and active status.
+contract TreasurySteward is EmergencyPausable {
 
     // ============ State ============
 
     address public immutable timelock;     // TimelockController address (governance-controlled)
-    address public immutable treasury;     // ArmadaTreasuryGov address
-    address public immutable governor;     // ArmadaGovernor address (for timing params)
     address public currentSteward;
 
     uint256 public termStart;
     uint256 public constant TERM_DURATION = 180 days; // 6-month term
 
-    // Steward action queue
-    uint256 public actionCount;
-    mapping(uint256 => StewardAction) public actions;
-
-    // Configurable delay for steward actions (veto window)
-    uint256 public actionDelay;
-
-    // Target whitelist — only whitelisted addresses can be called by steward actions
-    mapping(address => bool) public allowedTargets;
-
     // ============ Events ============
 
     event StewardElected(address indexed steward, uint256 termStart, uint256 termEnd);
     event StewardRemoved(address indexed steward);
-    event ActionProposed(uint256 indexed actionId, address indexed target, uint256 value, uint256 executeAfter);
-    event ActionExecuted(uint256 indexed actionId);
-    event ActionVetoed(uint256 indexed actionId);
-    event ActionCanceled(uint256 indexed actionId);
-    event ActionDelayUpdated(uint256 oldDelay, uint256 newDelay);
-    event TargetAdded(address indexed target);
-    event TargetRemoved(address indexed target);
 
     // ============ Modifiers ============
 
@@ -61,40 +34,18 @@ contract TreasurySteward is ReentrancyGuard, EmergencyPausable {
         _;
     }
 
-    modifier onlySteward() {
-        require(msg.sender == currentSteward, "TreasurySteward: not steward");
-        require(block.timestamp < termStart + TERM_DURATION, "TreasurySteward: term expired");
-        _;
-    }
-
     // ============ Constructor ============
 
     /// @param _timelock TimelockController address
-    /// @param _treasury ArmadaTreasuryGov address
-    /// @param _governor ArmadaGovernor address (used to derive minimum action delay)
-    /// @param _actionDelay Delay before steward actions can execute (veto window)
+    /// @param _guardian Emergency pause guardian address
+    /// @param _maxPauseDuration Maximum duration of emergency pause in seconds
     constructor(
         address _timelock,
-        address _treasury,
-        address _governor,
-        uint256 _actionDelay,
         address _guardian,
         uint256 _maxPauseDuration
     ) EmergencyPausable(_guardian, _maxPauseDuration, _timelock) {
         require(_timelock != address(0), "TreasurySteward: zero timelock");
-        require(_treasury != address(0), "TreasurySteward: zero treasury");
-        require(_governor != address(0), "TreasurySteward: zero governor");
         timelock = _timelock;
-        treasury = _treasury;
-        governor = _governor;
-
-        uint256 minDelay = minActionDelay();
-        require(_actionDelay >= minDelay, "TreasurySteward: delay below governance cycle");
-        actionDelay = _actionDelay;
-
-        // Treasury is permanently whitelisted
-        allowedTargets[_treasury] = true;
-        emit TargetAdded(_treasury);
     }
 
     // ============ Governance Functions (via timelock) ============
@@ -113,119 +64,7 @@ contract TreasurySteward is ReentrancyGuard, EmergencyPausable {
         currentSteward = address(0);
     }
 
-    /// @notice Veto a steward action (called by timelock after governance proposal)
-    function vetoAction(uint256 actionId) external onlyTimelock {
-        StewardAction storage action = actions[actionId];
-        require(action.id != 0, "TreasurySteward: unknown action");
-        require(!action.executed, "TreasurySteward: already executed");
-        require(!action.vetoed, "TreasurySteward: already vetoed");
-
-        action.vetoed = true;
-        emit ActionVetoed(actionId);
-    }
-
-    /// @notice Update the action delay (veto window)
-    function setActionDelay(uint256 _actionDelay) external onlyTimelock {
-        uint256 minDelay = minActionDelay();
-        require(_actionDelay >= minDelay, "TreasurySteward: delay below governance cycle");
-        emit ActionDelayUpdated(actionDelay, _actionDelay);
-        actionDelay = _actionDelay;
-    }
-
-    /// @notice Add a target to the whitelist (called by timelock after governance proposal)
-    function addAllowedTarget(address target) external onlyTimelock {
-        require(target != address(0), "TreasurySteward: zero target");
-        require(!allowedTargets[target], "TreasurySteward: already allowed");
-        allowedTargets[target] = true;
-        emit TargetAdded(target);
-    }
-
-    /// @notice Remove a target from the whitelist (called by timelock after governance proposal)
-    /// @dev Treasury cannot be removed — it is permanently whitelisted.
-    function removeAllowedTarget(address target) external onlyTimelock {
-        require(target != treasury, "TreasurySteward: cannot remove treasury");
-        require(allowedTargets[target], "TreasurySteward: not allowed");
-        allowedTargets[target] = false;
-        emit TargetRemoved(target);
-    }
-
-    // ============ Steward Functions ============
-
-    /// @notice Propose a steward action (queued for veto window)
-    /// @param target Contract to call (must be whitelisted)
-    /// @param data Encoded function call
-    /// @param value ETH value to send
-    function proposeAction(
-        address target,
-        bytes calldata data,
-        uint256 value
-    ) external onlySteward returns (uint256) {
-        require(allowedTargets[target], "TreasurySteward: target not allowed");
-
-        uint256 actionId = ++actionCount;
-        actions[actionId] = StewardAction({
-            id: actionId,
-            target: target,
-            data: data,
-            value: value,
-            timestamp: block.timestamp,
-            executed: false,
-            vetoed: false,
-            proposedBy: msg.sender
-        });
-
-        emit ActionProposed(actionId, target, value, block.timestamp + actionDelay);
-        return actionId;
-    }
-
-    /// @notice Cancel a proposed action (steward can only cancel actions they proposed)
-    function cancelAction(uint256 actionId) external onlySteward {
-        StewardAction storage action = actions[actionId];
-        require(action.id != 0, "TreasurySteward: unknown action");
-        require(!action.executed, "TreasurySteward: already executed");
-        require(!action.vetoed, "TreasurySteward: already vetoed");
-        require(action.proposedBy == msg.sender, "TreasurySteward: not your action");
-
-        action.vetoed = true;
-        emit ActionCanceled(actionId);
-    }
-
-    /// @notice Execute a proposed steward action (after delay, if not vetoed)
-    function executeAction(uint256 actionId) external onlySteward nonReentrant whenNotPaused {
-        StewardAction storage action = actions[actionId];
-        require(action.id != 0, "TreasurySteward: unknown action");
-        require(!action.executed, "TreasurySteward: already executed");
-        require(!action.vetoed, "TreasurySteward: vetoed");
-        require(action.proposedBy == currentSteward, "TreasurySteward: not proposed by current steward");
-        require(allowedTargets[action.target], "TreasurySteward: target not allowed");
-        require(
-            block.timestamp >= action.timestamp + actionDelay,
-            "TreasurySteward: delay not elapsed"
-        );
-
-        action.executed = true;
-
-        (bool success, bytes memory returnData) = action.target.call{value: action.value}(action.data);
-        if (!success) {
-            // Bubble up the original revert data so callers see the real reason
-            assembly {
-                revert(add(returnData, 32), mload(returnData))
-            }
-        }
-
-        emit ActionExecuted(actionId);
-    }
-
     // ============ View Functions ============
-
-    /// @notice Minimum action delay derived from governor timing: 120% of the fastest governance cycle
-    /// @dev Fastest cycle is Standard: votingDelay + votingPeriod + executionDelay
-    function minActionDelay() public view returns (uint256) {
-        (uint256 votingDelay, uint256 votingPeriod, uint256 executionDelay,) =
-            IArmadaGovernorTiming(governor).proposalTypeParams(ProposalType.Standard);
-        uint256 governanceCycle = votingDelay + votingPeriod + executionDelay;
-        return (governanceCycle * DELAY_SAFETY_MARGIN_BPS) / BPS_DENOMINATOR;
-    }
 
     function isStewardActive() external view returns (bool) {
         return currentSteward != address(0) && block.timestamp < termStart + TERM_DURATION;
@@ -234,18 +73,5 @@ contract TreasurySteward is ReentrancyGuard, EmergencyPausable {
     function termEnd() external view returns (uint256) {
         if (currentSteward == address(0)) return 0;
         return termStart + TERM_DURATION;
-    }
-
-    function getAction(uint256 actionId) external view returns (
-        address target,
-        uint256 value,
-        uint256 timestamp,
-        bool executed,
-        bool vetoed,
-        uint256 executeAfter,
-        address proposedBy
-    ) {
-        StewardAction storage a = actions[actionId];
-        return (a.target, a.value, a.timestamp, a.executed, a.vetoed, a.timestamp + actionDelay, a.proposedBy);
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -15,11 +15,26 @@ const DEPLOYER_PRIVATE_KEY = process.env.DEPLOYER_PRIVATE_KEY || ANVIL_KEY;
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.17",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.8.17",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
+    overrides: {
+      "contracts/governance/ArmadaGovernor.sol": {
+        version: "0.8.17",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 50,
+          },
+        },
       },
     },
   },

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -45,7 +45,6 @@ interface GovernanceDeployment {
   };
   config: {
     timelockMinDelay: number;
-    stewardActionDelay: number;
     totalSupply: string;
     treasuryAllocation: string;
   };
@@ -66,7 +65,6 @@ async function main() {
   }
 
   const timelockDelay = config.timelockDelay;
-  const stewardDelay = config.stewardDelay;
 
   // Emergency pause config: deployer as initial guardian, 14 day max pause
   // TODO: Transfer guardian to a dedicated multisig after deployment
@@ -78,7 +76,6 @@ async function main() {
   console.log(`Chain ID: ${chainId}`);
   console.log(`Environment: ${config.env}`);
   console.log(`Timelock delay: ${timelockDelay}s`);
-  console.log(`Steward delay: ${stewardDelay}s`);
   console.log("");
 
   // 1. Deploy TimelockController (needed before ArmadaToken for timelock address)
@@ -120,16 +117,20 @@ async function main() {
   const governorAddress = await governor.getAddress();
   console.log(`   ArmadaGovernor: ${governorAddress}`);
 
-  // 5. Deploy TreasurySteward
+  // 5. Deploy TreasurySteward (identity management only — proposals flow through governor)
   console.log("5. Deploying TreasurySteward...");
   const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
   const steward = await TreasurySteward.deploy(
-    timelockAddress, treasuryAddress, governorAddress, stewardDelay,
+    timelockAddress,
     guardianAddress, maxPauseDuration, nm.override()
   );
   await steward.deploymentTransaction()!.wait();
   const stewardAddress = await steward.getAddress();
   console.log(`   TreasurySteward: ${stewardAddress}`);
+
+  // 5b. Register steward contract on governor (one-time setter)
+  await (await governor.setStewardContract(stewardAddress, nm.override())).wait();
+  console.log(`   Governor: setStewardContract(${stewardAddress})`);
 
   // 6. Deploy RevenueCounter (UUPS proxy)
   console.log("6. Deploying RevenueCounter (UUPS proxy)...");
@@ -211,7 +212,6 @@ async function main() {
     },
     config: {
       timelockMinDelay: timelockDelay,
-      stewardActionDelay: stewardDelay,
       totalSupply: "12000000",
       treasuryAllocation: config.armDistribution.treasury,
     },

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -1,3 +1,6 @@
+// ABOUTME: Deployment script for Armada governance contracts (timelock, token, treasury, governor, steward).
+// ABOUTME: Handles role grants, steward contract registration, and whitelist initialization.
+
 /**
  * Deploy Armada Governance Contracts
  *

--- a/scripts/governance_demo.ts
+++ b/scripts/governance_demo.ts
@@ -82,11 +82,8 @@ async function main() {
   await governor.waitForDeployment();
 
   const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
-  // Steward action delay: 120% of governance cycle (2d + 5d + 2d = 9d)
-  const stewardActionDelay = Math.ceil((TWO_DAYS + FIVE_DAYS + TWO_DAYS) * 12000 / 10000);
   const stewardContract = await TreasurySteward.deploy(
-    tlAddr, await treasury.getAddress(), await governor.getAddress(), stewardActionDelay,
-    deployer.address, MAX_PAUSE
+    tlAddr, deployer.address, MAX_PAUSE
   );
   await stewardContract.waitForDeployment();
 
@@ -187,15 +184,13 @@ async function main() {
   console.log("-".repeat(70));
   console.log("");
 
-  // Elect Dave
+  // Elect Dave — the TreasurySteward contract tracks identity; the timelock calls electSteward
   const electTargets = [
     await stewardContract.getAddress(),
-    await treasury.getAddress(),
   ];
-  const electValues = [0n, 0n];
+  const electValues = [0n];
   const electCalldatas = [
     stewardContract.interface.encodeFunctionData("electSteward", [dave.address]),
-    treasury.interface.encodeFunctionData("setSteward", [dave.address]),
   ];
 
   await governor.connect(alice).propose(
@@ -218,21 +213,12 @@ async function main() {
   log("EXECUTE", `Dave is now treasury steward (6-month term)`);
   log("STATE", `Steward active: ${await stewardContract.isStewardActive()}`);
 
-  // Steward spends within budget
-  const spendAmount = ethers.parseUnits("200", 6);
-  await treasury.connect(dave).stewardSpend(
-    await usdc.getAddress(), eve.address, spendAmount
-  );
-  log("STEWARD", `Dave spends ${fmtUsdc(spendAmount)} from operational budget \u2192 succeeds`);
-  log("RESULT", `Eve USDC balance: ${fmtUsdc(await usdc.balanceOf(eve.address))}`);
-
-  // Steward proposes action via TreasurySteward (for veto demo)
-  // Set treasury steward to stewardContract for this action
-  // (Note: in production, treasury steward would be stewardContract from the start)
-  console.log("");
-  log("STEWARD", `Dave proposes action: transfer 5000 USDC to Eve via stewardContract`);
-  log("NOTE", `(In this demo, Dave uses direct treasury.stewardSpend for simple ops`);
-  log("NOTE", ` and stewardContract for vetoed-action demos)`);
+  // In the production flow, a steward submits spend requests via governance proposals
+  // (ArmadaGovernor.proposeStewardAction creates pass-by-default proposals).
+  // For demo brevity, we show the final governance-approved spend directly from the timelock.
+  // The timelock (owner) calls stewardSpend after steward budget token is authorized.
+  log("NOTE", `Steward spending flows through governance — demo skips full proposal cycle`);
+  log("NOTE", ` In production: Dave submits proposal \u2192 quorum approval \u2192 timelock executes stewardSpend`);
 
   // Create a veto-able action: governance proposes to veto a hypothetical action
   // For the demo, we show the veto governance proposal flow

--- a/scripts/governance_demo.ts
+++ b/scripts/governance_demo.ts
@@ -214,7 +214,7 @@ async function main() {
   log("STATE", `Steward active: ${await stewardContract.isStewardActive()}`);
 
   // In the production flow, a steward submits spend requests via governance proposals
-  // (ArmadaGovernor.proposeStewardAction creates pass-by-default proposals).
+  // (ArmadaGovernor.proposeStewardSpend creates pass-by-default proposals).
   // For demo brevity, we show the final governance-approved spend directly from the timelock.
   // The timelock (owner) calls stewardSpend after steward budget token is authorized.
   log("NOTE", `Steward spending flows through governance — demo skips full proposal cycle`);

--- a/test-foundry/GovernorSteward.t.sol
+++ b/test-foundry/GovernorSteward.t.sol
@@ -1,0 +1,608 @@
+// ABOUTME: Foundry tests for steward pass-by-default proposals, self-payment filter, and budget management.
+// ABOUTME: Covers the governor-based steward proposal flow where proposals pass unless community actively defeats them.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/ArmadaGovernor.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/governance/ArmadaTreasuryGov.sol";
+import "../contracts/governance/TreasurySteward.sol";
+import "../contracts/governance/IArmadaGovernance.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @dev Minimal mock ERC20 for budget tests
+contract MockToken is ERC20 {
+    constructor() ERC20("Mock USDC", "USDC") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/// @title GovernorStewardTest — Tests for steward pass-by-default proposals and budget enforcement
+contract GovernorStewardTest is Test {
+    // Mirror events
+    event ProposalCreated(
+        uint256 indexed proposalId,
+        address indexed proposer,
+        ProposalType proposalType,
+        uint256 voteStart,
+        uint256 voteEnd,
+        string description
+    );
+    event StewardContractSet(address indexed steward);
+    event StewardBudgetTokenAdded(address indexed token, uint256 limit, uint256 window);
+
+    ArmadaGovernor public governor;
+    ArmadaToken public armToken;
+    TimelockController public timelock;
+    ArmadaTreasuryGov public treasury;
+    TreasurySteward public stewardContract;
+    MockToken public usdc;
+
+    address public deployer = address(this);
+    address public alice = address(0xA11CE);
+    address public bob = address(0xB0B);
+    address public stewardPerson = address(0xDA7E);
+    address public windDown = address(0xD00D);
+
+    uint256 constant TOTAL_SUPPLY = 12_000_000 * 1e18;
+    uint256 constant BOND_AMOUNT = 1_000 * 1e18;
+    uint256 constant TWO_DAYS = 2 days;
+    uint256 constant SEVEN_DAYS = 7 days;
+    uint256 constant MAX_PAUSE = 14 days;
+    uint256 constant BUDGET_LIMIT = 10_000 * 1e6; // 10,000 USDC
+    uint256 constant BUDGET_WINDOW = 30 days;
+
+    function setUp() public {
+        // Deploy timelock
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        timelock = new TimelockController(TWO_DAYS, proposers, executors, deployer);
+
+        // Deploy ARM token
+        armToken = new ArmadaToken(deployer, address(timelock));
+
+        // Deploy treasury
+        treasury = new ArmadaTreasuryGov(address(timelock), deployer, MAX_PAUSE);
+
+        // Deploy governor
+        governor = new ArmadaGovernor(
+            address(armToken),
+            payable(address(timelock)),
+            address(treasury),
+            deployer,
+            MAX_PAUSE
+        );
+
+        // Deploy steward contract
+        stewardContract = new TreasurySteward(
+            address(timelock),
+            deployer,
+            MAX_PAUSE
+        );
+
+        // Register steward contract on governor
+        governor.setStewardContract(address(stewardContract));
+
+        // Whitelist addresses for ARM transfers
+        address[] memory whitelist = new address[](4);
+        whitelist[0] = deployer;
+        whitelist[1] = alice;
+        whitelist[2] = address(governor);
+        whitelist[3] = stewardPerson;
+        armToken.initWhitelist(whitelist);
+
+        // Distribute tokens
+        armToken.transfer(alice, TOTAL_SUPPLY * 20 / 100);
+        armToken.transfer(bob, TOTAL_SUPPLY * 15 / 100);
+        armToken.transfer(address(treasury), TOTAL_SUPPLY * 50 / 100);
+
+        // Delegate voting power
+        vm.prank(alice);
+        armToken.delegate(alice);
+        vm.prank(bob);
+        armToken.delegate(bob);
+
+        // Advance block for checkpoint availability
+        vm.roll(block.number + 1);
+
+        // Deploy mock USDC and fund treasury
+        usdc = new MockToken();
+        usdc.mint(address(treasury), 1_000_000 * 1e6);
+
+        // Grant timelock roles to governor
+        timelock.grantRole(timelock.PROPOSER_ROLE(), address(governor));
+        timelock.grantRole(timelock.EXECUTOR_ROLE(), address(governor));
+        timelock.grantRole(timelock.CANCELLER_ROLE(), address(governor));
+
+        // Elect steward person (this contract acts as timelock for the steward contract)
+        // The steward contract's timelock is the real timelock, so we prank as timelock
+        vm.prank(address(timelock));
+        stewardContract.electSteward(stewardPerson);
+    }
+
+    // ======== Helpers ========
+
+    /// @dev Create a steward proposal for stewardSpend
+    function _proposeStewardSpend(address recipient, uint256 amount) internal returns (uint256) {
+        address[] memory targets = new address[](1);
+        targets[0] = address(treasury);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "stewardSpend(address,address,uint256)",
+            address(usdc), recipient, amount
+        );
+
+        vm.prank(stewardPerson);
+        return governor.proposeStewardAction(targets, values, calldatas, "steward spend");
+    }
+
+    /// @dev Fast-forward past voting period and check state
+    function _passVotingPeriod(uint256 proposalId) internal {
+        // Steward proposals have 0 voting delay, 7d voting period
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Core: Pass-by-default
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_stewardProposal_passesWithNoVotes() public {
+        uint256 proposalId = _proposeStewardSpend(alice, 100 * 1e6);
+        _passVotingPeriod(proposalId);
+
+        // No votes at all → Succeeded (pass-by-default)
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Succeeded));
+    }
+
+    function test_stewardProposal_passesWithQuorumAndMajorityFor() public {
+        uint256 proposalId = _proposeStewardSpend(alice, 100 * 1e6);
+
+        // Alice votes FOR
+        vm.prank(alice);
+        governor.castVote(proposalId, 1); // FOR
+
+        _passVotingPeriod(proposalId);
+
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Succeeded));
+    }
+
+    function test_stewardProposal_defeatedWhenQuorumMetAndMajorityAgainst() public {
+        uint256 proposalId = _proposeStewardSpend(alice, 100 * 1e6);
+
+        // Both vote AGAINST (quorum met + majority against)
+        vm.prank(alice);
+        governor.castVote(proposalId, 0); // AGAINST
+        vm.prank(bob);
+        governor.castVote(proposalId, 0); // AGAINST
+
+        _passVotingPeriod(proposalId);
+
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Defeated));
+    }
+
+    function test_stewardProposal_passesWithBelowQuorumAgainstVotes() public {
+        // Create a small voter (5% of eligible supply = well below 20% quorum)
+        // Eligible supply = total - treasury = 6M. Quorum = 20% of 6M = 1.2M
+        address smallVoter = address(0xBEE);
+        uint256 smallAmount = 500_000 * 1e18; // 500k < 1.2M quorum
+        // Transfer from deployer's remaining tokens
+        armToken.transfer(smallVoter, smallAmount);
+        vm.prank(smallVoter);
+        armToken.delegate(smallVoter);
+        vm.roll(block.number + 1);
+
+        uint256 proposalId = _proposeStewardSpend(alice, 100 * 1e6);
+
+        // Only the small voter votes against — below quorum
+        vm.prank(smallVoter);
+        governor.castVote(proposalId, 0); // AGAINST
+
+        _passVotingPeriod(proposalId);
+
+        // Quorum not met → passes by default (NOT defeated)
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Succeeded));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Access control
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_proposeStewardAction_rejectsNonSteward() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(treasury);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("stewardSpend(address,address,uint256)", address(usdc), alice, 100);
+
+        vm.prank(alice);
+        vm.expectRevert("ArmadaGovernor: not current steward");
+        governor.proposeStewardAction(targets, values, calldatas, "test");
+    }
+
+    function test_proposeStewardAction_rejectsExpiredSteward() public {
+        // Warp past 6-month term
+        vm.warp(block.timestamp + 181 days);
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(treasury);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("stewardSpend(address,address,uint256)", address(usdc), alice, 100);
+
+        vm.prank(stewardPerson);
+        vm.expectRevert("ArmadaGovernor: steward not active");
+        governor.proposeStewardAction(targets, values, calldatas, "test");
+    }
+
+    function test_proposeStewardAction_rejectsRemovedSteward() public {
+        vm.prank(address(timelock));
+        stewardContract.removeSteward();
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(treasury);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("stewardSpend(address,address,uint256)", address(usdc), alice, 100);
+
+        vm.prank(stewardPerson);
+        vm.expectRevert("ArmadaGovernor: not current steward");
+        governor.proposeStewardAction(targets, values, calldatas, "test");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Type guards
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_propose_rejectsStewardType() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(governor);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("proposalCount()");
+
+        vm.prank(alice);
+        vm.expectRevert("ArmadaGovernor: auto-created only");
+        governor.propose(ProposalType.Steward, targets, values, calldatas, "sneak steward");
+    }
+
+    function test_setProposalTypeParams_rejectsStewardType() public {
+        ProposalParams memory params = ProposalParams({
+            votingDelay: 1 days,
+            votingPeriod: 7 days,
+            executionDelay: 2 days,
+            quorumBps: 2000
+        });
+
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaGovernor: immutable proposal type");
+        governor.setProposalTypeParams(ProposalType.Steward, params);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Self-payment filter
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_selfPaymentFilter_blocksStewdSpendToSteward() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(treasury);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "stewardSpend(address,address,uint256)",
+            address(usdc), stewardPerson, 100
+        );
+
+        vm.prank(stewardPerson);
+        vm.expectRevert("ArmadaGovernor: self-payment not allowed");
+        governor.proposeStewardAction(targets, values, calldatas, "self pay");
+    }
+
+    function test_selfPaymentFilter_blocksDistributeToSteward() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(treasury);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "distribute(address,address,uint256)",
+            address(usdc), stewardPerson, 100
+        );
+
+        vm.prank(stewardPerson);
+        vm.expectRevert("ArmadaGovernor: self-payment not allowed");
+        governor.proposeStewardAction(targets, values, calldatas, "self distribute");
+    }
+
+    function test_selfPaymentFilter_allowsNonStewardRecipient() public {
+        // Should not revert when recipient is not the steward
+        uint256 proposalId = _proposeStewardSpend(alice, 100 * 1e6);
+        assertTrue(proposalId > 0);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Wind-down blocks steward proposals
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_proposeStewardAction_blockedByWindDown() public {
+        // Setup wind-down
+        vm.prank(address(timelock));
+        governor.setWindDownContract(windDown);
+        vm.prank(windDown);
+        governor.setWindDownActive();
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(treasury);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("stewardSpend(address,address,uint256)", address(usdc), alice, 100);
+
+        vm.prank(stewardPerson);
+        vm.expectRevert("ArmadaGovernor: governance ended");
+        governor.proposeStewardAction(targets, values, calldatas, "test");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // setStewardContract
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_setStewardContract_locksAfterFirstCall() public {
+        // Already called in setUp, so second call should revert
+        vm.expectRevert("ArmadaGovernor: already locked");
+        governor.setStewardContract(address(0xBEEF));
+    }
+
+    function test_setStewardContract_rejectsNonDeployer() public {
+        // Deploy a fresh governor to test before lock
+        ArmadaGovernor freshGovernor = new ArmadaGovernor(
+            address(armToken),
+            payable(address(timelock)),
+            address(treasury),
+            deployer,
+            MAX_PAUSE
+        );
+
+        vm.prank(alice);
+        vm.expectRevert("ArmadaGovernor: not deployer");
+        freshGovernor.setStewardContract(address(stewardContract));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Budget management on treasury
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_addStewardBudgetToken_success() public {
+        vm.prank(address(timelock));
+        treasury.addStewardBudgetToken(address(usdc), BUDGET_LIMIT, BUDGET_WINDOW);
+
+        (uint256 limit, uint256 window, bool authorized) = treasury.stewardBudgets(address(usdc));
+        assertEq(limit, BUDGET_LIMIT);
+        assertEq(window, BUDGET_WINDOW);
+        assertTrue(authorized);
+    }
+
+    function test_addStewardBudgetToken_rejectsAlreadyAuthorized() public {
+        vm.prank(address(timelock));
+        treasury.addStewardBudgetToken(address(usdc), BUDGET_LIMIT, BUDGET_WINDOW);
+
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaTreasuryGov: token already authorized");
+        treasury.addStewardBudgetToken(address(usdc), BUDGET_LIMIT, BUDGET_WINDOW);
+    }
+
+    function test_updateStewardBudgetToken_success() public {
+        vm.prank(address(timelock));
+        treasury.addStewardBudgetToken(address(usdc), BUDGET_LIMIT, BUDGET_WINDOW);
+
+        uint256 newLimit = BUDGET_LIMIT * 2;
+        vm.prank(address(timelock));
+        treasury.updateStewardBudgetToken(address(usdc), newLimit, BUDGET_WINDOW);
+
+        (uint256 limit,,) = treasury.stewardBudgets(address(usdc));
+        assertEq(limit, newLimit);
+    }
+
+    function test_removeStewardBudgetToken_success() public {
+        vm.prank(address(timelock));
+        treasury.addStewardBudgetToken(address(usdc), BUDGET_LIMIT, BUDGET_WINDOW);
+
+        vm.prank(address(timelock));
+        treasury.removeStewardBudgetToken(address(usdc));
+
+        (,, bool authorized) = treasury.stewardBudgets(address(usdc));
+        assertFalse(authorized);
+    }
+
+    function test_budgetFunctions_rejectNonOwner() public {
+        vm.prank(alice);
+        vm.expectRevert("ArmadaTreasuryGov: not owner");
+        treasury.addStewardBudgetToken(address(usdc), BUDGET_LIMIT, BUDGET_WINDOW);
+    }
+
+    function test_stewardSpend_withinBudget() public {
+        // Setup budget via timelock
+        vm.prank(address(timelock));
+        treasury.addStewardBudgetToken(address(usdc), BUDGET_LIMIT, BUDGET_WINDOW);
+
+        uint256 spendAmount = BUDGET_LIMIT / 2;
+
+        // stewardSpend is now onlyOwner (timelock calls it)
+        vm.prank(address(timelock));
+        treasury.stewardSpend(address(usdc), alice, spendAmount);
+
+        assertEq(usdc.balanceOf(alice), spendAmount);
+        assertEq(treasury.stewardBudgetSpent(address(usdc)), spendAmount);
+    }
+
+    function test_stewardSpend_exceedsBudget() public {
+        vm.prank(address(timelock));
+        treasury.addStewardBudgetToken(address(usdc), BUDGET_LIMIT, BUDGET_WINDOW);
+
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaTreasuryGov: exceeds steward budget");
+        treasury.stewardSpend(address(usdc), alice, BUDGET_LIMIT + 1);
+    }
+
+    function test_stewardSpend_unauthorizedToken() public {
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaTreasuryGov: token not authorized for steward");
+        treasury.stewardSpend(address(usdc), alice, 100);
+    }
+
+    function test_stewardSpend_budgetWindowResets() public {
+        vm.prank(address(timelock));
+        treasury.addStewardBudgetToken(address(usdc), BUDGET_LIMIT, BUDGET_WINDOW);
+
+        // Spend full budget
+        vm.prank(address(timelock));
+        treasury.stewardSpend(address(usdc), alice, BUDGET_LIMIT);
+
+        // Can't spend more in same window
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaTreasuryGov: exceeds steward budget");
+        treasury.stewardSpend(address(usdc), alice, 1);
+
+        // Warp past window
+        vm.warp(block.timestamp + BUDGET_WINDOW + 1);
+
+        // Can spend again after window reset
+        vm.prank(address(timelock));
+        treasury.stewardSpend(address(usdc), alice, BUDGET_LIMIT);
+
+        assertEq(usdc.balanceOf(alice), BUDGET_LIMIT * 2);
+    }
+
+    function test_stewardSpend_multipleSpendsSameWindow() public {
+        vm.prank(address(timelock));
+        treasury.addStewardBudgetToken(address(usdc), BUDGET_LIMIT, BUDGET_WINDOW);
+
+        // Spend in 3 transactions
+        uint256 spend1 = BUDGET_LIMIT / 3;
+        uint256 spend2 = BUDGET_LIMIT / 3;
+        uint256 spend3 = BUDGET_LIMIT / 3;
+
+        vm.prank(address(timelock));
+        treasury.stewardSpend(address(usdc), alice, spend1);
+        vm.prank(address(timelock));
+        treasury.stewardSpend(address(usdc), alice, spend2);
+        vm.prank(address(timelock));
+        treasury.stewardSpend(address(usdc), alice, spend3);
+
+        assertEq(treasury.stewardBudgetSpent(address(usdc)), spend1 + spend2 + spend3);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Fuzz
+    // ══════════════════════════════════════════════════════════════════════
+
+    function testFuzz_passByDefault_passesUnlessQuorumAndMajorityAgainst(
+        uint256 forVotes,
+        uint256 againstVotes
+    ) public {
+        // Bound: alice has 20% of supply, bob has 15%
+        uint256 aliceVP = TOTAL_SUPPLY * 20 / 100;
+        uint256 bobVP = TOTAL_SUPPLY * 15 / 100;
+
+        // 0 = no vote, 1 = for, 2 = against
+        forVotes = bound(forVotes, 0, 2);
+        againstVotes = bound(againstVotes, 0, 2);
+
+        uint256 proposalId = _proposeStewardSpend(alice, 100 * 1e6);
+
+        // Cast votes based on fuzz params
+        if (forVotes == 1) {
+            vm.prank(alice);
+            governor.castVote(proposalId, 1); // FOR
+        } else if (forVotes == 2) {
+            vm.prank(alice);
+            governor.castVote(proposalId, 0); // AGAINST (alice votes against in "for" slot)
+        }
+
+        if (againstVotes == 1) {
+            vm.prank(bob);
+            governor.castVote(proposalId, 0); // AGAINST
+        } else if (againstVotes == 2) {
+            vm.prank(bob);
+            governor.castVote(proposalId, 1); // FOR
+        }
+
+        _passVotingPeriod(proposalId);
+
+        ProposalState s = governor.state(proposalId);
+
+        // Calculate expected result
+        uint256 totalFor;
+        uint256 totalAgainst;
+        if (forVotes == 1) totalFor += aliceVP;
+        else if (forVotes == 2) totalAgainst += aliceVP;
+        if (againstVotes == 1) totalAgainst += bobVP;
+        else if (againstVotes == 2) totalFor += bobVP;
+
+        uint256 quorumNeeded = governor.quorum(proposalId);
+        uint256 totalParticipation = totalFor + totalAgainst;
+
+        bool quorumMet = totalParticipation >= quorumNeeded;
+        bool majorityAgainst = totalAgainst > totalFor;
+
+        if (quorumMet && majorityAgainst) {
+            assertEq(uint256(s), uint256(ProposalState.Defeated), "should be defeated");
+        } else {
+            assertEq(uint256(s), uint256(ProposalState.Succeeded), "should succeed (pass-by-default)");
+        }
+    }
+
+    function testFuzz_nonStewardRejected(address caller) public {
+        vm.assume(caller != stewardPerson);
+        vm.assume(caller != address(0));
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(treasury);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("stewardSpend(address,address,uint256)", address(usdc), alice, 100);
+
+        vm.prank(caller);
+        vm.expectRevert("ArmadaGovernor: not current steward");
+        governor.proposeStewardAction(targets, values, calldatas, "test");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Budget fuzz
+    // ══════════════════════════════════════════════════════════════════════
+
+    function testFuzz_budgetArithmetic(uint256 spend1, uint256 spend2) public {
+        uint256 limit = 1_000_000 * 1e6; // 1M
+        spend1 = bound(spend1, 1, limit);
+        spend2 = bound(spend2, 0, limit);
+
+        // Fund treasury with enough USDC
+        usdc.mint(address(treasury), limit * 2);
+
+        vm.prank(address(timelock));
+        treasury.addStewardBudgetToken(address(usdc), limit, BUDGET_WINDOW);
+
+        vm.prank(address(timelock));
+        treasury.stewardSpend(address(usdc), alice, spend1);
+
+        if (spend1 + spend2 > limit) {
+            vm.prank(address(timelock));
+            vm.expectRevert("ArmadaTreasuryGov: exceeds steward budget");
+            treasury.stewardSpend(address(usdc), alice, spend2);
+        } else if (spend2 > 0) {
+            vm.prank(address(timelock));
+            treasury.stewardSpend(address(usdc), alice, spend2);
+
+            // Verify: spent + remaining = limit
+            uint256 spent = treasury.stewardBudgetSpent(address(usdc));
+            assertEq(spent, spend1 + spend2);
+            (uint256 budget, uint256 viewSpent, uint256 remaining) = treasury.getStewardBudget(address(usdc));
+            assertEq(budget, limit);
+            assertEq(viewSpent, spent);
+            assertEq(remaining, limit - spent);
+        }
+    }
+}

--- a/test-foundry/GovernorSteward.t.sol
+++ b/test-foundry/GovernorSteward.t.sol
@@ -127,19 +127,17 @@ contract GovernorStewardTest is Test {
 
     // ======== Helpers ========
 
-    /// @dev Create a steward proposal for stewardSpend
+    /// @dev Create a single steward spend proposal
     function _proposeStewardSpend(address recipient, uint256 amount) internal returns (uint256) {
-        address[] memory targets = new address[](1);
-        targets[0] = address(treasury);
-        uint256[] memory values = new uint256[](1);
-        bytes[] memory calldatas = new bytes[](1);
-        calldatas[0] = abi.encodeWithSignature(
-            "stewardSpend(address,address,uint256)",
-            address(usdc), recipient, amount
-        );
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        address[] memory recipients = new address[](1);
+        recipients[0] = recipient;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = amount;
 
         vm.prank(stewardPerson);
-        return governor.proposeStewardAction(targets, values, calldatas, "steward spend");
+        return governor.proposeStewardSpend(tokens, recipients, amounts, "steward spend");
     }
 
     /// @dev Fast-forward past voting period and check state
@@ -213,46 +211,49 @@ contract GovernorStewardTest is Test {
     // Access control
     // ══════════════════════════════════════════════════════════════════════
 
-    function test_proposeStewardAction_rejectsNonSteward() public {
-        address[] memory targets = new address[](1);
-        targets[0] = address(treasury);
-        uint256[] memory values = new uint256[](1);
-        bytes[] memory calldatas = new bytes[](1);
-        calldatas[0] = abi.encodeWithSignature("stewardSpend(address,address,uint256)", address(usdc), alice, 100);
+    function test_proposeStewardSpend_rejectsNonSteward() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
 
         vm.prank(alice);
         vm.expectRevert("ArmadaGovernor: not current steward");
-        governor.proposeStewardAction(targets, values, calldatas, "test");
+        governor.proposeStewardSpend(tokens, recipients, amounts, "test");
     }
 
-    function test_proposeStewardAction_rejectsExpiredSteward() public {
+    function test_proposeStewardSpend_rejectsExpiredSteward() public {
         // Warp past 6-month term
         vm.warp(block.timestamp + 181 days);
 
-        address[] memory targets = new address[](1);
-        targets[0] = address(treasury);
-        uint256[] memory values = new uint256[](1);
-        bytes[] memory calldatas = new bytes[](1);
-        calldatas[0] = abi.encodeWithSignature("stewardSpend(address,address,uint256)", address(usdc), alice, 100);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
 
         vm.prank(stewardPerson);
         vm.expectRevert("ArmadaGovernor: steward not active");
-        governor.proposeStewardAction(targets, values, calldatas, "test");
+        governor.proposeStewardSpend(tokens, recipients, amounts, "test");
     }
 
-    function test_proposeStewardAction_rejectsRemovedSteward() public {
+    function test_proposeStewardSpend_rejectsRemovedSteward() public {
         vm.prank(address(timelock));
         stewardContract.removeSteward();
 
-        address[] memory targets = new address[](1);
-        targets[0] = address(treasury);
-        uint256[] memory values = new uint256[](1);
-        bytes[] memory calldatas = new bytes[](1);
-        calldatas[0] = abi.encodeWithSignature("stewardSpend(address,address,uint256)", address(usdc), alice, 100);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
 
         vm.prank(stewardPerson);
         vm.expectRevert("ArmadaGovernor: not current steward");
-        governor.proposeStewardAction(targets, values, calldatas, "test");
+        governor.proposeStewardSpend(tokens, recipients, amounts, "test");
     }
 
     // ══════════════════════════════════════════════════════════════════════
@@ -288,34 +289,37 @@ contract GovernorStewardTest is Test {
     // Self-payment filter
     // ══════════════════════════════════════════════════════════════════════
 
-    function test_selfPaymentFilter_blocksStewdSpendToSteward() public {
-        address[] memory targets = new address[](1);
-        targets[0] = address(treasury);
-        uint256[] memory values = new uint256[](1);
-        bytes[] memory calldatas = new bytes[](1);
-        calldatas[0] = abi.encodeWithSignature(
-            "stewardSpend(address,address,uint256)",
-            address(usdc), stewardPerson, 100
-        );
+    function test_selfPaymentFilter_blocksStewardAsRecipient() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        address[] memory recipients = new address[](1);
+        recipients[0] = stewardPerson; // steward paying themselves
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
 
         vm.prank(stewardPerson);
         vm.expectRevert("ArmadaGovernor: self-payment not allowed");
-        governor.proposeStewardAction(targets, values, calldatas, "self pay");
+        governor.proposeStewardSpend(tokens, recipients, amounts, "self pay");
     }
 
-    function test_selfPaymentFilter_blocksDistributeToSteward() public {
-        address[] memory targets = new address[](1);
-        targets[0] = address(treasury);
-        uint256[] memory values = new uint256[](1);
-        bytes[] memory calldatas = new bytes[](1);
-        calldatas[0] = abi.encodeWithSignature(
-            "distribute(address,address,uint256)",
-            address(usdc), stewardPerson, 100
-        );
+    function test_selfPaymentFilter_blocksStewardInBatch() public {
+        // Batch of 3: second recipient is the steward
+        address[] memory tokens = new address[](3);
+        tokens[0] = address(usdc);
+        tokens[1] = address(usdc);
+        tokens[2] = address(usdc);
+        address[] memory recipients = new address[](3);
+        recipients[0] = alice;
+        recipients[1] = stewardPerson; // hidden self-payment in batch
+        recipients[2] = bob;
+        uint256[] memory amounts = new uint256[](3);
+        amounts[0] = 100;
+        amounts[1] = 200;
+        amounts[2] = 300;
 
         vm.prank(stewardPerson);
         vm.expectRevert("ArmadaGovernor: self-payment not allowed");
-        governor.proposeStewardAction(targets, values, calldatas, "self distribute");
+        governor.proposeStewardSpend(tokens, recipients, amounts, "batch self pay");
     }
 
     function test_selfPaymentFilter_allowsNonStewardRecipient() public {
@@ -328,22 +332,23 @@ contract GovernorStewardTest is Test {
     // Wind-down blocks steward proposals
     // ══════════════════════════════════════════════════════════════════════
 
-    function test_proposeStewardAction_blockedByWindDown() public {
+    function test_proposeStewardSpend_blockedByWindDown() public {
         // Setup wind-down
         vm.prank(address(timelock));
         governor.setWindDownContract(windDown);
         vm.prank(windDown);
         governor.setWindDownActive();
 
-        address[] memory targets = new address[](1);
-        targets[0] = address(treasury);
-        uint256[] memory values = new uint256[](1);
-        bytes[] memory calldatas = new bytes[](1);
-        calldatas[0] = abi.encodeWithSignature("stewardSpend(address,address,uint256)", address(usdc), alice, 100);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
 
         vm.prank(stewardPerson);
         vm.expectRevert("ArmadaGovernor: governance ended");
-        governor.proposeStewardAction(targets, values, calldatas, "test");
+        governor.proposeStewardSpend(tokens, recipients, amounts, "test");
     }
 
     // ══════════════════════════════════════════════════════════════════════
@@ -369,6 +374,52 @@ contract GovernorStewardTest is Test {
         vm.prank(alice);
         vm.expectRevert("ArmadaGovernor: not deployer");
         freshGovernor.setStewardContract(address(stewardContract));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Batch proposals
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_proposeStewardSpend_batchMultipleRecipients() public {
+        // Batch spend to alice and bob in one proposal
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(usdc);
+        tokens[1] = address(usdc);
+        address[] memory recipients = new address[](2);
+        recipients[0] = alice;
+        recipients[1] = bob;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 100 * 1e6;
+        amounts[1] = 200 * 1e6;
+
+        vm.prank(stewardPerson);
+        uint256 proposalId = governor.proposeStewardSpend(tokens, recipients, amounts, "batch spend");
+        assertTrue(proposalId > 0);
+    }
+
+    function test_proposeStewardSpend_rejectsEmptyArrays() public {
+        address[] memory tokens = new address[](0);
+        address[] memory recipients = new address[](0);
+        uint256[] memory amounts = new uint256[](0);
+
+        vm.prank(stewardPerson);
+        vm.expectRevert("ArmadaGovernor: empty proposal");
+        governor.proposeStewardSpend(tokens, recipients, amounts, "empty");
+    }
+
+    function test_proposeStewardSpend_rejectsLengthMismatch() public {
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(usdc);
+        tokens[1] = address(usdc);
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 100;
+        amounts[1] = 200;
+
+        vm.prank(stewardPerson);
+        vm.expectRevert("ArmadaGovernor: length mismatch");
+        governor.proposeStewardSpend(tokens, recipients, amounts, "mismatch");
     }
 
     // ══════════════════════════════════════════════════════════════════════
@@ -559,15 +610,16 @@ contract GovernorStewardTest is Test {
         vm.assume(caller != stewardPerson);
         vm.assume(caller != address(0));
 
-        address[] memory targets = new address[](1);
-        targets[0] = address(treasury);
-        uint256[] memory values = new uint256[](1);
-        bytes[] memory calldatas = new bytes[](1);
-        calldatas[0] = abi.encodeWithSignature("stewardSpend(address,address,uint256)", address(usdc), alice, 100);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100;
 
         vm.prank(caller);
         vm.expectRevert("ArmadaGovernor: not current steward");
-        governor.proposeStewardAction(targets, values, calldatas, "test");
+        governor.proposeStewardSpend(tokens, recipients, amounts, "test");
     }
 
     // ══════════════════════════════════════════════════════════════════════

--- a/test-foundry/GovernorSteward.t.sol
+++ b/test-foundry/GovernorSteward.t.sol
@@ -207,6 +207,29 @@ contract GovernorStewardTest is Test {
         assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Succeeded));
     }
 
+    function test_stewardProposal_passesOnTiedVote() public {
+        // Create a voter with equal power to bob (15%) so they can tie
+        // Deployer has 15% remaining (100% - 20% alice - 15% bob - 50% treasury)
+        address tieVoter = address(0x71ED);
+        armToken.transfer(tieVoter, TOTAL_SUPPLY * 15 / 100);
+        vm.prank(tieVoter);
+        armToken.delegate(tieVoter);
+        vm.roll(block.number + 1);
+
+        uint256 proposalId = _proposeStewardSpend(alice, 100 * 1e6);
+
+        // bob votes FOR (15%), tieVoter votes AGAINST (15%) — tied, quorum met (30% > 20%)
+        vm.prank(bob);
+        governor.castVote(proposalId, 1); // FOR
+        vm.prank(tieVoter);
+        governor.castVote(proposalId, 0); // AGAINST
+
+        _passVotingPeriod(proposalId);
+
+        // Tied vote is NOT a majority against → passes by default
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Succeeded));
+    }
+
     // ══════════════════════════════════════════════════════════════════════
     // Access control
     // ══════════════════════════════════════════════════════════════════════

--- a/test-foundry/StewardSecurity.t.sol
+++ b/test-foundry/StewardSecurity.t.sol
@@ -1,76 +1,29 @@
-// ABOUTME: Foundry tests for TreasurySteward security: target whitelist, action delay, cancel, and cross-steward guards.
-// ABOUTME: Covers issues #22 (unrestricted target + veto window), #34 (steward self-cancellation), #38 (cross-steward execution).
+// ABOUTME: Foundry tests for TreasurySteward identity management: election, removal, term, and access control.
+// ABOUTME: Validates the slimmed-down steward contract that tracks identity only (proposals flow through governor).
 
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
 import "../contracts/governance/TreasurySteward.sol";
-import "../contracts/governance/ArmadaGovernor.sol";
-import "../contracts/governance/ArmadaToken.sol";
-import "../contracts/governance/ArmadaTreasuryGov.sol";
 import "../contracts/governance/IArmadaGovernance.sol";
-import "@openzeppelin/contracts/governance/TimelockController.sol";
 
-/// @title StewardSecurityTest — Tests for target whitelist and minimum action delay
-/// @dev Covers fixes for issue #22
+/// @title StewardSecurityTest — Identity management tests for slimmed TreasurySteward
 contract StewardSecurityTest is Test {
     // Re-declare events for vm.expectEmit
-    event TargetAdded(address indexed target);
-    event TargetRemoved(address indexed target);
-    event ActionDelayUpdated(uint256 oldDelay, uint256 newDelay);
+    event StewardElected(address indexed steward, uint256 termStart, uint256 termEnd);
+    event StewardRemoved(address indexed steward);
 
-    ArmadaGovernor public governor;
-    ArmadaToken public armToken;
-    TimelockController public timelock;
-    ArmadaTreasuryGov public treasury;
     TreasurySteward public steward;
 
+    address public timelockAddr = address(0x71);
     address public stewardPerson = address(0xDA7E);
     address public attacker = address(0xBAD);
 
-    // Governor Standard proposal timing: 2d + 5d + 2d = 9 days
-    // Min delay = 9 days * 120% = 10.8 days = 933120 seconds
-    uint256 constant EXPECTED_MIN_DELAY = (2 days + 7 days + 2 days) * 12000 / 10000;
-    // Use exactly the min delay for test setup
-    uint256 constant TEST_ACTION_DELAY = EXPECTED_MIN_DELAY;
-
     function setUp() public {
-        // Deploy TimelockController (this test contract acts as admin)
-        address[] memory proposers = new address[](0);
-        address[] memory executors = new address[](0);
-        timelock = new TimelockController(
-            2 days,
-            proposers,
-            executors,
-            address(this)
-        );
-
-        // Deploy ARM token
-        armToken = new ArmadaToken(address(this), address(timelock));
-        address[] memory wl = new address[](1);
-        wl[0] = address(this);
-        armToken.initWhitelist(wl);
-
-        // Deploy treasury
-        treasury = new ArmadaTreasuryGov(address(timelock), address(this), 14 days);
-
-        // Deploy governor
-        governor = new ArmadaGovernor(
-            address(armToken),
-            payable(address(timelock)),
-            address(treasury),
-            address(this),
-            14 days
-        );
-
-        // Deploy steward with governor reference and valid delay
         steward = new TreasurySteward(
             address(this),  // this contract acts as timelock for test convenience
-            address(treasury),
-            address(governor),
-            TEST_ACTION_DELAY,
-            address(this),
+            address(this),  // guardian
             14 days
         );
 
@@ -82,441 +35,133 @@ contract StewardSecurityTest is Test {
     // Constructor validation
     // ══════════════════════════════════════════════════════════════════════
 
-    function test_constructor_rejectsZeroGovernor() public {
-        vm.expectRevert("TreasurySteward: zero governor");
+    function test_constructor_rejectsZeroTimelock() public {
+        vm.expectRevert("EmergencyPausable: zero timelock");
         new TreasurySteward(
-            address(this),
-            address(treasury),
             address(0),
-            TEST_ACTION_DELAY,
             address(this),
             14 days
         );
     }
 
-    function test_constructor_rejectsDelayBelowMin() public {
-        vm.expectRevert("TreasurySteward: delay below governance cycle");
-        new TreasurySteward(
-            address(this),
-            address(treasury),
-            address(governor),
-            1 days, // way below the ~10.8 day minimum
-            address(this),
-            14 days
-        );
-    }
-
-    function test_constructor_whitelistsTreasury() public view {
-        assertTrue(steward.allowedTargets(address(treasury)));
-    }
-
-    function test_constructor_acceptsExactMinDelay() public {
-        // Should not revert with exact minimum
-        TreasurySteward s = new TreasurySteward(
-            address(this),
-            address(treasury),
-            address(governor),
-            EXPECTED_MIN_DELAY,
-            address(this),
-            14 days
-        );
-        assertEq(s.actionDelay(), EXPECTED_MIN_DELAY);
-    }
-
     // ══════════════════════════════════════════════════════════════════════
-    // minActionDelay derivation
+    // Election
     // ══════════════════════════════════════════════════════════════════════
 
-    function test_minActionDelay_derivedFromGovernor() public view {
-        uint256 minDelay = steward.minActionDelay();
-        // Standard: 2d voting delay + 5d voting period + 2d execution delay = 9d
-        // 9 days * 120% = 10.8 days
-        assertEq(minDelay, EXPECTED_MIN_DELAY);
-    }
-
-    // ══════════════════════════════════════════════════════════════════════
-    // Target whitelist
-    // ══════════════════════════════════════════════════════════════════════
-
-    function test_proposeAction_rejectsNonWhitelistedTarget() public {
-        address badTarget = address(0xDEAD);
-        vm.prank(stewardPerson);
-        vm.expectRevert("TreasurySteward: target not allowed");
-        steward.proposeAction(badTarget, "", 0);
-    }
-
-    function test_proposeAction_acceptsWhitelistedTarget() public {
-        vm.prank(stewardPerson);
-        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
-        assertEq(actionId, 1);
-    }
-
-    function test_addAllowedTarget_onlyTimelock() public {
-        address newTarget = address(0xBEEF);
+    function test_electSteward_onlyTimelock() public {
         vm.prank(attacker);
         vm.expectRevert("TreasurySteward: not timelock");
-        steward.addAllowedTarget(newTarget);
+        steward.electSteward(address(0xCAFE));
     }
 
-    function test_addAllowedTarget_success() public {
-        address newTarget = address(0xBEEF);
-        steward.addAllowedTarget(newTarget);
-        assertTrue(steward.allowedTargets(newTarget));
+    function test_electSteward_rejectsZeroAddress() public {
+        vm.expectRevert("TreasurySteward: zero address");
+        steward.electSteward(address(0));
     }
 
-    function test_addAllowedTarget_rejectsZeroAddress() public {
-        vm.expectRevert("TreasurySteward: zero target");
-        steward.addAllowedTarget(address(0));
+    function test_electSteward_success() public {
+        address newSteward = address(0xCAFE);
+        steward.electSteward(newSteward);
+        assertEq(steward.currentSteward(), newSteward);
+        assertTrue(steward.isStewardActive());
     }
 
-    function test_addAllowedTarget_rejectsDuplicate() public {
-        vm.expectRevert("TreasurySteward: already allowed");
-        steward.addAllowedTarget(address(treasury));
+    function test_electSteward_emitsEvent() public {
+        address newSteward = address(0xCAFE);
+        vm.expectEmit(true, false, false, true);
+        emit StewardElected(newSteward, block.timestamp, block.timestamp + 180 days);
+        steward.electSteward(newSteward);
     }
 
-    function test_addAllowedTarget_emitsEvent() public {
-        address newTarget = address(0xBEEF);
-        vm.expectEmit(true, false, false, false);
-        emit TargetAdded(newTarget);
-        steward.addAllowedTarget(newTarget);
-    }
-
-    function test_removeAllowedTarget_onlyTimelock() public {
-        address target = address(0xBEEF);
-        steward.addAllowedTarget(target);
-
-        vm.prank(attacker);
-        vm.expectRevert("TreasurySteward: not timelock");
-        steward.removeAllowedTarget(target);
-    }
-
-    function test_removeAllowedTarget_cannotRemoveTreasury() public {
-        vm.expectRevert("TreasurySteward: cannot remove treasury");
-        steward.removeAllowedTarget(address(treasury));
-    }
-
-    function test_removeAllowedTarget_rejectsNonAllowed() public {
-        vm.expectRevert("TreasurySteward: not allowed");
-        steward.removeAllowedTarget(address(0xBEEF));
-    }
-
-    function test_removeAllowedTarget_success() public {
-        address target = address(0xBEEF);
-        steward.addAllowedTarget(target);
-        assertTrue(steward.allowedTargets(target));
-
-        steward.removeAllowedTarget(target);
-        assertFalse(steward.allowedTargets(target));
-    }
-
-    function test_removeAllowedTarget_emitsEvent() public {
-        address target = address(0xBEEF);
-        steward.addAllowedTarget(target);
-
-        vm.expectEmit(true, false, false, false);
-        emit TargetRemoved(target);
-        steward.removeAllowedTarget(target);
-    }
-
-    function test_proposeAction_failsAfterTargetRemoved() public {
-        address target = address(0xBEEF);
-        steward.addAllowedTarget(target);
-
-        // Can propose to new target
-        vm.prank(stewardPerson);
-        steward.proposeAction(target, "", 0);
-
-        // Remove target
-        steward.removeAllowedTarget(target);
-
-        // Can no longer propose to removed target
-        vm.prank(stewardPerson);
-        vm.expectRevert("TreasurySteward: target not allowed");
-        steward.proposeAction(target, "", 0);
-    }
-
-    function test_executeAction_rejectsRemovedTarget() public {
-        address target = address(0xBEEF);
-        steward.addAllowedTarget(target);
-
-        // Steward proposes action targeting the new target
-        vm.prank(stewardPerson);
-        uint256 actionId = steward.proposeAction(target, "", 0);
-
-        // Governance removes the target during the veto window
-        steward.removeAllowedTarget(target);
-
-        // Warp past delay
-        vm.warp(block.timestamp + TEST_ACTION_DELAY + 1);
-
-        // Execution should fail — target was removed after proposal
-        vm.prank(stewardPerson);
-        vm.expectRevert("TreasurySteward: target not allowed");
-        steward.executeAction(actionId);
-    }
-
-    // ══════════════════════════════════════════════════════════════════════
-    // setActionDelay with minimum enforcement
-    // ══════════════════════════════════════════════════════════════════════
-
-    function test_setActionDelay_rejectsBelowMin() public {
-        vm.expectRevert("TreasurySteward: delay below governance cycle");
-        steward.setActionDelay(1 days);
-    }
-
-    function test_setActionDelay_acceptsAboveMin() public {
-        uint256 newDelay = EXPECTED_MIN_DELAY + 1 days;
-        steward.setActionDelay(newDelay);
-        assertEq(steward.actionDelay(), newDelay);
-    }
-
-    function test_setActionDelay_acceptsExactMin() public {
-        steward.setActionDelay(EXPECTED_MIN_DELAY);
-        assertEq(steward.actionDelay(), EXPECTED_MIN_DELAY);
-    }
-
-    function test_setActionDelay_emitsEvent() public {
-        uint256 newDelay = EXPECTED_MIN_DELAY + 1 days;
-        vm.expectEmit(false, false, false, true);
-        emit ActionDelayUpdated(TEST_ACTION_DELAY, newDelay);
-        steward.setActionDelay(newDelay);
-    }
-
-    // ══════════════════════════════════════════════════════════════════════
-    // Fuzz: action delay always >= min
-    // ══════════════════════════════════════════════════════════════════════
-
-    function testFuzz_constructor_rejectsDelayBelowMin(uint256 delay) public {
-        uint256 minDelay = steward.minActionDelay();
-        delay = bound(delay, 0, minDelay - 1);
-
-        vm.expectRevert("TreasurySteward: delay below governance cycle");
-        new TreasurySteward(
-            address(this),
-            address(treasury),
-            address(governor),
-            delay,
-            address(this),
-            14 days
-        );
-    }
-
-    function testFuzz_setActionDelay_rejectsBelowMin(uint256 delay) public {
-        uint256 minDelay = steward.minActionDelay();
-        delay = bound(delay, 0, minDelay - 1);
-
-        vm.expectRevert("TreasurySteward: delay below governance cycle");
-        steward.setActionDelay(delay);
-    }
-
-    function testFuzz_proposeAction_rejectsArbitraryTarget(address target) public {
-        // Any target that isn't whitelisted should be rejected
-        vm.assume(!steward.allowedTargets(target));
-
-        vm.prank(stewardPerson);
-        vm.expectRevert("TreasurySteward: target not allowed");
-        steward.proposeAction(target, "", 0);
-    }
-
-    // ══════════════════════════════════════════════════════════════════════
-    // Issue #38: New steward cannot execute previous steward's actions
-    // ══════════════════════════════════════════════════════════════════════
-
-    function test_executeAction_rejectsDifferentStewardProposal() public {
-        // stewardPerson proposes an action
-        vm.prank(stewardPerson);
-        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
-
-        // Elect a new steward (this contract acts as timelock)
+    function test_electSteward_replacesExisting() public {
         address newSteward = address(0xCAFE);
         steward.electSteward(newSteward);
         assertEq(steward.currentSteward(), newSteward);
 
-        // Warp past the action delay
-        vm.warp(block.timestamp + TEST_ACTION_DELAY + 1);
-
-        // New steward tries to execute old steward's action — should revert
-        vm.prank(newSteward);
-        vm.expectRevert("TreasurySteward: not proposed by current steward");
-        steward.executeAction(actionId);
+        // Original steward is no longer current
+        assertTrue(steward.currentSteward() != stewardPerson);
     }
 
-    function test_executeAction_allowsReElectedSteward() public {
-        // stewardPerson proposes an action
-        vm.prank(stewardPerson);
-        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
+    // ══════════════════════════════════════════════════════════════════════
+    // Removal
+    // ══════════════════════════════════════════════════════════════════════
 
-        // Re-elect the same steward (new term, same address)
+    function test_removeSteward_onlyTimelock() public {
+        vm.prank(attacker);
+        vm.expectRevert("TreasurySteward: not timelock");
+        steward.removeSteward();
+    }
+
+    function test_removeSteward_success() public {
+        steward.removeSteward();
+        assertEq(steward.currentSteward(), address(0));
+        assertFalse(steward.isStewardActive());
+    }
+
+    function test_removeSteward_emitsEvent() public {
+        vm.expectEmit(true, false, false, false);
+        emit StewardRemoved(stewardPerson);
+        steward.removeSteward();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Term tracking
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_isStewardActive_trueWithinTerm() public view {
+        assertTrue(steward.isStewardActive());
+    }
+
+    function test_isStewardActive_falseAfterTermExpires() public {
+        vm.warp(block.timestamp + 180 days + 1);
+        assertFalse(steward.isStewardActive());
+    }
+
+    function test_isStewardActive_falseAfterRemoval() public {
+        steward.removeSteward();
+        assertFalse(steward.isStewardActive());
+    }
+
+    function test_termEnd_returnsZeroWhenNoSteward() public {
+        steward.removeSteward();
+        assertEq(steward.termEnd(), 0);
+    }
+
+    function test_termEnd_returnsCorrectValue() public view {
+        assertEq(steward.termEnd(), steward.termStart() + 180 days);
+    }
+
+    function test_reElection_resetsTerm() public {
+        uint256 originalTermStart = steward.termStart();
+
+        // Warp forward 90 days (mid-term)
+        vm.warp(block.timestamp + 90 days);
+
+        // Re-elect same person
         steward.electSteward(stewardPerson);
 
-        // Warp past the action delay
-        vm.warp(block.timestamp + TEST_ACTION_DELAY + 1);
-
-        // Same steward should still be able to execute their own action
-        vm.prank(stewardPerson);
-        // The call may fail for unrelated reasons (empty data to treasury),
-        // but it should NOT fail with "not proposed by current steward"
-        try steward.executeAction(actionId) {
-            // Success — proposedBy check passed
-        } catch (bytes memory reason) {
-            assertTrue(
-                keccak256(reason) != keccak256(abi.encodeWithSignature("Error(string)", "TreasurySteward: not proposed by current steward")),
-                "Should not revert with proposedBy check for re-elected steward"
-            );
-        }
-    }
-
-    function testFuzz_executeAction_rejectsCrossStewardAction(address newStewardAddr) public {
-        vm.assume(newStewardAddr != stewardPerson);
-        vm.assume(newStewardAddr != address(0));
-
-        // Current steward proposes
-        vm.prank(stewardPerson);
-        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
-
-        // Elect different steward
-        steward.electSteward(newStewardAddr);
-
-        vm.warp(block.timestamp + TEST_ACTION_DELAY + 1);
-
-        // New steward tries to execute — should fail
-        vm.prank(newStewardAddr);
-        vm.expectRevert("TreasurySteward: not proposed by current steward");
-        steward.executeAction(actionId);
+        // Term start should be updated
+        assertTrue(steward.termStart() > originalTermStart);
+        assertTrue(steward.isStewardActive());
     }
 
     // ══════════════════════════════════════════════════════════════════════
-    // Issue #34: Steward can cancel own proposed actions
+    // Fuzz: election access control
     // ══════════════════════════════════════════════════════════════════════
 
-    event ActionCanceled(uint256 indexed actionId);
+    function testFuzz_electSteward_rejectsNonTimelock(address caller) public {
+        vm.assume(caller != address(this)); // this contract acts as timelock
 
-    function test_cancelAction_stewardCancelsOwnAction() public {
-        vm.prank(stewardPerson);
-        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
-
-        vm.prank(stewardPerson);
-        vm.expectEmit(true, false, false, false);
-        emit ActionCanceled(actionId);
-        steward.cancelAction(actionId);
-
-        // Action should now be blocked from execution
-        vm.warp(block.timestamp + TEST_ACTION_DELAY + 1);
-        vm.prank(stewardPerson);
-        vm.expectRevert("TreasurySteward: vetoed");
-        steward.executeAction(actionId);
+        vm.prank(caller);
+        vm.expectRevert("TreasurySteward: not timelock");
+        steward.electSteward(address(0xCAFE));
     }
 
-    function test_cancelAction_rejectsNonSteward() public {
-        vm.prank(stewardPerson);
-        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
+    function testFuzz_removeSteward_rejectsNonTimelock(address caller) public {
+        vm.assume(caller != address(this));
 
-        vm.prank(attacker);
-        vm.expectRevert("TreasurySteward: not steward");
-        steward.cancelAction(actionId);
-    }
-
-    function test_cancelAction_rejectsDifferentStewardAction() public {
-        // Original steward proposes
-        vm.prank(stewardPerson);
-        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
-
-        // Elect a new steward
-        address newSteward = address(0xCAFE);
-        steward.electSteward(newSteward);
-
-        // New steward tries to cancel old steward's action — should revert
-        vm.prank(newSteward);
-        vm.expectRevert("TreasurySteward: not your action");
-        steward.cancelAction(actionId);
-    }
-
-    function test_cancelAction_rejectsAlreadyExecuted() public {
-        vm.prank(stewardPerson);
-        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
-
-        vm.warp(block.timestamp + TEST_ACTION_DELAY + 1);
-
-        // Mock treasury to accept the empty call so executeAction succeeds
-        vm.mockCall(address(treasury), bytes(""), abi.encode());
-
-        vm.prank(stewardPerson);
-        steward.executeAction(actionId);
-
-        // Try to cancel an already-executed action — should revert
-        vm.prank(stewardPerson);
-        vm.expectRevert("TreasurySteward: already executed");
-        steward.cancelAction(actionId);
-    }
-
-    function test_cancelAction_rejectsAlreadyVetoed() public {
-        vm.prank(stewardPerson);
-        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
-
-        // Governance vetoes (this contract acts as timelock)
-        steward.vetoAction(actionId);
-
-        // Steward tries to cancel an already-vetoed action
-        vm.prank(stewardPerson);
-        vm.expectRevert("TreasurySteward: already vetoed");
-        steward.cancelAction(actionId);
-    }
-
-    function test_cancelAction_rejectsUnknownAction() public {
-        vm.prank(stewardPerson);
-        vm.expectRevert("TreasurySteward: unknown action");
-        steward.cancelAction(999);
-    }
-
-    function testFuzz_cancelAction_rejectsCrossStewardCancel(address newStewardAddr) public {
-        vm.assume(newStewardAddr != stewardPerson);
-        vm.assume(newStewardAddr != address(0));
-
-        vm.prank(stewardPerson);
-        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
-
-        steward.electSteward(newStewardAddr);
-
-        vm.prank(newStewardAddr);
-        vm.expectRevert("TreasurySteward: not your action");
-        steward.cancelAction(actionId);
-    }
-
-    // ══════════════════════════════════════════════════════════════════════
-    // End-to-end: propose + execute with realistic delay
-    // ══════════════════════════════════════════════════════════════════════
-
-    function test_executeAction_afterRealisticDelay() public {
-        // Set treasury steward on the treasury so executeAction → stewardSpend works
-        // (treasury is owned by timelock, but in this test `this` is acting as timelock
-        //  for the steward — the treasury itself has address(timelock) as owner)
-        // We use a simple call to treasury target that won't revert (empty data)
-        vm.prank(stewardPerson);
-        uint256 actionId = steward.proposeAction(address(treasury), "", 0);
-
-        // Cannot execute before delay
-        vm.prank(stewardPerson);
-        vm.expectRevert("TreasurySteward: delay not elapsed");
-        steward.executeAction(actionId);
-
-        // Warp past the realistic delay
-        vm.warp(block.timestamp + TEST_ACTION_DELAY + 1);
-
-        // Now execution succeeds (empty call to treasury — will revert because no fallback,
-        // but that's fine — we're testing the delay enforcement, not the treasury call)
-        // Actually, empty data + 0 value to a contract without receive/fallback may succeed
-        // as a no-op in some cases. Let's just check it doesn't revert with "delay not elapsed"
-        vm.prank(stewardPerson);
-        // The call to treasury with empty data may or may not succeed depending on
-        // whether treasury has a fallback. We just verify the delay check passes.
-        try steward.executeAction(actionId) {
-            // Delay check passed and action executed
-        } catch (bytes memory reason) {
-            // If it reverts, it should NOT be because of the delay check
-            assertTrue(
-                keccak256(reason) != keccak256(abi.encodeWithSignature("Error(string)", "TreasurySteward: delay not elapsed")),
-                "Should not revert with delay error after sufficient time"
-            );
-        }
+        vm.prank(caller);
+        vm.expectRevert("TreasurySteward: not timelock");
+        steward.removeSteward();
     }
 }

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -196,7 +196,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       expect(seed0VotingPower).to.be.gt(0);
 
       // 9. Create a governance proposal (treasury owner is already the timelock from deployment)
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
       const proposalTx = await governor.propose(
         ProposalType.Standard,
         [await treasuryGov.getAddress()],
@@ -286,7 +286,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await mine(1);
 
       // Create proposal to check quorum
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
       await governor.propose(
         ProposalType.Standard,
         [await treasuryGov.getAddress()],
@@ -338,7 +338,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await armToken.connect(pooledSeed).delegate(pooledSeed.address);
       await mine(1);
 
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
       await expect(
         governor.connect(pooledSeed).propose(
           ProposalType.Standard,
@@ -390,7 +390,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // Create proposal (snapshot is taken at current block - 1)
       await mine(1);
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
       await governor.propose(
         ProposalType.Standard,
         [await treasuryGov.getAddress()],
@@ -481,7 +481,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // Create proposal — snapshot is block.number - 1
       // At snapshot: Alice has voting power, Bob does not
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
       await governor.propose(
         ProposalType.Standard,
         [await treasuryGov.getAddress()],
@@ -521,7 +521,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await armToken.connect(alice).delegate(alice.address);
       await mine(1);
 
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
       await governor.propose(
         ProposalType.Standard,
         [await treasuryGov.getAddress()],
@@ -563,7 +563,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await armToken.delegate(deployer.address);
       await mine(1);
 
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("setSteward", [deployer.address]);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
       await governor.propose(
         ProposalType.Standard,
         [await treasuryGov.getAddress()],
@@ -707,7 +707,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await mine(1);
 
       // Create a proposal to get quorum value
-      const dummyCalldata = localTreasury.interface.encodeFunctionData("setSteward", [localDeployer.address]);
+      const dummyCalldata = localTreasury.interface.encodeFunctionData("createClaim", [await localUsdc.getAddress(), localDeployer.address, 1]);
       await localGovernor.propose(
         ProposalType.Standard,
         [await localTreasury.getAddress()],
@@ -754,7 +754,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await mine(1);
 
       // Create proposal before claims
-      const dummyCalldata = localTreasury.interface.encodeFunctionData("setSteward", [localDeployer.address]);
+      const dummyCalldata = localTreasury.interface.encodeFunctionData("createClaim", [await localUsdc.getAddress(), localDeployer.address, 1]);
       await localGovernor.propose(
         ProposalType.Standard,
         [await localTreasury.getAddress()],
@@ -877,8 +877,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       await mine(1);
 
-      // Propose: set treasury steward (demo governance action)
-      const dummyCalldata = localTreasury.interface.encodeFunctionData("setSteward", [localDeployer.address]);
+      // Propose: create a claim (demo governance action)
+      const dummyCalldata = localTreasury.interface.encodeFunctionData("createClaim", [await localUsdc.getAddress(), localDeployer.address, 1]);
       await localGovernor.propose(
         ProposalType.Standard,
         [await localTreasury.getAddress()],

--- a/test/governance_adversarial.ts
+++ b/test/governance_adversarial.ts
@@ -103,13 +103,8 @@ describe("Governance Adversarial", function () {
     await governor.waitForDeployment();
 
     const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
-    // Minimum action delay = 120% of governance cycle (2d + 7d + 2d = 11d)
-    const stewardActionDelay = Math.ceil((TWO_DAYS + STANDARD_VOTING_PERIOD + STANDARD_EXECUTION_DELAY) * 12000 / 10000);
     stewardContract = await TreasurySteward.deploy(
       timelockAddr,
-      await treasuryContract.getAddress(),
-      await governor.getAddress(),
-      stewardActionDelay,
       deployer.address, MAX_PAUSE_DURATION
     );
     await stewardContract.waitForDeployment();
@@ -510,58 +505,33 @@ describe("Governance Adversarial", function () {
 
     it("TreasurySteward rejects zero timelock", async function () {
       const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
-      const stewardDelay = Math.ceil((TWO_DAYS + STANDARD_VOTING_PERIOD + STANDARD_EXECUTION_DELAY) * 12000 / 10000);
       // Zero timelock is caught by EmergencyPausable first
       await expect(
         TreasurySteward.deploy(
           ethers.ZeroAddress,
-          await treasuryContract.getAddress(),
-          await governor.getAddress(),
-          stewardDelay,
           deployer.address, MAX_PAUSE
         )
       ).to.be.revertedWith("EmergencyPausable: zero timelock");
     });
 
-    it("TreasurySteward rejects zero treasury", async function () {
+    it("TreasurySteward rejects zero guardian", async function () {
       const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
-      const stewardDelay = Math.ceil((TWO_DAYS + STANDARD_VOTING_PERIOD + STANDARD_EXECUTION_DELAY) * 12000 / 10000);
       await expect(
         TreasurySteward.deploy(
           await timelockController.getAddress(),
-          ethers.ZeroAddress,
-          await governor.getAddress(),
-          stewardDelay,
-          deployer.address, MAX_PAUSE
+          ethers.ZeroAddress, MAX_PAUSE
         )
-      ).to.be.revertedWith("TreasurySteward: zero treasury");
+      ).to.be.revertedWith("EmergencyPausable: zero guardian");
     });
 
-    it("TreasurySteward rejects zero governor", async function () {
-      const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
-      const stewardDelay = Math.ceil((TWO_DAYS + STANDARD_VOTING_PERIOD + STANDARD_EXECUTION_DELAY) * 12000 / 10000);
-      await expect(
-        TreasurySteward.deploy(
-          await timelockController.getAddress(),
-          await treasuryContract.getAddress(),
-          ethers.ZeroAddress,
-          stewardDelay,
-          deployer.address, MAX_PAUSE
-        )
-      ).to.be.revertedWith("TreasurySteward: zero governor");
-    });
-
-    it("TreasurySteward rejects delay below governance cycle", async function () {
+    it("TreasurySteward rejects zero maxPauseDuration", async function () {
       const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
       await expect(
         TreasurySteward.deploy(
           await timelockController.getAddress(),
-          await treasuryContract.getAddress(),
-          await governor.getAddress(),
-          ONE_DAY, // way below minimum
-          deployer.address, MAX_PAUSE
+          deployer.address, 0
         )
-      ).to.be.revertedWith("TreasurySteward: delay below governance cycle");
+      ).to.be.revertedWith("EmergencyPausable: zero duration");
     });
   });
 
@@ -816,200 +786,206 @@ describe("Governance Adversarial", function () {
   });
 
   // ============================================================
-  // 9. Steward Budget Snapshot
+  // 9. Steward Budget Enforcement
   // ============================================================
 
-  describe("Steward Budget Snapshot", function () {
+  describe("Steward Budget Enforcement", function () {
     // Deploy a standalone treasury with deployer as owner for direct steward tests.
     // The main treasuryContract is owned by the timelock, which complicates direct testing.
+    // stewardSpend is onlyOwner — deployer calls it directly as the authorized timelock/owner.
     let budgetTreasury: any;
     const TREASURY_USDC = ethers.parseUnits("1000000", 6); // $1M USDC
+    const STEWARD_LIMIT = ethers.parseUnits("10000", 6);   // $10K steward budget per window
+    const STEWARD_WINDOW = 30 * ONE_DAY;
 
     async function setupBudgetTreasury() {
       const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
       budgetTreasury = await ArmadaTreasuryGov.deploy(deployer.address, deployer.address, 14 * ONE_DAY);
       await budgetTreasury.waitForDeployment();
 
-      // Fund with USDC and set carol as steward
+      // Fund with USDC and authorize token for steward spending
       await usdc.mint(await budgetTreasury.getAddress(), TREASURY_USDC);
-      await budgetTreasury.setSteward(carol.address);
+      await budgetTreasury.addStewardBudgetToken(await usdc.getAddress(), STEWARD_LIMIT, STEWARD_WINDOW);
     }
 
-    it("budget is based on snapshotted balance, not current balance", async function () {
+    it("stewardSpend enforces the authorized budget limit", async function () {
       await setupBudgetTreasury();
 
-      // First spend triggers period reset and snapshots $1M balance
-      // Budget = 1% of $1M = $10K
-      const firstSpend = ethers.parseUnits("5000", 6); // $5K
-      await budgetTreasury.connect(carol).stewardSpend(
+      // $5K spend — within $10K limit
+      const firstSpend = ethers.parseUnits("5000", 6);
+      await budgetTreasury.stewardSpend(
         await usdc.getAddress(), dave.address, firstSpend
       );
 
-      // Deposit another $1M into treasury mid-period
-      await usdc.mint(await budgetTreasury.getAddress(), TREASURY_USDC);
-
-      // Budget should still be based on original $1M snapshot, not current $1.995M
-      // Remaining = $10K - $5K = $5K
-      const secondSpend = ethers.parseUnits("5000", 6); // $5K — should succeed
-      await budgetTreasury.connect(carol).stewardSpend(
+      // Another $5K — reaches limit
+      const secondSpend = ethers.parseUnits("5000", 6);
+      await budgetTreasury.stewardSpend(
         await usdc.getAddress(), dave.address, secondSpend
       );
 
       // $10K budget fully used — even $1 more should fail
       await expect(
-        budgetTreasury.connect(carol).stewardSpend(
+        budgetTreasury.stewardSpend(
           await usdc.getAddress(), dave.address, 1n
         )
-      ).to.be.revertedWith("ArmadaTreasuryGov: exceeds monthly budget");
+      ).to.be.revertedWith("ArmadaTreasuryGov: exceeds steward budget");
     });
 
-    it("budget does not shrink when treasury balance decreases mid-period", async function () {
+    it("stewardSpend budget resets after window expires", async function () {
       await setupBudgetTreasury();
 
-      // First spend triggers snapshot at $1M → budget = $10K
-      const smallSpend = ethers.parseUnits("1000", 6); // $1K
-      await budgetTreasury.connect(carol).stewardSpend(
-        await usdc.getAddress(), dave.address, smallSpend
+      // Use the full $10K budget
+      await budgetTreasury.stewardSpend(
+        await usdc.getAddress(), dave.address, STEWARD_LIMIT
       );
 
-      // Governance distributes $900K out of the treasury (owner = deployer in this test)
-      await budgetTreasury.distribute(
-        await usdc.getAddress(), alice.address, ethers.parseUnits("900000", 6)
-      );
+      // At limit — next spend fails
+      await expect(
+        budgetTreasury.stewardSpend(await usdc.getAddress(), dave.address, 1n)
+      ).to.be.revertedWith("ArmadaTreasuryGov: exceeds steward budget");
 
-      // Treasury now holds ~$99K, but budget is still based on $1M snapshot
-      // Remaining = $10K - $1K = $9K — steward can still spend up to $9K
-      const largeSpend = ethers.parseUnits("9000", 6);
-      await budgetTreasury.connect(carol).stewardSpend(
-        await usdc.getAddress(), dave.address, largeSpend
-      );
+      // Advance past window
+      await time.increase(STEWARD_WINDOW + 1);
 
-      expect(await usdc.balanceOf(dave.address)).to.equal(smallSpend + largeSpend);
+      // Budget resets — can spend again
+      await budgetTreasury.stewardSpend(
+        await usdc.getAddress(), dave.address, STEWARD_LIMIT
+      );
+      expect(await usdc.balanceOf(dave.address)).to.equal(STEWARD_LIMIT * 2n);
     });
 
-    it("new period snapshots the current balance", async function () {
+    it("getStewardBudget returns correct values during active window", async function () {
       await setupBudgetTreasury();
 
-      // First period: snapshot at $1M
-      const spend = ethers.parseUnits("5000", 6);
-      await budgetTreasury.connect(carol).stewardSpend(
+      const spend = ethers.parseUnits("3000", 6);
+      await budgetTreasury.stewardSpend(
         await usdc.getAddress(), dave.address, spend
       );
 
-      // Governance distributes $500K out
-      await budgetTreasury.distribute(
-        await usdc.getAddress(), alice.address, ethers.parseUnits("500000", 6)
+      const [budget, spent, remaining] = await budgetTreasury.getStewardBudget(await usdc.getAddress());
+      expect(budget).to.equal(STEWARD_LIMIT);
+      expect(spent).to.equal(spend);
+      expect(remaining).to.equal(STEWARD_LIMIT - spend);
+    });
+
+    it("getStewardBudget shows full budget after window expires", async function () {
+      await setupBudgetTreasury();
+
+      // Spend some in current window
+      const spend = ethers.parseUnits("3000", 6);
+      await budgetTreasury.stewardSpend(
+        await usdc.getAddress(), dave.address, spend
       );
 
-      // Fast-forward past the 30-day period
-      await time.increase(30 * ONE_DAY + 1);
+      // Advance past window
+      await time.increase(STEWARD_WINDOW + 1);
 
-      // New period: snapshot at current balance (~$495K)
-      // New budget = 1% of ~$495K = ~$4,950
-      const newBudget = ethers.parseUnits("4950", 6);
-      await budgetTreasury.connect(carol).stewardSpend(
-        await usdc.getAddress(), dave.address, newBudget
-      );
+      // Spent resets to 0 (view-level reset)
+      const [budget, spent, remaining] = await budgetTreasury.getStewardBudget(await usdc.getAddress());
+      expect(budget).to.equal(STEWARD_LIMIT);
+      expect(spent).to.equal(0n);
+      expect(remaining).to.equal(STEWARD_LIMIT);
+    });
 
-      // Exceeding the new (lower) budget should fail
+    it("non-owner cannot call stewardSpend", async function () {
+      await setupBudgetTreasury();
+
       await expect(
         budgetTreasury.connect(carol).stewardSpend(
-          await usdc.getAddress(), dave.address, 1n
+          await usdc.getAddress(), dave.address, ethers.parseUnits("100", 6)
         )
-      ).to.be.revertedWith("ArmadaTreasuryGov: exceeds monthly budget");
+      ).to.be.revertedWith("ArmadaTreasuryGov: not owner");
     });
 
-    it("getStewardBudget reflects snapshot during active period", async function () {
+    it("stewardSpend reverts for unauthorized token", async function () {
       await setupBudgetTreasury();
 
-      // Trigger first period
-      const spend = ethers.parseUnits("3000", 6);
-      await budgetTreasury.connect(carol).stewardSpend(
-        await usdc.getAddress(), dave.address, spend
-      );
+      // Deploy a second token not authorized for steward spending
+      const MockERC20 = await ethers.getContractFactory("MockUSDCV2");
+      const otherToken = await MockERC20.deploy("Other Token", "OTH");
+      await otherToken.waitForDeployment();
+      await otherToken.mint(await budgetTreasury.getAddress(), ethers.parseUnits("100000", 6));
 
-      // Deposit more USDC mid-period
-      await usdc.mint(await budgetTreasury.getAddress(), TREASURY_USDC);
-
-      // getStewardBudget should reflect the original snapshot, not current balance
-      const [budget, spent, remaining] = await budgetTreasury.getStewardBudget(await usdc.getAddress());
-      const expectedBudget = TREASURY_USDC / 100n; // 1% of $1M = $10K
-      expect(budget).to.equal(expectedBudget);
-      expect(spent).to.equal(spend);
-      expect(remaining).to.equal(expectedBudget - spend);
+      await expect(
+        budgetTreasury.stewardSpend(
+          await otherToken.getAddress(), dave.address, ethers.parseUnits("100", 6)
+        )
+      ).to.be.revertedWith("ArmadaTreasuryGov: token not authorized for steward");
     });
   });
 
-  describe("Steward Action Error Encoding", function () {
-    // Deploy a standalone steward with deployer as timelock for direct control.
+  describe("TreasurySteward Identity Management", function () {
+    // TreasurySteward is identity-only: election, term tracking, and removal.
+    // All calls to electSteward/removeSteward are onlyTimelock.
     let testSteward: any;
-    let testTreasury: any;
-    // Steward delay: 120% of governance cycle (2d + 7d + 2d = 11d)
-    const testStewardDelay = Math.ceil((TWO_DAYS + STANDARD_VOTING_PERIOD + STANDARD_EXECUTION_DELAY) * 12000 / 10000);
 
     async function setupStewardTest() {
-      const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
-      testTreasury = await ArmadaTreasuryGov.deploy(deployer.address, deployer.address, 14 * ONE_DAY);
-      await testTreasury.waitForDeployment();
-
       const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
       testSteward = await TreasurySteward.deploy(
-        deployer.address,                    // deployer acts as timelock
-        await testTreasury.getAddress(),
-        await governor.getAddress(),
-        testStewardDelay,
+        deployer.address,   // deployer acts as timelock for direct control
         deployer.address, 14 * ONE_DAY
       );
       await testSteward.waitForDeployment();
-
-      // Elect carol as steward
-      await testSteward.electSteward(carol.address);
-
-      // Fund treasury with USDC and set steward contract as the treasury's steward
-      await usdc.mint(await testTreasury.getAddress(), ethers.parseUnits("1000000", 6));
-      await testTreasury.setSteward(await testSteward.getAddress());
     }
 
-    it("failed executeAction bubbles up the original revert reason", async function () {
+    it("electSteward sets currentSteward and emits StewardElected", async function () {
       await setupStewardTest();
 
-      // Propose a spend that exceeds the budget (budget = 1% of $1M = $10K)
-      const overBudget = ethers.parseUnits("20000", 6); // $20K > $10K budget
-      const spendData = testTreasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), dave.address, overBudget
-      ]);
-      await testSteward.connect(carol).proposeAction(
-        await testTreasury.getAddress(), spendData, 0
-      );
-      await time.increase(testStewardDelay + 1);
+      await expect(testSteward.electSteward(carol.address))
+        .to.emit(testSteward, "StewardElected")
+        .withArgs(carol.address, (v: bigint) => v > 0n, (v: bigint) => v > 0n);
 
-      // The original revert reason from the treasury is bubbled up
-      await expect(
-        testSteward.connect(carol).executeAction(await testSteward.actionCount())
-      ).to.be.revertedWith("ArmadaTreasuryGov: exceeds monthly budget");
+      expect(await testSteward.currentSteward()).to.equal(carol.address);
+      expect(await testSteward.isStewardActive()).to.be.true;
     });
 
-    it("successful executeAction emits ActionExecuted", async function () {
+    it("removeSteward clears currentSteward and emits StewardRemoved", async function () {
       await setupStewardTest();
 
-      // Propose a spend within budget (budget = 1% of $1M = $10K)
-      const withinBudget = ethers.parseUnits("5000", 6); // $5K < $10K budget
-      const spendData = testTreasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), dave.address, withinBudget
-      ]);
-      await testSteward.connect(carol).proposeAction(
-        await testTreasury.getAddress(), spendData, 0
-      );
-      await time.increase(testStewardDelay + 1);
+      await testSteward.electSteward(carol.address);
+      await expect(testSteward.removeSteward())
+        .to.emit(testSteward, "StewardRemoved")
+        .withArgs(carol.address);
 
-      const actionId = await testSteward.actionCount();
+      expect(await testSteward.currentSteward()).to.equal(ethers.ZeroAddress);
+      expect(await testSteward.isStewardActive()).to.be.false;
+    });
 
-      // Successful action emits ActionExecuted
+    it("non-timelock cannot call electSteward", async function () {
+      await setupStewardTest();
+
       await expect(
-        testSteward.connect(carol).executeAction(actionId)
-      ).to.emit(testSteward, "ActionExecuted").withArgs(actionId);
+        testSteward.connect(carol).electSteward(carol.address)
+      ).to.be.revertedWith("TreasurySteward: not timelock");
+    });
 
-      expect(await usdc.balanceOf(dave.address)).to.equal(withinBudget);
+    it("non-timelock cannot call removeSteward", async function () {
+      await setupStewardTest();
+
+      await testSteward.electSteward(carol.address);
+      await expect(
+        testSteward.connect(carol).removeSteward()
+      ).to.be.revertedWith("TreasurySteward: not timelock");
+    });
+
+    it("isStewardActive returns false after TERM_DURATION expires", async function () {
+      await setupStewardTest();
+
+      await testSteward.electSteward(carol.address);
+      expect(await testSteward.isStewardActive()).to.be.true;
+
+      const termDuration = await testSteward.TERM_DURATION();
+      await time.increase(Number(termDuration) + 1);
+
+      expect(await testSteward.isStewardActive()).to.be.false;
+    });
+
+    it("electSteward zero address reverts", async function () {
+      await setupStewardTest();
+
+      await expect(
+        testSteward.electSteward(ethers.ZeroAddress)
+      ).to.be.revertedWith("TreasurySteward: zero address");
     });
   });
 

--- a/test/governance_emergency_pause.ts
+++ b/test/governance_emergency_pause.ts
@@ -33,7 +33,6 @@ const TREASURY_AMOUNT = TOTAL_SUPPLY * 65n / 100n; // 65% to treasury
 const ALICE_AMOUNT = TOTAL_SUPPLY * 20n / 100n;    // 20% to Alice (voter)
 const BOB_AMOUNT = TOTAL_SUPPLY * 15n / 100n;      // 15% to Bob (voter)
 const USDC_DECIMALS = 6;
-const STEWARD_ACTION_DELAY = Math.ceil((TWO_DAYS + STANDARD_VOTING_PERIOD + STANDARD_EXECUTION_DELAY) * 12000 / 10000);
 
 describe("Governance Emergency Pause", function () {
   let armToken: any;
@@ -139,9 +138,6 @@ describe("Governance Emergency Pause", function () {
     const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
     stewardContract = await TreasurySteward.deploy(
       timelockAddr,
-      await treasury.getAddress(),
-      await governor.getAddress(),
-      STEWARD_ACTION_DELAY,
       guardian.address, MAX_PAUSE_DURATION
     );
     await stewardContract.waitForDeployment();
@@ -392,8 +388,10 @@ describe("Governance Emergency Pause", function () {
       // Fund with USDC
       await usdc.mint(await standaloneTreasury.getAddress(), ethers.parseUnits("100000", USDC_DECIMALS));
 
-      // Set carol as steward
-      await standaloneTreasury.setSteward(carol.address);
+      // Authorize USDC for steward spending (deployer acts as owner/timelock)
+      await standaloneTreasury.addStewardBudgetToken(
+        await usdc.getAddress(), ethers.parseUnits("10000", USDC_DECIMALS), 30 * ONE_DAY
+      );
 
       // Create a claim for alice
       await standaloneTreasury.createClaim(
@@ -420,8 +418,9 @@ describe("Governance Emergency Pause", function () {
     it("stewardSpend reverts when paused", async function () {
       await standaloneTreasury.connect(guardian).emergencyPause();
 
+      // stewardSpend is onlyOwner — deployer acts as owner/timelock in this standalone setup
       await expect(
-        standaloneTreasury.connect(carol).stewardSpend(
+        standaloneTreasury.stewardSpend(
           await usdc.getAddress(), dave.address, ethers.parseUnits("100", USDC_DECIMALS)
         )
       ).to.be.revertedWith("Pausable: paused");
@@ -450,8 +449,8 @@ describe("Governance Emergency Pause", function () {
       // exerciseClaim should work
       await standaloneTreasury.connect(alice).exerciseClaim(1, ethers.parseUnits("100", USDC_DECIMALS));
 
-      // stewardSpend should work
-      await standaloneTreasury.connect(carol).stewardSpend(
+      // stewardSpend should work (deployer is owner/timelock in standalone setup)
+      await standaloneTreasury.stewardSpend(
         await usdc.getAddress(), dave.address, ethers.parseUnits("100", USDC_DECIMALS)
       );
     });
@@ -462,86 +461,57 @@ describe("Governance Emergency Pause", function () {
   // ============================================================
 
   describe("TreasurySteward Pause", function () {
+    // TreasurySteward is now identity-only: it tracks steward election and term,
+    // inheriting EmergencyPausable. These tests verify the pause mechanism on the steward contract.
     let standaloneSteward: any;
-    let standaloneTreasury: any;
 
     beforeEach(async function () {
-      // Deploy standalone treasury + steward with deployer as timelock
-      const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
-      standaloneTreasury = await ArmadaTreasuryGov.deploy(
-        deployer.address, guardian.address, MAX_PAUSE_DURATION
-      );
-      await standaloneTreasury.waitForDeployment();
-
+      // Deploy standalone steward with deployer as timelock for direct control
       const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
       standaloneSteward = await TreasurySteward.deploy(
         deployer.address,
-        await standaloneTreasury.getAddress(),
-        await governor.getAddress(),
-        STEWARD_ACTION_DELAY,
         guardian.address, MAX_PAUSE_DURATION
       );
       await standaloneSteward.waitForDeployment();
-
-      // Elect carol as steward
-      await standaloneSteward.electSteward(carol.address);
-
-      // Fund treasury and set steward contract as treasury's steward
-      await usdc.mint(await standaloneTreasury.getAddress(), ethers.parseUnits("1000000", USDC_DECIMALS));
-      await standaloneTreasury.setSteward(await standaloneSteward.getAddress());
     });
 
-    it("executeAction reverts when paused", async function () {
-      // Propose a valid action
-      const spendData = standaloneTreasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), dave.address, ethers.parseUnits("100", USDC_DECIMALS)
-      ]);
-      await standaloneSteward.connect(carol).proposeAction(
-        await standaloneTreasury.getAddress(), spendData, 0
-      );
-
-      // Wait for delay
-      await time.increase(STEWARD_ACTION_DELAY + 1);
-
-      // Pause the steward
+    it("guardian can pause the steward contract", async function () {
+      expect(await standaloneSteward.paused()).to.be.false;
       await standaloneSteward.connect(guardian).emergencyPause();
+      expect(await standaloneSteward.paused()).to.be.true;
+    });
 
-      // Execute should fail
+    it("non-guardian cannot pause the steward contract", async function () {
       await expect(
-        standaloneSteward.connect(carol).executeAction(1)
-      ).to.be.revertedWith("Pausable: paused");
+        standaloneSteward.connect(alice).emergencyPause()
+      ).to.be.revertedWith("EmergencyPausable: not guardian");
     });
 
-    it("proposeAction still works when paused (proposing is harmless)", async function () {
+    it("pause auto-expires after maxPauseDuration on steward", async function () {
       await standaloneSteward.connect(guardian).emergencyPause();
+      expect(await standaloneSteward.paused()).to.be.true;
 
-      const spendData = standaloneTreasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), dave.address, ethers.parseUnits("100", USDC_DECIMALS)
-      ]);
-      await standaloneSteward.connect(carol).proposeAction(
-        await standaloneTreasury.getAddress(), spendData, 0
-      );
+      await time.increase(MAX_PAUSE_DURATION + 1);
 
-      expect(await standaloneSteward.actionCount()).to.equal(1);
+      expect(await standaloneSteward.paused()).to.be.false;
     });
 
-    it("executeAction works after unpause", async function () {
-      const spendData = standaloneTreasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), dave.address, ethers.parseUnits("100", USDC_DECIMALS)
-      ]);
-      await standaloneSteward.connect(carol).proposeAction(
-        await standaloneTreasury.getAddress(), spendData, 0
-      );
-      await time.increase(STEWARD_ACTION_DELAY + 1);
+    it("timelock can unpause the steward contract early", async function () {
+      await standaloneSteward.connect(guardian).emergencyPause();
+      expect(await standaloneSteward.paused()).to.be.true;
 
-      // Pause then unpause
+      // deployer acts as timelock in this standalone setup
+      await standaloneSteward.connect(deployer).emergencyUnpause();
+      expect(await standaloneSteward.paused()).to.be.false;
+    });
+
+    it("steward election works after unpause", async function () {
       await standaloneSteward.connect(guardian).emergencyPause();
       await standaloneSteward.connect(deployer).emergencyUnpause();
 
-      // Should execute successfully
-      await standaloneSteward.connect(carol).executeAction(1);
-      const [,,, executed] = await standaloneSteward.getAction(1);
-      expect(executed).to.be.true;
+      // electSteward is onlyTimelock and not pause-gated — should succeed
+      await standaloneSteward.connect(deployer).electSteward(carol.address);
+      expect(await standaloneSteward.currentSteward()).to.equal(carol.address);
     });
   });
 

--- a/test/governance_integration.ts
+++ b/test/governance_integration.ts
@@ -665,16 +665,16 @@ describe("Governance Integration", function () {
       );
     }
 
-    // Helper: submit steward proposal via governor and pass it (no votes = pass-by-default)
-    async function passStewardProposal(
+    // Helper: submit steward spend proposal via governor and pass it (no votes = pass-by-default)
+    async function passStewardSpend(
       stewardSigner: any,
-      targets: string[],
-      values: bigint[],
-      calldatas: string[],
+      token: string,
+      recipient: string,
+      amount: bigint,
       description: string
     ): Promise<number> {
-      await governor.connect(stewardSigner).proposeStewardAction(
-        targets, values, calldatas, description
+      await governor.connect(stewardSigner).proposeStewardSpend(
+        [token], [recipient], [amount], description
       );
       const proposalId = Number(await governor.proposalCount());
 
@@ -702,13 +702,9 @@ describe("Governance Integration", function () {
 
       const spendAmount = ethers.parseUnits("500", USDC_DECIMALS);
 
-      await passStewardProposal(
+      await passStewardSpend(
         dave,
-        [await treasury.getAddress()],
-        [0n],
-        [treasury.interface.encodeFunctionData("stewardSpend", [
-          await usdc.getAddress(), carol.address, spendAmount
-        ])],
+        await usdc.getAddress(), carol.address, spendAmount,
         "Steward spend: 500 USDC to Carol"
       );
 
@@ -724,29 +720,23 @@ describe("Governance Integration", function () {
       expect(await stewardContract.isStewardActive()).to.be.false;
 
       // Steward tries to propose via governor — should fail
-      const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), carol.address, ethers.parseUnits("10", USDC_DECIMALS)
-      ]);
-
       await expect(
-        governor.connect(dave).proposeStewardAction(
-          [await treasury.getAddress()], [0n], [spendData],
+        governor.connect(dave).proposeStewardSpend(
+          [await usdc.getAddress()], [carol.address],
+          [ethers.parseUnits("10", USDC_DECIMALS)],
           "Late steward spend"
         )
       ).to.be.revertedWith("ArmadaGovernor: steward not active");
     });
 
-    it("should reject non-steward from calling proposeStewardAction", async function () {
+    it("should reject non-steward from calling proposeStewardSpend", async function () {
       await electDaveSteward();
-
-      const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), carol.address, ethers.parseUnits("10", USDC_DECIMALS)
-      ]);
 
       // Alice is not the steward
       await expect(
-        governor.connect(alice).proposeStewardAction(
-          [await treasury.getAddress()], [0n], [spendData],
+        governor.connect(alice).proposeStewardSpend(
+          [await usdc.getAddress()], [carol.address],
+          [ethers.parseUnits("10", USDC_DECIMALS)],
           "Unauthorized steward spend"
         )
       ).to.be.revertedWith("ArmadaGovernor: not current steward");
@@ -761,11 +751,8 @@ describe("Governance Integration", function () {
       const spendAmount = ethers.parseUnits("100", USDC_DECIMALS);
 
       // Submit steward proposal
-      await governor.connect(dave).proposeStewardAction(
-        [await treasury.getAddress()], [0n],
-        [treasury.interface.encodeFunctionData("stewardSpend", [
-          await usdc.getAddress(), carol.address, spendAmount
-        ])],
+      await governor.connect(dave).proposeStewardSpend(
+        [await usdc.getAddress()], [carol.address], [spendAmount],
         "Pass by default test"
       );
       const proposalId = Number(await governor.proposalCount());
@@ -781,11 +768,9 @@ describe("Governance Integration", function () {
       await electDaveSteward();
 
       // Submit steward proposal
-      await governor.connect(dave).proposeStewardAction(
-        [await treasury.getAddress()], [0n],
-        [treasury.interface.encodeFunctionData("stewardSpend", [
-          await usdc.getAddress(), carol.address, ethers.parseUnits("10", USDC_DECIMALS)
-        ])],
+      await governor.connect(dave).proposeStewardSpend(
+        [await usdc.getAddress()], [carol.address],
+        [ethers.parseUnits("10", USDC_DECIMALS)],
         "Community rejects this"
       );
       const proposalId = Number(await governor.proposalCount());
@@ -806,13 +791,10 @@ describe("Governance Integration", function () {
       await electDaveSteward();
 
       // Steward tries to pay themselves
-      const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), dave.address, ethers.parseUnits("100", USDC_DECIMALS)
-      ]);
-
       await expect(
-        governor.connect(dave).proposeStewardAction(
-          [await treasury.getAddress()], [0n], [spendData],
+        governor.connect(dave).proposeStewardSpend(
+          [await usdc.getAddress()], [dave.address],
+          [ethers.parseUnits("100", USDC_DECIMALS)],
           "Pay myself"
         )
       ).to.be.revertedWith("ArmadaGovernor: self-payment not allowed");

--- a/test/governance_integration.ts
+++ b/test/governance_integration.ts
@@ -15,7 +15,7 @@ import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
 // Proposal types (must match IArmadaGovernance.sol enum order)
-const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
+const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2, Steward: 3 };
 // Proposal states
 const ProposalState = {
   Pending: 0, Active: 1, Defeated: 2, Succeeded: 3,
@@ -60,9 +60,6 @@ describe("Governance Integration", function () {
   const ALICE_AMOUNT = TOTAL_SUPPLY * 20n / 100n;    // 20% to Alice (voter)
   const BOB_AMOUNT = TOTAL_SUPPLY * 15n / 100n;      // 15% to Bob (voter)
   const USDC_DECIMALS = 6;
-  // Minimum action delay = 120% of governance cycle (2d + 7d + 2d = 11d)
-  // 11 days * 1.2 = 13.2 days = 1140480 seconds
-  const STEWARD_ACTION_DELAY = Math.ceil((TWO_DAYS + STANDARD_VOTING_PERIOD + STANDARD_EXECUTION_DELAY) * 12000 / 10000);
 
   // Helper: mine a block so checkpoint reads work
   async function mineBlock() {
@@ -152,17 +149,17 @@ describe("Governance Integration", function () {
     );
     await governor.waitForDeployment();
 
-    // 5. Deploy TreasurySteward
+    // 5. Deploy TreasurySteward (identity management only)
     const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
     stewardContract = await TreasurySteward.deploy(
       timelockAddr,
-      await treasury.getAddress(),
-      await governor.getAddress(),
-      STEWARD_ACTION_DELAY,
       deployer.address,        // guardian
       MAX_PAUSE_DURATION
     );
     await stewardContract.waitForDeployment();
+
+    // 5b. Register steward contract on governor
+    await governor.setStewardContract(await stewardContract.getAddress());
 
     // 6. Configure token: whitelist addresses so transfers work, set treasury as noDelegation
     await armToken.initWhitelist([
@@ -502,14 +499,10 @@ describe("Governance Integration", function () {
     it("should elect steward via proposal with extended timing", async function () {
       const targets = [
         await stewardContract.getAddress(),
-        await treasury.getAddress(),
       ];
-      const values = [0n, 0n];
-      // setSteward sets the TreasurySteward contract (not the person) as treasury steward,
-      // so that executeAction() → treasury.stewardSpend() works (msg.sender = contract).
+      const values = [0n];
       const calldatas = [
         stewardContract.interface.encodeFunctionData("electSteward", [dave.address]),
-        treasury.interface.encodeFunctionData("setSteward", [await stewardContract.getAddress()]),
       ];
 
       await passProposal(
@@ -521,7 +514,6 @@ describe("Governance Integration", function () {
 
       expect(await stewardContract.currentSteward()).to.equal(dave.address);
       expect(await stewardContract.isStewardActive()).to.be.true;
-      expect(await treasury.steward()).to.equal(await stewardContract.getAddress());
     });
 
     it("should use 30% quorum for Extended proposals", async function () {
@@ -634,22 +626,17 @@ describe("Governance Integration", function () {
   });
 
   // ============================================================
-  // 7. Treasury Steward
+  // 7. Treasury Steward (governor-based flow)
   // ============================================================
 
   describe("Treasury Steward", function () {
-    // Helper: elect Dave as steward before each steward test.
-    // Sets the TreasurySteward contract as the treasury's steward so that
-    // executeAction() → treasury.stewardSpend() works (msg.sender = contract).
+    // Helper: elect Dave as steward and set up budget.
+    // Dave needs delegated ARM to post proposal bond (when ARM is transferable).
     async function electDaveSteward() {
-      const targets = [
-        await stewardContract.getAddress(),
-        await treasury.getAddress(),
-      ];
-      const values = [0n, 0n];
+      const targets = [await stewardContract.getAddress()];
+      const values = [0n];
       const calldatas = [
         stewardContract.interface.encodeFunctionData("electSteward", [dave.address]),
-        treasury.interface.encodeFunctionData("setSteward", [await stewardContract.getAddress()]),
       ];
 
       await passProposal(
@@ -660,45 +647,72 @@ describe("Governance Integration", function () {
       );
     }
 
-    it("should allow steward to spend within 1% monthly budget", async function () {
+    // Helper: set up steward budget for USDC on treasury (via governance)
+    async function setupStewardBudget(budgetLimit: bigint, budgetWindow: number) {
+      const targets = [await treasury.getAddress()];
+      const values = [0n];
+      const calldatas = [
+        treasury.interface.encodeFunctionData("addStewardBudgetToken", [
+          await usdc.getAddress(), budgetLimit, budgetWindow
+        ]),
+      ];
+
+      await passProposal(
+        alice,
+        [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
+        ProposalType.Extended, targets, values, calldatas,
+        "Add USDC steward budget"
+      );
+    }
+
+    // Helper: submit steward proposal via governor and pass it (no votes = pass-by-default)
+    async function passStewardProposal(
+      stewardSigner: any,
+      targets: string[],
+      values: bigint[],
+      calldatas: string[],
+      description: string
+    ): Promise<number> {
+      await governor.connect(stewardSigner).proposeStewardAction(
+        targets, values, calldatas, description
+      );
+      const proposalId = Number(await governor.proposalCount());
+
+      // Steward proposals have 0 voting delay, 7d voting period
+      // Pass-by-default: no votes needed — just wait past voting period
+      await time.increase(SEVEN_DAYS + 1);
+
+      // Queue
+      await governor.queue(proposalId);
+
+      // Fast-forward past execution delay (2d for Steward type)
+      await time.increase(TWO_DAYS + 1);
+
+      // Execute
+      await governor.execute(proposalId);
+
+      return proposalId;
+    }
+
+    it("should allow steward to spend within budget via governor proposal", async function () {
       await electDaveSteward();
 
-      const treasuryUsdcBalance = await usdc.balanceOf(await treasury.getAddress());
-      const budget = treasuryUsdcBalance / 100n; // 1%
-      const spendAmount = budget / 2n; // Spend half the budget
+      const budgetLimit = ethers.parseUnits("1000", USDC_DECIMALS);
+      await setupStewardBudget(budgetLimit, THIRTY_DAYS);
 
-      // Steward spends via action queue (proposeAction → delay → executeAction)
-      const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), carol.address, spendAmount
-      ]);
-      await stewardContract.connect(dave).proposeAction(
-        await treasury.getAddress(), spendData, 0
+      const spendAmount = ethers.parseUnits("500", USDC_DECIMALS);
+
+      await passStewardProposal(
+        dave,
+        [await treasury.getAddress()],
+        [0n],
+        [treasury.interface.encodeFunctionData("stewardSpend", [
+          await usdc.getAddress(), carol.address, spendAmount
+        ])],
+        "Steward spend: 500 USDC to Carol"
       );
-      await time.increase(STEWARD_ACTION_DELAY + 1);
-      await stewardContract.connect(dave).executeAction(await stewardContract.actionCount());
 
       expect(await usdc.balanceOf(carol.address)).to.equal(spendAmount);
-    });
-
-    it("should reject steward spending above budget", async function () {
-      await electDaveSteward();
-
-      const treasuryUsdcBalance = await usdc.balanceOf(await treasury.getAddress());
-      const overBudget = (treasuryUsdcBalance / 100n) + 1n; // Just over 1%
-
-      // Steward proposes over-budget spend via action queue
-      const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), carol.address, overBudget
-      ]);
-      await stewardContract.connect(dave).proposeAction(
-        await treasury.getAddress(), spendData, 0
-      );
-      await time.increase(STEWARD_ACTION_DELAY + 1);
-
-      // Execution reverts — the original treasury revert reason is bubbled up.
-      await expect(
-        stewardContract.connect(dave).executeAction(await stewardContract.actionCount())
-      ).to.be.revertedWith("ArmadaTreasuryGov: exceeds monthly budget");
     });
 
     it("should reject steward spending after term expires", async function () {
@@ -709,209 +723,99 @@ describe("Governance Integration", function () {
 
       expect(await stewardContract.isStewardActive()).to.be.false;
 
-      // Treasury stewardSpend still works (it checks msg.sender == steward, not term)
-      // But stewardContract.proposeAction checks term
+      // Steward tries to propose via governor — should fail
       const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
         await usdc.getAddress(), carol.address, ethers.parseUnits("10", USDC_DECIMALS)
       ]);
 
       await expect(
-        stewardContract.connect(dave).proposeAction(
-          await treasury.getAddress(), spendData, 0
+        governor.connect(dave).proposeStewardAction(
+          [await treasury.getAddress()], [0n], [spendData],
+          "Late steward spend"
         )
-      ).to.be.revertedWith("TreasurySteward: term expired");
+      ).to.be.revertedWith("ArmadaGovernor: steward not active");
     });
 
-    it("should allow governance to veto a steward action", async function () {
+    it("should reject non-steward from calling proposeStewardAction", async function () {
       await electDaveSteward();
 
-      // Steward proposes an action
       const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), carol.address, ethers.parseUnits("500", USDC_DECIMALS)
+        await usdc.getAddress(), carol.address, ethers.parseUnits("10", USDC_DECIMALS)
       ]);
 
-      await stewardContract.connect(dave).proposeAction(
-        await treasury.getAddress(), spendData, 0
-      );
-      const actionId = 1;
-
-      // Governance vetoes the action
-      const vetoTargets = [await stewardContract.getAddress()];
-      const vetoValues = [0n];
-      const vetoCalldatas = [
-        stewardContract.interface.encodeFunctionData("vetoAction", [actionId])
-      ];
-
-      await passProposal(
-        alice,
-        [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Standard, vetoTargets, vetoValues, vetoCalldatas,
-        "Veto steward action #1"
-      );
-
-      // Steward tries to execute the vetoed action
-      await time.increase(STEWARD_ACTION_DELAY + 1);
+      // Alice is not the steward
       await expect(
-        stewardContract.connect(dave).executeAction(actionId)
-      ).to.be.revertedWith("TreasurySteward: vetoed");
+        governor.connect(alice).proposeStewardAction(
+          [await treasury.getAddress()], [0n], [spendData],
+          "Unauthorized steward spend"
+        )
+      ).to.be.revertedWith("ArmadaGovernor: not current steward");
     });
 
-    it("should execute steward action after delay if not vetoed", async function () {
+    it("should pass steward proposal by default with no votes", async function () {
       await electDaveSteward();
+
+      const budgetLimit = ethers.parseUnits("1000", USDC_DECIMALS);
+      await setupStewardBudget(budgetLimit, THIRTY_DAYS);
 
       const spendAmount = ethers.parseUnits("100", USDC_DECIMALS);
-      const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), carol.address, spendAmount
-      ]);
 
-      await stewardContract.connect(dave).proposeAction(
-        await treasury.getAddress(), spendData, 0
+      // Submit steward proposal
+      await governor.connect(dave).proposeStewardAction(
+        [await treasury.getAddress()], [0n],
+        [treasury.interface.encodeFunctionData("stewardSpend", [
+          await usdc.getAddress(), carol.address, spendAmount
+        ])],
+        "Pass by default test"
       );
+      const proposalId = Number(await governor.proposalCount());
 
-      // Can't execute before delay
-      await expect(
-        stewardContract.connect(dave).executeAction(1)
-      ).to.be.revertedWith("TreasurySteward: delay not elapsed");
+      // Wait past voting period with NO votes
+      await time.increase(SEVEN_DAYS + 1);
 
-      // Wait for delay
-      await time.increase(STEWARD_ACTION_DELAY + 1);
-
-      // Now execute succeeds
-      await stewardContract.connect(dave).executeAction(1);
-      expect(await usdc.balanceOf(carol.address)).to.equal(spendAmount);
+      // Should be Succeeded (pass-by-default)
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Succeeded);
     });
 
-    it("should reject new steward executing previous steward's actions", async function () {
-      // Elect Dave as first steward
+    it("should defeat steward proposal when quorum met and majority against", async function () {
       await electDaveSteward();
 
-      // Dave proposes an action
-      const spendAmount = ethers.parseUnits("100", USDC_DECIMALS);
-      const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), carol.address, spendAmount
-      ]);
-      await stewardContract.connect(dave).proposeAction(
-        await treasury.getAddress(), spendData, 0
+      // Submit steward proposal
+      await governor.connect(dave).proposeStewardAction(
+        [await treasury.getAddress()], [0n],
+        [treasury.interface.encodeFunctionData("stewardSpend", [
+          await usdc.getAddress(), carol.address, ethers.parseUnits("10", USDC_DECIMALS)
+        ])],
+        "Community rejects this"
       );
-      const actionId = await stewardContract.actionCount();
+      const proposalId = Number(await governor.proposalCount());
 
-      // Elect Carol as new steward (replaces Dave)
-      const targets = [await stewardContract.getAddress()];
-      const values = [0n];
-      const calldatas = [
-        stewardContract.interface.encodeFunctionData("electSteward", [carol.address]),
-      ];
-      await passProposal(
-        alice,
-        [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Extended, targets, values, calldatas,
-        "Elect Carol as steward"
-      );
-      expect(await stewardContract.currentSteward()).to.equal(carol.address);
+      // Steward proposals have 0 voting delay, so voting is open immediately
+      // Both Alice and Bob vote AGAINST (enough for quorum)
+      await governor.connect(alice).castVote(proposalId, Vote.Against);
+      await governor.connect(bob).castVote(proposalId, Vote.Against);
 
-      // Wait for action delay to elapse
-      await time.increase(STEWARD_ACTION_DELAY + 1);
+      // Wait past voting period
+      await time.increase(SEVEN_DAYS + 1);
 
-      // Carol (new steward) tries to execute Dave's action — should fail
-      await expect(
-        stewardContract.connect(carol).executeAction(actionId)
-      ).to.be.revertedWith("TreasurySteward: not proposed by current steward");
+      // Should be Defeated (quorum met + majority against)
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Defeated);
     });
 
-    it("should allow steward to cancel own proposed action", async function () {
-      // Elect Dave as steward
+    it("should block self-payment in steward proposals", async function () {
       await electDaveSteward();
 
-      // Dave proposes an action
-      const spendAmount = ethers.parseUnits("100", USDC_DECIMALS);
+      // Steward tries to pay themselves
       const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), carol.address, spendAmount
+        await usdc.getAddress(), dave.address, ethers.parseUnits("100", USDC_DECIMALS)
       ]);
-      await stewardContract.connect(dave).proposeAction(
-        await treasury.getAddress(), spendData, 0
-      );
-      const actionId = await stewardContract.actionCount();
 
-      // Dave cancels the action
       await expect(
-        stewardContract.connect(dave).cancelAction(actionId)
-      ).to.emit(stewardContract, "ActionCanceled").withArgs(actionId);
-
-      // Wait for action delay
-      await time.increase(STEWARD_ACTION_DELAY + 1);
-
-      // Action should be blocked from execution (vetoed flag set)
-      await expect(
-        stewardContract.connect(dave).executeAction(actionId)
-      ).to.be.revertedWith("TreasurySteward: vetoed");
-    });
-
-    it("should reject new steward canceling previous steward's action", async function () {
-      // Elect Dave as steward
-      await electDaveSteward();
-
-      // Dave proposes an action
-      const spendAmount = ethers.parseUnits("100", USDC_DECIMALS);
-      const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), carol.address, spendAmount
-      ]);
-      await stewardContract.connect(dave).proposeAction(
-        await treasury.getAddress(), spendData, 0
-      );
-      const actionId = await stewardContract.actionCount();
-
-      // Elect Carol as new steward
-      const targets = [await stewardContract.getAddress()];
-      const values = [0n];
-      const calldatas = [
-        stewardContract.interface.encodeFunctionData("electSteward", [carol.address]),
-      ];
-      await passProposal(
-        alice,
-        [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Extended, targets, values, calldatas,
-        "Elect Carol as steward"
-      );
-
-      // Carol tries to cancel Dave's action — should fail
-      await expect(
-        stewardContract.connect(carol).cancelAction(actionId)
-      ).to.be.revertedWith("TreasurySteward: not your action");
-    });
-
-    it("should allow steward to execute own actions after re-election", async function () {
-      // Elect Dave as steward
-      await electDaveSteward();
-
-      // Dave proposes an action
-      const spendAmount = ethers.parseUnits("100", USDC_DECIMALS);
-      const spendData = treasury.interface.encodeFunctionData("stewardSpend", [
-        await usdc.getAddress(), carol.address, spendAmount
-      ]);
-      await stewardContract.connect(dave).proposeAction(
-        await treasury.getAddress(), spendData, 0
-      );
-      const actionId = await stewardContract.actionCount();
-
-      // Re-elect Dave (same person, new term)
-      const targets = [await stewardContract.getAddress()];
-      const values = [0n];
-      const calldatas = [
-        stewardContract.interface.encodeFunctionData("electSteward", [dave.address]),
-      ];
-      await passProposal(
-        alice,
-        [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Extended, targets, values, calldatas,
-        "Re-elect Dave"
-      );
-
-      // Wait for action delay
-      await time.increase(STEWARD_ACTION_DELAY + 1);
-
-      // Dave can still execute his own action after re-election
-      await stewardContract.connect(dave).executeAction(actionId);
-      expect(await usdc.balanceOf(carol.address)).to.equal(spendAmount);
+        governor.connect(dave).proposeStewardAction(
+          [await treasury.getAddress()], [0n], [spendData],
+          "Pay myself"
+        )
+      ).to.be.revertedWith("ArmadaGovernor: self-payment not allowed");
     });
   });
 
@@ -1193,7 +1097,7 @@ describe("Governance Integration", function () {
           ProposalType.VetoRatification,
           { votingDelay: 0, votingPeriod: SEVEN_DAYS, executionDelay: 0, quorumBps: 2000 }
         )
-      ).to.be.revertedWith("ArmadaGovernor: VetoRatification immutable");
+      ).to.be.revertedWith("ArmadaGovernor: immutable proposal type");
 
       await ethers.provider.send("hardhat_stopImpersonatingAccount", [timelockAddr]);
     });

--- a/test/governance_param_updates.ts
+++ b/test/governance_param_updates.ts
@@ -36,7 +36,8 @@ const TOTAL_SUPPLY = ethers.parseUnits("12000000", ARM_DECIMALS); // must match 
 const TREASURY_AMOUNT = TOTAL_SUPPLY * 65n / 100n; // 65% to treasury
 const ALICE_AMOUNT = TOTAL_SUPPLY * 20n / 100n;    // 20% to Alice (voter)
 const BOB_AMOUNT = TOTAL_SUPPLY * 15n / 100n;      // 15% to Bob (voter)
-const STEWARD_ACTION_DELAY = Math.ceil((TWO_DAYS + STANDARD_VOTING_PERIOD + STANDARD_EXECUTION_DELAY) * 12000 / 10000);
+// ProposalType enum values
+const ProposalType_Steward = 3;
 
 describe("Governance Parameter Updates", function () {
   let armToken: any;
@@ -150,9 +151,6 @@ describe("Governance Parameter Updates", function () {
     const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
     stewardContract = await TreasurySteward.deploy(
       timelockAddr,
-      await treasury.getAddress(),
-      await governor.getAddress(),
-      STEWARD_ACTION_DELAY,
       deployer.address, MAX_PAUSE_DURATION
     );
     await stewardContract.waitForDeployment();
@@ -496,45 +494,90 @@ describe("Governance Parameter Updates", function () {
   });
 
   // ============================================================
-  // 5. Steward Min Action Delay Coupling
+  // 5. Budget Management Extended Selectors
   // ============================================================
 
-  describe("Steward Min Action Delay Coupling", function () {
-    it("steward minActionDelay reflects updated governor timing", async function () {
-      const minDelayBefore = await stewardContract.minActionDelay();
+  describe("Budget Management Extended Selectors", function () {
+    it("addStewardBudgetToken is auto-classified as Extended", async function () {
+      const calldata = treasury.interface.encodeFunctionData(
+        "addStewardBudgetToken",
+        [carol.address, 10000, 30 * ONE_DAY]
+      );
 
-      // Shorten the Standard proposal cycle: 1d + 3d + 1d = 5d → 120% = 6d
+      // Propose as Standard — should be auto-upgraded to Extended
+      await governor.connect(alice).propose(
+        ProposalType.Standard,
+        [await treasury.getAddress()],
+        [0n],
+        [calldata],
+        "Add steward budget token"
+      );
+      const proposalId = await governor.proposalCount();
+      const [, proposalType] = await governor.getProposal(proposalId);
+      expect(proposalType).to.equal(ProposalType.Extended);
+    });
+
+    it("updateStewardBudgetToken is auto-classified as Extended", async function () {
+      const calldata = treasury.interface.encodeFunctionData(
+        "updateStewardBudgetToken",
+        [carol.address, 20000, 30 * ONE_DAY]
+      );
+
+      await governor.connect(alice).propose(
+        ProposalType.Standard,
+        [await treasury.getAddress()],
+        [0n],
+        [calldata],
+        "Update steward budget token"
+      );
+      const proposalId = await governor.proposalCount();
+      const [, proposalType] = await governor.getProposal(proposalId);
+      expect(proposalType).to.equal(ProposalType.Extended);
+    });
+
+    it("removeStewardBudgetToken is auto-classified as Extended", async function () {
+      const calldata = treasury.interface.encodeFunctionData(
+        "removeStewardBudgetToken",
+        [carol.address]
+      );
+
+      await governor.connect(alice).propose(
+        ProposalType.Standard,
+        [await treasury.getAddress()],
+        [0n],
+        [calldata],
+        "Remove steward budget token"
+      );
+      const proposalId = await governor.proposalCount();
+      const [, proposalType] = await governor.getProposal(proposalId);
+      expect(proposalType).to.equal(ProposalType.Extended);
+    });
+
+    it("setProposalTypeParams rejects Steward type", async function () {
       const newParams = {
         votingDelay: 1 * ONE_DAY,
-        votingPeriod: 3 * ONE_DAY,
-        executionDelay: 1 * ONE_DAY,
+        votingPeriod: 7 * ONE_DAY,
+        executionDelay: 2 * ONE_DAY,
         quorumBps: 2000,
       };
       const calldata = governor.interface.encodeFunctionData(
         "setProposalTypeParams",
-        [ProposalType.Standard, newParams]
+        [ProposalType_Steward, newParams]
       );
 
-      // setProposalTypeParams is an extended selector, so auto-classification
-      // upgrades this to Extended regardless of declared type
-      await passProposal(
-        alice,
-        [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Extended,
-        [await governor.getAddress()],
-        [0n],
-        [calldata],
-        "Shorten Standard proposal cycle"
-      );
-
-      const minDelayAfter = await stewardContract.minActionDelay();
-
-      // Before: (2d + 7d + 2d) * 1.2 = 13.2d
-      // After:  (1d + 3d + 1d) * 1.2 = 6d
-      expect(minDelayAfter).to.be.lt(minDelayBefore);
-
-      const expectedMinDelay = BigInt(Math.ceil((ONE_DAY + 3 * ONE_DAY + ONE_DAY) * 12000 / 10000));
-      expect(minDelayAfter).to.equal(expectedMinDelay);
+      // Pass the proposal containing setProposalTypeParams(Steward, ...)
+      // It should execute and revert with "immutable proposal type"
+      await expect(
+        passProposal(
+          alice,
+          [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
+          ProposalType.Extended,
+          [await governor.getAddress()],
+          [0n],
+          [calldata],
+          "Try to change Steward params"
+        )
+      ).to.be.revertedWith("TimelockController: underlying transaction reverted");
     });
   });
 });

--- a/test/governance_param_updates.ts
+++ b/test/governance_param_updates.ts
@@ -6,7 +6,7 @@
  * - Bounded parameter validation (min/max for all fields)
  * - Full governance lifecycle to change params (auto-classified as Extended)
  * - Quorum snapshotting: in-flight proposals unaffected by param changes
- * - TreasurySteward.minActionDelay() reflects updated governor timing
+ * - Budget management selectors auto-classified as Extended proposals
  */
 
 import { expect } from "chai";

--- a/test/governance_quiet_period.ts
+++ b/test/governance_quiet_period.ts
@@ -117,7 +117,7 @@ describe("Governance Quiet Period (T6.1)", function () {
   // Helper: create a basic proposal (async — resolves treasury address)
   async function propose(description = "Test proposal") {
     const treasuryAddress = await treasury.getAddress();
-    const calldata = treasury.interface.encodeFunctionData("setSteward", [deployer.address]);
+    const calldata = treasury.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
     return governor.propose(
       ProposalType.Standard,
       [treasuryAddress],

--- a/test/treasury_outflow.ts
+++ b/test/treasury_outflow.ts
@@ -48,8 +48,7 @@ describe("Treasury Outflow Rate Limits", function () {
     );
     await treasury.waitForDeployment();
 
-    // Set steward
-    await treasury.setSteward(stewardAddr.address);
+    // stewardAddr is used as a non-owner signer to test access-control rejections
   }
 
   async function fundTreasury(amount: bigint) {
@@ -317,8 +316,11 @@ describe("Treasury Outflow Rate Limits", function () {
       await fundTreasury(USDC(500_000));
       await initUsdcOutflow(); // 10% of $500K = $50K < $100K → limit = $100K
 
-      // Steward spends $5K (within 1% steward budget = $5K, and outflow limit)
-      await treasury.connect(stewardAddr).stewardSpend(
+      // Authorize USDC for steward spending (limit = $10K, window = 30d)
+      await treasury.addStewardBudgetToken(await usdc.getAddress(), USDC(10_000), THIRTY_DAYS);
+
+      // Owner calls stewardSpend — $5K within steward budget and outflow limit
+      await treasury.stewardSpend(
         await usdc.getAddress(), recipient.address, USDC(5_000)
       );
 
@@ -333,19 +335,21 @@ describe("Treasury Outflow Rate Limits", function () {
 
     it("should enforce outflow limit on stewardSpend independently of budget", async function () {
       // Tiny treasury: $60K, outflow limit with absolute = $50K
-      // Steward budget = 1% of $60K = $600 (budget is more restrictive here)
       // But outflow limit applies as an aggregate cap on all outflows
       await fundTreasury(USDC(60_000));
       await treasury.initOutflowConfig(
         await usdc.getAddress(), THIRTY_DAYS, 1000, USDC(50_000), USDC(50_000)
       );
 
+      // Authorize USDC for steward spending (large limit — outflow limit is more restrictive here)
+      await treasury.addStewardBudgetToken(await usdc.getAddress(), USDC(60_000), THIRTY_DAYS);
+
       // Governance distributes $50K (at the outflow limit)
       await treasury.distribute(await usdc.getAddress(), recipient.address, USDC(50_000));
 
-      // Steward spend of $1 should fail outflow limit (even if within budget)
+      // Steward spend of $1 should fail outflow limit (even if within steward budget)
       await expect(
-        treasury.connect(stewardAddr).stewardSpend(
+        treasury.stewardSpend(
           await usdc.getAddress(), recipient.address, 1n
         )
       ).to.be.revertedWith("ArmadaTreasuryGov: outflow limit exceeded");


### PR DESCRIPTION
## Summary

- Refactor steward from queue+veto model to **pass-by-default governance proposals** per spec (GAP 5.1 CRITICAL)
- Replace percentage-based 1% BPS budget with **governance-managed per-token budget table** with absolute limits (GAP 5.2 HIGH)
- Add **self-payment filter** preventing steward proposals from paying steward's own address (GAP 5.3 MEDIUM)

### Architecture change

**Before:** Steward → `TreasurySteward.proposeAction()` → queue → delay → `executeAction()` → `treasury.stewardSpend()`
**After:** Steward → `ArmadaGovernor.proposeStewardAction()` → 7d pass-by-default vote → `queue()` → timelock → `treasury.stewardSpend()`

### Key contract changes

| Contract | Change |
|----------|--------|
| `IArmadaGovernance.sol` | Add `Steward` to `ProposalType` enum, add `ITreasurySteward` interface, remove `StewardAction` struct |
| `ArmadaGovernor.sol` | Add `proposeStewardAction()`, `_checkSelfPayment()`, inverted `state()` logic for Steward type, steward contract one-time setter, budget mgmt extended selectors |
| `ArmadaTreasuryGov.sol` | Replace `STEWARD_BUDGET_BPS` with per-token `StewardBudget` table, change `stewardSpend()` to `onlyOwner`, add `addStewardBudgetToken/update/remove` |
| `TreasurySteward.sol` | Slim to identity management only (election, term, removal) — all action queue code removed |

### Test coverage

- **225 Foundry tests** pass (28 new in `GovernorSteward.t.sol`, 17 rewritten in `StewardSecurity.t.sol`)
- **643 Hardhat tests** pass (7 test files updated, integration tests rewritten for governor-based flow)

## Test plan

- [x] `npx hardhat compile` — no errors
- [x] `forge build` — no errors
- [x] `npm run test:governance` — 123 tests pass
- [x] `npm run test:all` — 643 tests pass (1 pending, pre-existing)
- [x] `npm run test:forge` — 225 tests pass
- [ ] `npm run halmos` — symbolic verification

### Known follow-ups

- `governance-ui/` references stale steward APIs (frontend is temporary per CLAUDE.md)
- `mcp-server/src/lib/deployments.ts` has stale `stewardActionDelay` type field

🤖 Generated with [Claude Code](https://claude.com/claude-code)