### PR TITLE
feat: make ArmadaGovernor UUPS upgradeable (Task 10.1)

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -1,20 +1,23 @@
 // SPDX-License-Identifier: MIT
-// ABOUTME: Custom governance engine with typed proposals, per-type quorum/timing, and timelock execution.
+// ABOUTME: UUPS-upgradeable governance engine with typed proposals, per-type quorum/timing, and timelock execution.
 // ABOUTME: Voting power comes from ARM token delegation (ERC20Votes), not from a separate locking contract.
 pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/governance/TimelockController.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./ArmadaToken.sol";
 import "./IArmadaGovernance.sol";
-import "./EmergencyPausable.sol";
+import "./EmergencyPausableUpgradeable.sol";
 import "../crowdfund/IArmadaCrowdfund.sol";
 
-/// @title ArmadaGovernor — Custom governance with typed proposals and ERC20Votes delegation
+/// @title ArmadaGovernor — UUPS-upgradeable governance with typed proposals and ERC20Votes delegation
 /// @notice Implements the Armada governance spec: proposal lifecycle, per-type quorum/timing,
-///         voting via delegated ARM tokens, and timelock execution.
-contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
+///         voting via delegated ARM tokens, and timelock execution. Upgradeable via UUPS,
+///         gated by the timelock (requires extended governance proposal).
+contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgradeable, EmergencyPausableUpgradeable {
 
     // ============ Types ============
 
@@ -58,10 +61,10 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
 
     // ============ State ============
 
-    ArmadaToken public immutable armToken;
-    TimelockController public immutable timelock;
-    address public immutable treasuryAddress;
-    address public immutable deployer;
+    ArmadaToken public armToken;
+    TimelockController public timelock;
+    address public treasuryAddress;
+    address public deployer;
 
     uint256 public proposalCount;
     mapping(uint256 => Proposal) private _proposals;
@@ -191,15 +194,30 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
     event AdapterDeauthorized(address indexed adapter);
     event AdapterFullyDeauthorized(address indexed adapter);
 
-    // ============ Constructor ============
+    // ============ Constructor & Initializer ============
 
-    constructor(
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initialize the governor behind a UUPS proxy.
+    /// @param _armToken ARM governance token address
+    /// @param _timelock TimelockController address for execution
+    /// @param _treasuryAddress Treasury contract address
+    /// @param _guardian Emergency pause guardian address
+    /// @param _maxPauseDuration Maximum pause duration in seconds
+    function initialize(
         address _armToken,
         address payable _timelock,
         address _treasuryAddress,
         address _guardian,
         uint256 _maxPauseDuration
-    ) EmergencyPausable(_guardian, _maxPauseDuration, _timelock) {
+    ) external initializer {
+        __ReentrancyGuard_init();
+        __UUPSUpgradeable_init();
+        __EmergencyPausable_init(_guardian, _maxPauseDuration, _timelock);
+
         require(_armToken != address(0), "ArmadaGovernor: zero armToken");
         require(_timelock != address(0), "ArmadaGovernor: zero timelock");
         require(_treasuryAddress != address(0), "ArmadaGovernor: zero treasury");
@@ -1125,4 +1143,18 @@ contract ArmadaGovernor is ReentrancyGuard, EmergencyPausable {
             "ArmadaGovernor: quiet period active"
         );
     }
+
+    // ============ UUPS ============
+
+    /// @dev Only the timelock (governance) can authorize upgrades.
+    ///      The upgradeTo/upgradeToAndCall selectors are registered as extended selectors,
+    ///      so upgrade proposals automatically require Extended-type quorum and timing.
+    function _authorizeUpgrade(address) internal override {
+        require(msg.sender == address(timelock), "ArmadaGovernor: not timelock");
+    }
+
+    // ============ Storage Gap ============
+
+    /// @dev Reserved storage for future upgrades. 23 state slots + 27 gap = 50 total.
+    uint256[27] private __gap;
 }

--- a/contracts/governance/EmergencyPausableUpgradeable.sol
+++ b/contracts/governance/EmergencyPausableUpgradeable.sol
@@ -1,0 +1,116 @@
+// ABOUTME: Upgradeable base contract providing emergency pause with auto-expiry and guardian role.
+// ABOUTME: Companion to EmergencyPausable.sol for UUPS-upgradeable contracts (e.g. ArmadaGovernor).
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+/// @title EmergencyPausableUpgradeable — Time-limited emergency pause with guardian role (upgradeable)
+/// @notice Provides a guardian-triggered pause that auto-expires after a configurable duration.
+///         Governance (the timelock) can always unpause early and rotate the guardian.
+///         The guardian cannot permanently freeze the system — the pause always expires.
+///         Implements pause logic directly (not extending OZ Pausable) because auto-expiry
+///         requires the internal pause flag and paused() to stay in sync, which OZ Pausable's
+///         private _paused flag prevents.
+abstract contract EmergencyPausableUpgradeable is Initializable {
+
+    // ============ State ============
+
+    /// @notice Whether the contract is currently in a paused state (internal flag)
+    bool private _paused;
+
+    /// @notice Address authorized to trigger emergency pause
+    address public guardian;
+
+    /// @notice Timestamp when the current pause expires (0 if not paused)
+    uint256 public pauseExpiry;
+
+    /// @notice Maximum duration a pause can last
+    uint256 public maxPauseDuration;
+
+    /// @notice Timelock address (governance authority for unpause and guardian rotation)
+    address public pauseTimelock;
+
+    // ============ Events ============
+
+    event EmergencyPaused(address indexed guardian, uint256 expiry);
+    event EmergencyUnpaused(address indexed caller);
+    event GuardianUpdated(address indexed oldGuardian, address indexed newGuardian);
+
+    // ============ Initializer ============
+
+    /// @param _guardian Initial guardian address
+    /// @param _maxPauseDuration Maximum pause duration in seconds
+    /// @param _pauseTimelock Timelock address (governance) that can unpause and set guardian
+    function __EmergencyPausable_init(
+        address _guardian,
+        uint256 _maxPauseDuration,
+        address _pauseTimelock
+    ) internal onlyInitializing {
+        require(_guardian != address(0), "EmergencyPausable: zero guardian");
+        require(_maxPauseDuration > 0, "EmergencyPausable: zero duration");
+        require(_pauseTimelock != address(0), "EmergencyPausable: zero timelock");
+
+        guardian = _guardian;
+        maxPauseDuration = _maxPauseDuration;
+        pauseTimelock = _pauseTimelock;
+    }
+
+    // ============ Modifiers ============
+
+    modifier onlyGuardian() {
+        require(msg.sender == guardian, "EmergencyPausable: not guardian");
+        _;
+    }
+
+    modifier onlyPauseTimelock() {
+        require(msg.sender == pauseTimelock, "EmergencyPausable: not timelock");
+        _;
+    }
+
+    /// @dev Reverts if the contract is paused (accounting for auto-expiry).
+    modifier whenNotPaused() {
+        require(!paused(), "Pausable: paused");
+        _;
+    }
+
+    // ============ View Functions ============
+
+    /// @notice Returns true only if paused AND the pause has not expired
+    function paused() public view virtual returns (bool) {
+        return _paused && block.timestamp < pauseExpiry;
+    }
+
+    // ============ Guardian Functions ============
+
+    /// @notice Guardian triggers emergency pause. Auto-expires after maxPauseDuration.
+    function emergencyPause() external onlyGuardian {
+        require(!paused(), "EmergencyPausable: already paused");
+        _paused = true;
+        pauseExpiry = block.timestamp + maxPauseDuration;
+        emit EmergencyPaused(msg.sender, pauseExpiry);
+    }
+
+    // ============ Governance Functions ============
+
+    /// @notice Governance (timelock) can unpause at any time
+    function emergencyUnpause() external onlyPauseTimelock {
+        require(paused(), "EmergencyPausable: not paused");
+        _paused = false;
+        pauseExpiry = 0;
+        emit EmergencyUnpaused(msg.sender);
+    }
+
+    /// @notice Governance (timelock) can rotate the guardian
+    function setGuardian(address _guardian) external onlyPauseTimelock {
+        require(_guardian != address(0), "EmergencyPausable: zero guardian");
+        emit GuardianUpdated(guardian, _guardian);
+        guardian = _guardian;
+    }
+
+    // ============ Storage Gap ============
+
+    /// @dev Reserved storage for future upgrades. 5 slots used above, 45 reserved = 50 total.
+    uint256[45] private __gap;
+}

--- a/contracts/governance/EmergencyPausableUpgradeable.sol
+++ b/contracts/governance/EmergencyPausableUpgradeable.sol
@@ -111,6 +111,7 @@ abstract contract EmergencyPausableUpgradeable is Initializable {
 
     // ============ Storage Gap ============
 
-    /// @dev Reserved storage for future upgrades. 5 slots used above, 45 reserved = 50 total.
-    uint256[45] private __gap;
+    /// @dev Reserved storage for future upgrades. 4 slots used above, 46 reserved = 50 total.
+    /// (_paused and guardian pack into the same slot as Initializable's fields.)
+    uint256[46] private __gap;
 }

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -47,6 +47,7 @@ interface GovernanceDeployment {
     armToken: string;
     treasury: string;
     governor: string;
+    governorImpl: string;
     steward: string;
     revenueCounter: string;
     revenueCounterImpl: string;
@@ -117,16 +118,26 @@ async function main() {
   const treasuryAddress = await treasury.getAddress();
   console.log(`   ArmadaTreasuryGov: ${treasuryAddress}`);
 
-  // 4. Deploy ArmadaGovernor
-  console.log("4. Deploying ArmadaGovernor...");
+  // 4. Deploy ArmadaGovernor (UUPS proxy)
+  console.log("4. Deploying ArmadaGovernor (UUPS proxy)...");
   const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-  const governor = await ArmadaGovernor.deploy(
+  const governorImpl = await ArmadaGovernor.deploy(nm.override());
+  await governorImpl.deploymentTransaction()!.wait();
+  const governorImplAddress = await governorImpl.getAddress();
+  console.log(`   ArmadaGovernor (impl): ${governorImplAddress}`);
+
+  const governorInitData = ArmadaGovernor.interface.encodeFunctionData("initialize", [
     armTokenAddress, timelockAddress, treasuryAddress,
-    guardianAddress, maxPauseDuration, nm.override()
+    guardianAddress, maxPauseDuration
+  ]);
+  const GovernorProxy = await ethers.getContractFactory("ERC1967Proxy");
+  const governorProxy = await GovernorProxy.deploy(
+    governorImplAddress, governorInitData, nm.override()
   );
-  await governor.deploymentTransaction()!.wait();
-  const governorAddress = await governor.getAddress();
-  console.log(`   ArmadaGovernor: ${governorAddress}`);
+  await governorProxy.deploymentTransaction()!.wait();
+  const governorAddress = await governorProxy.getAddress();
+  const governor = ArmadaGovernor.attach(governorAddress) as typeof governorImpl;
+  console.log(`   ArmadaGovernor (proxy): ${governorAddress}`);
 
   // 5. Deploy TreasurySteward (identity management only — proposals flow through governor)
   console.log("5. Deploying TreasurySteward...");
@@ -291,6 +302,7 @@ async function main() {
       armToken: armTokenAddress,
       treasury: treasuryAddress,
       governor: governorAddress,
+      governorImpl: governorImplAddress,
       steward: stewardAddress,
       revenueCounter: revenueCounterAddress,
       revenueCounterImpl: revenueCounterImplAddress,

--- a/scripts/full_lifecycle_demo.ts
+++ b/scripts/full_lifecycle_demo.ts
@@ -149,16 +149,19 @@ async function main() {
   await treasury.waitForDeployment();
   log("DEPLOY", `ArmadaTreasuryGov: ${await treasury.getAddress()}`);
 
-  // 1d. Governor (uses ArmadaToken ERC20Votes for voting power)
+  // 1d. Governor (UUPS proxy, uses ArmadaToken ERC20Votes for voting power)
   const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-  const governor = await ArmadaGovernor.deploy(
-    await armToken.getAddress(),
-    tlAddr,
-    await treasury.getAddress(),
+  const governorImpl = await ArmadaGovernor.deploy();
+  await governorImpl.waitForDeployment();
+  const governorInitData = ArmadaGovernor.interface.encodeFunctionData("initialize", [
+    await armToken.getAddress(), tlAddr, await treasury.getAddress(),
     deployer.address, MAX_PAUSE
-  );
-  await governor.waitForDeployment();
-  log("DEPLOY", `ArmadaGovernor: ${await governor.getAddress()}`);
+  ]);
+  const GovernorProxy = await ethers.getContractFactory("ERC1967Proxy");
+  const governorProxy = await GovernorProxy.deploy(await governorImpl.getAddress(), governorInitData);
+  await governorProxy.waitForDeployment();
+  const governor = ArmadaGovernor.attach(await governorProxy.getAddress()) as typeof governorImpl;
+  log("DEPLOY", `ArmadaGovernor (proxy): ${await governor.getAddress()}`);
 
   // 1e. TreasurySteward
   const TreasurySteward = await ethers.getContractFactory("TreasurySteward");

--- a/scripts/governance_demo.ts
+++ b/scripts/governance_demo.ts
@@ -73,13 +73,16 @@ async function main() {
   await treasury.waitForDeployment();
 
   const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-  const governor = await ArmadaGovernor.deploy(
-    await armToken.getAddress(),
-    tlAddr,
-    await treasury.getAddress(),
+  const governorImpl = await ArmadaGovernor.deploy();
+  await governorImpl.waitForDeployment();
+  const governorInitData = ArmadaGovernor.interface.encodeFunctionData("initialize", [
+    await armToken.getAddress(), tlAddr, await treasury.getAddress(),
     deployer.address, MAX_PAUSE
-  );
-  await governor.waitForDeployment();
+  ]);
+  const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
+  const governorProxy = await ERC1967Proxy.deploy(await governorImpl.getAddress(), governorInitData);
+  await governorProxy.waitForDeployment();
+  const governor = ArmadaGovernor.attach(await governorProxy.getAddress()) as typeof governorImpl;
 
   const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
   const stewardContract = await TreasurySteward.deploy(

--- a/test-foundry/AdapterRegistry.t.sol
+++ b/test-foundry/AdapterRegistry.t.sol
@@ -9,9 +9,10 @@ import "../contracts/governance/ArmadaToken.sol";
 import "../contracts/governance/ArmadaTreasuryGov.sol";
 import "../contracts/governance/IArmadaGovernance.sol";
 import "@openzeppelin/contracts/governance/TimelockController.sol";
+import "./helpers/GovernorDeployHelper.sol";
 
 /// @title AdapterRegistryTest — Tests for governance-managed adapter authorization lifecycle
-contract AdapterRegistryTest is Test {
+contract AdapterRegistryTest is Test, GovernorDeployHelper {
     // Mirror events from governor for expectEmit
     event AdapterAuthorized(address indexed adapter);
     event AdapterDeauthorized(address indexed adapter);
@@ -53,7 +54,7 @@ contract AdapterRegistryTest is Test {
         treasury = new ArmadaTreasuryGov(address(timelock), deployer, MAX_PAUSE);
 
         // Deploy governor
-        governor = new ArmadaGovernor(
+        governor = _deployGovernorProxy(
             address(armToken),
             payable(address(timelock)),
             address(treasury),

--- a/test-foundry/ArmadaWindDown.t.sol
+++ b/test-foundry/ArmadaWindDown.t.sol
@@ -12,6 +12,7 @@ import "../contracts/governance/ShieldPauseController.sol";
 import "../contracts/governance/ArmadaRedemption.sol";
 import "@openzeppelin/contracts/governance/TimelockController.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "./helpers/GovernorDeployHelper.sol";
 
 /// @dev Mock RevenueCounter for testing
 contract MockRevenueCounter {
@@ -28,7 +29,7 @@ contract MockUSDCWindDown is ERC20 {
     function mint(address to, uint256 amount) external { _mint(to, amount); }
 }
 
-contract ArmadaWindDownTest is Test {
+contract ArmadaWindDownTest is Test, GovernorDeployHelper {
     // Mirror events
     event WindDownTriggered(address indexed caller, uint256 timestamp);
     event TokenSwept(address indexed token, address indexed recipient, uint256 amount);
@@ -69,7 +70,7 @@ contract ArmadaWindDownTest is Test {
 
         armToken = new ArmadaToken(deployer, address(timelock));
         treasury = new ArmadaTreasuryGov(address(timelock), deployer, MAX_PAUSE);
-        governor = new ArmadaGovernor(
+        governor = _deployGovernorProxy(
             address(armToken),
             payable(address(timelock)),
             address(treasury),

--- a/test-foundry/GovernorClassificationBondWindDown.t.sol
+++ b/test-foundry/GovernorClassificationBondWindDown.t.sol
@@ -10,6 +10,7 @@ import "../contracts/governance/ArmadaTreasuryGov.sol";
 import "../contracts/governance/IArmadaGovernance.sol";
 import "@openzeppelin/contracts/governance/TimelockController.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "./helpers/GovernorDeployHelper.sol";
 
 /// @dev Minimal mock ERC20 for treasury balance checks in classification tests
 contract MockUSDC is ERC20 {
@@ -21,7 +22,7 @@ contract MockUSDC is ERC20 {
 }
 
 /// @title GovernorClassificationBondWindDownTest — Tests for extended classification, bond mechanism, and wind-down
-contract GovernorClassificationBondWindDownTest is Test {
+contract GovernorClassificationBondWindDownTest is Test, GovernorDeployHelper {
     // Mirror events from governor for expectEmit
     event WindDownActivated();
 
@@ -57,7 +58,7 @@ contract GovernorClassificationBondWindDownTest is Test {
         treasury = new ArmadaTreasuryGov(address(timelock), deployer, MAX_PAUSE);
 
         // Deploy governor
-        governor = new ArmadaGovernor(
+        governor = _deployGovernorProxy(
             address(armToken),
             payable(address(timelock)),
             address(treasury),

--- a/test-foundry/GovernorInvariant.t.sol
+++ b/test-foundry/GovernorInvariant.t.sol
@@ -6,6 +6,7 @@ import "../contracts/governance/ArmadaGovernor.sol";
 import "../contracts/governance/ArmadaToken.sol";
 import "../contracts/governance/IArmadaGovernance.sol";
 import "@openzeppelin/contracts/governance/TimelockController.sol";
+import "./helpers/GovernorDeployHelper.sol";
 
 // ══════════════════════════════════════════════════════════════════════════
 // INV-G1: ARM total supply is constant (matches INITIAL_SUPPLY)
@@ -265,7 +266,7 @@ contract GovernorHandler is Test {
 }
 
 /// @title GovernorInvariantTest — Foundry invariant test suite for ArmadaGovernor
-contract GovernorInvariantTest is Test {
+contract GovernorInvariantTest is Test, GovernorDeployHelper {
     ArmadaGovernor public governor;
     ArmadaToken public armToken;
     TimelockController public timelock;
@@ -295,7 +296,7 @@ contract GovernorInvariantTest is Test {
         treasuryAddr = address(0xBABE);
 
         // Deploy Governor
-        governor = new ArmadaGovernor(
+        governor = _deployGovernorProxy(
             address(armToken),
             payable(address(timelock)),
             treasuryAddr,

--- a/test-foundry/GovernorSteward.t.sol
+++ b/test-foundry/GovernorSteward.t.sol
@@ -12,6 +12,7 @@ import "../contracts/governance/TreasurySteward.sol";
 import "../contracts/governance/IArmadaGovernance.sol";
 import "@openzeppelin/contracts/governance/TimelockController.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "./helpers/GovernorDeployHelper.sol";
 
 /// @dev Minimal mock ERC20 for budget tests
 contract MockToken is ERC20 {
@@ -23,7 +24,7 @@ contract MockToken is ERC20 {
 }
 
 /// @title GovernorStewardTest — Tests for steward pass-by-default proposals and budget enforcement
-contract GovernorStewardTest is Test {
+contract GovernorStewardTest is Test, GovernorDeployHelper {
     // Mirror events
     event ProposalCreated(
         uint256 indexed proposalId,
@@ -70,7 +71,7 @@ contract GovernorStewardTest is Test {
         treasury = new ArmadaTreasuryGov(address(timelock), deployer, MAX_PAUSE);
 
         // Deploy governor
-        governor = new ArmadaGovernor(
+        governor = _deployGovernorProxy(
             address(armToken),
             payable(address(timelock)),
             address(treasury),
@@ -386,7 +387,7 @@ contract GovernorStewardTest is Test {
 
     function test_setStewardContract_rejectsNonDeployer() public {
         // Deploy a fresh governor to test before lock
-        ArmadaGovernor freshGovernor = new ArmadaGovernor(
+        ArmadaGovernor freshGovernor = _deployGovernorProxy(
             address(armToken),
             payable(address(timelock)),
             address(treasury),

--- a/test-foundry/GovernorUpgrade.t.sol
+++ b/test-foundry/GovernorUpgrade.t.sol
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Foundry tests for ArmadaGovernor UUPS upgradeability.
+// ABOUTME: Covers upgrade authorization, state persistence, re-init prevention, and storage compatibility.
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/ArmadaGovernor.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/governance/ArmadaTreasuryGov.sol";
+import "../contracts/governance/IArmadaGovernance.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "./helpers/GovernorDeployHelper.sol";
+
+/// @title ArmadaGovernorV2Mock — Minimal V2 for testing upgrade + state persistence
+contract ArmadaGovernorV2Mock is ArmadaGovernor {
+    uint256 public newV2Variable;
+
+    function setNewV2Variable(uint256 val) external {
+        require(msg.sender == address(timelock), "not timelock");
+        newV2Variable = val;
+    }
+
+    function v2Marker() external pure returns (string memory) {
+        return "v2";
+    }
+}
+
+/// @title GovernorUpgradeTest — UUPS upgrade lifecycle tests
+contract GovernorUpgradeTest is Test, GovernorDeployHelper {
+
+    ArmadaGovernor public governor;
+    ArmadaToken public armToken;
+    TimelockController public timelock;
+    ArmadaTreasuryGov public treasury;
+
+    address public deployer = address(this);
+    address public alice = address(0xA11CE);
+    address public bob = address(0xB0B);
+    address public attacker = address(0xBAD);
+
+    uint256 constant TOTAL_SUPPLY = 12_000_000 * 1e18;
+    uint256 constant TWO_DAYS = 2 days;
+    uint256 constant SEVEN_DAYS = 7 days;
+    uint256 constant MAX_PAUSE = 14 days;
+
+    function setUp() public {
+        // Deploy timelock
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        timelock = new TimelockController(TWO_DAYS, proposers, executors, deployer);
+
+        // Deploy ARM token
+        armToken = new ArmadaToken(deployer, address(timelock));
+
+        // Deploy treasury
+        treasury = new ArmadaTreasuryGov(address(timelock), deployer, MAX_PAUSE);
+
+        // Deploy governor behind proxy
+        governor = _deployGovernorProxy(
+            address(armToken),
+            payable(address(timelock)),
+            address(treasury),
+            deployer,
+            MAX_PAUSE
+        );
+
+        // Grant timelock roles to governor
+        timelock.grantRole(timelock.PROPOSER_ROLE(), address(governor));
+        timelock.grantRole(timelock.EXECUTOR_ROLE(), address(governor));
+        timelock.grantRole(timelock.CANCELLER_ROLE(), address(governor));
+
+        // Setup token distribution
+        address[] memory whitelist = new address[](4);
+        whitelist[0] = deployer;
+        whitelist[1] = alice;
+        whitelist[2] = bob;
+        whitelist[3] = address(treasury);
+        armToken.initWhitelist(whitelist);
+
+        armToken.transfer(alice, TOTAL_SUPPLY * 40 / 100);
+        armToken.transfer(bob, TOTAL_SUPPLY * 20 / 100);
+
+        // Delegate (activate voting power)
+        vm.prank(alice);
+        armToken.delegate(alice);
+        vm.prank(bob);
+        armToken.delegate(bob);
+        vm.roll(block.number + 1);
+    }
+
+    // ============ Upgrade Authorization ============
+
+    function test_upgrade_viaTimelockSucceeds() public {
+        ArmadaGovernorV2Mock v2Impl = new ArmadaGovernorV2Mock();
+
+        // Upgrade via timelock
+        vm.prank(address(timelock));
+        governor.upgradeTo(address(v2Impl));
+
+        // Verify V2 is active
+        ArmadaGovernorV2Mock upgraded = ArmadaGovernorV2Mock(address(governor));
+        assertEq(upgraded.v2Marker(), "v2");
+    }
+
+    function test_upgrade_fromNonTimelockReverts() public {
+        ArmadaGovernorV2Mock v2Impl = new ArmadaGovernorV2Mock();
+
+        vm.prank(attacker);
+        vm.expectRevert("ArmadaGovernor: not timelock");
+        governor.upgradeTo(address(v2Impl));
+    }
+
+    function test_upgrade_fromDeployerReverts() public {
+        ArmadaGovernorV2Mock v2Impl = new ArmadaGovernorV2Mock();
+
+        vm.prank(deployer);
+        vm.expectRevert("ArmadaGovernor: not timelock");
+        governor.upgradeTo(address(v2Impl));
+    }
+
+    // ============ State Persistence ============
+
+    function test_upgrade_statePersistsAcrossUpgrade() public {
+        // Set some state before upgrade
+        governor.setStewardContract(address(0x1234));
+
+        // Set security council via timelock
+        vm.prank(address(timelock));
+        governor.setSecurityCouncil(address(0x5C5C));
+
+        // Verify pre-upgrade state
+        assertEq(address(governor.armToken()), address(armToken));
+        assertEq(address(governor.timelock()), address(timelock));
+        assertEq(governor.treasuryAddress(), address(treasury));
+        assertEq(governor.stewardContract(), address(0x1234));
+        assertEq(governor.securityCouncil(), address(0x5C5C));
+
+        // Upgrade
+        ArmadaGovernorV2Mock v2Impl = new ArmadaGovernorV2Mock();
+        vm.prank(address(timelock));
+        governor.upgradeTo(address(v2Impl));
+
+        // Verify all state persists
+        assertEq(address(governor.armToken()), address(armToken));
+        assertEq(address(governor.timelock()), address(timelock));
+        assertEq(governor.treasuryAddress(), address(treasury));
+        assertEq(governor.stewardContract(), address(0x1234));
+        assertEq(governor.securityCouncil(), address(0x5C5C));
+        assertTrue(governor.stewardContractLocked());
+
+        // Verify V2 functionality works
+        ArmadaGovernorV2Mock upgraded = ArmadaGovernorV2Mock(address(governor));
+        vm.prank(address(timelock));
+        upgraded.setNewV2Variable(42);
+        assertEq(upgraded.newV2Variable(), 42);
+    }
+
+    function test_upgrade_proposalTypeParamsPersist() public {
+        // Check proposal params before upgrade
+        (uint256 delay, uint256 period, uint256 execDelay, uint256 quorum) =
+            governor.proposalTypeParams(ProposalType.Standard);
+        assertEq(delay, 2 days);
+        assertEq(period, 7 days);
+        assertEq(execDelay, 2 days);
+        assertEq(quorum, 2000);
+
+        // Upgrade
+        ArmadaGovernorV2Mock v2Impl = new ArmadaGovernorV2Mock();
+        vm.prank(address(timelock));
+        governor.upgradeTo(address(v2Impl));
+
+        // Verify params persist
+        (delay, period, execDelay, quorum) =
+            governor.proposalTypeParams(ProposalType.Standard);
+        assertEq(delay, 2 days);
+        assertEq(period, 7 days);
+        assertEq(execDelay, 2 days);
+        assertEq(quorum, 2000);
+    }
+
+    function test_upgrade_adapterRegistryPersists() public {
+        // Authorize an adapter
+        vm.prank(address(timelock));
+        governor.authorizeAdapter(address(0xADA));
+        assertTrue(governor.authorizedAdapters(address(0xADA)));
+
+        // Upgrade
+        ArmadaGovernorV2Mock v2Impl = new ArmadaGovernorV2Mock();
+        vm.prank(address(timelock));
+        governor.upgradeTo(address(v2Impl));
+
+        // Verify adapter state persists
+        assertTrue(governor.authorizedAdapters(address(0xADA)));
+    }
+
+    // ============ Initialization Guards ============
+
+    function test_initialize_cannotReinitialize() public {
+        vm.expectRevert("Initializable: contract is already initialized");
+        governor.initialize(
+            address(armToken),
+            payable(address(timelock)),
+            address(treasury),
+            deployer,
+            MAX_PAUSE
+        );
+    }
+
+    function test_initialize_implementationCannotBeInitialized() public {
+        ArmadaGovernor impl = new ArmadaGovernor();
+
+        vm.expectRevert("Initializable: contract is already initialized");
+        impl.initialize(
+            address(armToken),
+            payable(address(timelock)),
+            address(treasury),
+            deployer,
+            MAX_PAUSE
+        );
+    }
+
+    // ============ Extended Classification ============
+
+    function test_upgrade_selectorIsExtended() public {
+        // upgradeTo selector should be classified as extended
+        assertTrue(governor.extendedSelectors(bytes4(keccak256("upgradeTo(address)"))));
+        assertTrue(governor.extendedSelectors(bytes4(keccak256("upgradeToAndCall(address,bytes)"))));
+    }
+
+    // ============ Pause State Persistence ============
+
+    function test_upgrade_pauseStatePersists() public {
+        assertEq(governor.maxPauseDuration(), MAX_PAUSE);
+        assertEq(governor.pauseTimelock(), address(timelock));
+        assertEq(governor.guardian(), deployer);
+
+        // Upgrade
+        ArmadaGovernorV2Mock v2Impl = new ArmadaGovernorV2Mock();
+        vm.prank(address(timelock));
+        governor.upgradeTo(address(v2Impl));
+
+        // Verify pause state persists
+        assertEq(governor.maxPauseDuration(), MAX_PAUSE);
+        assertEq(governor.pauseTimelock(), address(timelock));
+        assertEq(governor.guardian(), deployer);
+    }
+
+    // ============ Wind-Down State Persistence ============
+
+    function test_upgrade_windDownStatePersists() public {
+        // Set wind-down contract via timelock
+        vm.prank(address(timelock));
+        governor.setWindDownContract(address(0xD00D));
+        assertTrue(governor.windDownContractSet());
+
+        // Upgrade
+        ArmadaGovernorV2Mock v2Impl = new ArmadaGovernorV2Mock();
+        vm.prank(address(timelock));
+        governor.upgradeTo(address(v2Impl));
+
+        // Verify wind-down state persists
+        assertEq(governor.windDownContract(), address(0xD00D));
+        assertTrue(governor.windDownContractSet());
+        assertFalse(governor.windDownActive());
+    }
+}

--- a/test-foundry/GovernorVeto.t.sol
+++ b/test-foundry/GovernorVeto.t.sol
@@ -9,9 +9,10 @@ import "../contracts/governance/ArmadaToken.sol";
 import "../contracts/governance/ArmadaTreasuryGov.sol";
 import "../contracts/governance/IArmadaGovernance.sol";
 import "@openzeppelin/contracts/governance/TimelockController.sol";
+import "./helpers/GovernorDeployHelper.sol";
 
 /// @title GovernorVetoTest — Tests for SC veto, ratification, ejection, and double-veto prevention
-contract GovernorVetoTest is Test {
+contract GovernorVetoTest is Test, GovernorDeployHelper {
     // Mirror events from governor for expectEmit
     event ProposalVetoed(uint256 indexed proposalId, bytes32 rationaleHash, uint256 ratificationId);
     event RatificationResolved(uint256 indexed ratificationId, bool vetoUpheld);
@@ -60,7 +61,7 @@ contract GovernorVetoTest is Test {
         treasury = new ArmadaTreasuryGov(address(timelock), deployer, MAX_PAUSE);
 
         // Deploy governor
-        governor = new ArmadaGovernor(
+        governor = _deployGovernorProxy(
             address(armToken),
             payable(address(timelock)),
             address(treasury),

--- a/test-foundry/ShieldPauseController.t.sol
+++ b/test-foundry/ShieldPauseController.t.sol
@@ -9,8 +9,9 @@ import "../contracts/governance/ArmadaGovernor.sol";
 import "../contracts/governance/ArmadaToken.sol";
 import "../contracts/governance/ArmadaTreasuryGov.sol";
 import "@openzeppelin/contracts/governance/TimelockController.sol";
+import "./helpers/GovernorDeployHelper.sol";
 
-contract ShieldPauseControllerTest is Test {
+contract ShieldPauseControllerTest is Test, GovernorDeployHelper {
     // Mirror events for expectEmit
     event ShieldsPaused(address indexed securityCouncil, uint256 expiry);
     event ShieldsUnpaused(address indexed caller);
@@ -43,7 +44,7 @@ contract ShieldPauseControllerTest is Test {
 
         armToken = new ArmadaToken(deployer, address(timelock));
         treasury = new ArmadaTreasuryGov(address(timelock), deployer, MAX_PAUSE);
-        governor = new ArmadaGovernor(
+        governor = _deployGovernorProxy(
             address(armToken),
             payable(address(timelock)),
             address(treasury),

--- a/test-foundry/helpers/GovernorDeployHelper.sol
+++ b/test-foundry/helpers/GovernorDeployHelper.sol
@@ -1,0 +1,31 @@
+// ABOUTME: Shared test helper for deploying ArmadaGovernor behind an ERC1967 UUPS proxy.
+// ABOUTME: Used by all Foundry test files that need a governor instance.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "../../contracts/governance/ArmadaGovernor.sol";
+
+abstract contract GovernorDeployHelper {
+    /// @dev Deploy ArmadaGovernor implementation + ERC1967Proxy and return the proxied instance.
+    function _deployGovernorProxy(
+        address _armToken,
+        address payable _timelock,
+        address _treasury,
+        address _guardian,
+        uint256 _maxPauseDuration
+    ) internal returns (ArmadaGovernor) {
+        ArmadaGovernor impl = new ArmadaGovernor();
+        bytes memory initData = abi.encodeWithSelector(
+            ArmadaGovernor.initialize.selector,
+            _armToken,
+            _timelock,
+            _treasury,
+            _guardian,
+            _maxPauseDuration
+        );
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        return ArmadaGovernor(address(proxy));
+    }
+}

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -11,6 +11,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { deployGovernorProxy } from "./helpers/deploy-governor";
 
 const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 const ProposalState = {
@@ -105,14 +106,12 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     await timelockController.waitForDeployment();
     const timelockAddr = await timelockController.getAddress();
 
-    const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-    governor = await ArmadaGovernor.deploy(
+    governor = await deployGovernorProxy(
       await armToken.getAddress(),
       timelockAddr,
       treasuryAddr.address,
       deployer.address, MAX_PAUSE_DURATION
     );
-    await governor.waitForDeployment();
 
     // Grant governor roles on timelock
     await timelockController.grantRole(PROPOSER_ROLE, await governor.getAddress());
@@ -637,14 +636,12 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       );
       await localTreasury.waitForDeployment();
 
-      const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-      localGovernor = await ArmadaGovernor.deploy(
+      localGovernor = await deployGovernorProxy(
         await localArmToken.getAddress(),
         localTlAddr,
         await localTreasury.getAddress(),
         localDeployer.address, LOCAL_MAX_PAUSE
       );
-      await localGovernor.waitForDeployment();
 
       // Grant governor roles on timelock
       const PROPOSER_ROLE = ethers.keccak256(ethers.toUtf8Bytes("PROPOSER_ROLE"));
@@ -921,14 +918,12 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
     it("non-deployer cannot call setExcludedAddresses", async function () {
       // Deploy a fresh governor to test (the existing one already has it locked)
-      const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-      const freshGovernor = await ArmadaGovernor.deploy(
+      const freshGovernor = await deployGovernorProxy(
         await localArmToken.getAddress(),
         await localTimelockController.getAddress(),
         await localTreasury.getAddress(),
         localDeployer.address, 14 * ONE_DAY
       );
-      await freshGovernor.waitForDeployment();
 
       // Non-deployer tries to call
       const nonDeployer = localSeeds[0];

--- a/test/gas_benchmark.ts
+++ b/test/gas_benchmark.ts
@@ -15,6 +15,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { deployGovernorProxy } from "./helpers/deploy-governor";
 
 const ONE_DAY = 86400;
 const THREE_WEEKS = 21 * ONE_DAY;
@@ -339,8 +340,7 @@ describe("Gas Benchmarks", function () {
       const timelock = await TimelockController.deploy(0, [deployer.address], [deployer.address], deployer.address);
 
       // Deploy governor
-      const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-      const governor = await ArmadaGovernor.deploy(
+      const governor = await deployGovernorProxy(
         await armToken.getAddress(),
         await timelock.getAddress(),
         deployer.address, // treasury

--- a/test/governance_adapter_registry.ts
+++ b/test/governance_adapter_registry.ts
@@ -5,6 +5,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { deployGovernorProxy } from "./helpers/deploy-governor";
 
 // Proposal types (must match IArmadaGovernance.sol enum order)
 const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2, Steward: 3 };
@@ -127,14 +128,12 @@ describe("Governance Adapter Registry", function () {
     await treasury.waitForDeployment();
 
     // 4. Deploy Governor
-    const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-    governor = await ArmadaGovernor.deploy(
+    governor = await deployGovernorProxy(
       await armToken.getAddress(),
       timelockAddr,
       await treasury.getAddress(),
       deployer.address, MAX_PAUSE_DURATION
     );
-    await governor.waitForDeployment();
 
     // 5. Configure timelock roles
     const govAddr = await governor.getAddress();

--- a/test/governance_adversarial.ts
+++ b/test/governance_adversarial.ts
@@ -476,13 +476,16 @@ describe("Governance Adversarial", function () {
         deployer.address, MAX_PAUSE
       ]);
       const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
-      await expect(ERC1967Proxy.deploy(await impl.getAddress(), initData)).to.be.reverted;
+      await expect(
+        ERC1967Proxy.deploy(await impl.getAddress(), initData)
+      ).to.be.revertedWith("ArmadaGovernor: zero armToken");
     });
 
     it("ArmadaGovernor rejects zero timelock", async function () {
       const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
       const impl = await ArmadaGovernor.deploy();
       await impl.waitForDeployment();
+      // Zero timelock is caught by EmergencyPausable first
       const initData = ArmadaGovernor.interface.encodeFunctionData("initialize", [
         await armToken.getAddress(),
         ethers.ZeroAddress,
@@ -490,7 +493,9 @@ describe("Governance Adversarial", function () {
         deployer.address, MAX_PAUSE
       ]);
       const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
-      await expect(ERC1967Proxy.deploy(await impl.getAddress(), initData)).to.be.reverted;
+      await expect(
+        ERC1967Proxy.deploy(await impl.getAddress(), initData)
+      ).to.be.revertedWith("EmergencyPausable: zero timelock");
     });
 
     it("ArmadaGovernor rejects zero treasury", async function () {
@@ -504,7 +509,9 @@ describe("Governance Adversarial", function () {
         deployer.address, MAX_PAUSE
       ]);
       const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
-      await expect(ERC1967Proxy.deploy(await impl.getAddress(), initData)).to.be.reverted;
+      await expect(
+        ERC1967Proxy.deploy(await impl.getAddress(), initData)
+      ).to.be.revertedWith("ArmadaGovernor: zero treasury");
     });
 
     it("TreasurySteward rejects zero timelock", async function () {

--- a/test/governance_adversarial.ts
+++ b/test/governance_adversarial.ts
@@ -13,6 +13,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { deployGovernorProxy } from "./helpers/deploy-governor";
 
 const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 const ProposalState = {
@@ -93,14 +94,12 @@ describe("Governance Adversarial", function () {
     );
     await treasuryContract.waitForDeployment();
 
-    const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-    governor = await ArmadaGovernor.deploy(
+    governor = await deployGovernorProxy(
       await armToken.getAddress(),
       timelockAddr,
       await treasuryContract.getAddress(),
       deployer.address, MAX_PAUSE_DURATION
     );
-    await governor.waitForDeployment();
 
     const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
     stewardContract = await TreasurySteward.deploy(
@@ -468,39 +467,44 @@ describe("Governance Adversarial", function () {
 
     it("ArmadaGovernor rejects zero armToken", async function () {
       const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-      await expect(
-        ArmadaGovernor.deploy(
-          ethers.ZeroAddress,
-          await timelockController.getAddress(),
-          await treasuryContract.getAddress(),
-          deployer.address, MAX_PAUSE
-        )
-      ).to.be.revertedWith("ArmadaGovernor: zero armToken");
+      const impl = await ArmadaGovernor.deploy();
+      await impl.waitForDeployment();
+      const initData = ArmadaGovernor.interface.encodeFunctionData("initialize", [
+        ethers.ZeroAddress,
+        await timelockController.getAddress(),
+        await treasuryContract.getAddress(),
+        deployer.address, MAX_PAUSE
+      ]);
+      const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
+      await expect(ERC1967Proxy.deploy(await impl.getAddress(), initData)).to.be.reverted;
     });
 
     it("ArmadaGovernor rejects zero timelock", async function () {
       const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-      // Zero timelock is caught by EmergencyPausable first
-      await expect(
-        ArmadaGovernor.deploy(
-          await armToken.getAddress(),
-          ethers.ZeroAddress,
-          await treasuryContract.getAddress(),
-          deployer.address, MAX_PAUSE
-        )
-      ).to.be.revertedWith("EmergencyPausable: zero timelock");
+      const impl = await ArmadaGovernor.deploy();
+      await impl.waitForDeployment();
+      const initData = ArmadaGovernor.interface.encodeFunctionData("initialize", [
+        await armToken.getAddress(),
+        ethers.ZeroAddress,
+        await treasuryContract.getAddress(),
+        deployer.address, MAX_PAUSE
+      ]);
+      const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
+      await expect(ERC1967Proxy.deploy(await impl.getAddress(), initData)).to.be.reverted;
     });
 
     it("ArmadaGovernor rejects zero treasury", async function () {
       const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-      await expect(
-        ArmadaGovernor.deploy(
-          await armToken.getAddress(),
-          await timelockController.getAddress(),
-          ethers.ZeroAddress,
-          deployer.address, MAX_PAUSE
-        )
-      ).to.be.revertedWith("ArmadaGovernor: zero treasury");
+      const impl = await ArmadaGovernor.deploy();
+      await impl.waitForDeployment();
+      const initData = ArmadaGovernor.interface.encodeFunctionData("initialize", [
+        await armToken.getAddress(),
+        await timelockController.getAddress(),
+        ethers.ZeroAddress,
+        deployer.address, MAX_PAUSE
+      ]);
+      const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
+      await expect(ERC1967Proxy.deploy(await impl.getAddress(), initData)).to.be.reverted;
     });
 
     it("TreasurySteward rejects zero timelock", async function () {

--- a/test/governance_emergency_pause.ts
+++ b/test/governance_emergency_pause.ts
@@ -13,6 +13,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { deployGovernorProxy } from "./helpers/deploy-governor";
 
 const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 const Vote = { Against: 0, For: 1, Abstain: 2 };
@@ -125,14 +126,12 @@ describe("Governance Emergency Pause", function () {
     await treasury.waitForDeployment();
 
     // 4. Deploy ArmadaGovernor (uses ArmadaToken ERC20Votes for voting power)
-    const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-    governor = await ArmadaGovernor.deploy(
+    governor = await deployGovernorProxy(
       await armToken.getAddress(),
       timelockAddr,
       await treasury.getAddress(),
       guardian.address, MAX_PAUSE_DURATION
     );
-    await governor.waitForDeployment();
 
     // 5. Deploy TreasurySteward
     const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
@@ -541,14 +540,12 @@ describe("Governance Emergency Pause", function () {
       // Deploy standalone governor with deployer as pauseTimelock via the guardian constructor param
       // Actually, the pauseTimelock IS the timelock param. So we need the governor to use
       // a timelock we control. Let's use the standaloneTimelock but keep deployer as admin.
-      const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-      standaloneGovernor = await ArmadaGovernor.deploy(
+      standaloneGovernor = await deployGovernorProxy(
         await armToken.getAddress(),
         tlAddr,
         await treasury.getAddress(),
         guardian.address, MAX_PAUSE_DURATION
       );
-      await standaloneGovernor.waitForDeployment();
 
       // Grant governor the proposer/executor roles on the timelock
       const PROPOSER_ROLE = await standaloneTimelock.PROPOSER_ROLE();

--- a/test/governance_integration.ts
+++ b/test/governance_integration.ts
@@ -13,6 +13,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { deployGovernorProxy } from "./helpers/deploy-governor";
 
 // Proposal types (must match IArmadaGovernance.sol enum order)
 const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2, Steward: 3 };
@@ -139,15 +140,13 @@ describe("Governance Integration", function () {
     await treasury.waitForDeployment();
 
     // 4. Deploy ArmadaGovernor
-    const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-    governor = await ArmadaGovernor.deploy(
+    governor = await deployGovernorProxy(
       await armToken.getAddress(),
       timelockAddr,
       await treasury.getAddress(),
       deployer.address,        // guardian
       MAX_PAUSE_DURATION
     );
-    await governor.waitForDeployment();
 
     // 5. Deploy TreasurySteward (identity management only)
     const TreasurySteward = await ethers.getContractFactory("TreasurySteward");

--- a/test/governance_param_updates.ts
+++ b/test/governance_param_updates.ts
@@ -13,6 +13,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { deployGovernorProxy } from "./helpers/deploy-governor";
 
 const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 const ProposalState = {
@@ -139,14 +140,12 @@ describe("Governance Parameter Updates", function () {
     );
     await treasury.waitForDeployment();
 
-    const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-    governor = await ArmadaGovernor.deploy(
+    governor = await deployGovernorProxy(
       await armToken.getAddress(),
       timelockAddr,
       await treasury.getAddress(),
       deployer.address, MAX_PAUSE_DURATION
     );
-    await governor.waitForDeployment();
 
     const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
     stewardContract = await TreasurySteward.deploy(
@@ -219,14 +218,12 @@ describe("Governance Parameter Updates", function () {
     let standaloneGovernor: any;
 
     beforeEach(async function () {
-      const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-      standaloneGovernor = await ArmadaGovernor.deploy(
+      standaloneGovernor = await deployGovernorProxy(
         await armToken.getAddress(),
         deployer.address,   // deployer acts as timelock
         await treasury.getAddress(),
         deployer.address, MAX_PAUSE_DURATION
       );
-      await standaloneGovernor.waitForDeployment();
     });
 
     const validParams = {
@@ -361,14 +358,12 @@ describe("Governance Parameter Updates", function () {
       await standaloneTimelock.waitForDeployment();
       const tlAddr = await standaloneTimelock.getAddress();
 
-      const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-      standaloneGovernor = await ArmadaGovernor.deploy(
+      standaloneGovernor = await deployGovernorProxy(
         await armToken.getAddress(),
         tlAddr,
         await treasury.getAddress(),
         deployer.address, MAX_PAUSE_DURATION
       );
-      await standaloneGovernor.waitForDeployment();
 
       // Grant roles — governor for proposals, deployer for direct schedule/execute in tests
       const PROPOSER_ROLE = await standaloneTimelock.PROPOSER_ROLE();

--- a/test/governance_quiet_period.ts
+++ b/test/governance_quiet_period.ts
@@ -13,6 +13,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { deployGovernorProxy } from "./helpers/deploy-governor";
 
 const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 const ONE_DAY = 86400;
@@ -88,15 +89,13 @@ describe("Governance Quiet Period (T6.1)", function () {
     await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
     await crowdfund.loadArm();
 
-    const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-    governor = await ArmadaGovernor.deploy(
+    governor = await deployGovernorProxy(
       await armToken.getAddress(),
       timelockAddr,
       treasuryAddr.address,
       deployer.address,
       MAX_PAUSE_DURATION
     );
-    await governor.waitForDeployment();
 
     // Grant governor roles on timelock
     await timelockController.grantRole(PROPOSER_ROLE, await governor.getAddress());

--- a/test/governance_upgrade.ts
+++ b/test/governance_upgrade.ts
@@ -1,0 +1,221 @@
+// ABOUTME: Hardhat tests for ArmadaGovernor UUPS upgradeability.
+// ABOUTME: Covers upgrade authorization, state persistence, re-init prevention, and extended classification.
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+import { deployGovernorProxy } from "./helpers/deploy-governor";
+
+describe("Governance UUPS Upgrade", function () {
+  let deployer: any, alice: any, bob: any, attacker: any;
+  let armToken: any, timelock: any, treasury: any, governor: any;
+
+  const TOTAL_SUPPLY = ethers.parseUnits("12000000", 18);
+  const MAX_PAUSE = 14 * 24 * 60 * 60; // 14 days in seconds
+  const TWO_DAYS = 2 * 24 * 60 * 60;
+
+  beforeEach(async function () {
+    [deployer, alice, bob, attacker] = await ethers.getSigners();
+
+    // Deploy timelock
+    const TimelockController = await ethers.getContractFactory("TimelockController");
+    timelock = await TimelockController.deploy(TWO_DAYS, [], [], deployer.address);
+    await timelock.waitForDeployment();
+    const timelockAddr = await timelock.getAddress();
+
+    // Deploy ARM token
+    const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+    armToken = await ArmadaToken.deploy(deployer.address, timelockAddr);
+    await armToken.waitForDeployment();
+    const armTokenAddr = await armToken.getAddress();
+
+    // Deploy treasury
+    const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+    treasury = await ArmadaTreasuryGov.deploy(timelockAddr, deployer.address, MAX_PAUSE);
+    await treasury.waitForDeployment();
+    const treasuryAddr = await treasury.getAddress();
+
+    // Deploy governor behind UUPS proxy
+    governor = await deployGovernorProxy(
+      armTokenAddr, timelockAddr, treasuryAddr,
+      deployer.address, MAX_PAUSE
+    );
+
+    // Grant timelock roles
+    const governorAddr = await governor.getAddress();
+    await timelock.grantRole(await timelock.PROPOSER_ROLE(), governorAddr);
+    await timelock.grantRole(await timelock.EXECUTOR_ROLE(), governorAddr);
+
+    // Grant deployer proposer/executor roles for direct timelock operations in tests
+    await timelock.grantRole(await timelock.PROPOSER_ROLE(), deployer.address);
+    await timelock.grantRole(await timelock.EXECUTOR_ROLE(), deployer.address);
+
+    // Setup tokens
+    const whitelist = [deployer.address, alice.address, bob.address, treasuryAddr];
+    await armToken.initWhitelist(whitelist);
+    await armToken.transfer(alice.address, TOTAL_SUPPLY * 40n / 100n);
+    await armToken.transfer(bob.address, TOTAL_SUPPLY * 20n / 100n);
+
+    // Delegate
+    await armToken.connect(alice).delegate(alice.address);
+    await armToken.connect(bob).delegate(bob.address);
+  });
+
+  describe("Upgrade Authorization", function () {
+    it("upgrade via timelock succeeds", async function () {
+      const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
+      const v2Impl = await ArmadaGovernor.deploy();
+      await v2Impl.waitForDeployment();
+
+      // Execute upgrade via timelock
+      const upgradeCalldata = governor.interface.encodeFunctionData(
+        "upgradeTo", [await v2Impl.getAddress()]
+      );
+      const governorAddr = await governor.getAddress();
+      await timelock.schedule(
+        governorAddr, 0, upgradeCalldata,
+        ethers.ZeroHash, ethers.id("upgrade-v2"), TWO_DAYS
+      );
+      await time.increase(TWO_DAYS + 1);
+      await timelock.execute(
+        governorAddr, 0, upgradeCalldata,
+        ethers.ZeroHash, ethers.id("upgrade-v2")
+      );
+
+      // Governor still works — read state through proxy
+      expect(await governor.treasuryAddress()).to.equal(await treasury.getAddress());
+    });
+
+    it("upgrade from non-timelock reverts", async function () {
+      const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
+      const v2Impl = await ArmadaGovernor.deploy();
+      await v2Impl.waitForDeployment();
+
+      await expect(
+        governor.connect(attacker).upgradeTo(await v2Impl.getAddress())
+      ).to.be.revertedWith("ArmadaGovernor: not timelock");
+    });
+
+    it("upgrade from deployer reverts", async function () {
+      const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
+      const v2Impl = await ArmadaGovernor.deploy();
+      await v2Impl.waitForDeployment();
+
+      await expect(
+        governor.connect(deployer).upgradeTo(await v2Impl.getAddress())
+      ).to.be.revertedWith("ArmadaGovernor: not timelock");
+    });
+  });
+
+  describe("State Persistence Across Upgrade", function () {
+    it("core state persists after upgrade", async function () {
+      // Record pre-upgrade state
+      const armTokenAddr = await governor.armToken();
+      const timelockAddr = await governor.timelock();
+      const treasuryAddr = await governor.treasuryAddress();
+      const deployerAddr = await governor.deployer();
+
+      // Deploy V2 and upgrade via timelock
+      const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
+      const v2Impl = await ArmadaGovernor.deploy();
+      await v2Impl.waitForDeployment();
+
+      const upgradeCalldata = governor.interface.encodeFunctionData(
+        "upgradeTo", [await v2Impl.getAddress()]
+      );
+      const governorAddr = await governor.getAddress();
+      await timelock.schedule(
+        governorAddr, 0, upgradeCalldata,
+        ethers.ZeroHash, ethers.id("upgrade-state"), TWO_DAYS
+      );
+      await time.increase(TWO_DAYS + 1);
+      await timelock.execute(
+        governorAddr, 0, upgradeCalldata,
+        ethers.ZeroHash, ethers.id("upgrade-state")
+      );
+
+      // Verify state persists
+      expect(await governor.armToken()).to.equal(armTokenAddr);
+      expect(await governor.timelock()).to.equal(timelockAddr);
+      expect(await governor.treasuryAddress()).to.equal(treasuryAddr);
+      expect(await governor.deployer()).to.equal(deployerAddr);
+    });
+
+    it("proposal type params persist after upgrade", async function () {
+      const [delay, period, execDelay, quorum] =
+        await governor.proposalTypeParams(0); // Standard
+      expect(delay).to.equal(TWO_DAYS);
+      expect(period).to.equal(7 * 24 * 60 * 60);
+      expect(execDelay).to.equal(TWO_DAYS);
+      expect(quorum).to.equal(2000);
+
+      // Upgrade
+      const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
+      const v2Impl = await ArmadaGovernor.deploy();
+      await v2Impl.waitForDeployment();
+
+      const upgradeCalldata = governor.interface.encodeFunctionData(
+        "upgradeTo", [await v2Impl.getAddress()]
+      );
+      const governorAddr = await governor.getAddress();
+      await timelock.schedule(
+        governorAddr, 0, upgradeCalldata,
+        ethers.ZeroHash, ethers.id("upgrade-params"), TWO_DAYS
+      );
+      await time.increase(TWO_DAYS + 1);
+      await timelock.execute(
+        governorAddr, 0, upgradeCalldata,
+        ethers.ZeroHash, ethers.id("upgrade-params")
+      );
+
+      // Verify params persist
+      const [d2, p2, e2, q2] = await governor.proposalTypeParams(0);
+      expect(d2).to.equal(TWO_DAYS);
+      expect(p2).to.equal(7 * 24 * 60 * 60);
+      expect(e2).to.equal(TWO_DAYS);
+      expect(q2).to.equal(2000);
+    });
+  });
+
+  describe("Initialization Guards", function () {
+    it("cannot re-initialize proxy", async function () {
+      await expect(
+        governor.initialize(
+          await armToken.getAddress(),
+          await timelock.getAddress(),
+          await treasury.getAddress(),
+          deployer.address,
+          MAX_PAUSE
+        )
+      ).to.be.revertedWith("Initializable: contract is already initialized");
+    });
+
+    it("implementation cannot be initialized directly", async function () {
+      const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
+      const impl = await ArmadaGovernor.deploy();
+      await impl.waitForDeployment();
+
+      await expect(
+        impl.initialize(
+          await armToken.getAddress(),
+          await timelock.getAddress(),
+          await treasury.getAddress(),
+          deployer.address,
+          MAX_PAUSE
+        )
+      ).to.be.revertedWith("Initializable: contract is already initialized");
+    });
+  });
+
+  describe("Extended Classification for Upgrades", function () {
+    it("upgradeTo selector is registered as extended", async function () {
+      const selector = ethers.id("upgradeTo(address)").slice(0, 10);
+      expect(await governor.extendedSelectors(selector)).to.be.true;
+    });
+
+    it("upgradeToAndCall selector is registered as extended", async function () {
+      const selector = ethers.id("upgradeToAndCall(address,bytes)").slice(0, 10);
+      expect(await governor.extendedSelectors(selector)).to.be.true;
+    });
+  });
+});

--- a/test/governance_veto.ts
+++ b/test/governance_veto.ts
@@ -5,6 +5,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { deployGovernorProxy } from "./helpers/deploy-governor";
 
 // Proposal types (must match IArmadaGovernance.sol enum order)
 const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
@@ -133,14 +134,12 @@ describe("Governance Veto", function () {
     await treasury.waitForDeployment();
 
     // 4. Deploy Governor
-    const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-    governor = await ArmadaGovernor.deploy(
+    governor = await deployGovernorProxy(
       await armToken.getAddress(),
       timelockAddr,
       await treasury.getAddress(),
       deployer.address, MAX_PAUSE_DURATION
     );
-    await governor.waitForDeployment();
 
     // 5. Configure timelock roles: PROPOSER, EXECUTOR, and CANCELLER for governor
     const PROPOSER_ROLE = await timelockController.PROPOSER_ROLE();

--- a/test/helpers/deploy-governor.ts
+++ b/test/helpers/deploy-governor.ts
@@ -1,0 +1,35 @@
+// ABOUTME: Shared test helper for deploying ArmadaGovernor behind an ERC1967 UUPS proxy.
+// ABOUTME: Used by all Hardhat test files that need a governor instance.
+
+import { ethers } from "hardhat";
+
+/**
+ * Deploy ArmadaGovernor implementation + ERC1967Proxy and return the proxied contract instance.
+ * Matches the production deployment pattern in scripts/deploy_governance.ts.
+ */
+export async function deployGovernorProxy(
+  armTokenAddress: string,
+  timelockAddress: string,
+  treasuryAddress: string,
+  guardianAddress: string,
+  maxPauseDuration: number | bigint
+) {
+  const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
+  const impl = await ArmadaGovernor.deploy();
+  await impl.waitForDeployment();
+
+  const initData = ArmadaGovernor.interface.encodeFunctionData("initialize", [
+    armTokenAddress,
+    timelockAddress,
+    treasuryAddress,
+    guardianAddress,
+    maxPauseDuration,
+  ]);
+
+  const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
+  const proxy = await ERC1967Proxy.deploy(await impl.getAddress(), initData);
+  await proxy.waitForDeployment();
+
+  const governor = ArmadaGovernor.attach(await proxy.getAddress());
+  return governor;
+}

--- a/test/winddown_redemption_integration.ts
+++ b/test/winddown_redemption_integration.ts
@@ -15,6 +15,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { deployGovernorProxy } from "./helpers/deploy-governor";
 
 const ONE_DAY = 86400;
 const TWO_DAYS = 2 * ONE_DAY;
@@ -88,15 +89,13 @@ describe("Wind-Down & Redemption Integration", function () {
     treasuryContract = await ArmadaTreasuryGov.deploy(timelockAddr, deployer.address, MAX_PAUSE_DURATION);
     await treasuryContract.waitForDeployment();
 
-    const ArmadaGovernor = await ethers.getContractFactory("ArmadaGovernor");
-    governor = await ArmadaGovernor.deploy(
+    governor = await deployGovernorProxy(
       await armToken.getAddress(),
       timelockAddr,
       await treasuryContract.getAddress(),
       deployer.address,
       MAX_PAUSE_DURATION,
     );
-    await governor.waitForDeployment();
 
     const TreasurySteward = await ethers.getContractFactory("TreasurySteward");
     stewardContract = await TreasurySteward.deploy(timelockAddr, deployer.address, MAX_PAUSE_DURATION);
@@ -570,10 +569,22 @@ describe("Wind-Down & Redemption Integration", function () {
       const addr1 = await usdc.getAddress();
       const addr2 = await weth.getAddress();
 
-      // Put higher address first (unsorted)
-      const tokens = addr1 > addr2 ? [addr1, addr2] : [addr2, addr1];
+      // Ensure Alice has ARM for this test (prior tests may have consumed her balance)
+      const redeemAmount = ethers.parseUnits("100", 18);
+      const aliceBalance = await armToken.balanceOf(alice.address);
+      if (aliceBalance < redeemAmount) {
+        // Top up from deployer (deployer is whitelisted and has remaining ARM)
+        const [deployer_] = await ethers.getSigners();
+        await armToken.connect(deployer_).transfer(alice.address, redeemAmount);
+      }
+
+      // Put higher address first (unsorted — descending order).
+      // Use lowercase for comparison because JS string comparison is case-sensitive
+      // but Solidity address comparison is numeric (case-insensitive).
+      const tokens = addr1.toLowerCase() > addr2.toLowerCase()
+        ? [addr1, addr2] : [addr2, addr1];
       await expect(
-        redemption.connect(alice).redeem(ALICE_AMOUNT, tokens, false)
+        redemption.connect(alice).redeem(redeemAmount, tokens, false)
       ).to.be.revertedWith("ArmadaRedemption: tokens not sorted/unique");
     });
 


### PR DESCRIPTION
## Summary

- Converts `ArmadaGovernor` from a plain contract to a UUPS-upgradeable proxy pattern (GAP 11.1)
- Creates `EmergencyPausableUpgradeable.sol` as the upgradeable companion to `EmergencyPausable`
- All 4 immutable fields (`armToken`, `timelock`, `treasuryAddress`, `deployer`) converted to storage variables
- Constructor replaced with `initialize()` external initializer; `_disableInitializers()` in constructor
- Upgrade authorization gated to timelock via `_authorizeUpgrade()`
- Storage gaps follow 50-slot convention per contract
- Pure refactor — no new governance functionality

## Changes

- **New:** `contracts/governance/EmergencyPausableUpgradeable.sol` — upgradeable base with init pattern + 45-slot gap
- **Modified:** `contracts/governance/ArmadaGovernor.sol` — UUPS conversion (Initializable, ReentrancyGuardUpgradeable, UUPSUpgradeable, EmergencyPausableUpgradeable)
- **New:** `test-foundry/helpers/GovernorDeployHelper.sol` — shared Foundry proxy deploy helper
- **New:** `test/helpers/deploy-governor.ts` — shared Hardhat proxy deploy helper
- **New:** `test-foundry/GovernorUpgrade.t.sol` — 11 UUPS-specific Foundry tests
- **New:** `test/governance_upgrade.ts` — 9 UUPS-specific Hardhat tests
- **Modified:** 7 Foundry test files — updated setUp() to use proxy deployment
- **Modified:** 10 Hardhat test files — updated deployment to use proxy pattern
- **Modified:** 3 deployment/demo scripts — impl+proxy deployment pattern
- **Fixed:** Latent address comparison bug in `winddown_redemption_integration.ts` (JS case-sensitive checksummed address comparison)

## Test plan

- [x] `npm run test:forge` — 363 passed, 0 failed
- [x] `npm run test:all` — 692 passed, 0 failed
- [x] Storage layout verified via `forge inspect ArmadaGovernor storage-layout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)