### PR TITLE
feat: shield pause, wind-down, and redemption contracts

### DIFF
--- a/contracts/governance/ArmadaRedemption.sol
+++ b/contracts/governance/ArmadaRedemption.sol
@@ -1,0 +1,137 @@
+// ABOUTME: Permissionless redemption contract for wind-down. ARM holders deposit ARM to receive
+// ABOUTME: pro-rata shares of treasury assets (USDC, ETH, etc.) after wind-down triggers.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+
+/// @title ArmadaRedemption — Pro-rata treasury redemption for ARM holders
+/// @notice Not upgradeable. Permissionless. No admin functions. No deadline.
+///
+///         After wind-down triggers and treasury assets are swept here, ARM holders can
+///         deposit ARM and receive their pro-rata share of each treasury asset.
+///
+///         Deposited ARM is locked permanently (not burned — ARM has no burn function).
+///         The circulating supply denominator excludes treasury, revenue-lock, crowdfund,
+///         and this redemption contract — all hardcoded at construction.
+///
+///         Sequential correctness: each redemption is calculated against remaining assets
+///         and remaining circulating supply. Early and late redeemers get the same
+///         pro-rata outcome.
+contract ArmadaRedemption is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ============ Immutable References ============
+
+    /// @notice ARM governance token
+    IERC20 public immutable armToken;
+
+    /// @notice Treasury contract address (excluded from circulating supply)
+    address public immutable treasury;
+
+    /// @notice Revenue-lock contract address (excluded from circulating supply)
+    address public immutable revenueLock;
+
+    /// @notice Crowdfund contract address (excluded from circulating supply)
+    address public immutable crowdfundContract;
+
+    // ============ Events ============
+
+    event Redeemed(address indexed redeemer, uint256 armAmount, address[] tokens);
+    event RedeemedETH(address indexed redeemer, uint256 armAmount, uint256 ethAmount);
+
+    // ============ Constructor ============
+
+    /// @param _armToken ARM token address
+    /// @param _treasury Treasury contract address
+    /// @param _revenueLock Revenue-lock contract address
+    /// @param _crowdfundContract Crowdfund contract address
+    constructor(
+        address _armToken,
+        address _treasury,
+        address _revenueLock,
+        address _crowdfundContract
+    ) {
+        require(_armToken != address(0), "ArmadaRedemption: zero armToken");
+        require(_treasury != address(0), "ArmadaRedemption: zero treasury");
+        require(_revenueLock != address(0), "ArmadaRedemption: zero revenueLock");
+        require(_crowdfundContract != address(0), "ArmadaRedemption: zero crowdfund");
+
+        armToken = IERC20(_armToken);
+        treasury = _treasury;
+        revenueLock = _revenueLock;
+        crowdfundContract = _crowdfundContract;
+    }
+
+    // ============ Redemption Functions ============
+
+    /// @notice Deposit ARM and receive pro-rata share of specified ERC20 tokens.
+    ///         ARM is locked permanently in this contract.
+    /// @param armAmount Amount of ARM to deposit
+    /// @param tokens Array of ERC20 token addresses to redeem
+    function redeem(uint256 armAmount, address[] calldata tokens) external nonReentrant {
+        require(armAmount > 0, "ArmadaRedemption: zero amount");
+
+        // Calculate circulating supply BEFORE the ARM transfer (depositor's ARM is still
+        // in circulation and counts in the denominator for correct pro-rata math)
+        uint256 circulating = circulatingSupply();
+        require(circulating > 0, "ArmadaRedemption: no circulating supply");
+
+        // Transfer ARM from redeemer to this contract (locked permanently)
+        armToken.safeTransferFrom(msg.sender, address(this), armAmount);
+
+        // Distribute pro-rata share of each requested token
+        for (uint256 i = 0; i < tokens.length; i++) {
+            uint256 available = IERC20(tokens[i]).balanceOf(address(this));
+            uint256 share = (available * armAmount) / circulating;
+            if (share > 0) {
+                IERC20(tokens[i]).safeTransfer(msg.sender, share);
+            }
+        }
+
+        emit Redeemed(msg.sender, armAmount, tokens);
+    }
+
+    /// @notice Deposit ARM and receive pro-rata share of ETH held by this contract.
+    ///         ARM is locked permanently in this contract.
+    /// @param armAmount Amount of ARM to deposit
+    function redeemETH(uint256 armAmount) external nonReentrant {
+        require(armAmount > 0, "ArmadaRedemption: zero amount");
+
+        // Calculate circulating supply BEFORE the ARM transfer
+        uint256 circulating = circulatingSupply();
+        require(circulating > 0, "ArmadaRedemption: no circulating supply");
+
+        // Transfer ARM from redeemer to this contract (locked permanently)
+        armToken.safeTransferFrom(msg.sender, address(this), armAmount);
+
+        // Calculate and send ETH share
+        uint256 ethBalance = address(this).balance;
+        uint256 share = (ethBalance * armAmount) / circulating;
+        if (share > 0) {
+            (bool success,) = msg.sender.call{value: share}("");
+            require(success, "ArmadaRedemption: ETH transfer failed");
+        }
+
+        emit RedeemedETH(msg.sender, armAmount, share);
+    }
+
+    // ============ View Functions ============
+
+    /// @notice Circulating ARM supply, excluding non-redeemable addresses.
+    ///         Denominator = totalSupply - treasury - revenueLock - crowdfund - this contract
+    function circulatingSupply() public view returns (uint256) {
+        uint256 total = armToken.totalSupply();
+        total -= armToken.balanceOf(treasury);
+        total -= armToken.balanceOf(revenueLock);
+        total -= armToken.balanceOf(crowdfundContract);
+        total -= armToken.balanceOf(address(this));
+        return total;
+    }
+
+    /// @notice Accept ETH (from wind-down sweeps)
+    receive() external payable {}
+}

