### PR TITLE
feat: crowdfund Phase A foundation (Tasks 2, 4, 6)

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -102,7 +102,6 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     // ============ Events ============
 
     event SeedAdded(address indexed seed);
-    event WindowStarted(uint256 windowStart, uint256 windowEnd, uint256 launchTeamInviteEnd);
     event Invited(address indexed inviter, address indexed invitee, uint8 hop);
     event InviteAdded(address indexed inviter, address indexed invitee, uint8 hop, uint16 newInviteCount);
     event Committed(address indexed participant, uint256 amount, uint256 totalForParticipant, uint8 hop);
@@ -121,32 +120,34 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         _;
     }
 
-    modifier inPhase(Phase _phase) {
-        require(phase == _phase, "ArmadaCrowdfund: wrong phase");
-        _;
-    }
-
     // ============ Constructor ============
 
+    /// @param _openTimestamp When the 3-week active window begins (must be >= block.timestamp)
     constructor(
         address _usdc,
         address _armToken,
         address _admin,
         address _treasury,
         address _launchTeam,
-        address _securityCouncil
+        address _securityCouncil,
+        uint256 _openTimestamp
     ) {
         require(_admin != address(0), "ArmadaCrowdfund: zero admin");
         require(_treasury != address(0), "ArmadaCrowdfund: zero treasury");
         require(_launchTeam != address(0), "ArmadaCrowdfund: zero launchTeam");
         require(_securityCouncil != address(0), "ArmadaCrowdfund: zero securityCouncil");
+        require(_openTimestamp >= block.timestamp, "ArmadaCrowdfund: openTimestamp in past");
         usdc = IERC20(_usdc);
         armToken = IERC20(_armToken);
         admin = _admin;
         treasury = _treasury;
         launchTeam = _launchTeam;
         securityCouncil = _securityCouncil;
-        phase = Phase.Setup;
+
+        windowStart = _openTimestamp;
+        windowEnd = _openTimestamp + WINDOW_DURATION;
+        launchTeamInviteEnd = _openTimestamp + LAUNCH_TEAM_INVITE_PERIOD;
+        // phase defaults to Phase.Active (value 0)
 
         hopConfigs[0] = HopConfig({ ceilingBps: 7000, capUsdc: 15_000 * 1e6, maxInvites: 3, maxInvitesReceived: 1 });
         hopConfigs[1] = HopConfig({ ceilingBps: 4500, capUsdc: 4_000 * 1e6,  maxInvites: 2, maxInvitesReceived: 10 });
@@ -155,17 +156,17 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
     // ============ Setup Phase ============
 
-    /// @notice Add seed addresses (hop 0). Allowed during Setup or week 1 of the active window.
+    /// @notice Add seed addresses (hop 0). Allowed before invite period ends (requires ARM loaded).
     function addSeeds(address[] calldata seeds) external onlyAdmin {
-        _requireSetupOrWeek1();
+        _requireArmLoadedAndPreInviteEnd();
         for (uint256 i = 0; i < seeds.length; i++) {
             _addSeed(seeds[i]);
         }
     }
 
-    /// @notice Add a single seed address (hop 0). Allowed during Setup or week 1 of the active window.
+    /// @notice Add a single seed address (hop 0). Allowed before invite period ends (requires ARM loaded).
     function addSeed(address seed) external onlyAdmin {
-        _requireSetupOrWeek1();
+        _requireArmLoadedAndPreInviteEnd();
         _addSeed(seed);
     }
 
@@ -185,7 +186,6 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
     /// @notice Verify the contract holds sufficient ARM for the maximum possible sale.
     ///         Permissionless. Idempotent: no-op if already loaded.
-    ///         Must be called before startWindow().
     function loadArm() external {
         if (armLoaded) return;
 
@@ -195,19 +195,6 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
         armLoaded = true;
         emit ArmLoaded(balance);
-    }
-
-    /// @notice Start the 3-week active window (invites + commits concurrent)
-    function startWindow() external onlyAdmin inPhase(Phase.Setup) {
-        require(hopStats[0].whitelistCount > 0, "ArmadaCrowdfund: no seeds");
-        require(armLoaded, "ArmadaCrowdfund: ARM not loaded");
-
-        windowStart = block.timestamp;
-        windowEnd = block.timestamp + WINDOW_DURATION;
-        launchTeamInviteEnd = block.timestamp + LAUNCH_TEAM_INVITE_PERIOD;
-        phase = Phase.Active;
-
-        emit WindowStarted(windowStart, windowEnd, launchTeamInviteEnd);
     }
 
     // ============ Invitation Phase ============
@@ -262,18 +249,20 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     ///         The launch team is a sentinel with predeclared invite budgets — it is not
     ///         a participant and cannot commit USDC.
     /// @param invitee Address to invite
-    /// @param hop Target hop level (must be 1 or 2)
-    function launchTeamInvite(address invitee, uint8 hop) external whenNotPaused {
+    /// @param fromHop Source hop level (0 = invite to hop-1, 1 = invite to hop-2)
+    function launchTeamInvite(address invitee, uint8 fromHop) external whenNotPaused {
         require(msg.sender == launchTeam, "ArmadaCrowdfund: not launch team");
         require(phase == Phase.Active, "ArmadaCrowdfund: not active");
         require(
             block.timestamp < launchTeamInviteEnd,
             "ArmadaCrowdfund: launch team invite window closed"
         );
-        require(hop == 1 || hop == 2, "ArmadaCrowdfund: invalid hop for launch team");
+        require(fromHop == 0 || fromHop == 1, "ArmadaCrowdfund: invalid hop for launch team");
         require(invitee != address(0), "ArmadaCrowdfund: zero address");
 
-        if (hop == 1) {
+        uint8 inviteeHop = fromHop + 1;
+
+        if (fromHop == 0) {
             require(launchTeamHop1Used < LAUNCH_TEAM_HOP1_BUDGET, "ArmadaCrowdfund: hop-1 budget exhausted");
             launchTeamHop1Used++;
         } else {
@@ -281,33 +270,33 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
             launchTeamHop2Used++;
         }
 
-        Participant storage inviteeNode = participants[invitee][hop];
+        Participant storage inviteeNode = participants[invitee][inviteeHop];
 
         if (!inviteeNode.isWhitelisted) {
             inviteeNode.isWhitelisted = true;
             inviteeNode.invitesReceived = 1;
             inviteeNode.invitedBy = msg.sender;
-            participantNodes.push(ParticipantNode(invitee, hop));
-            hopStats[hop].whitelistCount++;
+            participantNodes.push(ParticipantNode(invitee, inviteeHop));
+            hopStats[inviteeHop].whitelistCount++;
 
-            emit Invited(msg.sender, invitee, hop);
+            emit Invited(msg.sender, invitee, inviteeHop);
         } else {
             require(
-                inviteeNode.invitesReceived < hopConfigs[hop].maxInvitesReceived,
+                inviteeNode.invitesReceived < hopConfigs[inviteeHop].maxInvitesReceived,
                 "ArmadaCrowdfund: max invites received"
             );
             inviteeNode.invitesReceived++;
 
-            emit InviteAdded(msg.sender, invitee, hop, inviteeNode.invitesReceived);
+            emit InviteAdded(msg.sender, invitee, inviteeHop, inviteeNode.invitesReceived);
         }
     }
 
     // ============ Commitment Phase ============
 
     /// @notice Commit USDC to the crowdfund at a specific hop level
-    /// @param amount USDC amount to commit (6 decimals)
     /// @param hop Which of the caller's (address, hop) nodes to commit to
-    function commit(uint256 amount, uint8 hop) external nonReentrant whenNotPaused {
+    /// @param amount USDC amount to commit (6 decimals)
+    function commit(uint8 hop, uint256 amount) external nonReentrant whenNotPaused {
         require(phase == Phase.Active, "ArmadaCrowdfund: not active");
         require(armLoaded, "ArmadaCrowdfund: ARM not loaded");
         require(
@@ -678,12 +667,12 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
     // ============ Internal ============
 
-    /// @dev Enforces that seeds can only be added during Setup or week 1 of the active window.
-    function _requireSetupOrWeek1() internal view {
+    /// @dev Enforces that seeds can only be added before the invite period ends (requires ARM loaded).
+    function _requireArmLoadedAndPreInviteEnd() internal view {
+        require(armLoaded, "ArmadaCrowdfund: ARM not loaded");
         require(
-            phase == Phase.Setup ||
-            (phase == Phase.Active && block.timestamp < launchTeamInviteEnd),
-            "ArmadaCrowdfund: seeds only during setup or week 1"
+            block.timestamp < launchTeamInviteEnd,
+            "ArmadaCrowdfund: seeds only before invite period ends"
         );
     }
 

--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -154,7 +154,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         hopConfigs[2] = HopConfig({ ceilingBps: 0,    capUsdc: 1_000 * 1e6,  maxInvites: 0, maxInvitesReceived: 20 });
     }
 
-    // ============ Setup Phase ============
+    // ============ Seed Management ============
 
     /// @notice Add seed addresses (hop 0). Allowed before invite period ends (requires ARM loaded).
     function addSeeds(address[] calldata seeds) external onlyAdmin {
@@ -336,7 +336,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     // ============ Finalization ============
 
     /// @notice Security council emergency cancel. Immediate and irreversible.
-    ///         Available at any pre-finalization phase (Setup, Active, or post-window).
+    ///         Available during Active phase (pre- or post-window).
     function cancel() external {
         require(msg.sender == securityCouncil, "ArmadaCrowdfund: not security council");
         require(phase != Phase.Finalized, "ArmadaCrowdfund: already finalized");
@@ -669,6 +669,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
 
     /// @dev Enforces that seeds can only be added before the invite period ends (requires ARM loaded).
     function _requireArmLoadedAndPreInviteEnd() internal view {
+        require(phase == Phase.Active, "ArmadaCrowdfund: not active");
         require(armLoaded, "ArmadaCrowdfund: ARM not loaded");
         require(
             block.timestamp < launchTeamInviteEnd,

--- a/contracts/crowdfund/IArmadaCrowdfund.sol
+++ b/contracts/crowdfund/IArmadaCrowdfund.sol
@@ -9,7 +9,6 @@ pragma solidity ^0.8.17;
 // ========== Enums ==========
 
 enum Phase {
-    Setup,          // Admin configures seeds
     Active,         // Invites + commits happen concurrently (3-week window)
     Finalized,      // Allocations computed, claims open
     Canceled        // Below minimum raise, full refunds

--- a/crowdfund-frontend/src/components/AdminPanel.tsx
+++ b/crowdfund-frontend/src/components/AdminPanel.tsx
@@ -7,7 +7,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
-import { ShieldCheck, ShieldAlert, Play, Flag, Coins, Zap, Users } from 'lucide-react'
+import { ShieldCheck, ShieldAlert, Flag, Coins, Zap, Users } from 'lucide-react'
 import { Phase } from '@/types/crowdfund'
 import type { CrowdfundState } from '@/atoms/crowdfund'
 import type { useCrowdfund } from '@/hooks/useCrowdfund'
@@ -28,7 +28,7 @@ export function AdminPanel({ state, crowdfund, currentAddress }: AdminPanelProps
   const [seedInput, setSeedInput] = useState('')
   const [treasuryInput, setTreasuryInput] = useState('')
   const [ltInviteAddr, setLtInviteAddr] = useState('')
-  const [ltInviteHop, setLtInviteHop] = useState<1 | 2>(1)
+  const [ltInviteHop, setLtInviteHop] = useState<0 | 1>(0)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const isAdmin = currentAddress && state.adminAddress
@@ -112,12 +112,6 @@ export function AdminPanel({ state, crowdfund, currentAddress }: AdminPanelProps
     setIsSubmitting(false)
   }
 
-  const handleStartWindow = async () => {
-    setIsSubmitting(true)
-    await crowdfund.startWindow()
-    setIsSubmitting(false)
-  }
-
   const handleFinalize = async () => {
     setIsSubmitting(true)
     await crowdfund.finalize()
@@ -153,8 +147,8 @@ export function AdminPanel({ state, crowdfund, currentAddress }: AdminPanelProps
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        {/* Setup Phase: Add Seeds (admin only) */}
-        {phase === Phase.Setup && isAdmin && (
+        {/* Active Phase: Add Seeds + ARM Pre-Load (admin only, before window opens) */}
+        {phase === Phase.Active && isAdmin && Number(state.windowStart) > 0 && state.blockTimestamp < Number(state.windowStart) && (
           <>
             <div className="space-y-2">
               <div className="flex items-center justify-between">
@@ -218,21 +212,6 @@ export function AdminPanel({ state, crowdfund, currentAddress }: AdminPanelProps
               </div>
             </div>
 
-            <Button
-              onClick={handleStartWindow}
-              disabled={isSubmitting || !state.armLoaded || !state.hopStats || state.hopStats[0].whitelistCount === 0}
-              className="w-full gap-2"
-            >
-              <Play className="h-4 w-4" />
-              Start Window
-            </Button>
-            {!state.armLoaded && (
-              <p className="text-xs text-muted-foreground">ARM must be loaded before starting the window</p>
-            )}
-            {state.armLoaded && state.hopStats && state.hopStats[0].whitelistCount === 0 && (
-              <p className="text-xs text-muted-foreground">Add at least one seed first</p>
-            )}
-
             <Separator />
 
             <Button
@@ -252,7 +231,7 @@ export function AdminPanel({ state, crowdfund, currentAddress }: AdminPanelProps
         {phase === Phase.Active && isLaunchTeam && (() => {
           const budget = state.launchTeamBudget
           const inviteWindowOpen = state.blockTimestamp > 0 && state.blockTimestamp < Number(state.launchTeamInviteEnd)
-          const selectedBudget = ltInviteHop === 1 ? budget?.hop1Remaining : budget?.hop2Remaining
+          const selectedBudget = ltInviteHop === 0 ? budget?.hop1Remaining : budget?.hop2Remaining
           return (
             <div className="space-y-3">
               <div className="flex items-center gap-2 text-sm font-medium">
@@ -304,17 +283,17 @@ export function AdminPanel({ state, crowdfund, currentAddress }: AdminPanelProps
                     <Label>Hop</Label>
                     <div className="flex gap-2">
                       <Button
-                        variant={ltInviteHop === 1 ? 'default' : 'outline'}
+                        variant={ltInviteHop === 0 ? 'default' : 'outline'}
                         size="sm"
-                        onClick={() => setLtInviteHop(1)}
+                        onClick={() => setLtInviteHop(0)}
                         className="flex-1"
                       >
                         Hop 1 ({budget?.hop1Remaining ?? '?'} left)
                       </Button>
                       <Button
-                        variant={ltInviteHop === 2 ? 'default' : 'outline'}
+                        variant={ltInviteHop === 1 ? 'default' : 'outline'}
                         size="sm"
-                        onClick={() => setLtInviteHop(2)}
+                        onClick={() => setLtInviteHop(1)}
                         className="flex-1"
                       >
                         Hop 2 ({budget?.hop2Remaining ?? '?'} left)

--- a/crowdfund-frontend/src/components/SaleStatus.tsx
+++ b/crowdfund-frontend/src/components/SaleStatus.tsx
@@ -24,7 +24,7 @@ interface SaleStatusProps {
  * The contract phase maps directly to display state.
  */
 function getEffectivePhase(state: CrowdfundState, _now: number): Phase {
-  if (state.phase === null) return Phase.Setup
+  if (state.phase === null) return Phase.Active
   return state.phase
 }
 

--- a/crowdfund-frontend/src/config/abi.ts
+++ b/crowdfund-frontend/src/config/abi.ts
@@ -6,7 +6,6 @@ export const CROWDFUND_ABI = [
   'function addSeed(address seed) external',
   'function addSeeds(address[] calldata seeds) external',
   'function loadArm() external',
-  'function startWindow() external',
   'function finalize() external',
   'function cancel() external',
   'function withdrawUnallocatedArm() external',
@@ -15,12 +14,12 @@ export const CROWDFUND_ABI = [
 
   // Participant actions
   'function invite(address invitee, uint8 inviterHop) external',
-  'function commit(uint256 amount, uint8 hop) external',
+  'function commit(uint8 hop, uint256 amount) external',
   'function claim() external',
   'function claimRefund() external',
 
   // Launch team actions
-  'function launchTeamInvite(address invitee, uint8 hop) external',
+  'function launchTeamInvite(address invitee, uint8 fromHop) external',
 
   // State variables (public getters)
   'function phase() view returns (uint8)',
@@ -66,7 +65,6 @@ export const CROWDFUND_ABI = [
 
   // Events
   'event SeedAdded(address indexed seed)',
-  'event WindowStarted(uint256 windowStart, uint256 windowEnd, uint256 launchTeamInviteEnd)',
   'event Invited(address indexed inviter, address indexed invitee, uint8 hop)',
   'event InviteAdded(address indexed inviter, address indexed invitee, uint8 hop, uint16 newInviteCount)',
   'event Committed(address indexed participant, uint256 amount, uint256 totalForParticipant, uint8 hop)',

--- a/crowdfund-frontend/src/hooks/useCrowdfund.ts
+++ b/crowdfund-frontend/src/hooks/useCrowdfund.ts
@@ -134,7 +134,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
       // Fetch aggregate allocation if finalized and not in refund mode
       let currentAllocation = null
       let userHopAllocations: UserHopAllocation[] = []
-      if (parsedPhase === 2 && !isRefundMode) {
+      if (parsedPhase === 1 && !isRefundMode) {
         // Aggregate allocation for the claim button
         const hasCommitted = userHops.some((h) => h.participant.committed > 0n)
         if (hasCommitted) {
@@ -226,7 +226,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
       const contract = getCrowdfundContract(deployment, provider)
       const count = Number(await contract.getParticipantCount())
       const phase = Number(await contract.phase())
-      const isFinalized = phase === 2 // Phase.Finalized
+      const isFinalized = phase === 1 // Phase.Finalized
       const isRefundMode = isFinalized ? (await contract.refundMode()) as boolean : false
       const rows: ParticipantRow[] = []
 
@@ -394,15 +394,6 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
     [executeTx],
   )
 
-  const startWindow = useCallback(
-    () =>
-      executeTx('Starting window', (signer, dep) => {
-        const contract = getCrowdfundContract(dep, signer)
-        return contract.startWindow()
-      }),
-    [executeTx],
-  )
-
   const invite = useCallback(
     (invitee: string, inviterHop: number) =>
       executeTx('Sending invite', (signer, dep) => {
@@ -438,7 +429,7 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
           await approveTx.wait()
         }
 
-        return contract.commit(amount, hop)
+        return contract.commit(hop, amount)
       }),
     [executeTx],
   )
@@ -555,7 +546,6 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
     // Write operations
     addSeeds,
     loadArm,
-    startWindow,
     invite,
     launchTeamInvite,
     approveAndCommit,

--- a/crowdfund-frontend/src/types/crowdfund.test.ts
+++ b/crowdfund-frontend/src/types/crowdfund.test.ts
@@ -5,10 +5,9 @@ import { Phase, CROWDFUND_CONSTANTS } from './crowdfund'
 
 describe('Phase', () => {
   it('has correct numeric values', () => {
-    expect(Phase.Setup).toBe(0)
-    expect(Phase.Active).toBe(1)
-    expect(Phase.Finalized).toBe(2)
-    expect(Phase.Canceled).toBe(3)
+    expect(Phase.Active).toBe(0)
+    expect(Phase.Finalized).toBe(1)
+    expect(Phase.Canceled).toBe(2)
   })
 })
 

--- a/crowdfund-frontend/src/types/crowdfund.ts
+++ b/crowdfund-frontend/src/types/crowdfund.ts
@@ -2,10 +2,9 @@
 // ABOUTME: Used throughout the frontend to type contract return values.
 
 export const Phase = {
-  Setup: 0,
-  Active: 1,
-  Finalized: 2,
-  Canceled: 3,
+  Active: 0,
+  Finalized: 1,
+  Canceled: 2,
 } as const
 
 export type Phase = (typeof Phase)[keyof typeof Phase]

--- a/crowdfund-frontend/src/utils/format.test.ts
+++ b/crowdfund-frontend/src/utils/format.test.ts
@@ -97,7 +97,6 @@ describe('formatCountdown', () => {
 
 describe('phaseName', () => {
   it('returns correct names', () => {
-    expect(phaseName(Phase.Setup)).toBe('Setup')
     expect(phaseName(Phase.Active)).toBe('Active')
     expect(phaseName(Phase.Finalized)).toBe('Finalized')
     expect(phaseName(Phase.Canceled)).toBe('Canceled')
@@ -106,7 +105,7 @@ describe('phaseName', () => {
 
 describe('phaseColor', () => {
   it('returns non-empty class strings', () => {
-    expect(phaseColor(Phase.Setup)).toBeTruthy()
+    expect(phaseColor(Phase.Active)).toContain('info')
     expect(phaseColor(Phase.Finalized)).toContain('success')
     expect(phaseColor(Phase.Canceled)).toContain('destructive')
   })

--- a/crowdfund-frontend/src/utils/format.ts
+++ b/crowdfund-frontend/src/utils/format.ts
@@ -50,7 +50,6 @@ export function formatCountdown(seconds: number): string {
 /** Get human-readable phase name */
 export function phaseName(phase: Phase): string {
   switch (phase) {
-    case Phase.Setup: return 'Setup'
     case Phase.Active: return 'Active'
     case Phase.Finalized: return 'Finalized'
     case Phase.Canceled: return 'Canceled'
@@ -61,7 +60,6 @@ export function phaseName(phase: Phase): string {
 /** Get Tailwind color classes for a phase badge */
 export function phaseColor(phase: Phase): string {
   switch (phase) {
-    case Phase.Setup: return 'bg-muted text-muted-foreground'
     case Phase.Active: return 'bg-info/20 text-info'
     case Phase.Finalized: return 'bg-success/20 text-success'
     case Phase.Canceled: return 'bg-destructive/20 text-destructive'

--- a/scripts/crowdfund_demo.ts
+++ b/scripts/crowdfund_demo.ts
@@ -22,7 +22,7 @@
 
 import { ethers, network } from "hardhat";
 
-const PhaseNames = ["SETUP", "ACTIVE", "FINALIZED", "CANCELED"];
+const PhaseNames = ["ACTIVE", "FINALIZED", "CANCELED"];
 
 const THREE_WEEKS = 21 * 86400;
 
@@ -74,13 +74,15 @@ async function main() {
   await usdc.waitForDeployment();
 
   const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+  const openTimestamp = Math.floor(Date.now() / 1000) + 2; // 2 seconds in the future (Anvil)
   const crowdfund = await ArmadaCrowdfund.deploy(
     await usdc.getAddress(),
     await armToken.getAddress(),
     deployer.address,
     treasuryAddr.address,
     deployer.address,
-    deployer.address        // securityCouncil (demo)
+    deployer.address,       // securityCouncil (demo)
+    openTimestamp
   );
   await crowdfund.waitForDeployment();
 
@@ -99,7 +101,7 @@ async function main() {
 
   // ============ PHASE: SEEDS ============
   console.log("-".repeat(70));
-  console.log("  PHASE: SETUP (Add Seeds)");
+  console.log("  Add Seeds (before window opens)");
   console.log("-".repeat(70));
   console.log("");
 
@@ -116,8 +118,10 @@ async function main() {
   console.log("-".repeat(70));
   console.log("");
 
-  await crowdfund.startWindow();
-  log("START", `Crowdfund window opened`);
+  // Advance past openTimestamp so the window is active
+  await network.provider.send("evm_increaseTime", [3]);
+  await network.provider.send("evm_mine");
+  log("START", `Crowdfund window is open (past openTimestamp)`);
 
   // Each seed invites 3 hop-1 addresses
   let hop1Count = 0;
@@ -152,7 +156,7 @@ async function main() {
     const amount = ethers.parseUnits("15000", 6);
     await usdc.mint(seeds[i].address, amount);
     await usdc.connect(seeds[i]).approve(await crowdfund.getAddress(), amount);
-    await crowdfund.connect(seeds[i]).commit(amount, 0);
+    await crowdfund.connect(seeds[i]).commit(0, amount);
     log("COMMIT", `Seed-${String.fromCharCode(65 + i)} commits $15,000 USDC`);
   }
 
@@ -161,7 +165,7 @@ async function main() {
     const amount = ethers.parseUnits("4000", 6); // max hop-1 cap
     await usdc.mint(hop1Addrs[i].address, amount);
     await usdc.connect(hop1Addrs[i]).approve(await crowdfund.getAddress(), amount);
-    await crowdfund.connect(hop1Addrs[i]).commit(amount, 1);
+    await crowdfund.connect(hop1Addrs[i]).commit(1, amount);
   }
   log("COMMIT", `${hop1Count} hop-1 addresses commit $4,000 each`);
 
@@ -170,7 +174,7 @@ async function main() {
     const amount = ethers.parseUnits("1000", 6);
     await usdc.mint(hop2Addrs[i].address, amount);
     await usdc.connect(hop2Addrs[i]).approve(await crowdfund.getAddress(), amount);
-    await crowdfund.connect(hop2Addrs[i]).commit(amount, 2);
+    await crowdfund.connect(hop2Addrs[i]).commit(2, amount);
   }
   log("COMMIT", `${hop2Count} hop-2 addresses commit $1,000 each`);
 
@@ -203,13 +207,15 @@ async function main() {
   console.log("-".repeat(70));
   console.log("");
 
+  const openTimestamp2 = Math.floor(Date.now() / 1000) + 2;
   const cf2 = await ArmadaCrowdfund.deploy(
     await usdc.getAddress(),
     await armToken.getAddress(),
     deployer.address,
     treasuryAddr.address,
     deployer.address,
-    deployer.address        // securityCouncil (demo)
+    deployer.address,       // securityCouncil (demo)
+    openTimestamp2
   );
   await cf2.waitForDeployment();
 
@@ -222,15 +228,17 @@ async function main() {
   await cf2.addSeeds(bigSeeds.map(s => s.address));
   log("SETUP", `Added ${bigSeeds.length} seeds to second crowdfund`);
 
-  await cf2.startWindow();
-  log("START", "Crowdfund window opened");
+  // Advance past openTimestamp so the window is active
+  await network.provider.send("evm_increaseTime", [3]);
+  await network.provider.send("evm_mine");
+  log("START", "Crowdfund window is open (past openTimestamp)");
 
   // Each seed commits $15K
   for (const s of bigSeeds) {
     const amt = ethers.parseUnits("15000", 6);
     await usdc.mint(s.address, amt);
     await usdc.connect(s).approve(await cf2.getAddress(), amt);
-    await cf2.connect(s).commit(amt, 0);
+    await cf2.connect(s).commit(0, amt);
   }
   const total2 = await cf2.totalCommitted();
   log("COMMIT", `${bigSeeds.length} seeds commit $15K each = ${fmtUsdc(total2)}`);

--- a/scripts/crowdfund_populate.ts
+++ b/scripts/crowdfund_populate.ts
@@ -94,10 +94,10 @@ async function main() {
 
   // Check phase
   const phase = Number(await crowdfund.phase());
-  const PhaseNames = ["SETUP", "ACTIVE", "FINALIZED", "CANCELED"];
+  const PhaseNames = ["ACTIVE", "FINALIZED", "CANCELED"];
   if (phase !== 0) {
     throw new Error(
-      `Contract is in ${PhaseNames[phase]} phase (expected SETUP).\n` +
+      `Contract is in ${PhaseNames[phase]} phase (expected ACTIVE).\n` +
       `Redeploy with 'npm run chains && npm run setup' for a fresh contract.`
     );
   }
@@ -222,10 +222,19 @@ async function main() {
     log("ARM", "ARM already loaded");
   }
 
-  // ============ START WINDOW ============
-  const startTx = await crowdfund.startWindow();
-  await startTx.wait();
-  log("PHASE", "Crowdfund window opened (invites + commits concurrent)");
+  // ============ ADVANCE PAST WINDOW START ============
+  // The contract opens at its constructor-set openTimestamp.
+  // Ensure chain time is past windowStart before committing.
+  const windowStart = Number(await crowdfund.windowStart());
+  const curBlockPre = await ethers.provider.getBlock("latest");
+  const curTsPre = curBlockPre!.timestamp;
+  if (curTsPre < windowStart) {
+    const jumpToStart = windowStart - curTsPre + 1;
+    log("TIME", `Advancing ${jumpToStart}s to pass windowStart...`);
+    await network.provider.send("evm_increaseTime", [jumpToStart]);
+    await network.provider.send("evm_mine");
+  }
+  log("PHASE", "Crowdfund window is open (invites + commits concurrent)");
 
   // ============ INVITATIONS (if hops enabled) ============
   if (includeHops) {
@@ -290,7 +299,7 @@ async function main() {
       for (const p of batch) {
         const appTx = await usdc.connect(p).approve(crowdfundAddr, amount);
         await appTx.wait();
-        const cmtTx = await crowdfund.connect(p).commit(amount, hop);
+        const cmtTx = await crowdfund.connect(p).commit(hop, amount);
         await cmtTx.wait();
       }
 

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -98,7 +98,8 @@ async function main() {
   // 3. Deploy ArmadaCrowdfund (with treasury as immutable destination)
   console.log("3. Deploying ArmadaCrowdfund...");
   const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
-  const openTimestamp = Math.floor(Date.now() / 1000) + 60; // 1 minute in the future
+  const latestBlock = await ethers.provider.getBlock('latest');
+  const openTimestamp = latestBlock!.timestamp + 60; // 1 minute after latest block
   const crowdfund = await ArmadaCrowdfund.deploy(
     usdcAddress, armTokenAddress, deployer.address, treasuryAddress, deployer.address, deployer.address, openTimestamp, nm.override()
   );

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -98,8 +98,9 @@ async function main() {
   // 3. Deploy ArmadaCrowdfund (with treasury as immutable destination)
   console.log("3. Deploying ArmadaCrowdfund...");
   const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+  const openTimestamp = Math.floor(Date.now() / 1000) + 60; // 1 minute in the future
   const crowdfund = await ArmadaCrowdfund.deploy(
-    usdcAddress, armTokenAddress, deployer.address, treasuryAddress, deployer.address, deployer.address, nm.override()
+    usdcAddress, armTokenAddress, deployer.address, treasuryAddress, deployer.address, deployer.address, openTimestamp, nm.override()
   );
   await crowdfund.deploymentTransaction()!.wait();
   const crowdfundAddress = await crowdfund.getAddress();

--- a/scripts/full_lifecycle_demo.ts
+++ b/scripts/full_lifecycle_demo.ts
@@ -58,7 +58,7 @@ const TIMELOCK_MIN_DELAY   = TWO_DAYS;
 // Governance enums
 const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2 };
 const Vote = { Against: 0, For: 1, Abstain: 2 };
-const PhaseNames  = ["SETUP", "ACTIVE", "FINALIZED", "CANCELED"];
+const PhaseNames  = ["ACTIVE", "FINALIZED", "CANCELED"];
 const StateNames  = ["PENDING", "ACTIVE", "DEFEATED", "SUCCEEDED", "QUEUED", "EXECUTED", "CANCELED"];
 
 // ============ Utility Functions ============
@@ -181,13 +181,15 @@ async function main() {
   // 1g. Crowdfund (shared ARM token + unified treasury)
   log("DEPLOY", "Deploying crowdfund with shared ARM + treasury...");
   const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+  const openTimestamp = Math.floor(Date.now() / 1000) + 2; // 2 seconds in the future (Anvil)
   const crowdfund = await ArmadaCrowdfund.deploy(
     await usdc.getAddress(),
     await armToken.getAddress(),
     deployer.address,       // admin
     await treasury.getAddress(),  // immutable treasury destination
     deployer.address,       // launchTeam
-    deployer.address        // securityCouncil (demo: deployer acts as council)
+    deployer.address,       // securityCouncil (demo: deployer acts as council)
+    openTimestamp
   );
   await crowdfund.waitForDeployment();
   log("DEPLOY", `ArmadaCrowdfund: ${await crowdfund.getAddress()}`);
@@ -248,9 +250,10 @@ async function main() {
   await crowdfund.addSeeds(seeds.map(s => s.address));
   log("SEED", `Added ${seeds.length} seeds (hop 0, $${SEED_CAP} cap, 3 invites each)`);
 
-  // 2b: Start window (invites + commits concurrent for 3 weeks)
-  await crowdfund.startWindow();
-  log("START", "Crowdfund window opened (3-week duration, invites + commits concurrent)");
+  // 2b: Advance past openTimestamp so the window is active
+  await network.provider.send("evm_increaseTime", [3]);
+  await network.provider.send("evm_mine");
+  log("START", "Crowdfund window is open (past openTimestamp, 3-week duration)");
 
   // 2c: Invitation chains — first 3 seeds invite hop-1, hop-1 invite hop-2
   let hop1Count = 0;
@@ -283,7 +286,7 @@ async function main() {
     const amount = ethers.parseUnits(SEED_CAP, 6);
     await usdc.mint(s.address, amount);
     await usdc.connect(s).approve(await crowdfund.getAddress(), amount);
-    await crowdfund.connect(s).commit(amount, 0);
+    await crowdfund.connect(s).commit(0, amount);
   }
   log("COMMIT", `${seeds.length} seeds commit $${SEED_CAP} each = ${fmtUsdc(ethers.parseUnits(SEED_CAP, 6) * BigInt(seeds.length))}`);
 
@@ -292,7 +295,7 @@ async function main() {
     const amount = ethers.parseUnits(HOP1_CAP, 6);
     await usdc.mint(hop1Addrs[i].address, amount);
     await usdc.connect(hop1Addrs[i]).approve(await crowdfund.getAddress(), amount);
-    await crowdfund.connect(hop1Addrs[i]).commit(amount, 1);
+    await crowdfund.connect(hop1Addrs[i]).commit(1, amount);
   }
   log("COMMIT", `${hop1Count} hop-1 commit $${HOP1_CAP} each = ${fmtUsdc(ethers.parseUnits(HOP1_CAP, 6) * BigInt(hop1Count))}`);
 
@@ -301,7 +304,7 @@ async function main() {
     const amount = ethers.parseUnits(HOP2_CAP, 6);
     await usdc.mint(hop2Addrs[i].address, amount);
     await usdc.connect(hop2Addrs[i]).approve(await crowdfund.getAddress(), amount);
-    await crowdfund.connect(hop2Addrs[i]).commit(amount, 2);
+    await crowdfund.connect(hop2Addrs[i]).commit(2, amount);
   }
   log("COMMIT", `${hop2Count} hop-2 commit $${HOP2_CAP} each = ${fmtUsdc(ethers.parseUnits(HOP2_CAP, 6) * BigInt(hop2Count))}`);
 
@@ -366,7 +369,7 @@ async function main() {
   const [h2Alloc, h2Refund] = await crowdfund.getAllocation(hop2Addrs[0].address);
   log("CLAIM", `  ${hop2Claimers} hop-2 claim: ${fmtArm(h2Alloc)} + ${fmtUsdc(h2Refund)} refund each`);
 
-  verify("Phase is FINALIZED", phase === 2);
+  verify("Phase is FINALIZED", phase === 1);
   verify("Total committed > MIN_SALE ($1M)", totalCommitted > ethers.parseUnits("1000000", 6));
 
   // ================================================================

--- a/tasks/crowdfund.ts
+++ b/tasks/crowdfund.ts
@@ -6,7 +6,6 @@
  *
  * Usage:
  *   npx hardhat cf-add-seeds --addresses 0x1,0x2,0x3 --network hub
- *   npx hardhat cf-start --network hub
  *   npx hardhat cf-invite --invitee 0x... --network hub
  *   npx hardhat cf-commit --amount 5000 --network hub
  *   npx hardhat cf-finalize --network hub
@@ -19,7 +18,7 @@ import { task } from "hardhat/config";
 import * as fs from "fs";
 import * as path from "path";
 
-const PhaseNames = ["SETUP", "ACTIVE", "FINALIZED", "CANCELED"];
+const PhaseNames = ["ACTIVE", "FINALIZED", "CANCELED"];
 
 function loadCrowdfundDeployment(networkName: string) {
   const filePath = path.join(__dirname, "..", "deployments", `crowdfund-${networkName}.json`);
@@ -50,33 +49,6 @@ task("cf-add-seeds", "Add seed addresses (hop 0)")
 
     await crowdfund.addSeeds(seeds);
     console.log(`Added ${seeds.length} seed(s): ${seeds.join(", ")}`);
-  });
-
-task("cf-start", "Start the active window (invites + commits)")
-  .setAction(async (_, hre) => {
-    const { ethers } = hre;
-    const chainId = Number((await ethers.provider.getNetwork()).chainId);
-    const deployment = loadCrowdfundDeployment(getNetworkName(chainId));
-
-    const crowdfund = await ethers.getContractAt("ArmadaCrowdfund", deployment.contracts.crowdfund);
-
-    // Ensure ARM is loaded before starting window
-    const armLoaded = await crowdfund.armLoaded();
-    if (!armLoaded) {
-      console.log("ARM not loaded — calling loadArm()...");
-      await crowdfund.loadArm();
-      console.log("ARM loaded and verified");
-    }
-
-    await crowdfund.startWindow();
-
-    const winStart = await crowdfund.windowStart();
-    const winEnd = await crowdfund.windowEnd();
-    const ltEnd = await crowdfund.launchTeamInviteEnd();
-    console.log("Active window started (invites + commits concurrent)");
-    console.log(`  Window start: ${new Date(Number(winStart) * 1000).toISOString()}`);
-    console.log(`  Launch team invite cutoff: ${new Date(Number(ltEnd) * 1000).toISOString()}`);
-    console.log(`  Window ends: ${new Date(Number(winEnd) * 1000).toISOString()}`);
   });
 
 // ============ Active Window ============
@@ -115,7 +87,7 @@ task("cf-commit", "Commit USDC to the crowdfund")
     const crowdfund = await ethers.getContractAt("ArmadaCrowdfund", deployment.contracts.crowdfund);
 
     await usdcToken.approve(deployment.contracts.crowdfund, amount);
-    await crowdfund.commit(amount, hop);
+    await crowdfund.commit(hop, amount);
 
     const committed = await crowdfund.getCommitment(signer.address, hop);
     console.log(`Committed $${args.amount} USDC. Total committed: $${ethers.formatUnits(committed, 6)}`);
@@ -134,7 +106,7 @@ task("cf-finalize", "Finalize the crowdfund (compute allocations or cancel)")
 
     const phase = Number(await crowdfund.phase());
     console.log(`Crowdfund finalized: ${PhaseNames[phase]}`);
-    if (phase === 2) {
+    if (phase === 1) {
       // Finalized
       const saleSize = await crowdfund.saleSize();
       const totalAlloc = await crowdfund.totalAllocated();
@@ -156,7 +128,7 @@ task("cf-claim", "Claim ARM allocation and USDC refund")
     const phase = Number(await crowdfund.phase());
 
     const inRefundMode = await crowdfund.refundMode();
-    if (phase === 3 || inRefundMode) {
+    if (phase === 2 || inRefundMode) {
       // Canceled or refundMode — use claimRefund()
       await crowdfund.claimRefund();
       console.log("Full USDC refund claimed (sale was canceled or in refund mode)");
@@ -193,7 +165,7 @@ task("cf-stats", "Show crowdfund statistics")
       console.log(`  Hop ${h}: ${wc} whitelisted, ${uc} committed, $${ethers.formatUnits(tc, 6)} total`);
     }
 
-    if (Number(phase) === 2) {
+    if (Number(phase) === 1) {
       console.log(`\n  Sale size: $${ethers.formatUnits(await crowdfund.saleSize(), 6)}`);
       console.log(`  Total ARM allocated: ${ethers.formatUnits(await crowdfund.totalAllocated(), 18)}`);
     }
@@ -219,7 +191,7 @@ task("cf-allocation", "Check allocation for an address")
     console.log(`  Committed: $${ethers.formatUnits(committed, 6)}`);
 
     const phase = Number(await crowdfund.phase());
-    if (phase === 2) {
+    if (phase === 1) {
       const [alloc, refund, claimed] = await crowdfund.getAllocation(args.address);
       console.log(`  Allocation: ${ethers.formatUnits(alloc, 18)} ARM`);
       console.log(`  Refund: $${ethers.formatUnits(refund, 6)}`);

--- a/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
+++ b/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
@@ -31,7 +31,8 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
             admin,
             treasury,
             admin,
-            admin   // securityCouncil
+            admin,  // securityCouncil
+            block.timestamp
         );
 
         // Whitelist admin and crowdfund so token transfers work
@@ -44,11 +45,10 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
         armToken.transfer(address(crowdfund), ARM_FUNDING);
         crowdfund.loadArm();
 
-        // Start window to set windowEnd
+        // Add seeds (window is already open from constructor)
         address[] memory seeds = new address[](1);
         seeds[0] = address(0xA);
         crowdfund.addSeeds(seeds);
-        crowdfund.startWindow();
     }
 
     /// @notice Helper: cancel via security council
@@ -95,16 +95,17 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
 
     // ============ Phase guards: still reverts in pre-finalization phases ============
 
-    /// @notice Reverts in Setup phase
-    function test_withdrawUnallocatedArm_setupPhase_reverts() public {
-        // Deploy a fresh crowdfund still in Setup phase
+    /// @notice Reverts in Active phase (fresh deploy, not finalized or canceled)
+    function test_withdrawUnallocatedArm_activePhase_fresh_reverts() public {
+        // Deploy a fresh crowdfund in Active phase (no finalization or cancel)
         ArmadaCrowdfund fresh = new ArmadaCrowdfund(
             address(usdc),
             address(armToken),
             admin,
             treasury,
             admin,
-            admin   // securityCouncil
+            admin,  // securityCouncil
+            block.timestamp
         );
 
         vm.expectRevert("ArmadaCrowdfund: not finalized or canceled");
@@ -142,7 +143,8 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
             admin,
             treasury,
             admin,
-            admin   // securityCouncil
+            admin,  // securityCouncil
+            block.timestamp
         );
         armToken.addToWhitelist(address(fuzzCrowdfund));
         armToken.transfer(address(fuzzCrowdfund), funding);
@@ -151,7 +153,6 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
         address[] memory seeds = new address[](1);
         seeds[0] = address(0xA);
         fuzzCrowdfund.addSeeds(seeds);
-        fuzzCrowdfund.startWindow();
 
         // Cancel via security council (admin == securityCouncil in test setup)
         fuzzCrowdfund.cancel();

--- a/test-foundry/ArmadaCrowdfundRefundMode.t.sol
+++ b/test-foundry/ArmadaCrowdfundRefundMode.t.sol
@@ -35,7 +35,8 @@ contract ArmadaCrowdfundRefundModeTest is Test {
             admin,
             treasury,
             admin,
-            admin   // securityCouncil
+            admin,  // securityCouncil
+            block.timestamp
         );
 
         // Whitelist admin and crowdfund so token transfers work
@@ -54,7 +55,6 @@ contract ArmadaCrowdfundRefundModeTest is Test {
             seeds.push(address(uint160(0xA000 + i)));
         }
         crowdfund.addSeeds(seeds);
-        crowdfund.startWindow();
     }
 
     /// @notice Helper: each seed commits full $15K at hop-0
@@ -64,7 +64,7 @@ contract ArmadaCrowdfundRefundModeTest is Test {
             usdc.mint(seeds[i], amount);
             vm.startPrank(seeds[i]);
             usdc.approve(address(crowdfund), amount);
-            crowdfund.commit(amount, 0);
+            crowdfund.commit(0, amount);
             vm.stopPrank();
         }
     }
@@ -180,7 +180,7 @@ contract ArmadaCrowdfundRefundModeTest is Test {
     function test_refundMode_cannotHappenAfterExpansion() public {
         // Deploy a fresh crowdfund with 100 seeds to reach ELASTIC_TRIGGER
         ArmadaCrowdfund cf2 = new ArmadaCrowdfund(
-            address(usdc), address(armToken), admin, treasury, admin, admin
+            address(usdc), address(armToken), admin, treasury, admin, admin, block.timestamp
         );
         armToken.transfer(address(cf2), ARM_FUNDING);
         cf2.loadArm();
@@ -190,7 +190,6 @@ contract ArmadaCrowdfundRefundModeTest is Test {
             moreSeeds[i] = address(uint160(0xF000 + i));
         }
         cf2.addSeeds(moreSeeds);
-        cf2.startWindow();
 
         // 100 seeds × $15K = $1.5M = ELASTIC_TRIGGER, triggers expansion
         for (uint256 i = 0; i < 100; i++) {
@@ -198,7 +197,7 @@ contract ArmadaCrowdfundRefundModeTest is Test {
             usdc.mint(moreSeeds[i], amount);
             vm.startPrank(moreSeeds[i]);
             usdc.approve(address(cf2), amount);
-            cf2.commit(amount, 0);
+            cf2.commit(0, amount);
             vm.stopPrank();
         }
         assertEq(cf2.totalCommitted(), 1_500_000 * 1e6);
@@ -223,7 +222,7 @@ contract ArmadaCrowdfundRefundModeTest is Test {
         usdc.mint(seeds[seedIdx], commitAmount);
         vm.startPrank(seeds[seedIdx]);
         usdc.approve(address(crowdfund), commitAmount);
-        crowdfund.commit(commitAmount, 0);
+        crowdfund.commit(0, commitAmount);
         vm.stopPrank();
 
         // Need enough total to pass MIN_SALE for finalize to not revert.
@@ -241,7 +240,7 @@ contract ArmadaCrowdfundRefundModeTest is Test {
             usdc.mint(seeds[i], amount);
             vm.startPrank(seeds[i]);
             usdc.approve(address(crowdfund), amount);
-            crowdfund.commit(amount, 0);
+            crowdfund.commit(0, amount);
             vm.stopPrank();
             totalSoFar += amount;
         }
@@ -283,7 +282,7 @@ contract ArmadaCrowdfundRefundModeTest is Test {
         usdc.mint(seeds[0], amount);
         vm.startPrank(seeds[0]);
         usdc.approve(address(crowdfund), amount);
-        crowdfund.commit(amount, 0);
+        crowdfund.commit(0, amount);
         vm.stopPrank();
 
         vm.warp(crowdfund.windowEnd() + 1);
@@ -301,7 +300,7 @@ contract ArmadaCrowdfundRefundModeTest is Test {
         usdc.mint(seeds[0], amount);
         vm.startPrank(seeds[0]);
         usdc.approve(address(crowdfund), amount);
-        crowdfund.commit(amount, 0);
+        crowdfund.commit(0, amount);
         vm.stopPrank();
 
         // Window expires, nobody calls finalize or cancel
@@ -324,7 +323,7 @@ contract ArmadaCrowdfundRefundModeTest is Test {
         usdc.mint(seeds[0], amount);
         vm.startPrank(seeds[0]);
         usdc.approve(address(crowdfund), amount);
-        crowdfund.commit(amount, 0);
+        crowdfund.commit(0, amount);
         vm.stopPrank();
 
         // Still in active window
@@ -344,7 +343,7 @@ contract ArmadaCrowdfundRefundModeTest is Test {
             usdc.mint(seeds[i], amount);
             vm.startPrank(seeds[i]);
             usdc.approve(address(crowdfund), amount);
-            crowdfund.commit(amount, 0);
+            crowdfund.commit(0, amount);
             vm.stopPrank();
         }
 
@@ -362,7 +361,7 @@ contract ArmadaCrowdfundRefundModeTest is Test {
             usdc.mint(hop1Addrs[i], amount);
             vm.startPrank(hop1Addrs[i]);
             usdc.approve(address(crowdfund), amount);
-            crowdfund.commit(amount, 1);
+            crowdfund.commit(1, amount);
             vm.stopPrank();
         }
 

--- a/test-foundry/CrowdfundFullInvariant.t.sol
+++ b/test-foundry/CrowdfundFullInvariant.t.sol
@@ -71,7 +71,7 @@ contract CrowdfundFullHandler is Test {
         vm.startPrank(seed);
         usdc.approve(address(crowdfund), amount);
 
-        try crowdfund.commit(amount, 0) {
+        try crowdfund.commit(0, amount) {
             ghost_totalUsdcIn += amount;
             ghost_committed[seed] += amount;
             if (ghost_committed[seed] == amount) {
@@ -99,7 +99,7 @@ contract CrowdfundFullHandler is Test {
         vm.startPrank(addr);
         usdc.approve(address(crowdfund), amount);
 
-        try crowdfund.commit(amount, 1) {
+        try crowdfund.commit(1, amount) {
             ghost_totalUsdcIn += amount;
             ghost_committed[addr] += amount;
             if (ghost_committed[addr] == amount) {
@@ -127,7 +127,7 @@ contract CrowdfundFullHandler is Test {
         vm.startPrank(addr);
         usdc.approve(address(crowdfund), amount);
 
-        try crowdfund.commit(amount, 2) {
+        try crowdfund.commit(2, amount) {
             ghost_totalUsdcIn += amount;
             ghost_committed[addr] += amount;
             if (ghost_committed[addr] == amount) {
@@ -192,7 +192,8 @@ contract CrowdfundFullInvariantTest is Test {
             admin,
             address(0xBEEF), // treasury
             admin,
-            admin             // securityCouncil
+            admin,            // securityCouncil
+            block.timestamp
         );
 
         // Fund ARM to crowdfund and verify pre-load
@@ -212,9 +213,6 @@ contract CrowdfundFullInvariantTest is Test {
 
         // Setup phase: add seeds
         crowdfund.addSeeds(seeds);
-
-        // Start window
-        crowdfund.startWindow();
 
         // Do invitations
         uint256 hop1Idx = 0;

--- a/test-foundry/CrowdfundInvariant.t.sol
+++ b/test-foundry/CrowdfundInvariant.t.sol
@@ -79,7 +79,7 @@ contract CrowdfundHandler is Test {
         vm.startPrank(seed);
         usdc.approve(address(crowdfund), amount);
 
-        try crowdfund.commit(amount, 0) {
+        try crowdfund.commit(0, amount) {
             ghost_totalUsdcIn += amount;
             ghost_committed[seed] += amount;
             if (ghost_committed[seed] == amount) {
@@ -107,7 +107,7 @@ contract CrowdfundHandler is Test {
         vm.startPrank(addr);
         usdc.approve(address(crowdfund), amount);
 
-        try crowdfund.commit(amount, 1) {
+        try crowdfund.commit(1, amount) {
             ghost_totalUsdcIn += amount;
             ghost_committed[addr] += amount;
             if (ghost_committed[addr] == amount) {
@@ -135,7 +135,7 @@ contract CrowdfundHandler is Test {
         vm.startPrank(addr);
         usdc.approve(address(crowdfund), amount);
 
-        try crowdfund.commit(amount, 2) {
+        try crowdfund.commit(2, amount) {
             ghost_totalUsdcIn += amount;
             ghost_committed[addr] += amount;
             if (ghost_committed[addr] == amount) {
@@ -257,7 +257,8 @@ contract CrowdfundInvariantTest is Test {
             admin,
             address(0xBEEF), // treasury
             admin,
-            admin             // securityCouncil
+            admin,            // securityCouncil
+            block.timestamp
         );
 
         // Fund ARM to crowdfund and verify pre-load
@@ -278,9 +279,6 @@ contract CrowdfundInvariantTest is Test {
 
         // Setup phase: add seeds
         crowdfund.addSeeds(seeds);
-
-        // Start window
-        crowdfund.startWindow();
 
         // Do invitations: each seed invites up to 3 hop-1 addresses
         uint256 hop1Idx = 0;

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -79,13 +79,15 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     // Deploy crowdfund
     const CROWDFUND_ARM_FUNDING = ARM(1_800_000);
     const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+    const openTimestamp = (await time.latest()) + 300;
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
       deployer.address,
       treasuryAddr.address,
       deployer.address,
-      deployer.address        // securityCouncil
+      deployer.address,       // securityCouncil
+      openTimestamp            // openTimestamp
     );
     await crowdfund.waitForDeployment();
 
@@ -144,7 +146,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // 1. Add seeds and start invitations
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // 2. Seeds invite hop-1 addresses
       for (let i = 0; i < 3 && i < hop1Addrs.length; i++) {
@@ -156,7 +158,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
         const amount = USDC(15_000);
         await usdc.mint(seed.address, amount);
         await usdc.connect(seed).approve(await crowdfund.getAddress(), amount);
-        await crowdfund.connect(seed).commit(amount, 0);
+        await crowdfund.connect(seed).commit(0, amount);
       }
 
       // 4. Fast-forward past active window
@@ -164,7 +166,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // 5. Finalize
       await crowdfund.finalize();
-      expect(await crowdfund.phase()).to.equal(2); // Finalized
+      expect(await crowdfund.phase()).to.equal(1); // Finalized
 
       // 6. Seeds claim their ARM
       const claimedSeeds = seeds.slice(0, 5); // claim first 5 for governance testing
@@ -248,13 +250,13 @@ describe("Cross-Contract Integration (Phase 6)", function () {
   describe("Token Supply Consistency", function () {
     async function runCrowdfundAndClaim() {
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const seed of seeds) {
         const amount = USDC(15_000);
         await usdc.mint(seed.address, amount);
         await usdc.connect(seed).approve(await crowdfund.getAddress(), amount);
-        await crowdfund.connect(seed).commit(amount, 0);
+        await crowdfund.connect(seed).commit(0, amount);
       }
 
       await time.increase(THREE_WEEKS + 1);
@@ -356,13 +358,13 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     async function setupCrowdfundAndGovernance() {
       // Run crowdfund
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const seed of seeds) {
         const amount = USDC(15_000);
         await usdc.mint(seed.address, amount);
         await usdc.connect(seed).approve(await crowdfund.getAddress(), amount);
-        await crowdfund.connect(seed).commit(amount, 0);
+        await crowdfund.connect(seed).commit(0, amount);
       }
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
@@ -541,13 +543,13 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("unclaimed crowdfund participant cannot vote (no ARM, no delegation, no voting power)", async function () {
       // Run crowdfund but DON'T claim
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const seed of seeds) {
         const amount = USDC(15_000);
         await usdc.mint(seed.address, amount);
         await usdc.connect(seed).approve(await crowdfund.getAddress(), amount);
-        await crowdfund.connect(seed).commit(amount, 0);
+        await crowdfund.connect(seed).commit(0, amount);
       }
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
@@ -658,13 +660,15 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await localUsdc.waitForDeployment();
 
       const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      const localOpenTimestamp = (await time.latest()) + 300;
       localCrowdfund = await ArmadaCrowdfund.deploy(
         await localUsdc.getAddress(),
         await localArmToken.getAddress(),
         localDeployer.address,
         await localTreasury.getAddress(),
         localDeployer.address,
-        localDeployer.address   // securityCouncil
+        localDeployer.address,  // securityCouncil
+        localOpenTimestamp       // openTimestamp
       );
       await localCrowdfund.waitForDeployment();
 
@@ -728,13 +732,13 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("quorum denominator shifts as participants claim ARM from crowdfund", async function () {
       // Run crowdfund lifecycle
       await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
-      await localCrowdfund.startWindow();
+      { const ws = Number(await localCrowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
         await localUsdc.mint(seed.address, amount);
         await localUsdc.connect(seed).approve(await localCrowdfund.getAddress(), amount);
-        await localCrowdfund.connect(seed).commit(amount, 0);
+        await localCrowdfund.connect(seed).commit(0, amount);
       }
 
       await time.increase(THREE_WEEKS + 1);
@@ -788,13 +792,13 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("finalize pushes USDC proceeds to treasury contract", async function () {
       // Run crowdfund
       await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
-      await localCrowdfund.startWindow();
+      { const ws = Number(await localCrowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
         await localUsdc.mint(seed.address, amount);
         await localUsdc.connect(seed).approve(await localCrowdfund.getAddress(), amount);
-        await localCrowdfund.connect(seed).commit(amount, 0);
+        await localCrowdfund.connect(seed).commit(0, amount);
       }
 
       await time.increase(THREE_WEEKS + 1);
@@ -818,13 +822,13 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("withdrawUnallocatedArm sends ARM to treasury contract", async function () {
       // Run crowdfund
       await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
-      await localCrowdfund.startWindow();
+      { const ws = Number(await localCrowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
         await localUsdc.mint(seed.address, amount);
         await localUsdc.connect(seed).approve(await localCrowdfund.getAddress(), amount);
-        await localCrowdfund.connect(seed).commit(amount, 0);
+        await localCrowdfund.connect(seed).commit(0, amount);
       }
 
       await time.increase(THREE_WEEKS + 1);
@@ -843,13 +847,13 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("full lifecycle: crowdfund → claim → delegate → propose → vote → execute", async function () {
       // Run crowdfund
       await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
-      await localCrowdfund.startWindow();
+      { const ws = Number(await localCrowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
         await localUsdc.mint(seed.address, amount);
         await localUsdc.connect(seed).approve(await localCrowdfund.getAddress(), amount);
-        await localCrowdfund.connect(seed).commit(amount, 0);
+        await localCrowdfund.connect(seed).commit(0, amount);
       }
 
       await time.increase(THREE_WEEKS + 1);

--- a/test/crowdfund_adversarial.ts
+++ b/test/crowdfund_adversarial.ts
@@ -13,7 +13,7 @@ import { ethers } from "hardhat";
 import { time } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
-const Phase = { Setup: 0, Active: 1, Finalized: 2, Canceled: 3 };
+const Phase = { Active: 0, Finalized: 1, Canceled: 2 };
 
 const ONE_DAY = 86400;
 const THREE_WEEKS = 21 * ONE_DAY;
@@ -44,7 +44,7 @@ describe("Crowdfund Adversarial", function () {
     for (let i = 0; i < count; i++) {
       await crowdfund.connect(seeds[i]).invite(hop1Pool[i].address, 0);
       await fundAndApprove(hop1Pool[i], USDC(4_000));
-      await crowdfund.connect(hop1Pool[i]).commit(USDC(4_000), 1);
+      await crowdfund.connect(hop1Pool[i]).commit(1, USDC(4_000));
     }
   }
 
@@ -63,13 +63,15 @@ describe("Crowdfund Adversarial", function () {
     await armToken.initWhitelist([deployer.address]);
 
     const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+    const openTimestamp = (await time.latest()) + 300;
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
       deployer.address,
       treasuryAddr.address,
       deployer.address,
-      deployer.address        // securityCouncil
+      deployer.address,       // securityCouncil
+      openTimestamp
     );
     await crowdfund.waitForDeployment();
     await armToken.addToWhitelist(await crowdfund.getAddress());
@@ -120,12 +122,12 @@ describe("Crowdfund Adversarial", function () {
     it("sum of allocations + refunds == totalCommitted (70 seeds, pro-rata)", async function () {
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // All commit at max cap = 70 * $15K = $1.05M > MIN_SALE
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
@@ -186,7 +188,7 @@ describe("Crowdfund Adversarial", function () {
       // Setup: 70 seeds → each invites up to 3 hop-1 addresses
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // Seeds invite hop-1 addresses (use signers 71-140)
       const hop1Addrs = allSigners.slice(71, 141);
@@ -200,13 +202,13 @@ describe("Crowdfund Adversarial", function () {
       // Seeds commit $15K each
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       // Hop-1 commit $4K each
       for (let i = 0; i < hop1Count; i++) {
         await fundAndApprove(hop1Addrs[i], USDC(4_000));
-        await crowdfund.connect(hop1Addrs[i]).commit(USDC(4_000), 1);
+        await crowdfund.connect(hop1Addrs[i]).commit(1, USDC(4_000));
       }
 
       await time.increase(THREE_WEEKS + 1);
@@ -237,11 +239,11 @@ describe("Crowdfund Adversarial", function () {
     it("contract ARM balance covers all allocations after finalization", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
@@ -258,11 +260,11 @@ describe("Crowdfund Adversarial", function () {
     it("after all claims, contract balances are non-negative", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
@@ -301,10 +303,10 @@ describe("Crowdfund Adversarial", function () {
   describe("Boundary Conditions", function () {
     it("commit exactly at hop cap succeeds", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       await fundAndApprove(allSigners[1], USDC(15_000));
-      await crowdfund.connect(allSigners[1]).commit(USDC(15_000), 0);
+      await crowdfund.connect(allSigners[1]).commit(0, USDC(15_000));
 
       const committed = await crowdfund.getCommitment(allSigners[1].address, 0);
       expect(committed).to.equal(USDC(15_000));
@@ -312,14 +314,14 @@ describe("Crowdfund Adversarial", function () {
 
     it("commit over hop cap reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       await fundAndApprove(allSigners[1], USDC(15_010));
-      await crowdfund.connect(allSigners[1]).commit(USDC(15_000), 0);
+      await crowdfund.connect(allSigners[1]).commit(0, USDC(15_000));
 
       // $10 more (meets MIN_COMMIT but exceeds hop cap)
       await expect(
-        crowdfund.connect(allSigners[1]).commit(USDC(10), 0)
+        crowdfund.connect(allSigners[1]).commit(0, USDC(10))
       ).to.be.revertedWith("ArmadaCrowdfund: exceeds hop cap");
     });
 
@@ -331,16 +333,16 @@ describe("Crowdfund Adversarial", function () {
       // Let's use 66 seeds at $15K ($990K) + 1 seed at $10K ($10K) = $1,000,000
       const seeds = allSigners.slice(1, 68); // 67 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // 66 seeds at $15K
       for (let i = 0; i < 66; i++) {
         await fundAndApprove(seeds[i], USDC(15_000));
-        await crowdfund.connect(seeds[i]).commit(USDC(15_000), 0);
+        await crowdfund.connect(seeds[i]).commit(0, USDC(15_000));
       }
       // 1 seed at $10K to hit exactly $1M
       await fundAndApprove(seeds[66], USDC(10_000));
-      await crowdfund.connect(seeds[66]).commit(USDC(10_000), 0);
+      await crowdfund.connect(seeds[66]).commit(0, USDC(10_000));
 
       const total = await crowdfund.totalCommitted();
       expect(total).to.equal(USDC(1_000_000));
@@ -355,16 +357,16 @@ describe("Crowdfund Adversarial", function () {
       // 66 seeds at $15K = $990K. 1 seed at $9,999.999999 = $999,999.999999 < $1M
       const seeds = allSigners.slice(1, 68);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (let i = 0; i < 66; i++) {
         await fundAndApprove(seeds[i], USDC(15_000));
-        await crowdfund.connect(seeds[i]).commit(USDC(15_000), 0);
+        await crowdfund.connect(seeds[i]).commit(0, USDC(15_000));
       }
       // 1 wei less than $10K needed to reach $1M
       const shortAmount = USDC(10_000) - 1n;
       await fundAndApprove(seeds[66], shortAmount);
-      await crowdfund.connect(seeds[66]).commit(shortAmount, 0);
+      await crowdfund.connect(seeds[66]).commit(0, shortAmount);
 
       const total = await crowdfund.totalCommitted();
       expect(total).to.be.lt(USDC(1_000_000));
@@ -383,11 +385,11 @@ describe("Crowdfund Adversarial", function () {
       // Need 100 seeds at $15K each = $1,500,000
       const seeds = allSigners.slice(1, 101); // 100 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       const total = await crowdfund.totalCommitted();
@@ -404,16 +406,16 @@ describe("Crowdfund Adversarial", function () {
       // 99 seeds at $15K = $1,485,000. 1 seed at $14,999.999999
       const seeds = allSigners.slice(1, 101);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (let i = 0; i < 99; i++) {
         await fundAndApprove(seeds[i], USDC(15_000));
-        await crowdfund.connect(seeds[i]).commit(USDC(15_000), 0);
+        await crowdfund.connect(seeds[i]).commit(0, USDC(15_000));
       }
       // Last seed commits 1 wei less than $15K
       const shortAmount = USDC(15_000) - 1n;
       await fundAndApprove(seeds[99], shortAmount);
-      await crowdfund.connect(seeds[99]).commit(shortAmount, 0);
+      await crowdfund.connect(seeds[99]).commit(0, shortAmount);
 
       const total = await crowdfund.totalCommitted();
       expect(total).to.be.lt(USDC(1_500_000));
@@ -430,11 +432,11 @@ describe("Crowdfund Adversarial", function () {
       // there's no demand at those hops, unallocated capacity becomes treasury leftover.
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
@@ -451,7 +453,7 @@ describe("Crowdfund Adversarial", function () {
     it("finalize with all whitelisted but 0 committers reverts", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // Nobody commits — just fast-forward through the active window
       await time.increase(THREE_WEEKS + 1);
@@ -464,22 +466,22 @@ describe("Crowdfund Adversarial", function () {
 
     it("commit below MIN_COMMIT ($10 USDC) reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       await fundAndApprove(allSigners[1], USDC(10));
 
       // 1 wei reverts
       await expect(
-        crowdfund.connect(allSigners[1]).commit(1n, 0)
+        crowdfund.connect(allSigners[1]).commit(0, 1n)
       ).to.be.revertedWith("ArmadaCrowdfund: below minimum commitment");
 
       // $9.999999 reverts
       await expect(
-        crowdfund.connect(allSigners[1]).commit(USDC(10) - 1n, 0)
+        crowdfund.connect(allSigners[1]).commit(0, USDC(10) - 1n)
       ).to.be.revertedWith("ArmadaCrowdfund: below minimum commitment");
 
       // Exactly $10 succeeds
-      await crowdfund.connect(allSigners[1]).commit(USDC(10), 0);
+      await crowdfund.connect(allSigners[1]).commit(0, USDC(10));
       const committed = await crowdfund.getCommitment(allSigners[1].address, 0);
       expect(committed).to.equal(USDC(10));
     });
@@ -487,7 +489,7 @@ describe("Crowdfund Adversarial", function () {
     it("seed self-invite creates a hop-1 node (permitted in multi-node model)", async function () {
       const seed = allSigners[1];
       await crowdfund.addSeeds([seed.address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // Seed invites self — creates (seed, 1) node
       await crowdfund.connect(seed).invite(seed.address, 0);
@@ -499,7 +501,7 @@ describe("Crowdfund Adversarial", function () {
       const seed = allSigners[1];
       const invitee = allSigners[2];
       await crowdfund.addSeeds([seed.address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       const windowEnd = await crowdfund.windowEnd();
       // Warp to exactly windowEnd — invite should fail (strict <)
@@ -513,7 +515,7 @@ describe("Crowdfund Adversarial", function () {
       const seed = allSigners[1];
       const invitee = allSigners[2];
       await crowdfund.addSeeds([seed.address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       const windowEnd = await crowdfund.windowEnd();
       // Warp to 2 seconds before windowEnd — next tx executes at windowEnd - 1
@@ -524,13 +526,13 @@ describe("Crowdfund Adversarial", function () {
       expect(p.isWhitelisted).to.be.true;
     });
 
-    it("commit succeeds immediately after startWindow", async function () {
+    it("commit succeeds at window start", async function () {
       const seed = allSigners[1];
       await crowdfund.addSeeds([seed.address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       await fundAndApprove(seed, USDC(100));
-      await crowdfund.connect(seed).commit(USDC(100), 0);
+      await crowdfund.connect(seed).commit(0, USDC(100));
 
       const committed = await crowdfund.getCommitment(seed.address, 0);
       expect(committed).to.equal(USDC(100));
@@ -542,19 +544,19 @@ describe("Crowdfund Adversarial", function () {
   // ============================================================
 
   describe("Access Control & State Machine", function () {
-    it("commit during Setup phase reverts", async function () {
+    it("commit before window start reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
 
-      // We're in Setup phase — active window hasn't started
+      // Active window hasn't started yet
       await fundAndApprove(allSigners[1], USDC(15_000));
       await expect(
-        crowdfund.connect(allSigners[1]).commit(USDC(15_000), 0)
-      ).to.be.revertedWith("ArmadaCrowdfund: not active");
+        crowdfund.connect(allSigners[1]).commit(0, USDC(15_000))
+      ).to.be.revertedWith("ArmadaCrowdfund: not active window");
     });
 
     it("invite after window ends reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       await time.increase(THREE_WEEKS + 1); // past active window
 
       await expect(
@@ -565,7 +567,7 @@ describe("Crowdfund Adversarial", function () {
     it("finalize before window ends reverts", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       await expect(
         crowdfund.finalize()
@@ -574,21 +576,21 @@ describe("Crowdfund Adversarial", function () {
 
     it("addSeeds after week 1 of active window reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       await time.increase(ONE_WEEK + 1); // past launch team invite period
 
       await expect(
         crowdfund.addSeeds([allSigners[2].address])
-      ).to.be.revertedWith("ArmadaCrowdfund: seeds only during setup or week 1");
+      ).to.be.revertedWith("ArmadaCrowdfund: seeds only before invite period ends");
     });
 
     it("claim reverts when below minimum (should use claimRefund)", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       await fundAndApprove(seeds[0], USDC(15_000));
-      await crowdfund.connect(seeds[0]).commit(USDC(15_000), 0);
+      await crowdfund.connect(seeds[0]).commit(0, USDC(15_000));
 
       await time.increase(THREE_WEEKS + 1);
       // finalize reverts (below MIN_SALE), phase stays Active
@@ -608,11 +610,11 @@ describe("Crowdfund Adversarial", function () {
     it("claimRefund when phase is Finalized (not refundMode) reverts", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
@@ -630,11 +632,11 @@ describe("Crowdfund Adversarial", function () {
     it("non-admin can finalize (permissionless)", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await time.increase(THREE_WEEKS + 1);
 
@@ -646,11 +648,11 @@ describe("Crowdfund Adversarial", function () {
     it("non-admin can sweep unallocated ARM (permissionless)", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
@@ -662,11 +664,11 @@ describe("Crowdfund Adversarial", function () {
     it("withdrawUnallocatedArm second call reverts when nothing to sweep", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
@@ -687,6 +689,7 @@ describe("Crowdfund Adversarial", function () {
 
     it("constructor rejects zero admin address", async function () {
       const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      const localOpenTimestamp = (await time.latest()) + 300;
       await expect(
         ArmadaCrowdfund.deploy(
           await usdc.getAddress(),
@@ -694,13 +697,15 @@ describe("Crowdfund Adversarial", function () {
           ethers.ZeroAddress,
           treasuryAddr.address,
           deployer.address,
-          deployer.address
+          deployer.address,
+          localOpenTimestamp
         )
       ).to.be.revertedWith("ArmadaCrowdfund: zero admin");
     });
 
     it("constructor rejects zero treasury address", async function () {
       const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      const localOpenTimestamp = (await time.latest()) + 300;
       await expect(
         ArmadaCrowdfund.deploy(
           await usdc.getAddress(),
@@ -708,13 +713,15 @@ describe("Crowdfund Adversarial", function () {
           deployer.address,
           ethers.ZeroAddress,
           deployer.address,
-          deployer.address
+          deployer.address,
+          localOpenTimestamp
         )
       ).to.be.revertedWith("ArmadaCrowdfund: zero treasury");
     });
 
     it("constructor rejects zero securityCouncil address", async function () {
       const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      const localOpenTimestamp = (await time.latest()) + 300;
       await expect(
         ArmadaCrowdfund.deploy(
           await usdc.getAddress(),
@@ -722,7 +729,8 @@ describe("Crowdfund Adversarial", function () {
           deployer.address,
           treasuryAddr.address,
           deployer.address,
-          ethers.ZeroAddress
+          ethers.ZeroAddress,
+          localOpenTimestamp
         )
       ).to.be.revertedWith("ArmadaCrowdfund: zero securityCouncil");
     });
@@ -730,11 +738,11 @@ describe("Crowdfund Adversarial", function () {
     it("non-participant cannot claim", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
@@ -752,12 +760,12 @@ describe("Crowdfund Adversarial", function () {
     it("whitelisted-but-uncommitted participant cannot claim", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // Only first 69 seeds commit, seeds[69] does not
       for (let i = 0; i < 69; i++) {
         await fundAndApprove(seeds[i], USDC(15_000));
-        await crowdfund.connect(seeds[i]).commit(USDC(15_000), 0);
+        await crowdfund.connect(seeds[i]).commit(0, USDC(15_000));
       }
 
       // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
@@ -788,7 +796,7 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 54); // 53 seeds (indices 1-53)
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // Each of the first 52 seeds invites one hop-1 participant (signers 54-105)
       const hop1Invitees: SignerWithAddress[] = [];
@@ -801,12 +809,12 @@ describe("Crowdfund Adversarial", function () {
       // All 53 seeds commit $15K
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       // 52 hop-1 participants commit $4K
       for (const h of hop1Invitees) {
         await fundAndApprove(h, USDC(4_000));
-        await crowdfund.connect(h).commit(USDC(4_000), 1);
+        await crowdfund.connect(h).commit(1, USDC(4_000));
       }
 
       await time.increase(THREE_WEEKS + 1);
@@ -840,11 +848,11 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 69); // 68 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
@@ -886,11 +894,11 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
@@ -920,7 +928,7 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 54); // 53 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       const hop1Invitees: SignerWithAddress[] = [];
       for (let i = 0; i < 52; i++) {
@@ -931,11 +939,11 @@ describe("Crowdfund Adversarial", function () {
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       for (const h of hop1Invitees) {
         await fundAndApprove(h, USDC(4_000));
-        await crowdfund.connect(h).commit(USDC(4_000), 1);
+        await crowdfund.connect(h).commit(1, USDC(4_000));
       }
 
       await time.increase(THREE_WEEKS + 1);
@@ -966,11 +974,11 @@ describe("Crowdfund Adversarial", function () {
       // Deploy the attacker contract
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
@@ -993,10 +1001,10 @@ describe("Crowdfund Adversarial", function () {
     it("claimRefund() is protected by nonReentrant", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       await fundAndApprove(seeds[0], USDC(15_000));
-      await crowdfund.connect(seeds[0]).commit(USDC(15_000), 0);
+      await crowdfund.connect(seeds[0]).commit(0, USDC(15_000));
 
       await time.increase(THREE_WEEKS + 1);
       // finalize reverts (below MIN_SALE) — use deadline fallback
@@ -1016,9 +1024,9 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       // Add hop-1 demand to avoid refundMode (hop-0 ceiling $798K < MIN_SALE $1M)
@@ -1039,9 +1047,9 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
@@ -1058,11 +1066,11 @@ describe("Crowdfund Adversarial", function () {
     it("commit() is protected by nonReentrant", async function () {
       // Verify commit guard by confirming correct behavior under normal conditions
       await crowdfund.addSeeds([allSigners[1].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       await fundAndApprove(allSigners[1], USDC(15_000));
-      await crowdfund.connect(allSigners[1]).commit(USDC(10_000), 0);
-      await crowdfund.connect(allSigners[1]).commit(USDC(5_000), 0);
+      await crowdfund.connect(allSigners[1]).commit(0, USDC(10_000));
+      await crowdfund.connect(allSigners[1]).commit(0, USDC(5_000));
 
       const committed = await crowdfund.getCommitment(allSigners[1].address, 0);
       expect(committed).to.equal(USDC(15_000));

--- a/test/crowdfund_integration.ts
+++ b/test/crowdfund_integration.ts
@@ -17,7 +17,7 @@ import { time } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
 // Phase enum (must match IArmadaCrowdfund.sol)
-const Phase = { Setup: 0, Active: 1, Finalized: 2, Canceled: 3 };
+const Phase = { Active: 0, Finalized: 1, Canceled: 2 };
 
 // Time constants
 const ONE_DAY = 86400;
@@ -58,11 +58,11 @@ describe("Crowdfund Integration", function () {
   // Setup helper: add seeds and start the 3-week active window
   async function setupWithSeeds(seeds: SignerWithAddress[]) {
     await crowdfund.addSeeds(seeds.map(s => s.address));
-    await crowdfund.startWindow();
+    { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
   }
 
-  // Setup through active phase: seeds added and window started.
-  // Commits are permitted immediately after startWindow().
+  // Setup through active phase: seeds added and time advanced to window start.
+  // Commits are permitted once the active window opens.
   async function setupActive(seeds: SignerWithAddress[]) {
     await setupWithSeeds(seeds);
   }
@@ -75,7 +75,7 @@ describe("Crowdfund Integration", function () {
     for (let i = 0; i < count; i++) {
       await crowdfund.connect(seeds[i]).invite(hop1Pool[i].address, 0);
       await fundAndApprove(hop1Pool[i], USDC(4_000));
-      await crowdfund.connect(hop1Pool[i]).commit(USDC(4_000), 1);
+      await crowdfund.connect(hop1Pool[i]).commit(1, USDC(4_000));
     }
   }
 
@@ -96,13 +96,15 @@ describe("Crowdfund Integration", function () {
 
     // Deploy ArmadaCrowdfund
     const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+    const openTimestamp = (await time.latest()) + 300;
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
       deployer.address,
       treasury.address,
       deployer.address,
-      deployer.address        // securityCouncil
+      deployer.address,       // securityCouncil
+      openTimestamp
     );
     await crowdfund.waitForDeployment();
     await armToken.addToWhitelist(await crowdfund.getAddress());
@@ -125,9 +127,17 @@ describe("Crowdfund Integration", function () {
 
   describe("Setup Phase", function () {
     it("should deploy with correct initial state", async function () {
-      expect(await crowdfund.phase()).to.equal(Phase.Setup);
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
       expect(await crowdfund.totalCommitted()).to.equal(0);
       expect(await crowdfund.getParticipantCount()).to.equal(0);
+
+      // Verify window timestamps are set correctly
+      const ws = await crowdfund.windowStart();
+      const we = await crowdfund.windowEnd();
+      const ltie = await crowdfund.launchTeamInviteEnd();
+      expect(ws).to.be.gt(0);
+      expect(we - ws).to.equal(THREE_WEEKS);
+      expect(ltie - ws).to.equal(ONE_WEEK);
 
       // Check hop configs (overlapping ceilings: 70/45/0 — hop-2 uses floor+rollover, not BPS)
       const [ceilingBps0, cap0, maxInv0] = await crowdfund.hopConfigs(0);
@@ -184,12 +194,12 @@ describe("Crowdfund Integration", function () {
 
     it("should reject adding seeds after week 1 of active window", async function () {
       await crowdfund.addSeed(seed1.address);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       // Seeds allowed during week 1; fast-forward past launchTeamInviteEnd
       await time.increase(ONE_WEEK + 1);
       await expect(
         crowdfund.addSeed(seed2.address)
-      ).to.be.revertedWith("ArmadaCrowdfund: seeds only during setup or week 1");
+      ).to.be.revertedWith("ArmadaCrowdfund: seeds only before invite period ends");
     });
   });
 
@@ -210,13 +220,15 @@ describe("Crowdfund Integration", function () {
       await freshArmToken.initWhitelist([deployer.address]);
 
       const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      const freshOpenTimestamp = (await time.latest()) + 300;
       freshCrowdfund = await ArmadaCrowdfund.deploy(
         await usdc.getAddress(),
         await freshArmToken.getAddress(),
         deployer.address,
         treasury.address,
         deployer.address,
-        deployer.address        // securityCouncil
+        deployer.address,       // securityCouncil
+        freshOpenTimestamp
       );
       await freshCrowdfund.waitForDeployment();
       await freshArmToken.addToWhitelist(await freshCrowdfund.getAddress());
@@ -276,16 +288,15 @@ describe("Crowdfund Integration", function () {
       expect(await freshCrowdfund.armLoaded()).to.be.true;
     });
 
-    it("startWindow() reverts when ARM not loaded", async function () {
-      await freshCrowdfund.addSeed(seed1.address);
+    it("addSeed reverts when ARM not loaded", async function () {
       await expect(
-        freshCrowdfund.startWindow()
+        freshCrowdfund.addSeed(seed1.address)
       ).to.be.revertedWith("ArmadaCrowdfund: ARM not loaded");
     });
 
-    it("full deployment sequence: deploy → transfer → loadArm → startWindow", async function () {
-      // 1. Deploy (done in beforeEach)
-      expect(await freshCrowdfund.phase()).to.equal(Phase.Setup);
+    it("full deployment sequence: deploy → transfer → loadArm → addSeeds", async function () {
+      // 1. Deploy (done in beforeEach) — contract starts in Active phase
+      expect(await freshCrowdfund.phase()).to.equal(Phase.Active);
       expect(await freshCrowdfund.armLoaded()).to.be.false;
 
       // 2. Transfer ARM
@@ -295,9 +306,9 @@ describe("Crowdfund Integration", function () {
       await freshCrowdfund.loadArm();
       expect(await freshCrowdfund.armLoaded()).to.be.true;
 
-      // 4. Add seeds and start window
+      // 4. Add seeds — works now that ARM is loaded
       await freshCrowdfund.addSeed(seed1.address);
-      await freshCrowdfund.startWindow();
+      expect(await freshCrowdfund.isWhitelisted(seed1.address, 0)).to.be.true;
       expect(await freshCrowdfund.phase()).to.equal(Phase.Active);
     });
   });
@@ -309,38 +320,22 @@ describe("Crowdfund Integration", function () {
   describe("Active Window — Invitations", function () {
     it("should transition to active phase", async function () {
       await crowdfund.addSeed(seed1.address);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       expect(await crowdfund.phase()).to.equal(Phase.Active);
       expect(await crowdfund.windowEnd()).to.be.gt(0);
     });
 
-    it("startWindow() reverts when called by non-admin", async function () {
-      await crowdfund.addSeed(seed1.address);
-      await expect(
-        crowdfund.connect(outsider).startWindow()
-      ).to.be.revertedWith("ArmadaCrowdfund: not admin");
-    });
+    it("constructor sets window timestamps correctly", async function () {
+      const ws = await crowdfund.windowStart();
+      const we = await crowdfund.windowEnd();
+      const ltie = await crowdfund.launchTeamInviteEnd();
 
-    it("startWindow() reverts when called outside Setup phase", async function () {
-      await setupWithSeeds([seed1]);
-      // Already in Active phase — calling again should fail
-      await expect(
-        crowdfund.startWindow()
-      ).to.be.revertedWith("ArmadaCrowdfund: wrong phase");
-    });
-
-    it("startWindow() emits WindowStarted with correct timestamps", async function () {
-      await crowdfund.addSeed(seed1.address);
-      const tx = await crowdfund.startWindow();
-      const receipt = await tx.wait();
-      const event = receipt.logs.find((l: any) => l.fragment?.name === "WindowStarted");
-      expect(event).to.not.be.undefined;
-    });
-
-    it("should reject starting with no seeds", async function () {
-      await expect(
-        crowdfund.startWindow()
-      ).to.be.revertedWith("ArmadaCrowdfund: no seeds");
+      // windowEnd = windowStart + 3 weeks
+      expect(we - ws).to.equal(THREE_WEEKS);
+      // launchTeamInviteEnd = windowStart + 1 week
+      expect(ltie - ws).to.equal(ONE_WEEK);
+      // windowStart should be the openTimestamp we passed to constructor
+      expect(ws).to.be.gt(0);
     });
 
     it("addSeed() emits SeedAdded event", async function () {
@@ -474,7 +469,7 @@ describe("Crowdfund Integration", function () {
   describe("Active Window — Commitments", function () {
     it("commit() emits Committed event", async function () {
       await setupActive([seed1]);
-      await expect(crowdfund.connect(seed1).commit(USDC(5_000), 0))
+      await expect(crowdfund.connect(seed1).commit(0, USDC(5_000)))
         .to.emit(crowdfund, "Committed")
         .withArgs(seed1.address, USDC(5_000), USDC(5_000), 0);
     });
@@ -482,7 +477,7 @@ describe("Crowdfund Integration", function () {
     it("should allow whitelisted address to commit USDC", async function () {
       await setupActive([seed1]);
 
-      await crowdfund.connect(seed1).commit(USDC(5_000), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(5_000));
 
       const committed = await crowdfund.getCommitment(seed1.address, 0);
       expect(committed).to.equal(USDC(5_000));
@@ -492,9 +487,9 @@ describe("Crowdfund Integration", function () {
     it("should allow multiple commits up to cap", async function () {
       await setupActive([seed1]);
 
-      await crowdfund.connect(seed1).commit(USDC(5_000), 0);
-      await crowdfund.connect(seed1).commit(USDC(5_000), 0);
-      await crowdfund.connect(seed1).commit(USDC(5_000), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(5_000));
+      await crowdfund.connect(seed1).commit(0, USDC(5_000));
+      await crowdfund.connect(seed1).commit(0, USDC(5_000));
 
       const committed = await crowdfund.getCommitment(seed1.address, 0);
       expect(committed).to.equal(USDC(15_000));
@@ -504,7 +499,7 @@ describe("Crowdfund Integration", function () {
       await setupActive([seed1]);
 
       await expect(
-        crowdfund.connect(seed1).commit(USDC(15_001), 0)
+        crowdfund.connect(seed1).commit(0, USDC(15_001))
       ).to.be.revertedWith("ArmadaCrowdfund: exceeds hop cap");
     });
 
@@ -513,7 +508,7 @@ describe("Crowdfund Integration", function () {
       await crowdfund.connect(seed1).invite(hop1a.address, 0);
 
       await expect(
-        crowdfund.connect(hop1a).commit(USDC(4_001), 1)
+        crowdfund.connect(hop1a).commit(1, USDC(4_001))
       ).to.be.revertedWith("ArmadaCrowdfund: exceeds hop cap");
     });
 
@@ -523,7 +518,7 @@ describe("Crowdfund Integration", function () {
       await crowdfund.connect(hop1a).invite(hop2a.address, 1);
 
       await expect(
-        crowdfund.connect(hop2a).commit(USDC(1_001), 2)
+        crowdfund.connect(hop2a).commit(2, USDC(1_001))
       ).to.be.revertedWith("ArmadaCrowdfund: exceeds hop cap");
     });
 
@@ -532,7 +527,7 @@ describe("Crowdfund Integration", function () {
 
       await fundAndApprove(outsider, USDC(1_000));
       await expect(
-        crowdfund.connect(outsider).commit(USDC(1_000), 0)
+        crowdfund.connect(outsider).commit(0, USDC(1_000))
       ).to.be.revertedWith("ArmadaCrowdfund: not whitelisted");
     });
 
@@ -540,7 +535,7 @@ describe("Crowdfund Integration", function () {
       await setupWithSeeds([seed1]);
       await time.increase(THREE_WEEKS + 1); // past window end
       await expect(
-        crowdfund.connect(seed1).commit(USDC(1_000), 0)
+        crowdfund.connect(seed1).commit(0, USDC(1_000))
       ).to.be.revertedWith("ArmadaCrowdfund: not active window");
     });
 
@@ -548,7 +543,7 @@ describe("Crowdfund Integration", function () {
       await setupActive([seed1]);
 
       await expect(
-        crowdfund.connect(seed1).commit(USDC(9), 0)
+        crowdfund.connect(seed1).commit(0, USDC(9))
       ).to.be.revertedWith("ArmadaCrowdfund: below minimum commitment");
 
       await expect(
@@ -559,7 +554,7 @@ describe("Crowdfund Integration", function () {
     it("should accept commit of exactly $10 USDC", async function () {
       await setupActive([seed1]);
 
-      await crowdfund.connect(seed1).commit(USDC(10), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(10));
       const committed = await crowdfund.getCommitment(seed1.address, 0);
       expect(committed).to.equal(USDC(10));
     });
@@ -568,9 +563,9 @@ describe("Crowdfund Integration", function () {
       await setupWithSeeds([seed1, seed2]);
       await crowdfund.connect(seed1).invite(hop1a.address, 0);
 
-      await crowdfund.connect(seed1).commit(USDC(10_000), 0);
-      await crowdfund.connect(seed2).commit(USDC(8_000), 0);
-      await crowdfund.connect(hop1a).commit(USDC(3_000), 1);
+      await crowdfund.connect(seed1).commit(0, USDC(10_000));
+      await crowdfund.connect(seed2).commit(0, USDC(8_000));
+      await crowdfund.connect(hop1a).commit(1, USDC(3_000));
 
       const [tc0, uc0] = await crowdfund.getHopStats(0);
       expect(tc0).to.equal(USDC(18_000));
@@ -587,12 +582,12 @@ describe("Crowdfund Integration", function () {
       await setupActive([seed1]);
 
       // First commit: uniqueCommitters should go from 0 to 1
-      await crowdfund.connect(seed1).commit(USDC(1_000), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(1_000));
       const [, uc1] = await crowdfund.getHopStats(0);
       expect(uc1).to.equal(1);
 
       // Second commit from same address: uniqueCommitters should stay at 1
-      await crowdfund.connect(seed1).commit(USDC(1_000), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(1_000));
       const [, uc2] = await crowdfund.getHopStats(0);
       expect(uc2).to.equal(1);
     });
@@ -610,10 +605,10 @@ describe("Crowdfund Integration", function () {
 
     it("phase stays Active after commits", async function () {
       await setupActive([seed1, seed2]);
-      await crowdfund.connect(seed1).commit(USDC(1_000), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(1_000));
       expect(await crowdfund.phase()).to.equal(Phase.Active);
 
-      await crowdfund.connect(seed2).commit(USDC(1_000), 0);
+      await crowdfund.connect(seed2).commit(0, USDC(1_000));
       expect(await crowdfund.phase()).to.equal(Phase.Active);
     });
 
@@ -623,9 +618,9 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       expect(await crowdfund.phase()).to.equal(Phase.Active);
 
@@ -644,7 +639,7 @@ describe("Crowdfund Integration", function () {
       await setupActive([seed1]);
 
       // Commit well below elastic trigger ($1.5M)
-      await crowdfund.connect(seed1).commit(USDC(15_000), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(15_000));
       // Need to reach minimum ($1M), so fund many more seeds
       // For this test, let's just check elastic trigger logic with a known total
       await time.increase(THREE_WEEKS + 1);
@@ -663,11 +658,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // Each seed commits $15K, 80 seeds = $1.2M (above minimum, at base trigger)
       for (const s of seeds.slice(0, 68)) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       // Total: 68 × $15K = $1,020,000 — above MIN_SALE
 
@@ -697,11 +692,11 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // 70 seeds × $15K = $1,050,000 total committed (above min, below elastic trigger)
       for (const s of seeds.slice(0, 70)) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
@@ -733,10 +728,10 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds.slice(0, 68)) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
@@ -761,12 +756,12 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // Only 68 seeds commit — hop-0 ceiling = 70% of $1.14M (netRaise) = $798K
       // 68 * $15K = $1.02M committed (above MIN_SALE), but all in hop-0
       for (const s of seeds.slice(0, 68)) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
@@ -795,9 +790,9 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
@@ -809,7 +804,7 @@ describe("Crowdfund Integration", function () {
 
     it("should revert finalize when below minimum raise", async function () {
       await setupActive([seed1]);
-      await crowdfund.connect(seed1).commit(USDC(15_000), 0); // way below $1M min
+      await crowdfund.connect(seed1).commit(0, USDC(15_000)); // way below $1M min
 
       await time.increase(THREE_WEEKS + 1);
       await expect(
@@ -820,16 +815,18 @@ describe("Crowdfund Integration", function () {
       expect(await crowdfund.phase()).to.equal(Phase.Active);
     });
 
-    it("should require ARM pre-load before window can open", async function () {
+    it("should require ARM pre-load before seeds can be added", async function () {
       // Deploy a new crowdfund without ARM funding
       const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      const unfundedOpenTimestamp = (await time.latest()) + 300;
       const unfundedCrowdfund = await ArmadaCrowdfund.deploy(
         await usdc.getAddress(),
         await armToken.getAddress(),
         deployer.address,
         treasury.address,
         deployer.address,
-        deployer.address        // securityCouncil
+        deployer.address,       // securityCouncil
+        unfundedOpenTimestamp
       );
       await unfundedCrowdfund.waitForDeployment();
 
@@ -838,10 +835,9 @@ describe("Crowdfund Integration", function () {
         unfundedCrowdfund.loadArm()
       ).to.be.revertedWith("ArmadaCrowdfund: insufficient ARM for MAX_SALE");
 
-      // startWindow() reverts without loadArm()
-      await unfundedCrowdfund.addSeed(seed1.address);
+      // addSeed() reverts without loadArm() (armLoaded guard)
       await expect(
-        unfundedCrowdfund.startWindow()
+        unfundedCrowdfund.addSeed(seed1.address)
       ).to.be.revertedWith("ArmadaCrowdfund: ARM not loaded");
     });
   });
@@ -858,9 +854,9 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds.slice(0, 70)) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
@@ -888,9 +884,9 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds.slice(0, 68)) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
@@ -904,7 +900,7 @@ describe("Crowdfund Integration", function () {
 
     it("should allow full refund via deadline fallback (below min, no finalize)", async function () {
       await setupActive([seed1]);
-      await crowdfund.connect(seed1).commit(USDC(10_000), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(10_000));
 
       const usdcBefore = await usdc.balanceOf(seed1.address);
       await time.increase(THREE_WEEKS + 1);
@@ -916,7 +912,7 @@ describe("Crowdfund Integration", function () {
 
     it("should reject claimRefund during active window", async function () {
       await setupActive([seed1]);
-      await crowdfund.connect(seed1).commit(USDC(10_000), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(10_000));
 
       await expect(
         crowdfund.connect(seed1).claimRefund()
@@ -930,9 +926,9 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of committers) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
@@ -962,9 +958,9 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of committers) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
@@ -993,7 +989,7 @@ describe("Crowdfund Integration", function () {
     it("should return correct aggregate stats during sale", async function () {
       await setupWithSeeds([seed1, seed2]);
       await crowdfund.connect(seed1).invite(hop1a.address, 0);
-      await crowdfund.connect(seed1).commit(USDC(10_000), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(10_000));
 
       const [tc, phase_, ws, we] = await crowdfund.getSaleStats();
       expect(tc).to.equal(USDC(10_000));
@@ -1015,9 +1011,9 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds.slice(0, 68)) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
@@ -1033,9 +1029,9 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds.slice(0, 68)) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
@@ -1061,7 +1057,7 @@ describe("Crowdfund Integration", function () {
 
       // Setup
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // Invitations (some seeds invite hop-1 participants)
       // Use remaining signers for hop-1
@@ -1078,12 +1074,12 @@ describe("Crowdfund Integration", function () {
 
       // Commitments
       for (const s of seeds) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       // 49 seeds × $15K = $735,000
       // hop-1 commits
       for (let i = 0; i < hop1Idx; i++) {
-        await crowdfund.connect(hop1Signers[i]).commit(USDC(4_000), 1);
+        await crowdfund.connect(hop1Signers[i]).commit(1, USDC(4_000));
       }
       // 10 hop-1 × $4K = $40,000
       // Total: $775,000 — below $1M min → will cancel
@@ -1101,10 +1097,10 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       // 70 × $15K = $1,050,000 > MIN_SALE, < ELASTIC_TRIGGER ($1.5M)
 
@@ -1140,8 +1136,8 @@ describe("Crowdfund Integration", function () {
 
     it("cancellation (below minimum) — claimRefund via deadline fallback", async function () {
       await setupActive([seed1, seed2]);
-      await crowdfund.connect(seed1).commit(USDC(15_000), 0);
-      await crowdfund.connect(seed2).commit(USDC(10_000), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(15_000));
+      await crowdfund.connect(seed2).commit(0, USDC(10_000));
       // Total: $25K << $1M minimum
 
       await time.increase(THREE_WEEKS + 1);
@@ -1172,9 +1168,9 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
@@ -1195,7 +1191,7 @@ describe("Crowdfund Integration", function () {
       await crowdfund.pause();
 
       await expect(
-        crowdfund.launchTeamInvite(hop1a.address, 1)
+        crowdfund.launchTeamInvite(hop1a.address, 0)
       ).to.be.revertedWith("Pausable: paused");
     });
 
@@ -1208,7 +1204,7 @@ describe("Crowdfund Integration", function () {
       ).to.be.revertedWith("Pausable: paused");
 
       await expect(
-        crowdfund.connect(seed1).commit(USDC(1_000), 0)
+        crowdfund.connect(seed1).commit(0, USDC(1_000))
       ).to.be.revertedWith("Pausable: paused");
     });
 
@@ -1220,7 +1216,7 @@ describe("Crowdfund Integration", function () {
       await crowdfund.connect(seed1).invite(hop1a.address, 0);
       expect(await crowdfund.isWhitelisted(hop1a.address, 1)).to.be.true;
 
-      await crowdfund.connect(seed1).commit(USDC(1_000), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(1_000));
       const committed = await crowdfund.getCommitment(seed1.address, 0);
       expect(committed).to.equal(USDC(1_000));
     });
@@ -1231,9 +1227,9 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);
@@ -1255,7 +1251,7 @@ describe("Crowdfund Integration", function () {
     it("claimRefund() reverts while paused, works after unpause", async function () {
       await setupWithSeeds([seed1]);
       await fundAndApprove(seed1, USDC(1_000));
-      await crowdfund.connect(seed1).commit(USDC(1_000), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(1_000));
       await time.increase(THREE_WEEKS + 1);
       // finalize() reverts (below MIN_SALE) — use deadline fallback path
 
@@ -1304,13 +1300,15 @@ describe("Crowdfund Integration", function () {
 
     it("admin cannot pause post-finalization", async function () {
       // Need a crowdfund where admin != securityCouncil to test this
+      const pauseOpenTimestamp = (await time.latest()) + 300;
       const freshCrowdfund = await (await ethers.getContractFactory("ArmadaCrowdfund")).deploy(
         await usdc.getAddress(),
         await armToken.getAddress(),
         deployer.address,        // admin
         treasury.address,        // treasury
         deployer.address,        // launchTeam
-        outsider.address         // securityCouncil (different from admin)
+        outsider.address,        // securityCouncil (different from admin)
+        pauseOpenTimestamp
       );
       const freshAddr = await freshCrowdfund.getAddress();
       await armToken.transfer(freshAddr, ARM(1_800_000));
@@ -1323,9 +1321,9 @@ describe("Crowdfund Integration", function () {
         await usdc.connect(s).approve(freshAddr, USDC(15_000));
       }
       await freshCrowdfund.addSeeds(seeds.map(s => s.address));
-      await freshCrowdfund.startWindow();
+      { const ws = Number(await freshCrowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds) {
-        await freshCrowdfund.connect(s).commit(USDC(15_000), 0);
+        await freshCrowdfund.connect(s).commit(0, USDC(15_000));
       }
       // Add hop-1 to ensure totalAllocUsdc > MIN_SALE
       for (let i = 0; i < 51; i++) {
@@ -1333,7 +1331,7 @@ describe("Crowdfund Integration", function () {
         await freshCrowdfund.connect(seeds[i]).invite(invitee.address, 0);
         await usdc.mint(invitee.address, USDC(4_000));
         await usdc.connect(invitee).approve(freshAddr, USDC(4_000));
-        await freshCrowdfund.connect(invitee).commit(USDC(4_000), 1);
+        await freshCrowdfund.connect(invitee).commit(1, USDC(4_000));
       }
       await time.increase(THREE_WEEKS + 1);
       await freshCrowdfund.finalize();
@@ -1349,13 +1347,15 @@ describe("Crowdfund Integration", function () {
     });
 
     it("admin cannot pause post-cancel", async function () {
+      const cancelOpenTimestamp = (await time.latest()) + 300;
       const freshCrowdfund = await (await ethers.getContractFactory("ArmadaCrowdfund")).deploy(
         await usdc.getAddress(),
         await armToken.getAddress(),
         deployer.address,        // admin
         treasury.address,        // treasury
         deployer.address,        // launchTeam
-        outsider.address         // securityCouncil (different from admin)
+        outsider.address,        // securityCouncil (different from admin)
+        cancelOpenTimestamp
       );
 
       // Security council cancels
@@ -1384,9 +1384,9 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 200));
       await time.increase(THREE_WEEKS + 1);

--- a/test/crowdfund_launch_team.ts
+++ b/test/crowdfund_launch_team.ts
@@ -7,7 +7,7 @@ import { time } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
 // Phase enum (must match IArmadaCrowdfund.sol)
-const Phase = { Setup: 0, Active: 1, Finalized: 2, Canceled: 3 };
+const Phase = { Active: 0, Finalized: 1, Canceled: 2 };
 
 // Time constants
 const ONE_DAY = 86400;
@@ -56,17 +56,19 @@ describe("Launch Team & Seed Cap", function () {
     await armToken.initWhitelist([deployer.address]);
 
     const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+    const openTimestamp = (await time.latest()) + 300;
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
       deployer.address,   // admin
       treasury.address,   // treasury
       deployer.address,   // launchTeam (same as admin for local testing)
-      deployer.address    // securityCouncil
+      deployer.address,   // securityCouncil
+      openTimestamp        // openTimestamp
     );
     await crowdfund.waitForDeployment();
 
-    // Fund ARM for MAX_SALE and verify pre-load (required for startWindow)
+    // Fund ARM for MAX_SALE and verify pre-load
     const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
     await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
     await crowdfund.loadArm();
@@ -121,26 +123,26 @@ describe("Launch Team & Seed Cap", function () {
       [, , , invitee1, invitee2, seed1] = allSigners;
       // Add a seed and start the active window
       await crowdfund.addSeed(seed1.address);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
     });
 
     it("launch team can invite to hop-1", async function () {
-      await crowdfund.launchTeamInvite(invitee1.address, 1);
+      await crowdfund.launchTeamInvite(invitee1.address, 0);
       expect(await crowdfund.isWhitelisted(invitee1.address, 1)).to.be.true;
     });
 
     it("launch team can invite to hop-2", async function () {
-      await crowdfund.launchTeamInvite(invitee1.address, 2);
+      await crowdfund.launchTeamInvite(invitee1.address, 1);
       expect(await crowdfund.isWhitelisted(invitee1.address, 2)).to.be.true;
     });
 
-    it("reverts if hop is 0 (launch team cannot place seeds)", async function () {
+    it("reverts if fromHop >= 2 (only 0 and 1 are valid)", async function () {
       await expect(
-        crowdfund.launchTeamInvite(invitee1.address, 0)
+        crowdfund.launchTeamInvite(invitee1.address, 2)
       ).to.be.revertedWith("ArmadaCrowdfund: invalid hop for launch team");
     });
 
-    it("reverts if hop > 2", async function () {
+    it("reverts if fromHop > 2", async function () {
       await expect(
         crowdfund.launchTeamInvite(invitee1.address, 3)
       ).to.be.reverted;
@@ -148,54 +150,46 @@ describe("Launch Team & Seed Cap", function () {
 
     it("reverts if caller is not launch team", async function () {
       await expect(
-        crowdfund.connect(outsider).launchTeamInvite(invitee1.address, 1)
+        crowdfund.connect(outsider).launchTeamInvite(invitee1.address, 0)
       ).to.be.revertedWith("ArmadaCrowdfund: not launch team");
     });
 
     it("reverts if invitee is zero address", async function () {
       await expect(
-        crowdfund.launchTeamInvite(ethers.ZeroAddress, 1)
+        crowdfund.launchTeamInvite(ethers.ZeroAddress, 0)
       ).to.be.revertedWith("ArmadaCrowdfund: zero address");
     });
 
-    it("reverts before window starts (Setup phase)", async function () {
-      // Deploy a fresh crowdfund still in Setup
-      const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
-      const freshCrowdfund = await ArmadaCrowdfund.deploy(
-        await usdc.getAddress(),
-        await armToken.getAddress(),
-        deployer.address,
-        treasury.address,
-        deployer.address,
-        deployer.address        // securityCouncil
-      );
+    it("reverts after invite window closes", async function () {
+      // Advance past the 7-day launch team invite window
+      await time.increase(7 * ONE_DAY + 1);
       await expect(
-        freshCrowdfund.launchTeamInvite(invitee1.address, 1)
-      ).to.be.revertedWith("ArmadaCrowdfund: not active");
+        crowdfund.launchTeamInvite(invitee1.address, 0)
+      ).to.be.revertedWith("ArmadaCrowdfund: launch team invite window closed");
     });
 
     it("invite graph shows launch team as inviter", async function () {
-      await crowdfund.launchTeamInvite(invitee1.address, 1);
+      await crowdfund.launchTeamInvite(invitee1.address, 0);
       const inviter = await crowdfund.getInviteEdge(invitee1.address, 1);
       expect(inviter).to.equal(deployer.address); // launchTeam == deployer in test
     });
 
     it("hop-1 invitee has standard 2 hop-2 invite slots", async function () {
-      await crowdfund.launchTeamInvite(invitee1.address, 1);
+      await crowdfund.launchTeamInvite(invitee1.address, 0);
       // invitee1 is hop-1, should be able to invite 2 hop-2 addresses
       const remaining = await crowdfund.getInvitesRemaining(invitee1.address, 1);
       expect(remaining).to.equal(2);
     });
 
     it("hop-1 invitee can use their invite slots normally", async function () {
-      await crowdfund.launchTeamInvite(invitee1.address, 1);
+      await crowdfund.launchTeamInvite(invitee1.address, 0);
       // invitee1 invites invitee2 to hop-2
       await crowdfund.connect(invitee1).invite(invitee2.address, 1);
       expect(await crowdfund.isWhitelisted(invitee2.address, 2)).to.be.true;
     });
 
     it("hop-2 invitee cannot invite (maxInvites = 0)", async function () {
-      await crowdfund.launchTeamInvite(invitee1.address, 2);
+      await crowdfund.launchTeamInvite(invitee1.address, 1);
       // hop-2 has maxInvites = 0, so inviterHop must be < NUM_HOPS - 1
       await expect(
         crowdfund.connect(invitee1).invite(invitee2.address, 2)
@@ -203,8 +197,8 @@ describe("Launch Team & Seed Cap", function () {
     });
 
     it("whitelistCount increments correctly for launch team invites", async function () {
-      await crowdfund.launchTeamInvite(invitee1.address, 1);
-      await crowdfund.launchTeamInvite(invitee2.address, 2);
+      await crowdfund.launchTeamInvite(invitee1.address, 0);
+      await crowdfund.launchTeamInvite(invitee2.address, 1);
       const hop1Stats = await crowdfund.getHopStats(1);
       const hop2Stats = await crowdfund.getHopStats(2);
       expect(hop1Stats._whitelistCount).to.equal(1);
@@ -215,13 +209,13 @@ describe("Launch Team & Seed Cap", function () {
   describe("Budget Exhaustion", function () {
     beforeEach(async function () {
       await crowdfund.addSeed(allSigners[3].address);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
     });
 
     it("allows exactly 60 hop-1 invites", async function () {
       const addrs = makeAddresses(60);
       for (const addr of addrs) {
-        await crowdfund.launchTeamInvite(addr, 1);
+        await crowdfund.launchTeamInvite(addr, 0);
       }
       const [hop1Rem, hop2Rem] = await crowdfund.getLaunchTeamBudgetRemaining();
       expect(hop1Rem).to.equal(0);
@@ -231,17 +225,17 @@ describe("Launch Team & Seed Cap", function () {
     it("61st hop-1 invite reverts", async function () {
       const addrs = makeAddresses(61);
       for (let i = 0; i < 60; i++) {
-        await crowdfund.launchTeamInvite(addrs[i], 1);
+        await crowdfund.launchTeamInvite(addrs[i], 0);
       }
       await expect(
-        crowdfund.launchTeamInvite(addrs[60], 1)
+        crowdfund.launchTeamInvite(addrs[60], 0)
       ).to.be.revertedWith("ArmadaCrowdfund: hop-1 budget exhausted");
     });
 
     it("allows exactly 60 hop-2 invites", async function () {
       const addrs = makeAddresses(60);
       for (const addr of addrs) {
-        await crowdfund.launchTeamInvite(addr, 2);
+        await crowdfund.launchTeamInvite(addr, 1);
       }
       const [hop1Rem, hop2Rem] = await crowdfund.getLaunchTeamBudgetRemaining();
       expect(hop1Rem).to.equal(60);
@@ -251,10 +245,10 @@ describe("Launch Team & Seed Cap", function () {
     it("61st hop-2 invite reverts", async function () {
       const addrs = makeAddresses(61);
       for (let i = 0; i < 60; i++) {
-        await crowdfund.launchTeamInvite(addrs[i], 2);
+        await crowdfund.launchTeamInvite(addrs[i], 1);
       }
       await expect(
-        crowdfund.launchTeamInvite(addrs[60], 2)
+        crowdfund.launchTeamInvite(addrs[60], 1)
       ).to.be.revertedWith("ArmadaCrowdfund: hop-2 budget exhausted");
     });
 
@@ -265,9 +259,9 @@ describe("Launch Team & Seed Cap", function () {
       expect(h2).to.equal(60);
 
       // Use some
-      await crowdfund.launchTeamInvite(makeAddresses(1, 200)[0], 1);
-      await crowdfund.launchTeamInvite(makeAddresses(1, 300)[0], 2);
-      await crowdfund.launchTeamInvite(makeAddresses(1, 301)[0], 2);
+      await crowdfund.launchTeamInvite(makeAddresses(1, 199)[0], 0);
+      await crowdfund.launchTeamInvite(makeAddresses(1, 299)[0], 1);
+      await crowdfund.launchTeamInvite(makeAddresses(1, 300)[0], 1);
 
       [h1, h2] = await crowdfund.getLaunchTeamBudgetRemaining();
       expect(h1).to.equal(59);
@@ -278,19 +272,19 @@ describe("Launch Team & Seed Cap", function () {
   describe("7-Day Invite Window Timing", function () {
     beforeEach(async function () {
       await crowdfund.addSeed(allSigners[3].address);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
     });
 
     it("launch team invite on day 6 succeeds", async function () {
       await time.increase(6 * ONE_DAY);
-      await crowdfund.launchTeamInvite(allSigners[4].address, 1);
+      await crowdfund.launchTeamInvite(allSigners[4].address, 0);
       expect(await crowdfund.isWhitelisted(allSigners[4].address, 1)).to.be.true;
     });
 
     it("launch team invite on day 8 reverts (past week 1)", async function () {
       await time.increase(7 * ONE_DAY + 1);
       await expect(
-        crowdfund.launchTeamInvite(allSigners[4].address, 1)
+        crowdfund.launchTeamInvite(allSigners[4].address, 0)
       ).to.be.revertedWith("ArmadaCrowdfund: launch team invite window closed");
     });
 
@@ -298,7 +292,7 @@ describe("Launch Team & Seed Cap", function () {
       // At exactly windowStart + 7 days, the condition is NOT strictly less than
       await time.increase(7 * ONE_DAY);
       await expect(
-        crowdfund.launchTeamInvite(allSigners[4].address, 1)
+        crowdfund.launchTeamInvite(allSigners[4].address, 0)
       ).to.be.revertedWith("ArmadaCrowdfund: launch team invite window closed");
     });
 
@@ -314,7 +308,7 @@ describe("Launch Team & Seed Cap", function () {
   describe("Launch Team Cannot Commit", function () {
     beforeEach(async function () {
       await crowdfund.addSeed(allSigners[3].address);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
     });
 
     it("launch team address cannot commit USDC", async function () {
@@ -325,13 +319,15 @@ describe("Launch Team & Seed Cap", function () {
       // by deploying a separate crowdfund where launchTeam is a different address
       const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
       const ltSigner = allSigners[5];
+      const cfOpenTimestamp = (await time.latest()) + 300;
       const cf = await ArmadaCrowdfund.deploy(
         await usdc.getAddress(),
         await armToken.getAddress(),
         deployer.address,
         treasury.address,
-        ltSigner.address,  // separate launch team
-        deployer.address   // securityCouncil
+        ltSigner.address,   // separate launch team
+        deployer.address,   // securityCouncil
+        cfOpenTimestamp      // openTimestamp
       );
       await cf.waitForDeployment();
 
@@ -342,14 +338,14 @@ describe("Launch Team & Seed Cap", function () {
 
       // Add launchTeam as a seed (admin can do this)
       await cf.addSeed(ltSigner.address);
-      await cf.startWindow();
+      { const ws = Number(await cf.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // Fund the launch team address
       await fundAndApprove(ltSigner, USDC(15000));
 
       // Try to commit — should be blocked by launch team guard
       await expect(
-        cf.connect(ltSigner).commit(USDC(100), 0)
+        cf.connect(ltSigner).commit(0, USDC(100))
       ).to.be.revertedWith("ArmadaCrowdfund: launch team cannot commit");
     });
   });
@@ -360,72 +356,72 @@ describe("Launch Team & Seed Cap", function () {
     beforeEach(async function () {
       invitee = allSigners[4];
       await crowdfund.addSeed(allSigners[3].address);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
     });
 
     it("re-invite to same (address, hop) increments invitesReceived", async function () {
-      await crowdfund.launchTeamInvite(invitee.address, 1);
+      await crowdfund.launchTeamInvite(invitee.address, 0);
       expect(await crowdfund.getInvitesReceived(invitee.address, 1)).to.equal(1);
 
-      await crowdfund.launchTeamInvite(invitee.address, 1);
+      await crowdfund.launchTeamInvite(invitee.address, 0);
       expect(await crowdfund.getInvitesReceived(invitee.address, 1)).to.equal(2);
     });
 
     it("re-invite consumes budget", async function () {
-      await crowdfund.launchTeamInvite(invitee.address, 1);
-      await crowdfund.launchTeamInvite(invitee.address, 1);
+      await crowdfund.launchTeamInvite(invitee.address, 0);
+      await crowdfund.launchTeamInvite(invitee.address, 0);
 
       const [hop1Rem] = await crowdfund.getLaunchTeamBudgetRemaining();
       expect(hop1Rem).to.equal(58); // 60 - 2
     });
 
     it("re-invite scales effective cap", async function () {
-      await crowdfund.launchTeamInvite(invitee.address, 1);
+      await crowdfund.launchTeamInvite(invitee.address, 0);
       let cap = await crowdfund.getEffectiveCap(invitee.address, 1);
       expect(cap).to.equal(USDC(4000)); // 1 × $4k
 
-      await crowdfund.launchTeamInvite(invitee.address, 1);
+      await crowdfund.launchTeamInvite(invitee.address, 0);
       cap = await crowdfund.getEffectiveCap(invitee.address, 1);
       expect(cap).to.equal(USDC(8000)); // 2 × $4k
     });
 
     it("re-invite scales outgoing invite budget", async function () {
-      await crowdfund.launchTeamInvite(invitee.address, 1);
+      await crowdfund.launchTeamInvite(invitee.address, 0);
       expect(await crowdfund.getInvitesRemaining(invitee.address, 1)).to.equal(2);
 
-      await crowdfund.launchTeamInvite(invitee.address, 1);
+      await crowdfund.launchTeamInvite(invitee.address, 0);
       expect(await crowdfund.getInvitesRemaining(invitee.address, 1)).to.equal(4); // 2 × 2
     });
 
     it("re-invite capped at per-hop maxInvitesReceived (hop-1 = 10)", async function () {
       // Hop-1 cap is 10 — invite 10 times (uses 10 budget slots)
       for (let i = 0; i < 10; i++) {
-        await crowdfund.launchTeamInvite(invitee.address, 1);
+        await crowdfund.launchTeamInvite(invitee.address, 0);
       }
       expect(await crowdfund.getInvitesReceived(invitee.address, 1)).to.equal(10);
 
       // 11th re-invite should revert
       await expect(
-        crowdfund.launchTeamInvite(invitee.address, 1)
+        crowdfund.launchTeamInvite(invitee.address, 0)
       ).to.be.revertedWith("ArmadaCrowdfund: max invites received");
     });
 
     it("re-invite capped at per-hop maxInvitesReceived (hop-2 = 20)", async function () {
       // Hop-2 cap is 20 — invite 20 times (uses 20 budget slots)
       for (let i = 0; i < 20; i++) {
-        await crowdfund.launchTeamInvite(invitee.address, 2);
+        await crowdfund.launchTeamInvite(invitee.address, 1);
       }
       expect(await crowdfund.getInvitesReceived(invitee.address, 2)).to.equal(20);
 
       // 21st re-invite should revert
       await expect(
-        crowdfund.launchTeamInvite(invitee.address, 2)
+        crowdfund.launchTeamInvite(invitee.address, 1)
       ).to.be.revertedWith("ArmadaCrowdfund: max invites received");
     });
 
     it("emits InviteAdded on re-invite", async function () {
-      await crowdfund.launchTeamInvite(invitee.address, 1);
-      await expect(crowdfund.launchTeamInvite(invitee.address, 1))
+      await crowdfund.launchTeamInvite(invitee.address, 0);
+      await expect(crowdfund.launchTeamInvite(invitee.address, 0))
         .to.emit(crowdfund, "InviteAdded")
         .withArgs(deployer.address, invitee.address, 1, 2);
     });
@@ -434,6 +430,7 @@ describe("Launch Team & Seed Cap", function () {
   describe("Constructor Validation", function () {
     it("rejects zero launchTeam address", async function () {
       const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      const cvOpenTimestamp = (await time.latest()) + 300;
       await expect(
         ArmadaCrowdfund.deploy(
           await usdc.getAddress(),
@@ -441,7 +438,8 @@ describe("Launch Team & Seed Cap", function () {
           deployer.address,
           treasury.address,
           ethers.ZeroAddress,
-          deployer.address
+          deployer.address,
+          cvOpenTimestamp
         )
       ).to.be.revertedWith("ArmadaCrowdfund: zero launchTeam");
     });

--- a/test/crowdfund_multinode.ts
+++ b/test/crowdfund_multinode.ts
@@ -6,7 +6,7 @@ import { ethers } from "hardhat";
 import { time } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
-const Phase = { Setup: 0, Active: 1, Finalized: 2, Canceled: 3 };
+const Phase = { Active: 0, Finalized: 1, Canceled: 2 };
 
 const ONE_DAY = 86400;
 const THREE_WEEKS = 21 * ONE_DAY;
@@ -34,7 +34,7 @@ describe("Crowdfund Multi-Node", function () {
 
   async function setupWithSeeds(seeds: SignerWithAddress[]) {
     await crowdfund.addSeeds(seeds.map(s => s.address));
-    await crowdfund.startWindow();
+    { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
   }
 
   beforeEach(async function () {
@@ -51,13 +51,15 @@ describe("Crowdfund Multi-Node", function () {
     await armToken.initWhitelist([deployer.address]);
 
     const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+    const openTimestamp = (await time.latest()) + 300;
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
       deployer.address,
       treasury.address,
       deployer.address,
-      deployer.address        // securityCouncil
+      deployer.address,       // securityCouncil
+      openTimestamp            // openTimestamp
     );
     await crowdfund.waitForDeployment();
     await armToken.addToWhitelist(await crowdfund.getAddress());
@@ -146,7 +148,7 @@ describe("Crowdfund Multi-Node", function () {
       await crowdfund.connect(seed2).invite(alice.address, 0);
 
       // Alice can commit up to $8000
-      await crowdfund.connect(alice).commit(USDC(8_000), 1);
+      await crowdfund.connect(alice).commit(1, USDC(8_000));
       expect(await crowdfund.getCommitment(alice.address, 1)).to.equal(USDC(8_000));
     });
 
@@ -157,7 +159,7 @@ describe("Crowdfund Multi-Node", function () {
       await crowdfund.connect(seed1).invite(alice.address, 0);
 
       await expect(
-        crowdfund.connect(alice).commit(USDC(4_001), 1)
+        crowdfund.connect(alice).commit(1, USDC(4_001))
       ).to.be.revertedWith("ArmadaCrowdfund: exceeds hop cap");
     });
 
@@ -341,9 +343,9 @@ describe("Crowdfund Multi-Node", function () {
       expect(await crowdfund.getEffectiveCap(seed1.address, 2)).to.equal(USDC(6_000));  // 6 * $1k
 
       // Commit at all three hops
-      await crowdfund.connect(seed1).commit(USDC(15_000), 0);
-      await crowdfund.connect(seed1).commit(USDC(12_000), 1);
-      await crowdfund.connect(seed1).commit(USDC(6_000), 2);
+      await crowdfund.connect(seed1).commit(0, USDC(15_000));
+      await crowdfund.connect(seed1).commit(1, USDC(12_000));
+      await crowdfund.connect(seed1).commit(2, USDC(6_000));
 
       // Verify commitments
       expect(await crowdfund.getCommitment(seed1.address, 0)).to.equal(USDC(15_000));
@@ -364,8 +366,8 @@ describe("Crowdfund Multi-Node", function () {
       await setupWithSeeds([seed1]);
       await crowdfund.connect(seed1).invite(seed1.address, 0);
 
-      await crowdfund.connect(seed1).commit(USDC(100), 0);
-      await crowdfund.connect(seed1).commit(USDC(100), 1);
+      await crowdfund.connect(seed1).commit(0, USDC(100));
+      await crowdfund.connect(seed1).commit(1, USDC(100));
 
       // Each hop should show 1 unique committer
       const [, committers0] = await crowdfund.getHopStats(0);
@@ -379,9 +381,9 @@ describe("Crowdfund Multi-Node", function () {
       await crowdfund.connect(seed1).invite(seed1.address, 0);
 
       // Max out hop-0 cap
-      await crowdfund.connect(seed1).commit(USDC(15_000), 0);
+      await crowdfund.connect(seed1).commit(0, USDC(15_000));
       // Can still commit at hop-1 (independent cap)
-      await crowdfund.connect(seed1).commit(USDC(4_000), 1);
+      await crowdfund.connect(seed1).commit(1, USDC(4_000));
 
       expect(await crowdfund.getCommitment(seed1.address, 0)).to.equal(USDC(15_000));
       expect(await crowdfund.getCommitment(seed1.address, 1)).to.equal(USDC(4_000));
@@ -416,7 +418,7 @@ describe("Crowdfund Multi-Node", function () {
       // Use many seeds to get above MIN_SALE
       const seeds = signers.slice(1, 80);
       await crowdfund.addSeeds(seeds.map((s: SignerWithAddress) => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // seed1 self-invites to hop-1
       await crowdfund.connect(seed1).invite(seed1.address, 0);
@@ -432,17 +434,17 @@ describe("Crowdfund Multi-Node", function () {
       for (const s of seeds) {
         const extra = s.address === seed1.address ? USDC(19_000) : USDC(15_000);
         await fundAndApprove(s, extra);
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       // seed1 also commits $4k at hop-1
-      await crowdfund.connect(seed1).commit(USDC(4_000), 1);
+      await crowdfund.connect(seed1).commit(1, USDC(4_000));
 
       // hop-1 participants commit $4K each → 50 × $4K = $200K
       // totalAllocUsdc = $798K (hop-0) + $204K (hop-1) = $1,002K > MIN_SALE
       for (const h of hop1Pool) {
         await fundAndApprove(h, USDC(4_000));
-        await crowdfund.connect(h).commit(USDC(4_000), 1);
+        await crowdfund.connect(h).commit(1, USDC(4_000));
       }
 
       await time.increase(THREE_WEEKS + 1);
@@ -482,8 +484,8 @@ describe("Crowdfund Multi-Node", function () {
       await setupWithSeeds([seed1]);
       await crowdfund.connect(seed1).invite(seed1.address, 0);
 
-      await crowdfund.connect(seed1).commit(USDC(15_000), 0);
-      await crowdfund.connect(seed1).commit(USDC(4_000), 1);
+      await crowdfund.connect(seed1).commit(0, USDC(15_000));
+      await crowdfund.connect(seed1).commit(1, USDC(4_000));
 
       // Not enough total → finalize reverts, use claimRefund deadline fallback
       await time.increase(THREE_WEEKS + 1);

--- a/test/crowdfund_settlement.ts
+++ b/test/crowdfund_settlement.ts
@@ -6,7 +6,7 @@ import { ethers } from "hardhat";
 import { time } from "@nomicfoundation/hardhat-network-helpers";
 import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 
-const Phase = { Setup: 0, Active: 1, Finalized: 2, Canceled: 3 };
+const Phase = { Active: 0, Finalized: 1, Canceled: 2 };
 
 const USDC = (n: number) => BigInt(n) * 1_000_000n;
 const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
@@ -35,9 +35,9 @@ describe("Crowdfund Settlement Rework", function () {
       await fundAndApprove(s, commitUsdc);
     }
     await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
-    await crowdfund.startWindow();
+    { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
     for (const s of seeds) {
-      await crowdfund.connect(s).commit(commitUsdc, 0);
+      await crowdfund.connect(s).commit(0, commitUsdc);
     }
 
     // Add hop-1 demand to ensure net proceeds > MIN_SALE.
@@ -49,7 +49,7 @@ describe("Crowdfund Settlement Rework", function () {
         const hop1Idx = i * 3 + j;
         await crowdfund.connect(seeds[i]).invite(hop1Pool[hop1Idx].address, 0);
         await fundAndApprove(hop1Pool[hop1Idx], USDC(4_000));
-        await crowdfund.connect(hop1Pool[hop1Idx]).commit(USDC(4_000), 1);
+        await crowdfund.connect(hop1Pool[hop1Idx]).commit(1, USDC(4_000));
       }
     }
 
@@ -75,13 +75,15 @@ describe("Crowdfund Settlement Rework", function () {
     await armToken.initWhitelist([deployer.address]);
 
     const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+    const openTimestamp = (await time.latest()) + 300;
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
       deployer.address,
       treasury.address,
       deployer.address,         // launchTeam
-      securityCouncil.address   // securityCouncil
+      securityCouncil.address,  // securityCouncil
+      openTimestamp              // openTimestamp
     );
     await crowdfund.waitForDeployment();
     await armToken.addToWhitelist(await crowdfund.getAddress());
@@ -95,15 +97,15 @@ describe("Crowdfund Settlement Rework", function () {
   // ============================================================
 
   describe("Security Council Cancel (T4.5)", function () {
-    it("security council can cancel during Setup phase", async function () {
-      expect(await crowdfund.phase()).to.equal(Phase.Setup);
+    it("security council can cancel before window opens", async function () {
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
       await crowdfund.connect(securityCouncil).cancel();
       expect(await crowdfund.phase()).to.equal(Phase.Canceled);
     });
 
     it("security council can cancel during Active phase", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       expect(await crowdfund.phase()).to.equal(Phase.Active);
 
       await crowdfund.connect(securityCouncil).cancel();
@@ -112,7 +114,7 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("security council can cancel after window but before finalize", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       await time.increase(THREE_WEEKS + 1);
 
       // Window ended, but still Active phase
@@ -144,19 +146,19 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("after cancel: commit reverts", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       await fundAndApprove(allSigners[5], USDC(15_000));
 
       await crowdfund.connect(securityCouncil).cancel();
 
       await expect(
-        crowdfund.connect(allSigners[5]).commit(USDC(10_000), 0)
+        crowdfund.connect(allSigners[5]).commit(0, USDC(10_000))
       ).to.be.revertedWith("ArmadaCrowdfund: not active");
     });
 
     it("after cancel: finalize reverts", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       await time.increase(THREE_WEEKS + 1);
 
       await crowdfund.connect(securityCouncil).cancel();
@@ -168,9 +170,9 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("after cancel: claimRefund works", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       await fundAndApprove(allSigners[5], USDC(10_000));
-      await crowdfund.connect(allSigners[5]).commit(USDC(10_000), 0);
+      await crowdfund.connect(allSigners[5]).commit(0, USDC(10_000));
 
       const usdcBefore = await usdc.balanceOf(allSigners[5].address);
       await crowdfund.connect(securityCouncil).cancel();
@@ -192,9 +194,9 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("emits SaleCanceled event", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       await fundAndApprove(allSigners[5], USDC(10_000));
-      await crowdfund.connect(allSigners[5]).commit(USDC(10_000), 0);
+      await crowdfund.connect(allSigners[5]).commit(0, USDC(10_000));
 
       await expect(crowdfund.connect(securityCouncil).cancel())
         .to.emit(crowdfund, "SaleCanceled")
@@ -207,10 +209,10 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("claimRefund reverts for whitelisted address with zero commitment", async function () {
       await crowdfund.addSeeds([allSigners[5].address, allSigners[6].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       // allSigners[5] commits, allSigners[6] does not
       await fundAndApprove(allSigners[5], USDC(10_000));
-      await crowdfund.connect(allSigners[5]).commit(USDC(10_000), 0);
+      await crowdfund.connect(allSigners[5]).commit(0, USDC(10_000));
 
       await crowdfund.connect(securityCouncil).cancel();
 
@@ -271,9 +273,9 @@ describe("Crowdfund Settlement Rework", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await time.increase(THREE_WEEKS + 1);
 
@@ -328,9 +330,9 @@ describe("Crowdfund Settlement Rework", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
@@ -352,9 +354,9 @@ describe("Crowdfund Settlement Rework", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds) {
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
@@ -454,7 +456,7 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("after cancel: sweeps all ARM", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       await crowdfund.connect(securityCouncil).cancel();
 

--- a/test/gas_benchmark.ts
+++ b/test/gas_benchmark.ts
@@ -59,13 +59,15 @@ describe("Gas Benchmarks", function () {
       await armToken.initWhitelist([deployer.address]);
 
         const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+        const openTimestamp1 = (await time.latest()) + 300;
         const crowdfund = await ArmadaCrowdfund.deploy(
           await usdc.getAddress(),
           await armToken.getAddress(),
           deployer.address,
           deployer.address, // treasury
           deployer.address, // launchTeam
-          deployer.address  // securityCouncil
+          deployer.address, // securityCouncil
+          openTimestamp1    // openTimestamp
         );
 
         await armToken.addToWhitelist(await crowdfund.getAddress());
@@ -77,7 +79,7 @@ describe("Gas Benchmarks", function () {
         // Add seeds — all participants are hop-0 for simplicity
         const seeds = allSigners.slice(1, count + 1);
         await crowdfund.addSeeds(seeds.map(s => s.address));
-        await crowdfund.startWindow();
+        { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
         // Each seed commits $15K (max hop-0 cap)
         // Total: count * $15K. Need >= $1M (MIN_SALE) for finalize() to succeed.
@@ -87,7 +89,7 @@ describe("Gas Benchmarks", function () {
         for (const s of seeds) {
           await usdc.mint(s.address, commitAmount);
           await usdc.connect(s).approve(await crowdfund.getAddress(), commitAmount);
-          await crowdfund.connect(s).commit(commitAmount, 0);
+          await crowdfund.connect(s).commit(0, commitAmount);
         }
 
         // Skip to after active window
@@ -167,14 +169,20 @@ describe("Gas Benchmarks", function () {
       await armToken.initWhitelist([deployer.address]);
 
         const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+        const openTimestamp2 = (await time.latest()) + 300;
         const crowdfund = await ArmadaCrowdfund.deploy(
           await usdc.getAddress(),
           await armToken.getAddress(),
           deployer.address,
           deployer.address, // treasury
           deployer.address, // launchTeam
-          deployer.address  // securityCouncil
+          deployer.address, // securityCouncil
+          openTimestamp2    // openTimestamp
         );
+        await armToken.addToWhitelist(await crowdfund.getAddress());
+        const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
+        await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
+        await crowdfund.loadArm();
 
         const seeds = allSigners.slice(1, batchSize + 1);
         const tx = await crowdfund.addSeeds(seeds.map(s => s.address));
@@ -206,13 +214,15 @@ describe("Gas Benchmarks", function () {
       await armToken.initWhitelist([deployer.address]);
 
       const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      const openTimestamp3 = (await time.latest()) + 300;
       const crowdfund = await ArmadaCrowdfund.deploy(
         await usdc.getAddress(),
         await armToken.getAddress(),
         deployer.address,
         deployer.address, // treasury
         deployer.address, // launchTeam
-        deployer.address  // securityCouncil
+        deployer.address, // securityCouncil
+        openTimestamp3    // openTimestamp
       );
 
       await armToken.addToWhitelist(await crowdfund.getAddress());
@@ -222,12 +232,12 @@ describe("Gas Benchmarks", function () {
       const count = 100;
       const seeds = allSigners.slice(1, count + 1);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const s of seeds) {
         await usdc.mint(s.address, USDC(15_000));
         await usdc.connect(s).approve(await crowdfund.getAddress(), USDC(15_000));
-        await crowdfund.connect(s).commit(USDC(15_000), 0);
+        await crowdfund.connect(s).commit(0, USDC(15_000));
       }
 
       await time.increase(THREE_WEEKS + 1);
@@ -461,13 +471,15 @@ describe("Gas Benchmarks", function () {
       await armToken.initWhitelist([deployer.address]);
 
       const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      const openTimestamp4 = (await time.latest()) + 300;
       const crowdfund = await ArmadaCrowdfund.deploy(
         await usdc.getAddress(),
         await armToken.getAddress(),
         deployer.address,
         deployer.address, // treasury
         deployer.address, // launchTeam
-        deployer.address  // securityCouncil
+        deployer.address, // securityCouncil
+        openTimestamp4    // openTimestamp
       );
 
       await armToken.addToWhitelist(await crowdfund.getAddress());
@@ -476,7 +488,7 @@ describe("Gas Benchmarks", function () {
 
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // Fund all seeds
       for (const s of seeds) {
@@ -485,15 +497,15 @@ describe("Gas Benchmarks", function () {
       }
 
       // First commit (cold storage write — more expensive)
-      const tx1 = await crowdfund.connect(seeds[0]).commit(USDC(5_000), 0);
+      const tx1 = await crowdfund.connect(seeds[0]).commit(0, USDC(5_000));
       const r1 = await tx1.wait();
 
       // Second commit from same address (warm storage — cheaper)
-      const tx2 = await crowdfund.connect(seeds[0]).commit(USDC(5_000), 0);
+      const tx2 = await crowdfund.connect(seeds[0]).commit(0, USDC(5_000));
       const r2 = await tx2.wait();
 
       // First commit from different address
-      const tx3 = await crowdfund.connect(seeds[1]).commit(USDC(5_000), 0);
+      const tx3 = await crowdfund.connect(seeds[1]).commit(0, USDC(5_000));
       const r3 = await tx3.wait();
 
       console.log(`    commit() | first commit (cold)    | ${r1!.gasUsed.toLocaleString()} gas`);

--- a/test/governance_quiet_period.ts
+++ b/test/governance_quiet_period.ts
@@ -72,13 +72,15 @@ describe("Governance Quiet Period (T6.1)", function () {
 
     // Deploy crowdfund
     const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+    const openTimestamp = (await time.latest()) + 300;
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
       deployer.address,
       treasuryAddr.address,
       deployer.address,
-      deployer.address // securityCouncil
+      deployer.address, // securityCouncil
+      openTimestamp      // openTimestamp
     );
     await crowdfund.waitForDeployment();
 
@@ -139,13 +141,13 @@ describe("Governance Quiet Period (T6.1)", function () {
   // Helper: run crowdfund to finalization (normal path — above MIN_SALE)
   async function finalizeCrowdfund() {
     await crowdfund.addSeeds(seeds.map(s => s.address));
-    await crowdfund.startWindow();
+    { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
     for (const seed of seeds) {
       const amount = USDC(15_000);
       await usdc.mint(seed.address, amount);
       await usdc.connect(seed).approve(await crowdfund.getAddress(), amount);
-      await crowdfund.connect(seed).commit(amount, 0);
+      await crowdfund.connect(seed).commit(0, amount);
     }
 
     await time.increase(THREE_WEEKS + 1);
@@ -317,13 +319,13 @@ describe("Governance Quiet Period (T6.1)", function () {
       // No hop-1/2 participants → totalAllocUsdc = $840K < $1M → refundMode. ✓
       const refundSeeds = seeds.slice(0, 70);
       await crowdfund.addSeeds(refundSeeds.map(s => s.address));
-      await crowdfund.startWindow();
+      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       for (const seed of refundSeeds) {
         const amount = USDC(15_000);
         await usdc.mint(seed.address, amount);
         await usdc.connect(seed).approve(await crowdfund.getAddress(), amount);
-        await crowdfund.connect(seed).commit(amount, 0);
+        await crowdfund.connect(seed).commit(0, amount);
       }
 
       await time.increase(THREE_WEEKS + 1);


### PR DESCRIPTION
## Summary

Three spec-compliance foundation tasks for ArmadaCrowdfund, all independent but required before any subsequent crowdfund work:

- **Task 4**: Swap `commit()` param order from `(amount, hop)` to `(hop, amount)` — aligns with `invite()` convention
- **Task 6**: Change `launchTeamInvite()` param from `hop` (1/2) to `fromHop` (0/1) — aligns with `invite()` fromHop convention, internally computes `inviteeHop = fromHop + 1`
- **Task 2**: Replace `startWindow()` with constructor `openTimestamp` — removes `Phase.Setup`, contract starts in `Phase.Active`, window timing set immutably at deploy. Removes `WindowStarted` event and `inPhase` modifier.

27 files changed across contracts, tests, scripts, and frontend.

## Test plan

- [x] Foundry fuzz/invariant tests: **363 passing**
- [x] Hardhat integration tests: **689 passing**
- [ ] Manual verification of deployment scripts on local Anvil
- [ ] Frontend smoke test with crowdfund UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)