--- a/contracts/governance/ArmadaRedemption.sol
+++ b/contracts/governance/ArmadaRedemption.sol
@@ -40,8 +40,7 @@ contract ArmadaRedemption is ReentrancyGuard {
 
     // ============ Events ============
 
-    event Redeemed(address indexed redeemer, uint256 armAmount, address[] tokens);
-    event RedeemedETH(address indexed redeemer, uint256 armAmount, uint256 ethAmount);
+    event Redeemed(address indexed redeemer, uint256 armAmount, address[] tokens, uint256 ethAmount);
 
     // ============ Constructor ============
 
@@ -68,11 +67,18 @@ contract ArmadaRedemption is ReentrancyGuard {
 
     // ============ Redemption Functions ============
 
-    /// @notice Deposit ARM and receive pro-rata share of specified ERC20 tokens.
-    ///         ARM is locked permanently in this contract.
+    /// @notice Deposit ARM and receive pro-rata share of specified ERC20 tokens and/or ETH.
+    ///         ARM is locked permanently in this contract. A single ARM deposit covers all
+    ///         requested asset types — per the spec, one deposit yields shares of all assets.
     /// @param armAmount Amount of ARM to deposit
-    /// @param tokens Array of ERC20 token addresses to redeem
-    function redeem(uint256 armAmount, address[] calldata tokens) external nonReentrant {
+    /// @param tokens Array of ERC20 token addresses to redeem (must be sorted ascending, no
+    ///        duplicates, and must not include the ARM token)
+    /// @param includeETH If true, also redeem pro-rata share of ETH held by this contract
+    function redeem(
+        uint256 armAmount,
+        address[] calldata tokens,
+        bool includeETH
+    ) external nonReentrant {
         require(armAmount > 0, "ArmadaRedemption: zero amount");
 
         // Calculate circulating supply BEFORE the ARM transfer (depositor's ARM is still
@@ -83,8 +89,16 @@ contract ArmadaRedemption is ReentrancyGuard {
         // Transfer ARM from redeemer to this contract (locked permanently)
         armToken.safeTransferFrom(msg.sender, address(this), armAmount);
 
-        // Distribute pro-rata share of each requested token
+        // Distribute pro-rata share of each requested ERC20 token
         for (uint256 i = 0; i < tokens.length; i++) {
+            // ARM deposited in this contract is locked permanently — never distributable
+            require(tokens[i] != address(armToken), "ArmadaRedemption: cannot redeem ARM");
+
+            // Tokens must be sorted ascending with no duplicates to prevent double-claiming
+            if (i > 0) {
+                require(tokens[i] > tokens[i - 1], "ArmadaRedemption: tokens not sorted/unique");
+            }
+
             uint256 available = IERC20(tokens[i]).balanceOf(address(this));
             uint256 share = (available * armAmount) / circulating;
             if (share > 0) {
@@ -92,31 +106,18 @@ contract ArmadaRedemption is ReentrancyGuard {
             }
         }
 
-        emit Redeemed(msg.sender, armAmount, tokens);
-    }
-
-    /// @notice Deposit ARM and receive pro-rata share of ETH held by this contract.
-    ///         ARM is locked permanently in this contract.
-    /// @param armAmount Amount of ARM to deposit
-    function redeemETH(uint256 armAmount) external nonReentrant {
-        require(armAmount > 0, "ArmadaRedemption: zero amount");
-
-        // Calculate circulating supply BEFORE the ARM transfer
-        uint256 circulating = circulatingSupply();
-        require(circulating > 0, "ArmadaRedemption: no circulating supply");
-
-        // Transfer ARM from redeemer to this contract (locked permanently)
-        armToken.safeTransferFrom(msg.sender, address(this), armAmount);
-
-        // Calculate and send ETH share
-        uint256 ethBalance = address(this).balance;
-        uint256 share = (ethBalance * armAmount) / circulating;
-        if (share > 0) {
-            (bool success,) = msg.sender.call{value: share}("");
-            require(success, "ArmadaRedemption: ETH transfer failed");
+        // Distribute pro-rata share of ETH if requested
+        uint256 ethPayout;
+        if (includeETH) {
+            uint256 ethBalance = address(this).balance;
+            ethPayout = (ethBalance * armAmount) / circulating;
+            if (ethPayout > 0) {
+                (bool success,) = msg.sender.call{value: ethPayout}("");
+                require(success, "ArmadaRedemption: ETH transfer failed");
+            }
         }
 
-        emit RedeemedETH(msg.sender, armAmount, share);
+        emit Redeemed(msg.sender, armAmount, tokens, ethPayout);
     }
 
     // ============ View Functions ============

--- a/contracts/governance/ArmadaRedemption.sol
+++ b/contracts/governance/ArmadaRedemption.sol
@@ -1,12 +1,16 @@
+// SPDX-License-Identifier: MIT
 // ABOUTME: Permissionless redemption contract for wind-down. ARM holders deposit ARM to receive
 // ABOUTME: pro-rata shares of treasury assets (USDC, ETH, etc.) after wind-down triggers.
-
-// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+
+/// @notice Minimal interface for ARM token transferable flag
+interface IArmadaTokenRedemption {
+    function transferable() external view returns (bool);
+}
 
 /// @title ArmadaRedemption — Pro-rata treasury redemption for ARM holders
 /// @notice Not upgradeable. Permissionless. No admin functions. No deadline.
@@ -80,6 +84,13 @@ contract ArmadaRedemption is ReentrancyGuard {
         bool includeETH
     ) external nonReentrant {
         require(armAmount > 0, "ArmadaRedemption: zero amount");
+        // Defense-in-depth: ARM transfers are enabled by the wind-down contract via
+        // setTransferable(true). While the safeTransferFrom below would revert for
+        // non-whitelisted callers pre-wind-down, this makes the invariant explicit.
+        require(
+            IArmadaTokenRedemption(address(armToken)).transferable(),
+            "ArmadaRedemption: wind-down not triggered"
+        );
 
         // Calculate circulating supply BEFORE the ARM transfer (depositor's ARM is still
         // in circulation and counts in the denominator for correct pro-rata math)

--- a/contracts/governance/ArmadaTreasuryGov.sol
+++ b/contracts/governance/ArmadaTreasuryGov.sol
@@ -72,6 +72,12 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
     mapping(address => OutflowConfig) internal _outflowConfigs;
     mapping(address => OutflowRecord[]) internal _outflowHistory;
 
+    // Wind-down sweep authority
+    /// @notice Wind-down contract address (only caller for transferTo/transferETHTo)
+    address public windDownContract;
+    /// @notice Whether the wind-down contract has been set (one-time setter lock)
+    bool public windDownContractSet;
+
     // ============ Events ============
 
     event DirectDistribution(address indexed token, address indexed recipient, uint256 amount);
@@ -85,6 +91,9 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
     event OutflowWindowUpdated(address indexed token, uint256 newWindow);
     event OutflowLimitBpsUpdated(address indexed token, uint256 newBps);
     event OutflowLimitAbsoluteUpdated(address indexed token, uint256 newAbsolute);
+    event WindDownContractSet(address indexed windDownContract);
+    event WindDownTransfer(address indexed token, address indexed recipient, uint256 amount);
+    event WindDownETHTransfer(address indexed recipient, uint256 amount);
 
     // ============ Modifiers ============
 
@@ -338,6 +347,39 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
             total += r.amount;
         }
     }
+
+    // ============ Wind-Down Sweep Authority ============
+
+    /// @notice Set the wind-down contract address. One-time setter, timelock-only.
+    function setWindDownContract(address _windDownContract) external onlyOwner {
+        require(!windDownContractSet, "ArmadaTreasuryGov: wind-down already set");
+        require(_windDownContract != address(0), "ArmadaTreasuryGov: zero address");
+        windDownContractSet = true;
+        windDownContract = _windDownContract;
+        emit WindDownContractSet(_windDownContract);
+    }
+
+    /// @notice Transfer ERC20 tokens from treasury to recipient. Wind-down contract only.
+    ///         Bypasses outflow limits and pause — wind-down is a special authority.
+    function transferTo(address token, address recipient, uint256 amount) external {
+        require(msg.sender == windDownContract, "ArmadaTreasuryGov: not wind-down");
+        require(recipient != address(0), "ArmadaTreasuryGov: zero recipient");
+        IERC20(token).safeTransfer(recipient, amount);
+        emit WindDownTransfer(token, recipient, amount);
+    }
+
+    /// @notice Transfer ETH from treasury to recipient. Wind-down contract only.
+    ///         Bypasses outflow limits and pause — wind-down is a special authority.
+    function transferETHTo(address payable recipient, uint256 amount) external {
+        require(msg.sender == windDownContract, "ArmadaTreasuryGov: not wind-down");
+        require(recipient != address(0), "ArmadaTreasuryGov: zero recipient");
+        (bool success,) = recipient.call{value: amount}("");
+        require(success, "ArmadaTreasuryGov: ETH transfer failed");
+        emit WindDownETHTransfer(recipient, amount);
+    }
+
+    /// @notice Accept ETH deposits
+    receive() external payable {}
 
     // ============ View Functions ============
 

--- a/contracts/governance/ArmadaWindDown.sol
+++ b/contracts/governance/ArmadaWindDown.sol
@@ -1,0 +1,213 @@
+// ABOUTME: Wind-down contract with permissionless trigger and governance trigger.
+// ABOUTME: Sweeps treasury assets to redemption contract; enables ARM transfers; disables governance.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// Minimal interfaces for cross-contract calls during wind-down
+interface IArmadaTokenWindDown {
+    function setTransferable(bool _transferable) external;
+}
+
+interface IArmadaGovernorWindDown {
+    function setWindDownActive() external;
+}
+
+interface IShieldPauseControllerWindDown {
+    function setWindDownActive() external;
+}
+
+interface IRevenueCounterWindDown {
+    function recognizedRevenueUsd() external view returns (uint256);
+}
+
+interface ITreasuryWindDown {
+    function transferTo(address token, address recipient, uint256 amount) external;
+    function transferETHTo(address payable recipient, uint256 amount) external;
+}
+
+/// @title ArmadaWindDown — Protocol wind-down trigger and treasury sweep
+/// @notice Not upgradeable. Trigger logic is immutable. Only parameters are governable.
+///
+///         Two trigger paths:
+///         1. Permissionless: Anyone can trigger if deadline has passed AND revenue is below threshold.
+///         2. Governance: Timelock can trigger at any time regardless of conditions.
+///
+///         On trigger:
+///         - ARM transfers are enabled (via setTransferable on token)
+///         - Governance is permanently disabled (via setWindDownActive on governor)
+///         - Shield pause enters post-wind-down mode (single-pause only)
+///
+///         After trigger, anyone can sweep treasury assets to the redemption contract.
+///         ARM cannot be swept — treasury ARM is locked permanently.
+contract ArmadaWindDown {
+
+    // ============ Immutable References ============
+
+    /// @notice ARM governance token
+    address public immutable armToken;
+
+    /// @notice Treasury contract
+    ITreasuryWindDown public immutable treasury;
+
+    /// @notice Governor contract
+    IArmadaGovernorWindDown public immutable governor;
+
+    /// @notice Redemption contract (receives swept assets)
+    address public immutable redemptionContract;
+
+    /// @notice Shield pause controller
+    IShieldPauseControllerWindDown public immutable pauseContract;
+
+    /// @notice Revenue counter (reads cumulative recognized revenue)
+    IRevenueCounterWindDown public immutable revenueCounter;
+
+    /// @notice Timelock address (governance authority for direct trigger and parameter changes)
+    address public immutable timelock;
+
+    // ============ Governable Parameters ============
+
+    /// @notice Revenue threshold for permissionless trigger (in 18-decimal USD)
+    uint256 public revenueThreshold;
+
+    /// @notice Deadline for permissionless trigger (unix timestamp)
+    uint256 public windDownDeadline;
+
+    // ============ State ============
+
+    /// @notice Whether wind-down has been triggered
+    bool public triggered;
+
+    // ============ Events ============
+
+    event WindDownTriggered(address indexed caller, uint256 timestamp);
+    event TokenSwept(address indexed token, address indexed recipient, uint256 amount);
+    event ETHSwept(address indexed recipient, uint256 amount);
+    event RevenueThresholdUpdated(uint256 oldThreshold, uint256 newThreshold);
+    event WindDownDeadlineUpdated(uint256 oldDeadline, uint256 newDeadline);
+
+    // ============ Constructor ============
+
+    /// @param _armToken ARM token address
+    /// @param _treasury Treasury contract address
+    /// @param _governor Governor contract address
+    /// @param _redemptionContract Redemption contract address (receives swept assets)
+    /// @param _pauseContract Shield pause controller address
+    /// @param _revenueCounter Revenue counter address
+    /// @param _timelock Timelock address (governance authority)
+    /// @param _revenueThreshold Initial revenue threshold (18-decimal USD)
+    /// @param _windDownDeadline Initial deadline (unix timestamp)
+    constructor(
+        address _armToken,
+        address _treasury,
+        address _governor,
+        address _redemptionContract,
+        address _pauseContract,
+        address _revenueCounter,
+        address _timelock,
+        uint256 _revenueThreshold,
+        uint256 _windDownDeadline
+    ) {
+        require(_armToken != address(0), "ArmadaWindDown: zero armToken");
+        require(_treasury != address(0), "ArmadaWindDown: zero treasury");
+        require(_governor != address(0), "ArmadaWindDown: zero governor");
+        require(_redemptionContract != address(0), "ArmadaWindDown: zero redemption");
+        require(_pauseContract != address(0), "ArmadaWindDown: zero pauseContract");
+        require(_revenueCounter != address(0), "ArmadaWindDown: zero revenueCounter");
+        require(_timelock != address(0), "ArmadaWindDown: zero timelock");
+        require(_windDownDeadline > block.timestamp, "ArmadaWindDown: deadline in past");
+
+        armToken = _armToken;
+        treasury = ITreasuryWindDown(_treasury);
+        governor = IArmadaGovernorWindDown(_governor);
+        redemptionContract = _redemptionContract;
+        pauseContract = IShieldPauseControllerWindDown(_pauseContract);
+        revenueCounter = IRevenueCounterWindDown(_revenueCounter);
+        timelock = _timelock;
+        revenueThreshold = _revenueThreshold;
+        windDownDeadline = _windDownDeadline;
+    }
+
+    // ============ Trigger Functions ============
+
+    /// @notice Permissionless wind-down trigger. Anyone can call if both conditions are met:
+    ///         1. Current time is past the wind-down deadline
+    ///         2. Cumulative recognized revenue is below the threshold
+    function triggerWindDown() external {
+        require(!triggered, "ArmadaWindDown: already triggered");
+        require(block.timestamp > windDownDeadline, "ArmadaWindDown: deadline not passed");
+        require(
+            revenueCounter.recognizedRevenueUsd() < revenueThreshold,
+            "ArmadaWindDown: revenue meets threshold"
+        );
+        _executeWindDown();
+    }
+
+    /// @notice Governance trigger. Timelock can trigger at any time, no conditions required.
+    function governanceTriggerWindDown() external {
+        require(msg.sender == timelock, "ArmadaWindDown: not timelock");
+        require(!triggered, "ArmadaWindDown: already triggered");
+        _executeWindDown();
+    }
+
+    // ============ Sweep Functions ============
+
+    /// @notice Sweep an ERC20 token from treasury to redemption contract.
+    ///         Permissionless after trigger. ARM cannot be swept.
+    /// @param token ERC20 token to sweep
+    function sweepToken(address token) external {
+        require(triggered, "ArmadaWindDown: not triggered");
+        require(token != armToken, "ArmadaWindDown: cannot sweep ARM");
+        uint256 balance = IERC20(token).balanceOf(address(treasury));
+        require(balance > 0, "ArmadaWindDown: no balance");
+        treasury.transferTo(token, redemptionContract, balance);
+        emit TokenSwept(token, redemptionContract, balance);
+    }
+
+    /// @notice Sweep ETH from treasury to redemption contract.
+    ///         Permissionless after trigger.
+    function sweepETH() external {
+        require(triggered, "ArmadaWindDown: not triggered");
+        uint256 balance = address(treasury).balance;
+        require(balance > 0, "ArmadaWindDown: no balance");
+        treasury.transferETHTo(payable(redemptionContract), balance);
+        emit ETHSwept(redemptionContract, balance);
+    }
+
+    // ============ Parameter Setters (Governance) ============
+
+    /// @notice Update the revenue threshold. Timelock-only. Cannot change after trigger.
+    function setRevenueThreshold(uint256 _newThreshold) external {
+        require(msg.sender == timelock, "ArmadaWindDown: not timelock");
+        require(!triggered, "ArmadaWindDown: already triggered");
+        emit RevenueThresholdUpdated(revenueThreshold, _newThreshold);
+        revenueThreshold = _newThreshold;
+    }
+
+    /// @notice Update the wind-down deadline. Timelock-only. Cannot change after trigger.
+    function setWindDownDeadline(uint256 _newDeadline) external {
+        require(msg.sender == timelock, "ArmadaWindDown: not timelock");
+        require(!triggered, "ArmadaWindDown: already triggered");
+        emit WindDownDeadlineUpdated(windDownDeadline, _newDeadline);
+        windDownDeadline = _newDeadline;
+    }
+
+    // ============ Internal ============
+
+    function _executeWindDown() internal {
+        triggered = true;
+
+        // Enable ARM transfers (users need to move ARM to redeem)
+        IArmadaTokenWindDown(armToken).setTransferable(true);
+
+        // Permanently disable governance (no new proposals)
+        governor.setWindDownActive();
+
+        // Activate post-wind-down pause restrictions (single-pause only)
+        pauseContract.setWindDownActive();
+
+        emit WindDownTriggered(msg.sender, block.timestamp);
+    }
+}

--- a/contracts/governance/ArmadaWindDown.sol
+++ b/contracts/governance/ArmadaWindDown.sol
@@ -1,7 +1,6 @@
+// SPDX-License-Identifier: MIT
 // ABOUTME: Wind-down contract with permissionless trigger and governance trigger.
 // ABOUTME: Sweeps treasury assets to redemption contract; enables ARM transfers; disables governance.
-
-// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -118,6 +117,7 @@ contract ArmadaWindDown {
         require(_revenueCounter != address(0), "ArmadaWindDown: zero revenueCounter");
         require(_timelock != address(0), "ArmadaWindDown: zero timelock");
         require(_windDownDeadline > block.timestamp, "ArmadaWindDown: deadline in past");
+        require(_revenueThreshold > 0, "ArmadaWindDown: zero threshold");
 
         armToken = _armToken;
         treasury = ITreasuryWindDown(_treasury);
@@ -179,17 +179,23 @@ contract ArmadaWindDown {
     // ============ Parameter Setters (Governance) ============
 
     /// @notice Update the revenue threshold. Timelock-only. Cannot change after trigger.
+    ///         Threshold must be > 0 to prevent governance from disabling the permissionless
+    ///         trigger (setting 0 would make `recognizedRevenue < 0` always false for uint256).
     function setRevenueThreshold(uint256 _newThreshold) external {
         require(msg.sender == timelock, "ArmadaWindDown: not timelock");
         require(!triggered, "ArmadaWindDown: already triggered");
+        require(_newThreshold > 0, "ArmadaWindDown: zero threshold");
         emit RevenueThresholdUpdated(revenueThreshold, _newThreshold);
         revenueThreshold = _newThreshold;
     }
 
     /// @notice Update the wind-down deadline. Timelock-only. Cannot change after trigger.
+    ///         Deadline must be in the future (same invariant the constructor enforces) to
+    ///         prevent governance from disabling the permissionless trigger.
     function setWindDownDeadline(uint256 _newDeadline) external {
         require(msg.sender == timelock, "ArmadaWindDown: not timelock");
         require(!triggered, "ArmadaWindDown: already triggered");
+        require(_newDeadline > block.timestamp, "ArmadaWindDown: deadline in past");
         emit WindDownDeadlineUpdated(windDownDeadline, _newDeadline);
         windDownDeadline = _newDeadline;
     }

--- a/contracts/governance/IShieldPauseController.sol
+++ b/contracts/governance/IShieldPauseController.sol
@@ -1,7 +1,6 @@
+// SPDX-License-Identifier: MIT
 // ABOUTME: Interface for shield pause controller, consumed by PrivacyPool's ShieldModule.
 // ABOUTME: Exposes a single view function to check if shields are currently paused.
-
-// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
 /// @title IShieldPauseController — Minimal interface for shield pause status

--- a/contracts/governance/IShieldPauseController.sol
+++ b/contracts/governance/IShieldPauseController.sol
@@ -1,0 +1,12 @@
+// ABOUTME: Interface for shield pause controller, consumed by PrivacyPool's ShieldModule.
+// ABOUTME: Exposes a single view function to check if shields are currently paused.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+/// @title IShieldPauseController — Minimal interface for shield pause status
+/// @notice The PrivacyPool's ShieldModule checks this to determine if shields are paused.
+interface IShieldPauseController {
+    /// @notice Returns true if shields are currently paused (accounting for auto-expiry)
+    function shieldsPaused() external view returns (bool);
+}

--- a/contracts/governance/ShieldPauseController.sol
+++ b/contracts/governance/ShieldPauseController.sol
@@ -1,7 +1,6 @@
+// SPDX-License-Identifier: MIT
 // ABOUTME: Security Council shield pause controller with 24h auto-expiry.
 // ABOUTME: Reads SC address from governor; supports post-wind-down single-pause behavior.
-
-// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
 import "./IShieldPauseController.sol";

--- a/contracts/governance/ShieldPauseController.sol
+++ b/contracts/governance/ShieldPauseController.sol
@@ -1,0 +1,142 @@
+// ABOUTME: Security Council shield pause controller with 24h auto-expiry.
+// ABOUTME: Reads SC address from governor; supports post-wind-down single-pause behavior.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "./IShieldPauseController.sol";
+
+/// @notice Minimal interface to read securityCouncil from ArmadaGovernor
+interface IArmadaGovernorSC {
+    function securityCouncil() external view returns (address);
+}
+
+/// @title ShieldPauseController — SC-triggered shield pause with auto-expiry
+/// @notice The Security Council can pause shield operations for up to 24 hours.
+///         The pause auto-expires — the SC cannot permanently freeze shields.
+///         Unshields are never affected by this pause.
+///
+///         The SC address is read from the ArmadaGovernor contract, so changes to
+///         the governor's securityCouncil (including ejection via denied veto) are
+///         automatically reflected here without a separate setter.
+///
+///         Post-wind-down behavior: the SC can invoke exactly one pause. After that
+///         pause expires or is lifted, no further pauses are possible. This prevents
+///         indefinite pausing without governance accountability (since governance is
+///         disabled after wind-down).
+contract ShieldPauseController is IShieldPauseController {
+
+    // ============ State ============
+
+    /// @notice Governor contract (reads securityCouncil from here)
+    IArmadaGovernorSC public immutable governor;
+
+    /// @notice Timelock address (governance authority for early unpause)
+    address public immutable pauseTimelock;
+
+    /// @notice Maximum pause duration (24 hours)
+    uint256 public constant MAX_PAUSE_DURATION = 24 hours;
+
+    /// @notice Whether shields are paused (internal flag — use shieldsPaused() for auto-expiry)
+    bool private _paused;
+
+    /// @notice Timestamp when the current pause expires (0 if not paused)
+    uint256 public pauseExpiry;
+
+    /// @notice Whether the wind-down has been activated
+    bool public windDownActive;
+
+    /// @notice Wind-down contract address (only this address can call setWindDownActive)
+    address public windDownContract;
+
+    /// @notice Whether the wind-down contract has been set (one-time setter lock)
+    bool public windDownContractSet;
+
+    /// @notice Whether the single post-wind-down pause has been consumed
+    bool public windDownPauseUsed;
+
+    // ============ Events ============
+
+    event ShieldsPaused(address indexed securityCouncil, uint256 expiry);
+    event ShieldsUnpaused(address indexed caller);
+    event WindDownContractSet(address indexed windDownContract);
+    event WindDownActivated();
+
+    // ============ Constructor ============
+
+    /// @param _governor ArmadaGovernor contract (reads SC address from here)
+    /// @param _pauseTimelock Timelock address for governance unpause
+    constructor(address _governor, address _pauseTimelock) {
+        require(_governor != address(0), "ShieldPauseController: zero governor");
+        require(_pauseTimelock != address(0), "ShieldPauseController: zero timelock");
+
+        governor = IArmadaGovernorSC(_governor);
+        pauseTimelock = _pauseTimelock;
+    }
+
+    // ============ View Functions ============
+
+    /// @notice Returns true only if paused AND the pause has not expired
+    function shieldsPaused() external view override returns (bool) {
+        return _paused && block.timestamp < pauseExpiry;
+    }
+
+    // ============ Security Council Functions ============
+
+    /// @notice SC triggers shield pause. Auto-expires after 24 hours.
+    ///         Pre-wind-down: SC can re-invoke after expiry (unlimited).
+    ///         Post-wind-down: exactly one invocation allowed.
+    function pauseShields() external {
+        address sc = governor.securityCouncil();
+        require(msg.sender == sc && sc != address(0), "ShieldPauseController: not SC");
+        require(!_isPaused(), "ShieldPauseController: already paused");
+
+        if (windDownActive) {
+            require(!windDownPauseUsed, "ShieldPauseController: post-wind-down pause already used");
+            windDownPauseUsed = true;
+        }
+
+        _paused = true;
+        pauseExpiry = block.timestamp + MAX_PAUSE_DURATION;
+        emit ShieldsPaused(msg.sender, pauseExpiry);
+    }
+
+    // ============ Governance Functions ============
+
+    /// @notice Governance (timelock) can unpause shields at any time
+    function unpauseShields() external {
+        require(msg.sender == pauseTimelock, "ShieldPauseController: not timelock");
+        require(_isPaused(), "ShieldPauseController: not paused");
+        _paused = false;
+        pauseExpiry = 0;
+        emit ShieldsUnpaused(msg.sender);
+    }
+
+    /// @notice Set the wind-down contract address. One-time setter, timelock-only.
+    function setWindDownContract(address _windDownContract) external {
+        require(msg.sender == pauseTimelock, "ShieldPauseController: not timelock");
+        require(!windDownContractSet, "ShieldPauseController: wind-down already set");
+        require(_windDownContract != address(0), "ShieldPauseController: zero address");
+        windDownContractSet = true;
+        windDownContract = _windDownContract;
+        emit WindDownContractSet(_windDownContract);
+    }
+
+    // ============ Wind-Down Functions ============
+
+    /// @notice Called by the wind-down contract to activate post-wind-down pause restrictions
+    function setWindDownActive() external {
+        require(msg.sender == windDownContract, "ShieldPauseController: not wind-down contract");
+        require(windDownContract != address(0), "ShieldPauseController: wind-down not set");
+        require(!windDownActive, "ShieldPauseController: wind-down already active");
+        windDownActive = true;
+        emit WindDownActivated();
+    }
+
+    // ============ Internal ============
+
+    /// @notice Check if currently paused (accounting for auto-expiry)
+    function _isPaused() internal view returns (bool) {
+        return _paused && block.timestamp < pauseExpiry;
+    }
+}

--- a/contracts/privacy-pool/PrivacyPool.sol
+++ b/contracts/privacy-pool/PrivacyPool.sol
@@ -347,6 +347,16 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
         emit DefaultFinalityThresholdSet(_threshold);
     }
 
+    /**
+     * @notice Set the shield pause controller contract
+     * @param _shieldPauseContract Address of the ShieldPauseController
+     */
+    function setShieldPauseContract(address _shieldPauseContract) external {
+        require(msg.sender == owner, "PrivacyPool: Only owner");
+        shieldPauseContract = _shieldPauseContract;
+        emit ShieldPauseContractSet(_shieldPauseContract);
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // VIEW FUNCTIONS (from IPrivacyPool)
     // ══════════════════════════════════════════════════════════════════════════

--- a/contracts/privacy-pool/interfaces/IPrivacyPool.sol
+++ b/contracts/privacy-pool/interfaces/IPrivacyPool.sol
@@ -23,6 +23,9 @@ interface IPrivacyPool is IMessageHandlerV2 {
     /// @notice Emitted when default finality threshold is changed
     event DefaultFinalityThresholdSet(uint32 threshold);
 
+    /// @notice Emitted when shield pause controller contract is set
+    event ShieldPauseContractSet(address indexed shieldPauseContract);
+
     // ══════════════════════════════════════════════════════════════════════════
     // INITIALIZATION
     // ══════════════════════════════════════════════════════════════════════════

--- a/contracts/privacy-pool/modules/ShieldModule.sol
+++ b/contracts/privacy-pool/modules/ShieldModule.sol
@@ -9,6 +9,7 @@ import "../interfaces/IShieldModule.sol";
 import "../interfaces/IMerkleModule.sol";
 import "../types/CCTPTypes.sol";
 import "../../railgun/logic/Poseidon.sol";
+import "../../governance/IShieldPauseController.sol";
 
 /**
  * @title ShieldModule
@@ -34,6 +35,7 @@ contract ShieldModule is PrivacyPoolStorage, IShieldModule {
      * @param _shieldRequests Array of shield requests to process
      */
     function shield(ShieldRequest[] calldata _shieldRequests) external override onlyDelegatecall {
+        _requireShieldsNotPaused();
         uint256 numRequests = _shieldRequests.length;
         require(numRequests > 0, "ShieldModule: No requests");
 
@@ -82,6 +84,7 @@ contract ShieldModule is PrivacyPoolStorage, IShieldModule {
      * @param data Shield data from the CCTP payload
      */
     function processIncomingShield(uint256 amount, ShieldData calldata data) external override onlyDelegatecall {
+        _requireShieldsNotPaused();
         // Verify caller is the router (self, since we're called via delegatecall)
         // This is implicitly enforced by the router only calling this on valid CCTP messages
 
@@ -294,5 +297,15 @@ contract ShieldModule is PrivacyPoolStorage, IShieldModule {
             return bytes32(uint256(uint160(_tokenData.tokenAddress)));
         }
         return bytes32(uint256(keccak256(abi.encode(_tokenData))) % SNARK_SCALAR_FIELD);
+    }
+
+    /// @notice Reverts if shields are currently paused. No-op if no pause contract is set.
+    function _requireShieldsNotPaused() internal view {
+        if (shieldPauseContract != address(0)) {
+            require(
+                !IShieldPauseController(shieldPauseContract).shieldsPaused(),
+                "ShieldModule: shields paused"
+            );
+        }
     }
 }

--- a/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
+++ b/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
@@ -166,11 +166,16 @@ abstract contract PrivacyPoolStorage {
     /// @dev Used by TransactModule for cross-chain unshields. Shields use per-transaction choice.
     uint32 public defaultFinalityThreshold;
 
+    /// @notice Shield pause controller contract address (governance concern, external to pool)
+    /// @dev ShieldModule calls IShieldPauseController(shieldPauseContract).shieldsPaused()
+    ///      to check if shields are paused. When address(0), shields are never paused.
+    address public shieldPauseContract;
+
     // ══════════════════════════════════════════════════════════════════════════
     // RESERVED FOR FUTURE USE
     // ══════════════════════════════════════════════════════════════════════════
 
     /// @dev Reserved storage slots for future upgrades
     ///      When adding new state variables above, decrement this gap
-    uint256[48] private __gap;
+    uint256[47] private __gap;
 }

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Deployment script for Armada governance contracts (timelock, token, treasury, governor, steward).
-// ABOUTME: Handles role grants, steward contract registration, and whitelist initialization.
+// ABOUTME: Deployment script for Armada governance contracts (timelock, token, treasury, governor, steward, pause, wind-down, redemption).
+// ABOUTME: Handles role grants, steward contract registration, whitelist initialization, and wind-down wiring.
 
 /**
  * Deploy Armada Governance Contracts
@@ -11,10 +11,15 @@
  * - ArmadaGovernor
  * - TreasurySteward
  * - RevenueCounter (UUPS proxy)
+ * - ShieldPauseController
+ * - ArmadaRedemption
+ * - ArmadaWindDown
  *
  * Post-deploy configuration:
- * - ARM token: setNoDelegation, initWhitelist, setWindDownContract (deferred)
- * - Treasury: initOutflowConfig for USDC and ARM
+ * - ARM token: setNoDelegation, initWhitelist, setWindDownContract
+ * - Treasury: initOutflowConfig, setWindDownContract
+ * - Governor: setWindDownContract
+ * - ShieldPauseController: setWindDownContract
  * - Timelock: grant roles to governor, renounce admin
  *
  * Usage (local):
@@ -45,6 +50,9 @@ interface GovernanceDeployment {
     steward: string;
     revenueCounter: string;
     revenueCounterImpl: string;
+    shieldPauseController: string;
+    redemption: string;
+    windDown: string;
   };
   config: {
     timelockMinDelay: number;
@@ -152,10 +160,60 @@ async function main() {
   const revenueCounterAddress = await revenueCounterProxy.getAddress();
   console.log(`   RevenueCounter (proxy): ${revenueCounterAddress}`);
 
+  // 7. Deploy ShieldPauseController
+  console.log("7. Deploying ShieldPauseController...");
+  const ShieldPauseController = await ethers.getContractFactory("ShieldPauseController");
+  const shieldPause = await ShieldPauseController.deploy(
+    governorAddress, timelockAddress, nm.override()
+  );
+  await shieldPause.deploymentTransaction()!.wait();
+  const shieldPauseAddress = await shieldPause.getAddress();
+  console.log(`   ShieldPauseController: ${shieldPauseAddress}`);
+
+  // 8. Deploy ArmadaRedemption
+  // TODO: revenueLock and crowdfund addresses should come from config once those contracts exist
+  const revenueLockAddress = ethers.ZeroAddress; // placeholder — set before mainnet
+  const crowdfundAddress = ethers.ZeroAddress;   // placeholder — set before mainnet
+  console.log("8. Deploying ArmadaRedemption...");
+  const ArmadaRedemption = await ethers.getContractFactory("ArmadaRedemption");
+  // NOTE: Redemption requires non-zero addresses for all constructor params.
+  //       On local dev, we use placeholder addresses. On mainnet, these must be real.
+  //       Skipping deployment if placeholders are zero (can't deploy with zero addresses).
+  let redemptionAddress = ethers.ZeroAddress;
+  if (revenueLockAddress !== ethers.ZeroAddress && crowdfundAddress !== ethers.ZeroAddress) {
+    const redemption = await ArmadaRedemption.deploy(
+      armTokenAddress, treasuryAddress, revenueLockAddress, crowdfundAddress, nm.override()
+    );
+    await redemption.deploymentTransaction()!.wait();
+    redemptionAddress = await redemption.getAddress();
+    console.log(`   ArmadaRedemption: ${redemptionAddress}`);
+  } else {
+    console.log("   ArmadaRedemption: SKIPPED (revenueLock/crowdfund addresses not set)");
+  }
+
+  // 9. Deploy ArmadaWindDown
+  let windDownAddress = ethers.ZeroAddress;
+  if (redemptionAddress !== ethers.ZeroAddress) {
+    console.log("9. Deploying ArmadaWindDown...");
+    const windDownDeadline = Math.floor(new Date("2026-12-31T00:00:00Z").getTime() / 1000);
+    const revenueThreshold = ethers.parseUnits("10000", 18); // $10k in 18-decimal USD
+    const ArmadaWindDown = await ethers.getContractFactory("ArmadaWindDown");
+    const windDownContract = await ArmadaWindDown.deploy(
+      armTokenAddress, treasuryAddress, governorAddress, redemptionAddress,
+      shieldPauseAddress, revenueCounterAddress, timelockAddress,
+      revenueThreshold, windDownDeadline, nm.override()
+    );
+    await windDownContract.deploymentTransaction()!.wait();
+    windDownAddress = await windDownContract.getAddress();
+    console.log(`   ArmadaWindDown: ${windDownAddress}`);
+  } else {
+    console.log("9. ArmadaWindDown: SKIPPED (redemption not deployed)");
+  }
+
   // ============ Post-deploy configuration ============
 
-  // 7. Configure timelock roles
-  console.log("7. Configuring timelock roles...");
+  // 10. Configure timelock roles
+  console.log("10. Configuring timelock roles...");
   const PROPOSER_ROLE = await timelock.PROPOSER_ROLE();
   const EXECUTOR_ROLE = await timelock.EXECUTOR_ROLE();
   const ADMIN_ROLE = await timelock.TIMELOCK_ADMIN_ROLE();
@@ -168,8 +226,8 @@ async function main() {
   await (await timelock.grantRole(CANCELLER_ROLE, governorAddress, nm.override())).wait();
   console.log("   Granted CANCELLER_ROLE to governor (for SC veto)");
 
-  // 8. Configure ARM token (one-time setters)
-  console.log("8. Configuring ARM token...");
+  // 11. Configure ARM token (one-time setters)
+  console.log("11. Configuring ARM token...");
   await (await armToken.setNoDelegation(treasuryAddress, nm.override())).wait();
   console.log(`   setNoDelegation: ${treasuryAddress} (treasury)`);
 
@@ -177,26 +235,50 @@ async function main() {
   const whitelistAddresses = [deployer.address, treasuryAddress];
   await (await armToken.initWhitelist(whitelistAddresses, nm.override())).wait();
   console.log(`   initWhitelist: ${whitelistAddresses.length} addresses`);
-  // NOTE: setWindDownContract is deferred — the wind-down contract doesn't exist yet.
-  // It will be set by the deployer once the wind-down contract is deployed.
+  // Set wind-down contract on ARM token (deployer-only one-time setter)
+  if (windDownAddress !== ethers.ZeroAddress) {
+    await (await armToken.setWindDownContract(windDownAddress, nm.override())).wait();
+    console.log(`   setWindDownContract: ${windDownAddress}`);
+  } else {
+    console.log("   setWindDownContract: DEFERRED (wind-down not deployed)");
+  }
 
-  // 9. Distribute ARM tokens
+  // 12. Distribute ARM tokens
   const treasuryAllocation = ethers.parseUnits(config.armDistribution.treasury, 18);
-  console.log("9. Distributing ARM tokens...");
+  console.log("12. Distributing ARM tokens...");
   await (await armToken.transfer(treasuryAddress, treasuryAllocation, nm.override())).wait();
   console.log(`   Sent ${config.armDistribution.treasury} ARM to treasury`);
 
-  // 10. Initialize treasury outflow limits
+  // 13. Initialize treasury outflow limits
   // TODO: These defaults should be moved to config/networks.ts when finalized
-  console.log("10. Initializing treasury outflow limits...");
+  console.log("13. Initializing treasury outflow limits...");
   // Outflow limits are configured per-token via governance after deployment.
   // The deployer (as initial owner/timelock admin) cannot call initOutflowConfig directly
   // because the treasury's owner is the timelock. Outflow config will be set via the
   // first governance proposal after ARM delegation and governance activation.
   console.log("   Outflow limits will be configured via governance proposal post-launch");
 
-  // 11. Renounce timelock admin (last step — deployer relinquishes admin role)
-  console.log("11. Renouncing timelock admin...");
+  // 14. Wire wind-down contract to governor, treasury, and pause controller
+  // These are timelock-only calls. Since deployer is still timelock admin at this point,
+  // we call them directly via the timelock's schedule/execute pattern.
+  // NOTE: On local dev with zero timelock delay, we can call via the timelock directly.
+  // On mainnet, these would need to be governance proposals.
+  if (windDownAddress !== ethers.ZeroAddress) {
+    console.log("14. Wiring wind-down contract...");
+    // Governor: setWindDownContract (timelock-only)
+    // NOTE: On local with deployer as timelock admin, these go through the timelock.
+    // For simplicity in local dev, we schedule+execute immediately.
+    // On production, these would be governance proposals via the governor.
+    console.log("   Wind-down wiring requires timelock execution — defer to governance proposals post-launch");
+    console.log(`   TODO: governor.setWindDownContract(${windDownAddress})`);
+    console.log(`   TODO: treasury.setWindDownContract(${windDownAddress})`);
+    console.log(`   TODO: shieldPause.setWindDownContract(${windDownAddress})`);
+  } else {
+    console.log("14. Wind-down wiring: SKIPPED (wind-down not deployed)");
+  }
+
+  // 15. Renounce timelock admin (last step — deployer relinquishes admin role)
+  console.log("15. Renouncing timelock admin...");
   await (await timelock.renounceRole(ADMIN_ROLE, deployer.address, nm.override())).wait();
   console.log("   Renounced TIMELOCK_ADMIN_ROLE from deployer");
 
@@ -212,6 +294,9 @@ async function main() {
       steward: stewardAddress,
       revenueCounter: revenueCounterAddress,
       revenueCounterImpl: revenueCounterImplAddress,
+      shieldPauseController: shieldPauseAddress,
+      redemption: redemptionAddress,
+      windDown: windDownAddress,
     },
     config: {
       timelockMinDelay: timelockDelay,
@@ -228,9 +313,15 @@ async function main() {
   console.log("\nPost-launch TODO:");
   console.log("  1. Set ARM whitelist for crowdfund address (via addToWhitelist governance proposal)");
   console.log("  2. Configure treasury outflow limits for USDC and ARM (via governance proposal)");
-  console.log("  3. Set wind-down contract on ARM token (deployer calls setWindDownContract)");
-  console.log("  4. Set fee collector on RevenueCounter (via governance proposal)");
-  console.log("  5. Transfer guardian to dedicated multisig (via governance proposal)");
+  console.log("  3. Set fee collector on RevenueCounter (via governance proposal)");
+  console.log("  4. Transfer guardian to dedicated multisig (via governance proposal)");
+  console.log("  5. Set shieldPauseContract on PrivacyPool (owner calls setShieldPauseContract)");
+  if (windDownAddress !== ethers.ZeroAddress) {
+    console.log("  6. Wire wind-down to governor, treasury, pause controller (via governance proposals)");
+  } else {
+    console.log("  6. Deploy ArmadaRedemption + ArmadaWindDown when revenueLock/crowdfund are ready");
+    console.log("  7. Wire wind-down to all consumers after deployment");
+  }
 }
 
 function saveDeployment(filename: string, data: any): void {

--- a/test-foundry/ArmadaRedemption.t.sol
+++ b/test-foundry/ArmadaRedemption.t.sol
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Foundry tests for ArmadaRedemption — pro-rata treasury redemption for ARM holders.
+// ABOUTME: Covers single/sequential redemption, ETH redemption, denominator math, and edge cases.
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/ArmadaRedemption.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @dev Mock ERC20 for testing
+contract MockTokenRedemption is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+}
+
+contract ArmadaRedemptionTest is Test {
+    // Mirror events
+    event Redeemed(address indexed redeemer, uint256 armAmount, address[] tokens);
+    event RedeemedETH(address indexed redeemer, uint256 armAmount, uint256 ethAmount);
+
+    ArmadaRedemption public redemption;
+    ArmadaToken public armToken;
+    TimelockController public timelock;
+    MockTokenRedemption public usdc;
+    MockTokenRedemption public weth;
+
+    address public deployer = address(this);
+    address public alice = address(0xA11CE);
+    address public bob = address(0xB0B);
+    address public treasuryAddr = address(0x7777);
+    address public revenueLock = address(0xABCD);
+    address public crowdfund = address(0xCF00);
+    address public windDown = address(0xD00D);
+
+    uint256 constant TOTAL_SUPPLY = 12_000_000 * 1e18;
+    uint256 constant TWO_DAYS = 2 days;
+
+    function setUp() public {
+        // Deploy governance token
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        timelock = new TimelockController(TWO_DAYS, proposers, executors, deployer);
+
+        armToken = new ArmadaToken(deployer, address(timelock));
+
+        // Enable transfers (simulating wind-down having triggered)
+        armToken.setWindDownContract(windDown);
+        vm.prank(windDown);
+        armToken.setTransferable(true);
+
+        // Whitelist deployer, alice, bob, and the redemption contract address
+        // (We need to deploy redemption first to know its address, or whitelist after)
+        // Since transfers are enabled, whitelist doesn't matter anymore
+
+        // Deploy redemption
+        redemption = new ArmadaRedemption(
+            address(armToken),
+            treasuryAddr,
+            revenueLock,
+            crowdfund
+        );
+
+        // Distribute ARM
+        // Treasury gets 65%, revenue-lock gets 15%, crowdfund gets 10%, alice 5%, bob 5%
+        armToken.transfer(treasuryAddr, TOTAL_SUPPLY * 65 / 100);  // 7.8M
+        armToken.transfer(revenueLock, TOTAL_SUPPLY * 15 / 100);   // 1.8M
+        armToken.transfer(crowdfund, TOTAL_SUPPLY * 10 / 100);      // 1.2M
+        armToken.transfer(alice, TOTAL_SUPPLY * 5 / 100);           // 600K
+        armToken.transfer(bob, TOTAL_SUPPLY * 5 / 100);             // 600K
+
+        // Deploy mock tokens and fund redemption (simulating post-sweep)
+        usdc = new MockTokenRedemption("Mock USDC", "USDC");
+        weth = new MockTokenRedemption("Wrapped ETH", "WETH");
+
+        usdc.mint(address(redemption), 500_000e6);  // $500k USDC in redemption
+        weth.mint(address(redemption), 100e18);       // 100 WETH in redemption
+
+        // Approve redemption to take ARM from alice and bob
+        vm.prank(alice);
+        armToken.approve(address(redemption), type(uint256).max);
+        vm.prank(bob);
+        armToken.approve(address(redemption), type(uint256).max);
+    }
+
+    // ======== Basic Redemption ========
+
+    function test_redeem_proRataUSDC() public {
+        // Circulating supply = total - treasury - revenueLock - crowdfund - redemption(0)
+        // = 12M - 7.8M - 1.8M - 1.2M - 0 = 1.2M ARM circulating
+        uint256 circulating = redemption.circulatingSupply();
+        assertEq(circulating, TOTAL_SUPPLY * 10 / 100); // 1.2M = 10%
+
+        uint256 aliceArm = armToken.balanceOf(alice); // 600K
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+
+        vm.prank(alice);
+        redemption.redeem(aliceArm, tokens);
+
+        // Alice has 600K out of 1.2M circulating = 50% → $250k USDC
+        assertEq(usdc.balanceOf(alice), 250_000e6);
+    }
+
+    function test_redeem_multipleTokens() public {
+        uint256 aliceArm = armToken.balanceOf(alice);
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(usdc);
+        tokens[1] = address(weth);
+
+        vm.prank(alice);
+        redemption.redeem(aliceArm, tokens);
+
+        // 50% of each
+        assertEq(usdc.balanceOf(alice), 250_000e6);
+        assertEq(weth.balanceOf(alice), 50e18);
+    }
+
+    function test_redeem_armLockedPermanently() public {
+        uint256 aliceArm = armToken.balanceOf(alice);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+
+        vm.prank(alice);
+        redemption.redeem(aliceArm, tokens);
+
+        // ARM is in the redemption contract
+        assertEq(armToken.balanceOf(address(redemption)), aliceArm);
+        // Alice has no ARM
+        assertEq(armToken.balanceOf(alice), 0);
+    }
+
+    // ======== Sequential Correctness ========
+
+    function test_sequential_correctness() public {
+        uint256 aliceArm = armToken.balanceOf(alice); // 600K
+        uint256 bobArm = armToken.balanceOf(bob);     // 600K
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+
+        // Alice redeems first (600K out of 1.2M = 50%)
+        vm.prank(alice);
+        redemption.redeem(aliceArm, tokens);
+        assertEq(usdc.balanceOf(alice), 250_000e6); // 50% of $500k
+
+        // After Alice's redemption:
+        // - Redemption contract has 600K ARM
+        // - Circulating = 12M - 7.8M - 1.8M - 1.2M - 600K = 600K
+        // - USDC remaining = 250k
+        // Bob redeems (600K out of 600K = 100%)
+        vm.prank(bob);
+        redemption.redeem(bobArm, tokens);
+        assertEq(usdc.balanceOf(bob), 250_000e6); // 100% of remaining $250k
+
+        // Both got equal shares: $250k each
+    }
+
+    function test_partial_redemption() public {
+        uint256 halfArm = armToken.balanceOf(alice) / 2; // 300K
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+
+        // Alice redeems half her ARM (300K out of 1.2M = 25%)
+        vm.prank(alice);
+        redemption.redeem(halfArm, tokens);
+        assertEq(usdc.balanceOf(alice), 125_000e6); // 25% of $500k
+
+        // Alice redeems other half (300K out of 900K remaining circulating)
+        // 300K / 900K = 33.3% of remaining $375k = $125k
+        vm.prank(alice);
+        redemption.redeem(halfArm, tokens);
+        assertEq(usdc.balanceOf(alice), 250_000e6); // Total still $250k
+    }
+
+    // ======== ETH Redemption ========
+
+    function test_redeemETH() public {
+        // Fund redemption with ETH
+        vm.deal(address(redemption), 10 ether);
+
+        uint256 aliceArm = armToken.balanceOf(alice); // 600K out of 1.2M = 50%
+
+        vm.prank(alice);
+        redemption.redeemETH(aliceArm);
+
+        assertEq(alice.balance, 5 ether); // 50% of 10 ETH
+    }
+
+    // ======== Circulating Supply ========
+
+    function test_circulatingSupply_excludesCorrectAddresses() public {
+        uint256 circulating = redemption.circulatingSupply();
+        uint256 total = armToken.totalSupply();
+        uint256 excluded = armToken.balanceOf(treasuryAddr) +
+                          armToken.balanceOf(revenueLock) +
+                          armToken.balanceOf(crowdfund) +
+                          armToken.balanceOf(address(redemption));
+
+        assertEq(circulating, total - excluded);
+    }
+
+    function test_circulatingSupply_shrinksAfterRedemption() public {
+        uint256 circulatingBefore = redemption.circulatingSupply();
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+
+        uint256 aliceArm = armToken.balanceOf(alice);
+        vm.prank(alice);
+        redemption.redeem(aliceArm, tokens);
+
+        uint256 circulatingAfter = redemption.circulatingSupply();
+        assertTrue(circulatingAfter < circulatingBefore);
+        assertEq(circulatingAfter, circulatingBefore - aliceArm);
+    }
+
+    // ======== Edge Cases ========
+
+    function test_revert_zeroArmAmount() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+
+        vm.prank(alice);
+        vm.expectRevert("ArmadaRedemption: zero amount");
+        redemption.redeem(0, tokens);
+    }
+
+    function test_revert_zeroArmAmount_eth() public {
+        vm.prank(alice);
+        vm.expectRevert("ArmadaRedemption: zero amount");
+        redemption.redeemETH(0);
+    }
+
+    function test_redeem_emptyTokenList() public {
+        address[] memory tokens = new address[](0);
+        uint256 aliceArm = armToken.balanceOf(alice);
+
+        // Should succeed — ARM is transferred, but no tokens distributed
+        vm.prank(alice);
+        redemption.redeem(aliceArm, tokens);
+
+        // ARM is locked
+        assertEq(armToken.balanceOf(alice), 0);
+        assertEq(armToken.balanceOf(address(redemption)), aliceArm);
+    }
+
+    function test_redeem_tokenWithZeroBalance() public {
+        MockTokenRedemption emptyToken = new MockTokenRedemption("Empty", "EMPTY");
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(emptyToken);
+
+        uint256 aliceArm = armToken.balanceOf(alice);
+        vm.prank(alice);
+        redemption.redeem(aliceArm, tokens);
+
+        assertEq(emptyToken.balanceOf(alice), 0);
+    }
+
+    function test_redemptionCanReceiveETH() public {
+        vm.deal(address(this), 1 ether);
+        (bool success,) = address(redemption).call{value: 1 ether}("");
+        assertTrue(success);
+        assertEq(address(redemption).balance, 1 ether);
+    }
+
+    // ======== Constructor Validation ========
+
+    function test_constructorRejectsZeroArmToken() public {
+        vm.expectRevert("ArmadaRedemption: zero armToken");
+        new ArmadaRedemption(address(0), treasuryAddr, revenueLock, crowdfund);
+    }
+
+    function test_constructorRejectsZeroTreasury() public {
+        vm.expectRevert("ArmadaRedemption: zero treasury");
+        new ArmadaRedemption(address(armToken), address(0), revenueLock, crowdfund);
+    }
+
+    function test_constructorRejectsZeroRevenueLock() public {
+        vm.expectRevert("ArmadaRedemption: zero revenueLock");
+        new ArmadaRedemption(address(armToken), treasuryAddr, address(0), crowdfund);
+    }
+
+    function test_constructorRejectsZeroCrowdfund() public {
+        vm.expectRevert("ArmadaRedemption: zero crowdfund");
+        new ArmadaRedemption(address(armToken), treasuryAddr, revenueLock, address(0));
+    }
+}

--- a/test-foundry/ArmadaRedemption.t.sol
+++ b/test-foundry/ArmadaRedemption.t.sol
@@ -401,6 +401,35 @@ contract ArmadaRedemptionTest is Test {
         assertEq(address(redemption).balance, 1 ether);
     }
 
+    // ======== Wind-Down Gate ========
+
+    function test_revert_redeemBeforeWindDown() public {
+        // Deploy a fresh ARM token where transferable is still false
+        ArmadaToken freshArm = new ArmadaToken(deployer, address(timelock));
+
+        // Enable transfers on freshArm so we can distribute, then disable
+        freshArm.setWindDownContract(windDown);
+        vm.prank(windDown);
+        freshArm.setTransferable(true);
+
+        ArmadaRedemption freshRedemption = new ArmadaRedemption(
+            address(freshArm), treasuryAddr, revenueLock, crowdfund
+        );
+
+        freshArm.transfer(alice, 1000e18);
+        vm.prank(alice);
+        freshArm.approve(address(freshRedemption), type(uint256).max);
+
+        // Disable transfers (simulating pre-wind-down state)
+        vm.prank(windDown);
+        freshArm.setTransferable(false);
+
+        address[] memory tokens = new address[](0);
+        vm.prank(alice);
+        vm.expectRevert("ArmadaRedemption: wind-down not triggered");
+        freshRedemption.redeem(1000e18, tokens, false);
+    }
+
     // ======== Constructor Validation ========
 
     function test_constructorRejectsZeroArmToken() public {

--- a/test-foundry/ArmadaRedemption.t.sol
+++ b/test-foundry/ArmadaRedemption.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // ABOUTME: Foundry tests for ArmadaRedemption — pro-rata treasury redemption for ARM holders.
-// ABOUTME: Covers single/sequential redemption, ETH redemption, denominator math, and edge cases.
+// ABOUTME: Covers single/sequential redemption, ETH redemption, denominator math, guards, and edge cases.
 pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
@@ -17,8 +17,7 @@ contract MockTokenRedemption is ERC20 {
 
 contract ArmadaRedemptionTest is Test {
     // Mirror events
-    event Redeemed(address indexed redeemer, uint256 armAmount, address[] tokens);
-    event RedeemedETH(address indexed redeemer, uint256 armAmount, uint256 ethAmount);
+    event Redeemed(address indexed redeemer, uint256 armAmount, address[] tokens, uint256 ethAmount);
 
     ArmadaRedemption public redemption;
     ArmadaToken public armToken;
@@ -97,7 +96,7 @@ contract ArmadaRedemptionTest is Test {
         tokens[0] = address(usdc);
 
         vm.prank(alice);
-        redemption.redeem(aliceArm, tokens);
+        redemption.redeem(aliceArm, tokens, false);
 
         // Alice has 600K out of 1.2M circulating = 50% → $250k USDC
         assertEq(usdc.balanceOf(alice), 250_000e6);
@@ -106,11 +105,17 @@ contract ArmadaRedemptionTest is Test {
     function test_redeem_multipleTokens() public {
         uint256 aliceArm = armToken.balanceOf(alice);
         address[] memory tokens = new address[](2);
-        tokens[0] = address(usdc);
-        tokens[1] = address(weth);
+        // Must be sorted ascending
+        if (address(usdc) < address(weth)) {
+            tokens[0] = address(usdc);
+            tokens[1] = address(weth);
+        } else {
+            tokens[0] = address(weth);
+            tokens[1] = address(usdc);
+        }
 
         vm.prank(alice);
-        redemption.redeem(aliceArm, tokens);
+        redemption.redeem(aliceArm, tokens, false);
 
         // 50% of each
         assertEq(usdc.balanceOf(alice), 250_000e6);
@@ -123,7 +128,7 @@ contract ArmadaRedemptionTest is Test {
         tokens[0] = address(usdc);
 
         vm.prank(alice);
-        redemption.redeem(aliceArm, tokens);
+        redemption.redeem(aliceArm, tokens, false);
 
         // ARM is in the redemption contract
         assertEq(armToken.balanceOf(address(redemption)), aliceArm);
@@ -142,7 +147,7 @@ contract ArmadaRedemptionTest is Test {
 
         // Alice redeems first (600K out of 1.2M = 50%)
         vm.prank(alice);
-        redemption.redeem(aliceArm, tokens);
+        redemption.redeem(aliceArm, tokens, false);
         assertEq(usdc.balanceOf(alice), 250_000e6); // 50% of $500k
 
         // After Alice's redemption:
@@ -151,7 +156,7 @@ contract ArmadaRedemptionTest is Test {
         // - USDC remaining = 250k
         // Bob redeems (600K out of 600K = 100%)
         vm.prank(bob);
-        redemption.redeem(bobArm, tokens);
+        redemption.redeem(bobArm, tokens, false);
         assertEq(usdc.balanceOf(bob), 250_000e6); // 100% of remaining $250k
 
         // Both got equal shares: $250k each
@@ -165,13 +170,13 @@ contract ArmadaRedemptionTest is Test {
 
         // Alice redeems half her ARM (300K out of 1.2M = 25%)
         vm.prank(alice);
-        redemption.redeem(halfArm, tokens);
+        redemption.redeem(halfArm, tokens, false);
         assertEq(usdc.balanceOf(alice), 125_000e6); // 25% of $500k
 
         // Alice redeems other half (300K out of 900K remaining circulating)
         // 300K / 900K = 33.3% of remaining $375k = $125k
         vm.prank(alice);
-        redemption.redeem(halfArm, tokens);
+        redemption.redeem(halfArm, tokens, false);
         assertEq(usdc.balanceOf(alice), 250_000e6); // Total still $250k
     }
 
@@ -182,11 +187,110 @@ contract ArmadaRedemptionTest is Test {
         vm.deal(address(redemption), 10 ether);
 
         uint256 aliceArm = armToken.balanceOf(alice); // 600K out of 1.2M = 50%
+        address[] memory tokens = new address[](0);
 
         vm.prank(alice);
-        redemption.redeemETH(aliceArm);
+        redemption.redeem(aliceArm, tokens, true);
 
         assertEq(alice.balance, 5 ether); // 50% of 10 ETH
+    }
+
+    function test_redeem_ERC20AndETHTogether() public {
+        // Fund redemption with ETH
+        vm.deal(address(redemption), 10 ether);
+
+        uint256 aliceArm = armToken.balanceOf(alice); // 600K out of 1.2M = 50%
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+
+        vm.prank(alice);
+        redemption.redeem(aliceArm, tokens, true);
+
+        // Gets 50% of both in one deposit
+        assertEq(usdc.balanceOf(alice), 250_000e6);
+        assertEq(alice.balance, 5 ether);
+    }
+
+    function test_sequential_ERC20AndETH() public {
+        // Fund redemption with ETH
+        vm.deal(address(redemption), 10 ether);
+
+        uint256 aliceArm = armToken.balanceOf(alice); // 600K
+        uint256 bobArm = armToken.balanceOf(bob);     // 600K
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+
+        // Alice redeems all assets in one call
+        vm.prank(alice);
+        redemption.redeem(aliceArm, tokens, true);
+        assertEq(usdc.balanceOf(alice), 250_000e6);
+        assertEq(alice.balance, 5 ether);
+
+        // Bob redeems — gets 100% of remaining
+        vm.prank(bob);
+        redemption.redeem(bobArm, tokens, true);
+        assertEq(usdc.balanceOf(bob), 250_000e6);
+        assertEq(bob.balance, 5 ether);
+    }
+
+    // ======== ARM Token Guard ========
+
+    function test_revert_cannotRedeemARM() public {
+        uint256 aliceArm = armToken.balanceOf(alice);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(armToken);
+
+        vm.prank(alice);
+        vm.expectRevert("ArmadaRedemption: cannot redeem ARM");
+        redemption.redeem(aliceArm, tokens, false);
+    }
+
+    function test_revert_cannotRedeemARMInMultiTokenList() public {
+        uint256 aliceArm = armToken.balanceOf(alice);
+        address[] memory tokens = new address[](2);
+        // Put ARM as second token (after a valid token)
+        if (address(usdc) < address(armToken)) {
+            tokens[0] = address(usdc);
+            tokens[1] = address(armToken);
+        } else {
+            tokens[0] = address(armToken);
+            tokens[1] = address(usdc);
+        }
+
+        vm.prank(alice);
+        vm.expectRevert("ArmadaRedemption: cannot redeem ARM");
+        redemption.redeem(aliceArm, tokens, false);
+    }
+
+    // ======== Duplicate Token Guard ========
+
+    function test_revert_duplicateTokens() public {
+        uint256 aliceArm = armToken.balanceOf(alice);
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(usdc);
+        tokens[1] = address(usdc);
+
+        vm.prank(alice);
+        vm.expectRevert("ArmadaRedemption: tokens not sorted/unique");
+        redemption.redeem(aliceArm, tokens, false);
+    }
+
+    function test_revert_unsortedTokens() public {
+        uint256 aliceArm = armToken.balanceOf(alice);
+        address[] memory tokens = new address[](2);
+        // Put higher address first
+        if (address(usdc) > address(weth)) {
+            tokens[0] = address(usdc);
+            tokens[1] = address(weth);
+        } else {
+            tokens[0] = address(weth);
+            tokens[1] = address(usdc);
+        }
+
+        vm.prank(alice);
+        vm.expectRevert("ArmadaRedemption: tokens not sorted/unique");
+        redemption.redeem(aliceArm, tokens, false);
     }
 
     // ======== Circulating Supply ========
@@ -210,7 +314,7 @@ contract ArmadaRedemptionTest is Test {
 
         uint256 aliceArm = armToken.balanceOf(alice);
         vm.prank(alice);
-        redemption.redeem(aliceArm, tokens);
+        redemption.redeem(aliceArm, tokens, false);
 
         uint256 circulatingAfter = redemption.circulatingSupply();
         assertTrue(circulatingAfter < circulatingBefore);
@@ -225,13 +329,15 @@ contract ArmadaRedemptionTest is Test {
 
         vm.prank(alice);
         vm.expectRevert("ArmadaRedemption: zero amount");
-        redemption.redeem(0, tokens);
+        redemption.redeem(0, tokens, false);
     }
 
     function test_revert_zeroArmAmount_eth() public {
+        address[] memory tokens = new address[](0);
+
         vm.prank(alice);
         vm.expectRevert("ArmadaRedemption: zero amount");
-        redemption.redeemETH(0);
+        redemption.redeem(0, tokens, true);
     }
 
     function test_redeem_emptyTokenList() public {
@@ -240,7 +346,7 @@ contract ArmadaRedemptionTest is Test {
 
         // Should succeed — ARM is transferred, but no tokens distributed
         vm.prank(alice);
-        redemption.redeem(aliceArm, tokens);
+        redemption.redeem(aliceArm, tokens, false);
 
         // ARM is locked
         assertEq(armToken.balanceOf(alice), 0);
@@ -254,9 +360,38 @@ contract ArmadaRedemptionTest is Test {
 
         uint256 aliceArm = armToken.balanceOf(alice);
         vm.prank(alice);
-        redemption.redeem(aliceArm, tokens);
+        redemption.redeem(aliceArm, tokens, false);
 
         assertEq(emptyToken.balanceOf(alice), 0);
+    }
+
+    function test_redeem_ethOnlyNoERC20() public {
+        vm.deal(address(redemption), 10 ether);
+        address[] memory tokens = new address[](0);
+
+        uint256 aliceArm = armToken.balanceOf(alice);
+        vm.prank(alice);
+        redemption.redeem(aliceArm, tokens, true);
+
+        assertEq(alice.balance, 5 ether);
+        // No USDC should have been touched
+        assertEq(usdc.balanceOf(alice), 0);
+    }
+
+    function test_redeem_includeETHFalse_noETHSent() public {
+        vm.deal(address(redemption), 10 ether);
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+
+        uint256 aliceArm = armToken.balanceOf(alice);
+        vm.prank(alice);
+        redemption.redeem(aliceArm, tokens, false);
+
+        // Got USDC but no ETH
+        assertEq(usdc.balanceOf(alice), 250_000e6);
+        assertEq(alice.balance, 0);
+        // ETH still in contract
+        assertEq(address(redemption).balance, 10 ether);
     }
 
     function test_redemptionCanReceiveETH() public {

--- a/test-foundry/ArmadaWindDown.t.sol
+++ b/test-foundry/ArmadaWindDown.t.sol
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Foundry tests for ArmadaWindDown — permissionless trigger, governance trigger, and treasury sweeps.
+// ABOUTME: Covers trigger conditions, hook activation (token, governor, pause), sweep mechanics, and parameter setters.
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/ArmadaWindDown.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/governance/ArmadaGovernor.sol";
+import "../contracts/governance/ArmadaTreasuryGov.sol";
+import "../contracts/governance/ShieldPauseController.sol";
+import "../contracts/governance/ArmadaRedemption.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @dev Mock RevenueCounter for testing
+contract MockRevenueCounter {
+    uint256 public recognizedRevenueUsd;
+
+    function setRevenue(uint256 _revenue) external {
+        recognizedRevenueUsd = _revenue;
+    }
+}
+
+/// @dev Mock ERC20 for treasury balance tests
+contract MockUSDCWindDown is ERC20 {
+    constructor() ERC20("Mock USDC", "USDC") {}
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+}
+
+contract ArmadaWindDownTest is Test {
+    // Mirror events
+    event WindDownTriggered(address indexed caller, uint256 timestamp);
+    event TokenSwept(address indexed token, address indexed recipient, uint256 amount);
+    event ETHSwept(address indexed recipient, uint256 amount);
+    event RevenueThresholdUpdated(uint256 oldThreshold, uint256 newThreshold);
+    event WindDownDeadlineUpdated(uint256 oldDeadline, uint256 newDeadline);
+
+    ArmadaWindDown public windDown;
+    ArmadaToken public armToken;
+    ArmadaGovernor public governor;
+    ArmadaTreasuryGov public treasury;
+    ShieldPauseController public pauseController;
+    MockRevenueCounter public revenueCounter;
+    ArmadaRedemption public redemption;
+    TimelockController public timelock;
+    MockUSDCWindDown public usdc;
+
+    address public deployer = address(this);
+    address public alice = address(0xA11CE);
+    address public randomUser = address(0xCAFE);
+    address public revenueLock = address(0xABCD);
+    address public crowdfund = address(0xCF00);
+
+    uint256 constant TOTAL_SUPPLY = 12_000_000 * 1e18;
+    uint256 constant TWO_DAYS = 2 days;
+    uint256 constant MAX_PAUSE = 14 days;
+    uint256 constant REVENUE_THRESHOLD = 10_000 * 1e18; // $10k
+    uint256 constant WIND_DOWN_DEADLINE = 1_798_761_600; // Dec 31, 2026 (approx)
+
+    function setUp() public {
+        // Set block.timestamp to a reasonable starting point
+        vm.warp(1_700_000_000); // Nov 2023
+
+        // Deploy governance stack
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        timelock = new TimelockController(TWO_DAYS, proposers, executors, deployer);
+
+        armToken = new ArmadaToken(deployer, address(timelock));
+        treasury = new ArmadaTreasuryGov(address(timelock), deployer, MAX_PAUSE);
+        governor = new ArmadaGovernor(
+            address(armToken),
+            payable(address(timelock)),
+            address(treasury),
+            deployer,
+            MAX_PAUSE
+        );
+        pauseController = new ShieldPauseController(address(governor), address(timelock));
+        revenueCounter = new MockRevenueCounter();
+        usdc = new MockUSDCWindDown();
+
+        // Deploy redemption (needs ARM token + excluded addresses)
+        redemption = new ArmadaRedemption(
+            address(armToken),
+            address(treasury),
+            revenueLock,
+            crowdfund
+        );
+
+        // Deploy wind-down
+        windDown = new ArmadaWindDown(
+            address(armToken),
+            address(treasury),
+            address(governor),
+            address(redemption),
+            address(pauseController),
+            address(revenueCounter),
+            address(timelock),
+            REVENUE_THRESHOLD,
+            WIND_DOWN_DEADLINE
+        );
+
+        // Register wind-down on all consumers
+        armToken.setWindDownContract(address(windDown));
+
+        vm.startPrank(address(timelock));
+        governor.setWindDownContract(address(windDown));
+        pauseController.setWindDownContract(address(windDown));
+        treasury.setWindDownContract(address(windDown));
+        vm.stopPrank();
+
+        // Grant timelock roles to governor
+        timelock.grantRole(timelock.PROPOSER_ROLE(), address(governor));
+        timelock.grantRole(timelock.EXECUTOR_ROLE(), address(governor));
+
+        // Setup ARM token whitelist
+        address[] memory whitelist = new address[](4);
+        whitelist[0] = deployer;
+        whitelist[1] = address(treasury);
+        whitelist[2] = address(governor);
+        whitelist[3] = alice;
+        armToken.initWhitelist(whitelist);
+
+        // Distribute tokens
+        armToken.transfer(address(treasury), TOTAL_SUPPLY * 65 / 100);
+        armToken.transfer(alice, TOTAL_SUPPLY * 20 / 100);
+
+        // Fund treasury with USDC
+        usdc.mint(address(treasury), 500_000e6);
+    }
+
+    // ======== Permissionless Trigger ========
+
+    function test_permissionlessTrigger_succeeds() public {
+        // Past deadline, revenue below threshold
+        vm.warp(WIND_DOWN_DEADLINE + 1);
+        revenueCounter.setRevenue(REVENUE_THRESHOLD - 1);
+
+        vm.expectEmit(true, false, false, true);
+        emit WindDownTriggered(randomUser, block.timestamp);
+        vm.prank(randomUser);
+        windDown.triggerWindDown();
+
+        assertTrue(windDown.triggered());
+    }
+
+    function test_permissionlessTrigger_failsBeforeDeadline() public {
+        revenueCounter.setRevenue(0);
+        // Still before deadline
+        vm.warp(WIND_DOWN_DEADLINE - 1);
+
+        vm.prank(randomUser);
+        vm.expectRevert("ArmadaWindDown: deadline not passed");
+        windDown.triggerWindDown();
+    }
+
+    function test_permissionlessTrigger_failsAboveThreshold() public {
+        vm.warp(WIND_DOWN_DEADLINE + 1);
+        revenueCounter.setRevenue(REVENUE_THRESHOLD); // exactly at threshold
+
+        vm.prank(randomUser);
+        vm.expectRevert("ArmadaWindDown: revenue meets threshold");
+        windDown.triggerWindDown();
+    }
+
+    function test_permissionlessTrigger_failsAtExactDeadline() public {
+        revenueCounter.setRevenue(0);
+        vm.warp(WIND_DOWN_DEADLINE); // at deadline, not past
+
+        vm.prank(randomUser);
+        vm.expectRevert("ArmadaWindDown: deadline not passed");
+        windDown.triggerWindDown();
+    }
+
+    // ======== Governance Trigger ========
+
+    function test_governanceTrigger_succeeds() public {
+        // Timelock can trigger at any time
+        vm.prank(address(timelock));
+        vm.expectEmit(true, false, false, true);
+        emit WindDownTriggered(address(timelock), block.timestamp);
+        windDown.governanceTriggerWindDown();
+
+        assertTrue(windDown.triggered());
+    }
+
+    function test_governanceTrigger_failsForNonTimelock() public {
+        vm.prank(randomUser);
+        vm.expectRevert("ArmadaWindDown: not timelock");
+        windDown.governanceTriggerWindDown();
+    }
+
+    function test_doubleTriggerReverts() public {
+        vm.prank(address(timelock));
+        windDown.governanceTriggerWindDown();
+
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaWindDown: already triggered");
+        windDown.governanceTriggerWindDown();
+    }
+
+    // ======== Wind-Down Hook Effects ========
+
+    function test_executeWindDown_setsTokenTransferable() public {
+        assertFalse(armToken.transferable());
+
+        vm.prank(address(timelock));
+        windDown.governanceTriggerWindDown();
+
+        assertTrue(armToken.transferable());
+    }
+
+    function test_executeWindDown_disablesGovernance() public {
+        assertFalse(governor.windDownActive());
+
+        vm.prank(address(timelock));
+        windDown.governanceTriggerWindDown();
+
+        assertTrue(governor.windDownActive());
+    }
+
+    function test_executeWindDown_activatesPauseWindDown() public {
+        assertFalse(pauseController.windDownActive());
+
+        vm.prank(address(timelock));
+        windDown.governanceTriggerWindDown();
+
+        assertTrue(pauseController.windDownActive());
+    }
+
+    // ======== Sweep Token ========
+
+    function test_sweepToken_movesToRedemption() public {
+        _triggerWindDown();
+
+        uint256 balance = usdc.balanceOf(address(treasury));
+        vm.expectEmit(true, true, false, true);
+        emit TokenSwept(address(usdc), address(redemption), balance);
+        windDown.sweepToken(address(usdc));
+
+        assertEq(usdc.balanceOf(address(redemption)), balance);
+        assertEq(usdc.balanceOf(address(treasury)), 0);
+    }
+
+    function test_sweepToken_revertsForARM() public {
+        _triggerWindDown();
+
+        vm.expectRevert("ArmadaWindDown: cannot sweep ARM");
+        windDown.sweepToken(address(armToken));
+    }
+
+    function test_sweepToken_revertsBeforeTrigger() public {
+        vm.expectRevert("ArmadaWindDown: not triggered");
+        windDown.sweepToken(address(usdc));
+    }
+
+    function test_sweepToken_revertsNoBalance() public {
+        _triggerWindDown();
+
+        MockUSDCWindDown otherToken = new MockUSDCWindDown();
+        vm.expectRevert("ArmadaWindDown: no balance");
+        windDown.sweepToken(address(otherToken));
+    }
+
+    function test_sweepToken_permissionless() public {
+        _triggerWindDown();
+
+        // Anyone can call sweep
+        vm.prank(randomUser);
+        windDown.sweepToken(address(usdc));
+
+        assertEq(usdc.balanceOf(address(redemption)), 500_000e6);
+    }
+
+    // ======== Sweep ETH ========
+
+    function test_sweepETH_movesToRedemption() public {
+        _triggerWindDown();
+        _fundTreasuryETH(10 ether);
+
+        vm.expectEmit(true, false, false, true);
+        emit ETHSwept(address(redemption), 10 ether);
+        windDown.sweepETH();
+
+        assertEq(address(redemption).balance, 10 ether);
+        assertEq(address(treasury).balance, 0);
+    }
+
+    function test_sweepETH_revertsBeforeTrigger() public {
+        _fundTreasuryETH(10 ether);
+
+        vm.expectRevert("ArmadaWindDown: not triggered");
+        windDown.sweepETH();
+    }
+
+    function test_sweepETH_revertsNoBalance() public {
+        _triggerWindDown();
+
+        vm.expectRevert("ArmadaWindDown: no balance");
+        windDown.sweepETH();
+    }
+
+    // ======== Parameter Setters ========
+
+    function test_setRevenueThreshold_timelockOnly() public {
+        vm.prank(address(timelock));
+        vm.expectEmit(false, false, false, true);
+        emit RevenueThresholdUpdated(REVENUE_THRESHOLD, 50_000e18);
+        windDown.setRevenueThreshold(50_000e18);
+
+        assertEq(windDown.revenueThreshold(), 50_000e18);
+    }
+
+    function test_setRevenueThreshold_nonTimelockReverts() public {
+        vm.prank(randomUser);
+        vm.expectRevert("ArmadaWindDown: not timelock");
+        windDown.setRevenueThreshold(50_000e18);
+    }
+
+    function test_setWindDownDeadline_timelockOnly() public {
+        uint256 newDeadline = WIND_DOWN_DEADLINE + 365 days;
+        vm.prank(address(timelock));
+        vm.expectEmit(false, false, false, true);
+        emit WindDownDeadlineUpdated(WIND_DOWN_DEADLINE, newDeadline);
+        windDown.setWindDownDeadline(newDeadline);
+
+        assertEq(windDown.windDownDeadline(), newDeadline);
+    }
+
+    function test_parameterSetters_revertAfterTrigger() public {
+        _triggerWindDown();
+
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaWindDown: already triggered");
+        windDown.setRevenueThreshold(50_000e18);
+
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaWindDown: already triggered");
+        windDown.setWindDownDeadline(WIND_DOWN_DEADLINE + 365 days);
+    }
+
+    // ======== Constructor Validation ========
+
+    function test_constructorRejectsZeroAddresses() public {
+        vm.expectRevert("ArmadaWindDown: zero armToken");
+        new ArmadaWindDown(
+            address(0), address(treasury), address(governor), address(redemption),
+            address(pauseController), address(revenueCounter), address(timelock),
+            REVENUE_THRESHOLD, WIND_DOWN_DEADLINE
+        );
+    }
+
+    function test_constructorRejectsDeadlineInPast() public {
+        vm.expectRevert("ArmadaWindDown: deadline in past");
+        new ArmadaWindDown(
+            address(armToken), address(treasury), address(governor), address(redemption),
+            address(pauseController), address(revenueCounter), address(timelock),
+            REVENUE_THRESHOLD, block.timestamp - 1
+        );
+    }
+
+    // ======== Helpers ========
+
+    function _triggerWindDown() internal {
+        vm.prank(address(timelock));
+        windDown.governanceTriggerWindDown();
+    }
+
+    function _fundTreasuryETH(uint256 amount) internal {
+        vm.deal(address(this), amount);
+        (bool success,) = address(treasury).call{value: amount}("");
+        require(success, "ETH transfer failed");
+    }
+}

--- a/test-foundry/ArmadaWindDown.t.sol
+++ b/test-foundry/ArmadaWindDown.t.sol
@@ -360,6 +360,35 @@ contract ArmadaWindDownTest is Test {
         );
     }
 
+    function test_constructorRejectsZeroThreshold() public {
+        vm.expectRevert("ArmadaWindDown: zero threshold");
+        new ArmadaWindDown(
+            address(armToken), address(treasury), address(governor), address(redemption),
+            address(pauseController), address(revenueCounter), address(timelock),
+            0, WIND_DOWN_DEADLINE
+        );
+    }
+
+    // ======== Parameter Bounds ========
+
+    function test_setRevenueThreshold_rejectsZero() public {
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaWindDown: zero threshold");
+        windDown.setRevenueThreshold(0);
+    }
+
+    function test_setWindDownDeadline_rejectsPastTimestamp() public {
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaWindDown: deadline in past");
+        windDown.setWindDownDeadline(block.timestamp - 1);
+    }
+
+    function test_setWindDownDeadline_rejectsCurrentTimestamp() public {
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaWindDown: deadline in past");
+        windDown.setWindDownDeadline(block.timestamp);
+    }
+
     // ======== Helpers ========
 
     function _triggerWindDown() internal {

--- a/test-foundry/ShieldPauseController.t.sol
+++ b/test-foundry/ShieldPauseController.t.sol
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Foundry tests for ShieldPauseController — SC pause, auto-expiry, and post-wind-down behavior.
+// ABOUTME: Covers SC authorization via governor, 24h expiry, timelock unpause, and single post-wind-down pause.
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/ShieldPauseController.sol";
+import "../contracts/governance/ArmadaGovernor.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/governance/ArmadaTreasuryGov.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+
+contract ShieldPauseControllerTest is Test {
+    // Mirror events for expectEmit
+    event ShieldsPaused(address indexed securityCouncil, uint256 expiry);
+    event ShieldsUnpaused(address indexed caller);
+    event WindDownContractSet(address indexed windDownContract);
+    event WindDownActivated();
+
+    ShieldPauseController public pauseController;
+    ArmadaGovernor public governor;
+    ArmadaToken public armToken;
+    TimelockController public timelock;
+    ArmadaTreasuryGov public treasury;
+
+    address public deployer = address(this);
+    address public alice = address(0xA11CE);
+    address public bob = address(0xB0B);
+    address public securityCouncil = address(0x5C5C);
+    address public windDown = address(0xD00D);
+    address public randomUser = address(0xCAFE);
+
+    uint256 constant TOTAL_SUPPLY = 12_000_000 * 1e18;
+    uint256 constant TWO_DAYS = 2 days;
+    uint256 constant MAX_PAUSE = 14 days;
+    uint256 constant TWENTY_FOUR_HOURS = 24 hours;
+
+    function setUp() public {
+        // Deploy governance stack
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        timelock = new TimelockController(TWO_DAYS, proposers, executors, deployer);
+
+        armToken = new ArmadaToken(deployer, address(timelock));
+        treasury = new ArmadaTreasuryGov(address(timelock), deployer, MAX_PAUSE);
+        governor = new ArmadaGovernor(
+            address(armToken),
+            payable(address(timelock)),
+            address(treasury),
+            deployer,
+            MAX_PAUSE
+        );
+
+        // Set SC on governor
+        vm.prank(address(timelock));
+        governor.setSecurityCouncil(securityCouncil);
+
+        // Deploy shield pause controller
+        pauseController = new ShieldPauseController(address(governor), address(timelock));
+    }
+
+    // ======== Basic Pause / Unpause ========
+
+    function test_SC_canPauseShields() public {
+        vm.prank(securityCouncil);
+        vm.expectEmit(true, false, false, true);
+        emit ShieldsPaused(securityCouncil, block.timestamp + TWENTY_FOUR_HOURS);
+        pauseController.pauseShields();
+
+        assertTrue(pauseController.shieldsPaused());
+    }
+
+    function test_pauseAutoExpiresAfter24Hours() public {
+        vm.prank(securityCouncil);
+        pauseController.pauseShields();
+        assertTrue(pauseController.shieldsPaused());
+
+        // Just before expiry — still paused
+        vm.warp(block.timestamp + TWENTY_FOUR_HOURS - 1);
+        assertTrue(pauseController.shieldsPaused());
+
+        // At expiry — no longer paused
+        vm.warp(block.timestamp + 1);
+        assertFalse(pauseController.shieldsPaused());
+    }
+
+    function test_SC_canRePauseAfterExpiry() public {
+        // First pause
+        vm.prank(securityCouncil);
+        pauseController.pauseShields();
+
+        // Expire
+        vm.warp(block.timestamp + TWENTY_FOUR_HOURS);
+        assertFalse(pauseController.shieldsPaused());
+
+        // Second pause
+        vm.prank(securityCouncil);
+        pauseController.pauseShields();
+        assertTrue(pauseController.shieldsPaused());
+    }
+
+    function test_SC_cannotPauseWhenAlreadyPaused() public {
+        vm.prank(securityCouncil);
+        pauseController.pauseShields();
+
+        vm.prank(securityCouncil);
+        vm.expectRevert("ShieldPauseController: already paused");
+        pauseController.pauseShields();
+    }
+
+    function test_nonSC_cannotPause() public {
+        vm.prank(randomUser);
+        vm.expectRevert("ShieldPauseController: not SC");
+        pauseController.pauseShields();
+    }
+
+    function test_ejectedSC_cannotPause() public {
+        // Eject SC by setting to address(0)
+        vm.prank(address(timelock));
+        governor.setSecurityCouncil(address(0));
+
+        vm.prank(securityCouncil);
+        vm.expectRevert("ShieldPauseController: not SC");
+        pauseController.pauseShields();
+    }
+
+    function test_timelockCanUnpauseEarly() public {
+        vm.prank(securityCouncil);
+        pauseController.pauseShields();
+        assertTrue(pauseController.shieldsPaused());
+
+        vm.prank(address(timelock));
+        vm.expectEmit(true, false, false, false);
+        emit ShieldsUnpaused(address(timelock));
+        pauseController.unpauseShields();
+
+        assertFalse(pauseController.shieldsPaused());
+    }
+
+    function test_timelockCannotUnpauseWhenNotPaused() public {
+        vm.prank(address(timelock));
+        vm.expectRevert("ShieldPauseController: not paused");
+        pauseController.unpauseShields();
+    }
+
+    function test_nonTimelockCannotUnpause() public {
+        vm.prank(securityCouncil);
+        pauseController.pauseShields();
+
+        vm.prank(randomUser);
+        vm.expectRevert("ShieldPauseController: not timelock");
+        pauseController.unpauseShields();
+    }
+
+    // ======== SC Change Propagation ========
+
+    function test_governorSCChangeAffectsWhoCanPause() public {
+        address newSC = address(0x5C5C5C);
+
+        // Change SC on governor
+        vm.prank(address(timelock));
+        governor.setSecurityCouncil(newSC);
+
+        // Old SC cannot pause
+        vm.prank(securityCouncil);
+        vm.expectRevert("ShieldPauseController: not SC");
+        pauseController.pauseShields();
+
+        // New SC can pause
+        vm.prank(newSC);
+        pauseController.pauseShields();
+        assertTrue(pauseController.shieldsPaused());
+    }
+
+    // ======== Wind-Down Contract Setup ========
+
+    function test_setWindDownContract() public {
+        vm.prank(address(timelock));
+        vm.expectEmit(true, false, false, false);
+        emit WindDownContractSet(windDown);
+        pauseController.setWindDownContract(windDown);
+
+        assertEq(pauseController.windDownContract(), windDown);
+        assertTrue(pauseController.windDownContractSet());
+    }
+
+    function test_setWindDownContract_onlyOnce() public {
+        vm.prank(address(timelock));
+        pauseController.setWindDownContract(windDown);
+
+        vm.prank(address(timelock));
+        vm.expectRevert("ShieldPauseController: wind-down already set");
+        pauseController.setWindDownContract(address(0x999));
+    }
+
+    function test_setWindDownContract_onlyTimelock() public {
+        vm.prank(randomUser);
+        vm.expectRevert("ShieldPauseController: not timelock");
+        pauseController.setWindDownContract(windDown);
+    }
+
+    function test_setWindDownContract_rejectsZero() public {
+        vm.prank(address(timelock));
+        vm.expectRevert("ShieldPauseController: zero address");
+        pauseController.setWindDownContract(address(0));
+    }
+
+    // ======== Wind-Down Activation ========
+
+    function test_setWindDownActive() public {
+        vm.prank(address(timelock));
+        pauseController.setWindDownContract(windDown);
+
+        vm.prank(windDown);
+        vm.expectEmit(false, false, false, false);
+        emit WindDownActivated();
+        pauseController.setWindDownActive();
+
+        assertTrue(pauseController.windDownActive());
+    }
+
+    function test_setWindDownActive_onlyWindDownContract() public {
+        vm.prank(address(timelock));
+        pauseController.setWindDownContract(windDown);
+
+        vm.prank(randomUser);
+        vm.expectRevert("ShieldPauseController: not wind-down contract");
+        pauseController.setWindDownActive();
+    }
+
+    function test_setWindDownActive_cannotCallTwice() public {
+        vm.prank(address(timelock));
+        pauseController.setWindDownContract(windDown);
+
+        vm.prank(windDown);
+        pauseController.setWindDownActive();
+
+        vm.prank(windDown);
+        vm.expectRevert("ShieldPauseController: wind-down already active");
+        pauseController.setWindDownActive();
+    }
+
+    // ======== Post-Wind-Down Pause Behavior (Task 4.4) ========
+
+    function test_postWindDown_singlePauseAllowed() public {
+        // Setup wind-down
+        vm.prank(address(timelock));
+        pauseController.setWindDownContract(windDown);
+        vm.prank(windDown);
+        pauseController.setWindDownActive();
+
+        // SC can pause once
+        vm.prank(securityCouncil);
+        pauseController.pauseShields();
+        assertTrue(pauseController.shieldsPaused());
+    }
+
+    function test_postWindDown_secondPauseReverts() public {
+        // Setup wind-down
+        vm.prank(address(timelock));
+        pauseController.setWindDownContract(windDown);
+        vm.prank(windDown);
+        pauseController.setWindDownActive();
+
+        // First pause
+        vm.prank(securityCouncil);
+        pauseController.pauseShields();
+
+        // Expire the pause
+        vm.warp(block.timestamp + TWENTY_FOUR_HOURS);
+        assertFalse(pauseController.shieldsPaused());
+
+        // Second pause reverts
+        vm.prank(securityCouncil);
+        vm.expectRevert("ShieldPauseController: post-wind-down pause already used");
+        pauseController.pauseShields();
+    }
+
+    function test_preWindDown_unlimitedPauses() public {
+        // Multiple pause/expire cycles before wind-down
+        for (uint256 i = 0; i < 5; i++) {
+            vm.prank(securityCouncil);
+            pauseController.pauseShields();
+            assertTrue(pauseController.shieldsPaused());
+
+            vm.warp(block.timestamp + TWENTY_FOUR_HOURS);
+            assertFalse(pauseController.shieldsPaused());
+        }
+    }
+
+    // ======== Edge Cases ========
+
+    function test_shieldsPaused_returnsFalseByDefault() public view {
+        assertFalse(pauseController.shieldsPaused());
+    }
+
+    function test_MAX_PAUSE_DURATION_is24Hours() public view {
+        assertEq(pauseController.MAX_PAUSE_DURATION(), 24 hours);
+    }
+
+    function test_constructorRejectsZeroGovernor() public {
+        vm.expectRevert("ShieldPauseController: zero governor");
+        new ShieldPauseController(address(0), address(timelock));
+    }
+
+    function test_constructorRejectsZeroTimelock() public {
+        vm.expectRevert("ShieldPauseController: zero timelock");
+        new ShieldPauseController(address(governor), address(0));
+    }
+}

--- a/test-foundry/TreasurySweepAuthority.t.sol
+++ b/test-foundry/TreasurySweepAuthority.t.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Foundry tests for treasury wind-down sweep authority (transferTo, transferETHTo).
+// ABOUTME: Verifies wind-down-only access, outflow limit bypass, and ETH handling.
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/ArmadaTreasuryGov.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @dev Minimal mock ERC20 for testing
+contract MockToken is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+}
+
+contract TreasurySweepAuthorityTest is Test {
+    // Mirror events
+    event WindDownContractSet(address indexed windDownContract);
+    event WindDownTransfer(address indexed token, address indexed recipient, uint256 amount);
+    event WindDownETHTransfer(address indexed recipient, uint256 amount);
+
+    ArmadaTreasuryGov public treasury;
+    MockToken public usdc;
+
+    address public timelockAddr = address(0x7171); // mock timelock (owner)
+    address public guardian = address(0x6666);
+    address public windDown = address(0xD00D);
+    address public recipient = address(0xBEEF);
+    address public randomUser = address(0xCAFE);
+
+    uint256 constant MAX_PAUSE = 14 days;
+
+    function setUp() public {
+        treasury = new ArmadaTreasuryGov(timelockAddr, guardian, MAX_PAUSE);
+        usdc = new MockToken("Mock USDC", "USDC");
+
+        // Fund treasury with USDC
+        usdc.mint(address(treasury), 1_000_000e6);
+    }
+
+    // ======== setWindDownContract ========
+
+    function test_setWindDownContract_success() public {
+        vm.prank(timelockAddr);
+        vm.expectEmit(true, false, false, false);
+        emit WindDownContractSet(windDown);
+        treasury.setWindDownContract(windDown);
+
+        assertEq(treasury.windDownContract(), windDown);
+        assertTrue(treasury.windDownContractSet());
+    }
+
+    function test_setWindDownContract_onlyOwner() public {
+        vm.prank(randomUser);
+        vm.expectRevert("ArmadaTreasuryGov: not owner");
+        treasury.setWindDownContract(windDown);
+    }
+
+    function test_setWindDownContract_onlyOnce() public {
+        vm.prank(timelockAddr);
+        treasury.setWindDownContract(windDown);
+
+        vm.prank(timelockAddr);
+        vm.expectRevert("ArmadaTreasuryGov: wind-down already set");
+        treasury.setWindDownContract(address(0x999));
+    }
+
+    function test_setWindDownContract_rejectsZero() public {
+        vm.prank(timelockAddr);
+        vm.expectRevert("ArmadaTreasuryGov: zero address");
+        treasury.setWindDownContract(address(0));
+    }
+
+    // ======== transferTo ========
+
+    function test_transferTo_windDownOnly() public {
+        _setupWindDown();
+
+        uint256 amount = 500_000e6;
+        vm.prank(windDown);
+        vm.expectEmit(true, true, false, true);
+        emit WindDownTransfer(address(usdc), recipient, amount);
+        treasury.transferTo(address(usdc), recipient, amount);
+
+        assertEq(usdc.balanceOf(recipient), amount);
+        assertEq(usdc.balanceOf(address(treasury)), 500_000e6);
+    }
+
+    function test_transferTo_revertsForOwner() public {
+        _setupWindDown();
+
+        vm.prank(timelockAddr);
+        vm.expectRevert("ArmadaTreasuryGov: not wind-down");
+        treasury.transferTo(address(usdc), recipient, 100e6);
+    }
+
+    function test_transferTo_revertsForRandom() public {
+        _setupWindDown();
+
+        vm.prank(randomUser);
+        vm.expectRevert("ArmadaTreasuryGov: not wind-down");
+        treasury.transferTo(address(usdc), recipient, 100e6);
+    }
+
+    function test_transferTo_revertsZeroRecipient() public {
+        _setupWindDown();
+
+        vm.prank(windDown);
+        vm.expectRevert("ArmadaTreasuryGov: zero recipient");
+        treasury.transferTo(address(usdc), address(0), 100e6);
+    }
+
+    function test_transferTo_bypassesOutflowLimits() public {
+        _setupWindDown();
+
+        // Initialize very tight outflow limits
+        vm.prank(timelockAddr);
+        treasury.initOutflowConfig(address(usdc), 30 days, 100, 1e6, 1e6); // 1% or $1 absolute
+
+        // Transfer entire balance (way over the limit) — should succeed
+        uint256 fullBalance = usdc.balanceOf(address(treasury));
+        vm.prank(windDown);
+        treasury.transferTo(address(usdc), recipient, fullBalance);
+
+        assertEq(usdc.balanceOf(recipient), fullBalance);
+    }
+
+    // ======== transferETHTo ========
+
+    function test_transferETHTo_windDownOnly() public {
+        _setupWindDown();
+        _fundTreasuryETH(5 ether);
+
+        vm.prank(windDown);
+        vm.expectEmit(true, false, false, true);
+        emit WindDownETHTransfer(recipient, 5 ether);
+        treasury.transferETHTo(payable(recipient), 5 ether);
+
+        assertEq(recipient.balance, 5 ether);
+    }
+
+    function test_transferETHTo_revertsForNonWindDown() public {
+        _setupWindDown();
+        _fundTreasuryETH(5 ether);
+
+        vm.prank(randomUser);
+        vm.expectRevert("ArmadaTreasuryGov: not wind-down");
+        treasury.transferETHTo(payable(recipient), 5 ether);
+    }
+
+    function test_transferETHTo_revertsZeroRecipient() public {
+        _setupWindDown();
+        _fundTreasuryETH(5 ether);
+
+        vm.prank(windDown);
+        vm.expectRevert("ArmadaTreasuryGov: zero recipient");
+        treasury.transferETHTo(payable(address(0)), 5 ether);
+    }
+
+    // ======== Treasury can receive ETH ========
+
+    function test_treasuryCanReceiveETH() public {
+        _fundTreasuryETH(10 ether);
+        assertEq(address(treasury).balance, 10 ether);
+    }
+
+    // ======== Helpers ========
+
+    function _setupWindDown() internal {
+        vm.prank(timelockAddr);
+        treasury.setWindDownContract(windDown);
+    }
+
+    function _fundTreasuryETH(uint256 amount) internal {
+        vm.deal(address(this), amount);
+        (bool success,) = address(treasury).call{value: amount}("");
+        require(success, "ETH transfer failed");
+    }
+}

--- a/test/governance_adversarial.ts
+++ b/test/governance_adversarial.ts
@@ -989,23 +989,18 @@ describe("Governance Adversarial", function () {
     });
   });
 
-  describe("Treasury ETH Rejection", function () {
-    it("treasury rejects direct ETH transfers", async function () {
-      await expect(
-        deployer.sendTransaction({
-          to: await treasuryContract.getAddress(),
-          value: ethers.parseEther("1.0"),
-        })
-      ).to.be.reverted;
-    });
-
-    it("treasury rejects ETH via selfdestruct-style forced sends", async function () {
-      // Even without receive(), ETH can be forced via selfdestruct.
-      // This test documents that the contract has no way to recover forced ETH,
-      // but at least it won't silently accept voluntary transfers.
+  describe("Treasury ETH Handling", function () {
+    it("treasury accepts direct ETH transfers (needed for wind-down sweep)", async function () {
       const treasuryAddr = await treasuryContract.getAddress();
       const balanceBefore = await ethers.provider.getBalance(treasuryAddr);
-      expect(balanceBefore).to.equal(0n);
+
+      await deployer.sendTransaction({
+        to: treasuryAddr,
+        value: ethers.parseEther("1.0"),
+      });
+
+      const balanceAfter = await ethers.provider.getBalance(treasuryAddr);
+      expect(balanceAfter).to.equal(balanceBefore + ethers.parseEther("1.0"));
     });
   });
 });

--- a/test/winddown_redemption_integration.ts
+++ b/test/winddown_redemption_integration.ts
@@ -1,0 +1,682 @@
+// ABOUTME: Integration tests for wind-down, shield pause, and redemption contracts.
+// ABOUTME: Tests full lifecycle: pause → wind-down trigger → sweep → redemption, plus cross-contract wiring.
+
+/**
+ * Wind-Down & Redemption Integration Tests
+ *
+ * End-to-end testing of the wind-down lifecycle:
+ * - ShieldPauseController: SC pause, auto-expiry, timelock unpause, post-wind-down single-pause
+ * - ArmadaWindDown: permissionless + governance trigger, hook effects, treasury sweep
+ * - ArmadaRedemption: pro-rata ERC20 + ETH redemption, guards, sequential correctness
+ * - Cross-contract: wind-down triggers ARM transferability, disables governance, activates pause restrictions
+ */
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
+import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+
+const ONE_DAY = 86400;
+const TWO_DAYS = 2 * ONE_DAY;
+const TWENTY_FOUR_HOURS = ONE_DAY;
+
+const ARM_DECIMALS = 18;
+const TOTAL_SUPPLY = ethers.parseUnits("12000000", ARM_DECIMALS);
+const TREASURY_AMOUNT = TOTAL_SUPPLY * 65n / 100n;
+const REVENUE_LOCK_AMOUNT = TOTAL_SUPPLY * 15n / 100n;
+const CROWDFUND_AMOUNT = TOTAL_SUPPLY * 10n / 100n;
+const ALICE_AMOUNT = TOTAL_SUPPLY * 5n / 100n;
+const BOB_AMOUNT = TOTAL_SUPPLY * 5n / 100n;
+
+const REVENUE_THRESHOLD = ethers.parseUnits("10000", 18); // $10k in 18-decimal
+const MAX_PAUSE_DURATION = 14 * ONE_DAY;
+
+describe("Wind-Down & Redemption Integration", function () {
+  let armToken: any;
+  let timelockController: any;
+  let governor: any;
+  let treasuryContract: any;
+  let stewardContract: any;
+  let shieldPauseController: any;
+  let windDown: any;
+  let redemption: any;
+  let revenueCounter: any;
+  let usdc: any;
+
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let carol: SignerWithAddress; // security council
+  let revenueLockAddr: SignerWithAddress; // stand-in for revenue-lock contract
+  let crowdfundAddr: SignerWithAddress;   // stand-in for crowdfund contract
+
+  let windDownDeadline: number;
+
+  async function mineBlock() {
+    await mine(1);
+  }
+
+  // Impersonate the timelock for direct calls
+  async function asTimelock() {
+    const timelockAddr = await timelockController.getAddress();
+    await ethers.provider.send("hardhat_impersonateAccount", [timelockAddr]);
+    await deployer.sendTransaction({ to: timelockAddr, value: ethers.parseEther("1") });
+    return await ethers.getSigner(timelockAddr) as unknown as SignerWithAddress;
+  }
+
+  async function stopImpersonatingTimelock() {
+    await ethers.provider.send("hardhat_stopImpersonatingAccount", [
+      await timelockController.getAddress(),
+    ]);
+  }
+
+  beforeEach(async function () {
+    [deployer, alice, bob, carol, revenueLockAddr, crowdfundAddr] = await ethers.getSigners();
+
+    // --- Deploy base contracts ---
+
+    const TimelockController = await ethers.getContractFactory("TimelockController");
+    timelockController = await TimelockController.deploy(TWO_DAYS, [], [], deployer.address);
+    await timelockController.waitForDeployment();
+    const timelockAddr = await timelockController.getAddress();
+
+    const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+    armToken = await ArmadaToken.deploy(deployer.address, timelockAddr);
+    await armToken.waitForDeployment();
+
+    const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+    treasuryContract = await ArmadaTreasuryGov.deploy(timelockAddr, deployer.address, MAX_PAUSE_DURATION);
+    await treasuryContract.waitForDeployment();
+
+    const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
+    governor = await ArmadaGovernor.deploy(
+      await armToken.getAddress(),
+      timelockAddr,
+      await treasuryContract.getAddress(),
+      deployer.address,
+      MAX_PAUSE_DURATION,
+    );
+    await governor.waitForDeployment();
+
+    const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
+    stewardContract = await TreasurySteward.deploy(timelockAddr, deployer.address, MAX_PAUSE_DURATION);
+    await stewardContract.waitForDeployment();
+
+    // Deploy mock USDC
+    const MockUSDCV2 = await ethers.getContractFactory("MockUSDCV2");
+    usdc = await MockUSDCV2.deploy("Mock USDC", "USDC");
+    await usdc.waitForDeployment();
+
+    // Deploy RevenueCounter behind proxy
+    const RevenueCounter = await ethers.getContractFactory("RevenueCounter");
+    const rcImpl = await RevenueCounter.deploy();
+    await rcImpl.waitForDeployment();
+    const initData = RevenueCounter.interface.encodeFunctionData("initialize", [timelockAddr]);
+    const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
+    const rcProxy = await ERC1967Proxy.deploy(await rcImpl.getAddress(), initData);
+    await rcProxy.waitForDeployment();
+    revenueCounter = RevenueCounter.attach(await rcProxy.getAddress());
+
+    // Deploy ShieldPauseController
+    const ShieldPauseController = await ethers.getContractFactory("ShieldPauseController");
+    shieldPauseController = await ShieldPauseController.deploy(
+      await governor.getAddress(),
+      timelockAddr,
+    );
+    await shieldPauseController.waitForDeployment();
+
+    // Deploy ArmadaRedemption
+    const ArmadaRedemption = await ethers.getContractFactory("ArmadaRedemption");
+    redemption = await ArmadaRedemption.deploy(
+      await armToken.getAddress(),
+      await treasuryContract.getAddress(),
+      revenueLockAddr.address,
+      crowdfundAddr.address,
+    );
+    await redemption.waitForDeployment();
+
+    // Deploy ArmadaWindDown (deadline 1 year from now)
+    windDownDeadline = (await time.latest()) + 365 * ONE_DAY;
+    const ArmadaWindDown = await ethers.getContractFactory("ArmadaWindDown");
+    windDown = await ArmadaWindDown.deploy(
+      await armToken.getAddress(),
+      await treasuryContract.getAddress(),
+      await governor.getAddress(),
+      await redemption.getAddress(),
+      await shieldPauseController.getAddress(),
+      await revenueCounter.getAddress(),
+      timelockAddr,
+      REVENUE_THRESHOLD,
+      windDownDeadline,
+    );
+    await windDown.waitForDeployment();
+
+    // --- Wire contracts ---
+
+    // ARM token: set wind-down contract (deployer-only)
+    await armToken.setWindDownContract(await windDown.getAddress());
+
+    // Timelock-only wiring via impersonation
+    const timelockSigner = await asTimelock();
+
+    // Governor: set SC, set wind-down contract
+    await governor.connect(timelockSigner).setSecurityCouncil(carol.address);
+    await governor.connect(timelockSigner).setWindDownContract(await windDown.getAddress());
+
+    // Treasury: set wind-down contract
+    await treasuryContract.connect(timelockSigner).setWindDownContract(await windDown.getAddress());
+
+    // ShieldPauseController: set wind-down contract
+    await shieldPauseController.connect(timelockSigner).setWindDownContract(await windDown.getAddress());
+
+    await stopImpersonatingTimelock();
+
+    // --- Configure timelock roles ---
+    const PROPOSER_ROLE = await timelockController.PROPOSER_ROLE();
+    const EXECUTOR_ROLE = await timelockController.EXECUTOR_ROLE();
+    const ADMIN_ROLE = await timelockController.TIMELOCK_ADMIN_ROLE();
+
+    await timelockController.grantRole(PROPOSER_ROLE, await governor.getAddress());
+    await timelockController.grantRole(EXECUTOR_ROLE, await governor.getAddress());
+    await timelockController.renounceRole(ADMIN_ROLE, deployer.address);
+
+    // --- Configure ARM token and distribute ---
+    await armToken.setNoDelegation(await treasuryContract.getAddress());
+    await armToken.initWhitelist([
+      deployer.address,
+      await treasuryContract.getAddress(),
+      alice.address,
+      bob.address,
+      revenueLockAddr.address,
+      crowdfundAddr.address,
+      await redemption.getAddress(),
+    ]);
+
+    // Distribute ARM
+    await armToken.transfer(await treasuryContract.getAddress(), TREASURY_AMOUNT);
+    await armToken.transfer(revenueLockAddr.address, REVENUE_LOCK_AMOUNT);
+    await armToken.transfer(crowdfundAddr.address, CROWDFUND_AMOUNT);
+    await armToken.transfer(alice.address, ALICE_AMOUNT);
+    await armToken.transfer(bob.address, BOB_AMOUNT);
+
+    // Delegate for governance
+    await armToken.connect(alice).delegate(alice.address);
+    await armToken.connect(bob).delegate(bob.address);
+
+    // Fund treasury with USDC (simulating fee accrual)
+    await usdc.mint(await treasuryContract.getAddress(), ethers.parseUnits("500000", 6));
+
+    // Fund treasury with ETH
+    await deployer.sendTransaction({
+      to: await treasuryContract.getAddress(),
+      value: ethers.parseEther("10"),
+    });
+
+    await mineBlock();
+  });
+
+  // ============================================================
+  // ShieldPauseController
+  // ============================================================
+
+  describe("ShieldPauseController", function () {
+    it("SC can pause shields and pause auto-expires after 24h", async function () {
+      // SC pauses
+      await shieldPauseController.connect(carol).pauseShields();
+      expect(await shieldPauseController.shieldsPaused()).to.be.true;
+
+      // Time passes just under 24h — still paused
+      await time.increase(TWENTY_FOUR_HOURS - 10);
+      expect(await shieldPauseController.shieldsPaused()).to.be.true;
+
+      // After 24h — auto-expired
+      await time.increase(20);
+      expect(await shieldPauseController.shieldsPaused()).to.be.false;
+    });
+
+    it("non-SC address cannot pause shields", async function () {
+      await expect(
+        shieldPauseController.connect(alice).pauseShields()
+      ).to.be.revertedWith("ShieldPauseController: not SC");
+    });
+
+    it("SC can re-pause after expiry (pre-wind-down)", async function () {
+      await shieldPauseController.connect(carol).pauseShields();
+      await time.increase(TWENTY_FOUR_HOURS + 1);
+      expect(await shieldPauseController.shieldsPaused()).to.be.false;
+
+      // Re-pause succeeds
+      await shieldPauseController.connect(carol).pauseShields();
+      expect(await shieldPauseController.shieldsPaused()).to.be.true;
+    });
+
+    it("SC cannot pause while already paused", async function () {
+      await shieldPauseController.connect(carol).pauseShields();
+      await expect(
+        shieldPauseController.connect(carol).pauseShields()
+      ).to.be.revertedWith("ShieldPauseController: already paused");
+    });
+
+    it("timelock can unpause shields early", async function () {
+      await shieldPauseController.connect(carol).pauseShields();
+      expect(await shieldPauseController.shieldsPaused()).to.be.true;
+
+      const timelockSigner = await asTimelock();
+      await shieldPauseController.connect(timelockSigner).unpauseShields();
+      await stopImpersonatingTimelock();
+
+      expect(await shieldPauseController.shieldsPaused()).to.be.false;
+    });
+
+    it("SC change via governor propagates immediately to pause controller", async function () {
+      // Carol is SC, can pause
+      await shieldPauseController.connect(carol).pauseShields();
+      await time.increase(TWENTY_FOUR_HOURS + 1);
+
+      // Alice cannot pause (not SC)
+      await expect(
+        shieldPauseController.connect(alice).pauseShields()
+      ).to.be.revertedWith("ShieldPauseController: not SC");
+
+      // Governor's SC changes are read live — pause controller reads from governor
+      // (In production, SC would be changed via governance. Here we just verify the
+      // read-through. We cannot call setSecurityCouncil again because it's timelock-only
+      // and timelock admin was renounced, but the test above proves propagation works.)
+    });
+  });
+
+  // ============================================================
+  // ArmadaWindDown — Trigger
+  // ============================================================
+
+  describe("ArmadaWindDown Trigger", function () {
+    it("permissionless trigger succeeds when deadline passed + revenue below threshold", async function () {
+      // Fast-forward past deadline
+      await time.increaseTo(windDownDeadline + 1);
+
+      // Revenue is 0, below $10k threshold
+      await windDown.connect(alice).triggerWindDown();
+      expect(await windDown.triggered()).to.be.true;
+    });
+
+    it("permissionless trigger reverts before deadline", async function () {
+      await expect(
+        windDown.connect(alice).triggerWindDown()
+      ).to.be.revertedWith("ArmadaWindDown: deadline not passed");
+    });
+
+    it("permissionless trigger reverts if revenue meets threshold", async function () {
+      // Set revenue above threshold via attestation
+      const timelockSigner = await asTimelock();
+      await revenueCounter.connect(timelockSigner).attestRevenue(REVENUE_THRESHOLD);
+      await stopImpersonatingTimelock();
+
+      await time.increaseTo(windDownDeadline + 1);
+      await expect(
+        windDown.connect(alice).triggerWindDown()
+      ).to.be.revertedWith("ArmadaWindDown: revenue meets threshold");
+    });
+
+    it("governance trigger works regardless of conditions", async function () {
+      // Revenue above threshold, deadline not passed — governance can still trigger
+      const timelockSigner = await asTimelock();
+      await revenueCounter.connect(timelockSigner).attestRevenue(REVENUE_THRESHOLD);
+      await windDown.connect(timelockSigner).governanceTriggerWindDown();
+      await stopImpersonatingTimelock();
+
+      expect(await windDown.triggered()).to.be.true;
+    });
+
+    it("non-timelock cannot use governance trigger", async function () {
+      await expect(
+        windDown.connect(alice).governanceTriggerWindDown()
+      ).to.be.revertedWith("ArmadaWindDown: not timelock");
+    });
+
+    it("cannot trigger twice", async function () {
+      await time.increaseTo(windDownDeadline + 1);
+      await windDown.triggerWindDown();
+      await expect(
+        windDown.triggerWindDown()
+      ).to.be.revertedWith("ArmadaWindDown: already triggered");
+    });
+  });
+
+  // ============================================================
+  // ArmadaWindDown — Hook Effects
+  // ============================================================
+
+  describe("ArmadaWindDown Hook Effects", function () {
+    beforeEach(async function () {
+      // Trigger wind-down
+      await time.increaseTo(windDownDeadline + 1);
+      await windDown.triggerWindDown();
+    });
+
+    it("ARM transfers are enabled after wind-down", async function () {
+      // ARM was non-transferable before (except whitelisted). After wind-down,
+      // setTransferable(true) is called. A non-whitelisted address should be able to transfer.
+      const dave = (await ethers.getSigners())[6];
+
+      // Give dave some ARM (alice is whitelisted, so she can transfer)
+      await armToken.connect(alice).transfer(dave.address, ethers.parseUnits("100", 18));
+
+      // dave is NOT whitelisted but transfers should work because ARM is now globally transferable
+      await armToken.connect(dave).transfer(alice.address, ethers.parseUnits("50", 18));
+      expect(await armToken.balanceOf(dave.address)).to.equal(ethers.parseUnits("50", 18));
+    });
+
+    it("governance is disabled after wind-down", async function () {
+      expect(await governor.windDownActive()).to.be.true;
+    });
+
+    it("shield pause controller enters wind-down mode", async function () {
+      expect(await shieldPauseController.windDownActive()).to.be.true;
+    });
+
+    it("post-wind-down: SC gets exactly one pause", async function () {
+      // First pause succeeds
+      await shieldPauseController.connect(carol).pauseShields();
+      expect(await shieldPauseController.shieldsPaused()).to.be.true;
+
+      // Wait for expiry
+      await time.increase(TWENTY_FOUR_HOURS + 1);
+      expect(await shieldPauseController.shieldsPaused()).to.be.false;
+
+      // Second pause reverts
+      await expect(
+        shieldPauseController.connect(carol).pauseShields()
+      ).to.be.revertedWith("ShieldPauseController: post-wind-down pause already used");
+    });
+
+    it("parameter setters frozen after trigger", async function () {
+      const timelockSigner = await asTimelock();
+      await expect(
+        windDown.connect(timelockSigner).setRevenueThreshold(0n)
+      ).to.be.revertedWith("ArmadaWindDown: already triggered");
+      await expect(
+        windDown.connect(timelockSigner).setWindDownDeadline(0n)
+      ).to.be.revertedWith("ArmadaWindDown: already triggered");
+      await stopImpersonatingTimelock();
+    });
+  });
+
+  // ============================================================
+  // ArmadaWindDown — Sweep
+  // ============================================================
+
+  describe("ArmadaWindDown Sweep", function () {
+    beforeEach(async function () {
+      await time.increaseTo(windDownDeadline + 1);
+      await windDown.triggerWindDown();
+    });
+
+    it("sweepToken moves USDC from treasury to redemption", async function () {
+      const usdcBefore = await usdc.balanceOf(await redemption.getAddress());
+      expect(usdcBefore).to.equal(0n);
+
+      await windDown.sweepToken(await usdc.getAddress());
+
+      const usdcAfter = await usdc.balanceOf(await redemption.getAddress());
+      expect(usdcAfter).to.equal(ethers.parseUnits("500000", 6));
+    });
+
+    it("sweepETH moves ETH from treasury to redemption", async function () {
+      const ethBefore = await ethers.provider.getBalance(await redemption.getAddress());
+      expect(ethBefore).to.equal(0n);
+
+      await windDown.sweepETH();
+
+      const ethAfter = await ethers.provider.getBalance(await redemption.getAddress());
+      expect(ethAfter).to.equal(ethers.parseEther("10"));
+    });
+
+    it("sweep is permissionless — anyone can call", async function () {
+      await windDown.connect(bob).sweepToken(await usdc.getAddress());
+      expect(await usdc.balanceOf(await redemption.getAddress())).to.equal(
+        ethers.parseUnits("500000", 6),
+      );
+    });
+
+    it("cannot sweep ARM", async function () {
+      await expect(
+        windDown.sweepToken(await armToken.getAddress())
+      ).to.be.revertedWith("ArmadaWindDown: cannot sweep ARM");
+    });
+
+    it("sweep reverts before trigger", async function () {
+      // Deploy a fresh wind-down that hasn't been triggered
+      const ArmadaWindDown = await ethers.getContractFactory("ArmadaWindDown");
+      const freshDeadline = (await time.latest()) + 365 * ONE_DAY;
+      const fresh = await ArmadaWindDown.deploy(
+        await armToken.getAddress(),
+        await treasuryContract.getAddress(),
+        await governor.getAddress(),
+        await redemption.getAddress(),
+        await shieldPauseController.getAddress(),
+        await revenueCounter.getAddress(),
+        deployer.address, // use deployer as fake timelock
+        REVENUE_THRESHOLD,
+        freshDeadline,
+      );
+      await fresh.waitForDeployment();
+
+      await expect(
+        fresh.sweepToken(await usdc.getAddress())
+      ).to.be.revertedWith("ArmadaWindDown: not triggered");
+    });
+  });
+
+  // ============================================================
+  // ArmadaRedemption
+  // ============================================================
+
+  describe("ArmadaRedemption", function () {
+    beforeEach(async function () {
+      // Trigger wind-down and sweep assets to redemption
+      await time.increaseTo(windDownDeadline + 1);
+      await windDown.triggerWindDown();
+      await windDown.sweepToken(await usdc.getAddress());
+      await windDown.sweepETH();
+
+      // Approve redemption to take ARM
+      await armToken.connect(alice).approve(
+        await redemption.getAddress(),
+        ethers.MaxUint256,
+      );
+      await armToken.connect(bob).approve(
+        await redemption.getAddress(),
+        ethers.MaxUint256,
+      );
+    });
+
+    it("pro-rata USDC redemption", async function () {
+      // Circulating = total - treasury - revenueLock - crowdfund - redemption(0 ARM)
+      // = 12M - 7.8M - 1.8M - 1.2M - 0 = 1.2M
+      const circulating = await redemption.circulatingSupply();
+      expect(circulating).to.equal(TOTAL_SUPPLY * 10n / 100n); // 1.2M
+
+      const tokens = [await usdc.getAddress()];
+      await redemption.connect(alice).redeem(ALICE_AMOUNT, tokens, false);
+
+      // Alice has 600K / 1.2M = 50% → $250k
+      expect(await usdc.balanceOf(alice.address)).to.equal(ethers.parseUnits("250000", 6));
+    });
+
+    it("pro-rata ETH redemption", async function () {
+      const tokens: string[] = [];
+      await redemption.connect(alice).redeem(ALICE_AMOUNT, tokens, true);
+
+      // 50% of 10 ETH = 5 ETH
+      expect(await ethers.provider.getBalance(await redemption.getAddress())).to.equal(
+        ethers.parseEther("5"),
+      );
+    });
+
+    it("combined ERC20 + ETH in one deposit", async function () {
+      const tokens = [await usdc.getAddress()];
+      await redemption.connect(alice).redeem(ALICE_AMOUNT, tokens, true);
+
+      expect(await usdc.balanceOf(alice.address)).to.equal(ethers.parseUnits("250000", 6));
+      // Alice's ETH balance increased (exact check is hard due to gas, check contract balance)
+      const ethRemaining = await ethers.provider.getBalance(await redemption.getAddress());
+      expect(ethRemaining).to.equal(ethers.parseEther("5"));
+    });
+
+    it("sequential correctness — equal shares for equal ARM", async function () {
+      const tokens = [await usdc.getAddress()];
+
+      // Alice redeems first
+      await redemption.connect(alice).redeem(ALICE_AMOUNT, tokens, true);
+      const aliceUsdc = await usdc.balanceOf(alice.address);
+
+      // Bob redeems second — should get the same share
+      await redemption.connect(bob).redeem(BOB_AMOUNT, tokens, true);
+      const bobUsdc = await usdc.balanceOf(bob.address);
+
+      expect(aliceUsdc).to.equal(bobUsdc);
+      expect(aliceUsdc).to.equal(ethers.parseUnits("250000", 6));
+    });
+
+    it("ARM is permanently locked after redemption", async function () {
+      const tokens = [await usdc.getAddress()];
+      await redemption.connect(alice).redeem(ALICE_AMOUNT, tokens, false);
+
+      expect(await armToken.balanceOf(alice.address)).to.equal(0n);
+      expect(await armToken.balanceOf(await redemption.getAddress())).to.equal(ALICE_AMOUNT);
+    });
+
+    it("rejects ARM token in tokens array", async function () {
+      const tokens = [await armToken.getAddress()];
+      await expect(
+        redemption.connect(alice).redeem(ALICE_AMOUNT, tokens, false)
+      ).to.be.revertedWith("ArmadaRedemption: cannot redeem ARM");
+    });
+
+    it("rejects duplicate tokens", async function () {
+      const usdcAddr = await usdc.getAddress();
+      const tokens = [usdcAddr, usdcAddr];
+      await expect(
+        redemption.connect(alice).redeem(ALICE_AMOUNT, tokens, false)
+      ).to.be.revertedWith("ArmadaRedemption: tokens not sorted/unique");
+    });
+
+    it("rejects unsorted tokens", async function () {
+      // Deploy a second token to test sorting
+      const MockUSDCV2 = await ethers.getContractFactory("MockUSDCV2");
+      const weth = await MockUSDCV2.deploy("Wrapped ETH", "WETH");
+      await weth.waitForDeployment();
+
+      const addr1 = await usdc.getAddress();
+      const addr2 = await weth.getAddress();
+
+      // Put higher address first (unsorted)
+      const tokens = addr1 > addr2 ? [addr1, addr2] : [addr2, addr1];
+      await expect(
+        redemption.connect(alice).redeem(ALICE_AMOUNT, tokens, false)
+      ).to.be.revertedWith("ArmadaRedemption: tokens not sorted/unique");
+    });
+
+    it("rejects zero ARM amount", async function () {
+      const tokens = [await usdc.getAddress()];
+      await expect(
+        redemption.connect(alice).redeem(0n, tokens, false)
+      ).to.be.revertedWith("ArmadaRedemption: zero amount");
+    });
+
+    it("circulating supply shrinks as ARM is deposited", async function () {
+      const circulatingBefore = await redemption.circulatingSupply();
+
+      const tokens = [await usdc.getAddress()];
+      await redemption.connect(alice).redeem(ALICE_AMOUNT, tokens, false);
+
+      const circulatingAfter = await redemption.circulatingSupply();
+      expect(circulatingAfter).to.equal(circulatingBefore - ALICE_AMOUNT);
+    });
+  });
+
+  // ============================================================
+  // End-to-End: Full Wind-Down Lifecycle
+  // ============================================================
+
+  describe("End-to-End Lifecycle", function () {
+    it("full wind-down → sweep → redeem cycle", async function () {
+      // 1. SC pauses shields (pre-wind-down)
+      await shieldPauseController.connect(carol).pauseShields();
+      expect(await shieldPauseController.shieldsPaused()).to.be.true;
+
+      // 2. Pause auto-expires
+      await time.increase(TWENTY_FOUR_HOURS + 1);
+      expect(await shieldPauseController.shieldsPaused()).to.be.false;
+
+      // 3. Deadline passes, revenue stays at 0
+      await time.increaseTo(windDownDeadline + 1);
+
+      // 4. Anyone triggers wind-down
+      await expect(windDown.connect(bob).triggerWindDown())
+        .to.emit(windDown, "WindDownTriggered");
+
+      // 5. Verify all hook effects
+      expect(await governor.windDownActive()).to.be.true;
+      expect(await shieldPauseController.windDownActive()).to.be.true;
+
+      // 6. Sweep treasury to redemption
+      await windDown.connect(alice).sweepToken(await usdc.getAddress());
+      await windDown.connect(alice).sweepETH();
+
+      const redemptionUsdc = await usdc.balanceOf(await redemption.getAddress());
+      const redemptionEth = await ethers.provider.getBalance(await redemption.getAddress());
+      expect(redemptionUsdc).to.equal(ethers.parseUnits("500000", 6));
+      expect(redemptionEth).to.equal(ethers.parseEther("10"));
+
+      // 7. Alice and Bob approve and redeem
+      await armToken.connect(alice).approve(await redemption.getAddress(), ethers.MaxUint256);
+      await armToken.connect(bob).approve(await redemption.getAddress(), ethers.MaxUint256);
+
+      const tokens = [await usdc.getAddress()];
+
+      await redemption.connect(alice).redeem(ALICE_AMOUNT, tokens, true);
+      await redemption.connect(bob).redeem(BOB_AMOUNT, tokens, true);
+
+      // Both get 50% of USDC
+      expect(await usdc.balanceOf(alice.address)).to.equal(ethers.parseUnits("250000", 6));
+      expect(await usdc.balanceOf(bob.address)).to.equal(ethers.parseUnits("250000", 6));
+
+      // Redemption contract is drained of USDC
+      expect(await usdc.balanceOf(await redemption.getAddress())).to.equal(0n);
+
+      // All ARM is locked in redemption
+      expect(await armToken.balanceOf(await redemption.getAddress())).to.equal(
+        ALICE_AMOUNT + BOB_AMOUNT,
+      );
+
+      // Circulating supply is now 0
+      expect(await redemption.circulatingSupply()).to.equal(0n);
+    });
+
+    it("SC single-pause post-wind-down then redemption", async function () {
+      await time.increaseTo(windDownDeadline + 1);
+      await windDown.triggerWindDown();
+
+      // SC gets one pause post-wind-down
+      await shieldPauseController.connect(carol).pauseShields();
+      expect(await shieldPauseController.shieldsPaused()).to.be.true;
+
+      // Wait for expiry
+      await time.increase(TWENTY_FOUR_HOURS + 1);
+
+      // Cannot pause again
+      await expect(
+        shieldPauseController.connect(carol).pauseShields()
+      ).to.be.revertedWith("ShieldPauseController: post-wind-down pause already used");
+
+      // Sweep and redeem still works
+      await windDown.sweepToken(await usdc.getAddress());
+      await armToken.connect(alice).approve(await redemption.getAddress(), ethers.MaxUint256);
+
+      const tokens = [await usdc.getAddress()];
+      await redemption.connect(alice).redeem(ALICE_AMOUNT, tokens, false);
+      expect(await usdc.balanceOf(alice.address)).to.equal(ethers.parseUnits("250000", 6));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **ShieldPauseController** (Task 4.2, 4.4): SC-triggered 24h auto-expiry shield pause. Reads SC address from governor (always in sync). Post-wind-down: single non-renewable pause. ShieldModule integration pauses `shield()` and `processIncomingShield()` only — unshield never pauseable.
- **ArmadaWindDown** (Task 7.1): Non-upgradeable wind-down contract. Permissionless trigger (deadline + revenue threshold) and governance trigger. Activates hooks: ARM transferable, governance disabled, pause wind-down. Permissionless treasury sweeps to redemption post-trigger.
- **Treasury sweep authority** (Task 7.2): `transferTo`/`transferETHTo` on ArmadaTreasuryGov, bypassing outflow limits. Wind-down contract only. `receive()` for ETH.
- **ArmadaRedemption** (Task 8.1): Non-upgradeable pro-rata redemption. Deposit ARM → receive share of treasury assets (ERC20 + ETH). Circulating supply excludes treasury, revenueLock, crowdfund, redemption contract. Sequential correctness verified.

### New files
- `contracts/governance/ShieldPauseController.sol`, `IShieldPauseController.sol`
- `contracts/governance/ArmadaWindDown.sol`
- `contracts/governance/ArmadaRedemption.sol`
- 4 Foundry test files (78 tests total)

### Modified files
- `ArmadaTreasuryGov.sol` — wind-down sweep authority + `receive()`
- `ShieldModule.sol` — pause check on shield/processIncomingShield
- `PrivacyPoolStorage.sol` — added `shieldPauseContract` slot (gap 48→47)
- `PrivacyPool.sol` — `setShieldPauseContract()` setter
- `deploy_governance.ts` — deploys + wires new contracts
- `governance_adversarial.ts` — treasury now accepts ETH

## Test plan
- [x] 307 Foundry tests pass (`npm run test:forge`)
- [x] 642 Hardhat tests pass (`npm run test:all`)
- [ ] Review ShieldPauseController SC authorization flow
- [ ] Review ArmadaWindDown trigger conditions and hook sequence
- [ ] Review ArmadaRedemption pro-rata math and sequential correctness
- [ ] Review treasury sweep authority bypass of outflow limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)