### PR TITLE
feat: crowdfund Phase B (Tasks 3, 5, 7)

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -8,13 +8,15 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import "./IArmadaCrowdfund.sol";
 
 /// @title ArmadaCrowdfund — Word-of-mouth whitelist crowdfund with hop-based allocation
 /// @notice Implements the full crowdfund lifecycle: seed management, invitation chains,
 ///         USDC commitment escrow, deterministic allocation with pro-rata scaling and rollover,
 ///         elastic expansion, and refund mechanism.
-contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
+contract ArmadaCrowdfund is ReentrancyGuard, Pausable, EIP712 {
     using SafeERC20 for IERC20;
 
     // ============ Constants ============
@@ -36,15 +38,16 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     uint8 public constant LAUNCH_TEAM_HOP1_BUDGET = 60;          // launch team direct hop-1 invite slots
     uint8 public constant LAUNCH_TEAM_HOP2_BUDGET = 60;          // launch team direct hop-2 invite slots
 
+    // EIP-712 typehash for off-chain invite signatures
+    bytes32 public constant INVITE_TYPEHASH = keccak256(
+        "Invite(address invitee,uint8 fromHop,uint256 nonce,uint256 deadline)"
+    );
+
     // ============ Immutable ============
 
     IERC20 public immutable usdc;
     IERC20 public immutable armToken;
-    address public immutable admin;
     /// @notice Protocol treasury — destination for sale proceeds and unallocated ARM.
-    // TODO: Admin is immutable. For production, add an admin transfer function
-    // so governance (timelock) can take over post-sale admin duties.
-    // Tracked in Codeberg issue.
     address public immutable treasury;
     /// @notice Launch team sentinel — issues predeclared invite budgets, not a participant.
     address public immutable launchTeam;
@@ -69,6 +72,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     // Aggregate stats
     HopStats[3] public hopStats;
     uint256 public totalCommitted;
+    uint256 public cappedDemand;    // sum of capped deposits (set at finalization)
 
     // Finalization results
     uint256 public saleSize;
@@ -99,10 +103,13 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     // 7-day governance quiet period. Set on both normal and refundMode paths.
     uint256 public finalizedAt;
 
+    // EIP-712 invite nonce tracking — used/revoked nonces per inviter
+    mapping(address => mapping(uint256 => bool)) public usedNonces;
+
     // ============ Events ============
 
     event SeedAdded(address indexed seed);
-    event Invited(address indexed inviter, address indexed invitee, uint8 hop);
+    event Invited(address indexed inviter, address indexed invitee, uint8 hop, uint256 nonce);
     event InviteAdded(address indexed inviter, address indexed invitee, uint8 hop, uint16 newInviteCount);
     event Committed(address indexed participant, uint256 amount, uint256 totalForParticipant, uint8 hop);
     event SaleFinalized(uint256 saleSize, uint256 totalAllocUsdc, uint256 totalAllocArm, uint256 treasuryLeftoverUsdc);
@@ -112,11 +119,12 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     event UnallocatedArmWithdrawn(address indexed treasury, uint256 amount);
     event ArmLoaded(uint256 balance);
     event SaleFinalizedRefundMode(uint256 totalCommitted, uint256 netProceeds);
+    event InviteNonceRevoked(address indexed inviter, uint256 nonce);
 
     // ============ Modifiers ============
 
-    modifier onlyAdmin() {
-        require(msg.sender == admin, "ArmadaCrowdfund: not admin");
+    modifier onlyLaunchTeam() {
+        require(msg.sender == launchTeam, "ArmadaCrowdfund: not launch team");
         _;
     }
 
@@ -126,20 +134,17 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     constructor(
         address _usdc,
         address _armToken,
-        address _admin,
         address _treasury,
         address _launchTeam,
         address _securityCouncil,
         uint256 _openTimestamp
-    ) {
-        require(_admin != address(0), "ArmadaCrowdfund: zero admin");
+    ) EIP712("ArmadaCrowdfund", "1") {
         require(_treasury != address(0), "ArmadaCrowdfund: zero treasury");
         require(_launchTeam != address(0), "ArmadaCrowdfund: zero launchTeam");
         require(_securityCouncil != address(0), "ArmadaCrowdfund: zero securityCouncil");
         require(_openTimestamp >= block.timestamp, "ArmadaCrowdfund: openTimestamp in past");
         usdc = IERC20(_usdc);
         armToken = IERC20(_armToken);
-        admin = _admin;
         treasury = _treasury;
         launchTeam = _launchTeam;
         securityCouncil = _securityCouncil;
@@ -157,7 +162,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     // ============ Seed Management ============
 
     /// @notice Add seed addresses (hop 0). Allowed before invite period ends (requires ARM loaded).
-    function addSeeds(address[] calldata seeds) external onlyAdmin {
+    function addSeeds(address[] calldata seeds) external onlyLaunchTeam {
         _requireArmLoadedAndPreInviteEnd();
         for (uint256 i = 0; i < seeds.length; i++) {
             _addSeed(seeds[i]);
@@ -165,7 +170,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     }
 
     /// @notice Add a single seed address (hop 0). Allowed before invite period ends (requires ARM loaded).
-    function addSeed(address seed) external onlyAdmin {
+    function addSeed(address seed) external onlyLaunchTeam {
         _requireArmLoadedAndPreInviteEnd();
         _addSeed(seed);
     }
@@ -230,7 +235,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
             participantNodes.push(ParticipantNode(invitee, inviteeHop));
             hopStats[inviteeHop].whitelistCount++;
 
-            emit Invited(msg.sender, invitee, inviteeHop);
+            emit Invited(msg.sender, invitee, inviteeHop, 0);
         } else {
             // Subsequent invite — increment counter (scales cap + outgoing budget)
             require(
@@ -279,7 +284,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
             participantNodes.push(ParticipantNode(invitee, inviteeHop));
             hopStats[inviteeHop].whitelistCount++;
 
-            emit Invited(msg.sender, invitee, inviteeHop);
+            emit Invited(msg.sender, invitee, inviteeHop, 0);
         } else {
             require(
                 inviteeNode.invitesReceived < hopConfigs[inviteeHop].maxInvitesReceived,
@@ -310,12 +315,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         require(p.isWhitelisted, "ArmadaCrowdfund: not whitelisted");
         require(amount >= MIN_COMMIT, "ArmadaCrowdfund: below minimum commitment");
 
-        // Invite-scaling cap: invitesReceived * per-slot cap
-        uint256 effectiveCap = uint256(p.invitesReceived) * hopConfigs[hop].capUsdc;
-        require(
-            p.committed + amount <= effectiveCap,
-            "ArmadaCrowdfund: exceeds hop cap"
-        );
+        // Over-cap deposits are accepted. Excess beyond effective cap is refunded
+        // at settlement. Capped demand is computed at finalization time.
 
         bool firstCommit = (p.committed == 0);
 
@@ -331,6 +332,107 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         usdc.safeTransferFrom(msg.sender, address(this), amount);
 
         emit Committed(msg.sender, amount, p.committed, hop);
+    }
+
+    /// @notice Redeem an off-chain EIP-712 signed invite and commit USDC in one transaction.
+    ///         The inviter signs an invite ticket off-chain; the invitee (msg.sender) presents
+    ///         the signature along with their USDC commitment.
+    /// @param inviter Address that signed the invite
+    /// @param fromHop Source hop level of the inviter (invitee joins at fromHop + 1)
+    /// @param nonce Unique nonce for this invite (must be > 0; 0 is reserved for direct invites)
+    /// @param deadline Timestamp after which the invite expires
+    /// @param signature EIP-712 signature from inviter (supports EOA and EIP-1271 wallets)
+    /// @param amount USDC amount to commit (6 decimals)
+    function commitWithInvite(
+        address inviter,
+        uint8 fromHop,
+        uint256 nonce,
+        uint256 deadline,
+        bytes calldata signature,
+        uint256 amount
+    ) external nonReentrant whenNotPaused {
+        require(phase == Phase.Active, "ArmadaCrowdfund: not active");
+        require(armLoaded, "ArmadaCrowdfund: ARM not loaded");
+        require(
+            block.timestamp >= windowStart && block.timestamp <= windowEnd,
+            "ArmadaCrowdfund: not active window"
+        );
+        require(nonce > 0, "ArmadaCrowdfund: zero nonce");
+        require(block.timestamp <= deadline, "ArmadaCrowdfund: invite expired");
+        require(!usedNonces[inviter][nonce], "ArmadaCrowdfund: nonce already used");
+
+        // Verify EIP-712 signature
+        bytes32 structHash = keccak256(abi.encode(
+            INVITE_TYPEHASH,
+            msg.sender,     // invitee
+            fromHop,
+            nonce,
+            deadline
+        ));
+        bytes32 digest = _hashTypedDataV4(structHash);
+        require(
+            SignatureChecker.isValidSignatureNow(inviter, digest, signature),
+            "ArmadaCrowdfund: invalid invite signature"
+        );
+
+        // Mark nonce as used
+        usedNonces[inviter][nonce] = true;
+
+        // --- Invite logic (adapted from invite()) ---
+        require(fromHop < NUM_HOPS - 1, "ArmadaCrowdfund: max hop reached");
+
+        Participant storage inviterNode = participants[inviter][fromHop];
+        require(inviterNode.isWhitelisted, "ArmadaCrowdfund: inviter not whitelisted");
+        uint16 maxBudget = inviterNode.invitesReceived * uint16(hopConfigs[fromHop].maxInvites);
+        require(inviterNode.invitesSent < maxBudget, "ArmadaCrowdfund: invite limit reached");
+
+        uint8 inviteeHop = fromHop + 1;
+        Participant storage inviteeNode = participants[msg.sender][inviteeHop];
+
+        if (!inviteeNode.isWhitelisted) {
+            inviteeNode.isWhitelisted = true;
+            inviteeNode.invitesReceived = 1;
+            inviteeNode.invitedBy = inviter;
+            participantNodes.push(ParticipantNode(msg.sender, inviteeHop));
+            hopStats[inviteeHop].whitelistCount++;
+
+            emit Invited(inviter, msg.sender, inviteeHop, nonce);
+        } else {
+            require(
+                inviteeNode.invitesReceived < hopConfigs[inviteeHop].maxInvitesReceived,
+                "ArmadaCrowdfund: max invites received"
+            );
+            inviteeNode.invitesReceived++;
+            emit InviteAdded(inviter, msg.sender, inviteeHop, inviteeNode.invitesReceived);
+        }
+        inviterNode.invitesSent++;
+
+        // --- Commit logic (adapted from commit()) ---
+        require(msg.sender != launchTeam, "ArmadaCrowdfund: launch team cannot commit");
+        require(amount >= MIN_COMMIT, "ArmadaCrowdfund: below minimum commitment");
+
+        bool firstCommit = (inviteeNode.committed == 0);
+
+        inviteeNode.committed += amount;
+        hopStats[inviteeHop].totalCommitted += amount;
+        totalCommitted += amount;
+
+        if (firstCommit) {
+            hopStats[inviteeHop].uniqueCommitters++;
+        }
+
+        usdc.safeTransferFrom(msg.sender, address(this), amount);
+
+        emit Committed(msg.sender, amount, inviteeNode.committed, inviteeHop);
+    }
+
+    /// @notice Revoke an invite nonce so it can no longer be used.
+    /// @param nonce The nonce to revoke (must be > 0)
+    function revokeInviteNonce(uint256 nonce) external {
+        require(nonce > 0, "ArmadaCrowdfund: zero nonce");
+        require(!usedNonces[msg.sender][nonce], "ArmadaCrowdfund: nonce already used");
+        usedNonces[msg.sender][nonce] = true;
+        emit InviteNonceRevoked(msg.sender, nonce);
     }
 
     // ============ Finalization ============
@@ -351,10 +453,15 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     function finalize() external nonReentrant whenNotPaused {
         require(block.timestamp > windowEnd, "ArmadaCrowdfund: window not ended");
         require(phase == Phase.Active, "ArmadaCrowdfund: already finalized");
-        require(totalCommitted >= MIN_SALE, "ArmadaCrowdfund: below minimum raise");
 
-        // Step 1: Elastic expansion
-        if (totalCommitted >= ELASTIC_TRIGGER) {
+        // Compute capped demand by iterating all participant nodes. Over-cap
+        // deposits are accepted during commit() but only capped amounts count
+        // toward minimum raise, expansion trigger, and hop-level allocation.
+        _computeCappedDemand();
+        require(cappedDemand >= MIN_SALE, "ArmadaCrowdfund: below minimum raise");
+
+        // Step 1: Elastic expansion (based on capped demand)
+        if (cappedDemand >= ELASTIC_TRIGGER) {
             saleSize = MAX_SALE;
         } else {
             saleSize = BASE_SALE;
@@ -428,7 +535,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
             hasCommitment = true;
             require(!p.claimed, "ArmadaCrowdfund: already claimed");
 
-            (uint256 allocArm, , uint256 refundUsdc) = _computeAllocation(p.committed, h);
+            uint256 effectiveCap = uint256(p.invitesReceived) * hopConfigs[h].capUsdc;
+            (uint256 allocArm, , uint256 refundUsdc) = _computeAllocation(p.committed, h, effectiveCap);
 
             p.claimed = true;
             p.allocation = allocArm;    // store for record-keeping
@@ -459,10 +567,21 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     ///         2. Phase.Canceled — security council cancel
     ///         3. Deadline fallback — window expired, not finalized, below MIN_SALE
     function claimRefund() external nonReentrant whenNotPaused {
+        // Deadline fallback path: compute capped demand on-the-fly to check
+        // if the sale failed to meet minimum. Only runs in the edge case where
+        // the window expired without finalization.
+        bool deadlineFallback = false;
+        if (!refundMode && phase != Phase.Canceled) {
+            if (block.timestamp > windowEnd && phase != Phase.Finalized) {
+                _computeCappedDemand();
+                deadlineFallback = cappedDemand < MIN_SALE;
+            }
+        }
+
         require(
             refundMode ||
             phase == Phase.Canceled ||
-            (block.timestamp > windowEnd && phase != Phase.Finalized && totalCommitted < MIN_SALE),
+            deadlineFallback,
             "ArmadaCrowdfund: refund not available"
         );
 
@@ -518,28 +637,28 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     // ============ Emergency Pause ============
 
     /// @notice Pause invite(), commit(), claim(), and claimRefund() in case of emergency.
-    ///         Pre-finalization: admin or security council. Post-finalization/cancel: security council only.
+    ///         Pre-finalization: launch team or security council. Post-finalization/cancel: security council only.
     function pause() external {
         if (phase == Phase.Finalized || phase == Phase.Canceled) {
             require(msg.sender == securityCouncil, "ArmadaCrowdfund: only security council");
         } else {
             require(
-                msg.sender == admin || msg.sender == securityCouncil,
-                "ArmadaCrowdfund: not admin or security council"
+                msg.sender == launchTeam || msg.sender == securityCouncil,
+                "ArmadaCrowdfund: not launch team or security council"
             );
         }
         _pause();
     }
 
     /// @notice Unpause to resume normal operations.
-    ///         Pre-finalization: admin or security council. Post-finalization/cancel: security council only.
+    ///         Pre-finalization: launch team or security council. Post-finalization/cancel: security council only.
     function unpause() external {
         if (phase == Phase.Finalized || phase == Phase.Canceled) {
             require(msg.sender == securityCouncil, "ArmadaCrowdfund: only security council");
         } else {
             require(
-                msg.sender == admin || msg.sender == securityCouncil,
-                "ArmadaCrowdfund: not admin or security council"
+                msg.sender == launchTeam || msg.sender == securityCouncil,
+                "ArmadaCrowdfund: not launch team or security council"
             );
         }
         _unpause();
@@ -550,12 +669,13 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     /// @notice Get aggregate stats for a hop (visible during sale)
     function getHopStats(uint8 hop) external view returns (
         uint256 _totalCommitted,
+        uint256 _cappedCommitted,
         uint32 _uniqueCommitters,
         uint32 _whitelistCount
     ) {
         require(hop < NUM_HOPS, "ArmadaCrowdfund: invalid hop");
         HopStats storage s = hopStats[hop];
-        return (s.totalCommitted, s.uniqueCommitters, s.whitelistCount);
+        return (s.totalCommitted, s.cappedCommitted, s.uniqueCommitters, s.whitelistCount);
     }
 
     /// @notice Get overall sale stats
@@ -617,7 +737,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
                 totalAllocArm += p.allocation;
                 totalRefundUsdc += p.refund;
             } else {
-                (uint256 allocArm, , uint256 refundUsdc) = _computeAllocation(p.committed, h);
+                uint256 effectiveCap = uint256(p.invitesReceived) * hopConfigs[h].capUsdc;
+                (uint256 allocArm, , uint256 refundUsdc) = _computeAllocation(p.committed, h, effectiveCap);
                 totalAllocArm += allocArm;
                 totalRefundUsdc += refundUsdc;
             }
@@ -638,7 +759,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         if (p.claimed) {
             return (p.allocation, p.refund, true);
         }
-        (uint256 allocArm, , uint256 refundUsdc) = _computeAllocation(p.committed, hop);
+        uint256 effectiveCap = uint256(p.invitesReceived) * hopConfigs[hop].capUsdc;
+        (uint256 allocArm, , uint256 refundUsdc) = _computeAllocation(p.committed, hop, effectiveCap);
         return (allocArm, refundUsdc, false);
     }
 
@@ -691,7 +813,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         uint256 hop1Ceiling = (available * hopConfigs[1].ceilingBps) / 10000;
 
         // --- Hop-0: allocate from available pool ---
-        uint256 demand = hopStats[0].totalCommitted;
+        // Uses cappedCommitted (set by _computeCappedDemand) — over-cap deposits excluded
+        uint256 demand = hopStats[0].cappedCommitted;
         uint256 alloc = demand <= hop0Ceiling ? demand : hop0Ceiling;
         uint256 leftover = hop0Ceiling - alloc;
         uint256 remainingAvailable = available - alloc;
@@ -702,7 +825,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         totalAllocArm_ = (alloc * 1e18) / ARM_PRICE;
 
         // --- Hop-1: allocate from remaining available, ceiling boosted by hop-0 leftover ---
-        demand = hopStats[1].totalCommitted;
+        demand = hopStats[1].cappedCommitted;
         uint256 hop1EffCeiling = hop1Ceiling + leftover;
         if (hop1EffCeiling > remainingAvailable) {
             hop1EffCeiling = remainingAvailable;
@@ -716,7 +839,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
         totalAllocArm_ += (alloc * 1e18) / ARM_PRICE;
 
         // --- Hop-2: allocate from floor + hop-1 leftover (no BPS ceiling) ---
-        demand = hopStats[2].totalCommitted;
+        demand = hopStats[2].cappedCommitted;
         uint256 hop2EffCeiling = hop2Floor + leftover;
         alloc = demand <= hop2EffCeiling ? demand : hop2EffCeiling;
 
@@ -727,24 +850,51 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable {
     }
 
     /// @dev Compute allocation for a participant from stored hop-level ceilings/demands.
-    ///      Uses the budget-capped ceiling stored at finalization for pro-rata scaling.
-    function _computeAllocation(uint256 committed, uint8 hop) internal view returns (
+    ///      Uses capped committed amount (min of raw committed and effectiveCap) for
+    ///      allocation math. Over-cap excess is refunded in full.
+    function _computeAllocation(uint256 committed, uint8 hop, uint256 effectiveCap) internal view returns (
         uint256 allocArm,
         uint256 allocUsdc,
         uint256 refundUsdc
     ) {
         if (committed == 0) return (0, 0, 0);
 
+        uint256 cappedCommitted = committed < effectiveCap ? committed : effectiveCap;
+
         if (finalDemands[hop] <= finalCeilings[hop]) {
-            // Under-subscribed: full allocation
-            allocUsdc = committed;
-            allocArm = (committed * 1e18) / ARM_PRICE;
+            // Under-subscribed: full allocation of capped amount
+            allocUsdc = cappedCommitted;
         } else {
-            // Over-subscribed: pro-rata
-            allocUsdc = (committed * finalCeilings[hop]) / finalDemands[hop];
-            // Compute ARM directly to avoid divide-before-multiply precision loss
-            allocArm = (committed * finalCeilings[hop] * 1e18) / (finalDemands[hop] * ARM_PRICE);
+            // Over-subscribed: pro-rata of capped amount
+            allocUsdc = (cappedCommitted * finalCeilings[hop]) / finalDemands[hop];
         }
+        allocArm = (allocUsdc * 1e18) / ARM_PRICE;
+        // Refund = raw committed minus allocated (includes over-cap excess + pro-rata excess)
         refundUsdc = committed - allocUsdc;
+    }
+
+    /// @dev Iterate all participant nodes and compute capped demand per hop and globally.
+    ///      Sets hopStats[h].cappedCommitted and cappedDemand. Matches spec finalization
+    ///      pseudocode step 1-2: cap each (address, hop) at invitesReceived * capUsdc.
+    function _computeCappedDemand() internal {
+        uint256 globalCapped = 0;
+        // Reset per-hop capped totals
+        for (uint8 h = 0; h < NUM_HOPS; h++) {
+            hopStats[h].cappedCommitted = 0;
+        }
+
+        uint256 len = participantNodes.length;
+        for (uint256 i = 0; i < len; i++) {
+            ParticipantNode storage node = participantNodes[i];
+            Participant storage p = participants[node.addr][node.hop];
+            if (p.committed == 0) continue;
+
+            uint256 effectiveCap = uint256(p.invitesReceived) * hopConfigs[node.hop].capUsdc;
+            uint256 capped = p.committed < effectiveCap ? p.committed : effectiveCap;
+            hopStats[node.hop].cappedCommitted += capped;
+            globalCapped += capped;
+        }
+
+        cappedDemand = globalCapped;
     }
 }

--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -378,7 +378,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable, EIP712 {
         // Mark nonce as used
         usedNonces[inviter][nonce] = true;
 
-        // --- Invite logic (adapted from invite()) ---
+        // --- Whitelist registration ---
         require(fromHop < NUM_HOPS - 1, "ArmadaCrowdfund: max hop reached");
 
         Participant storage inviterNode = participants[inviter][fromHop];
@@ -407,7 +407,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable, EIP712 {
         }
         inviterNode.invitesSent++;
 
-        // --- Commit logic (adapted from commit()) ---
+        // --- USDC escrow ---
         require(msg.sender != launchTeam, "ArmadaCrowdfund: launch team cannot commit");
         require(amount >= MIN_COMMIT, "ArmadaCrowdfund: below minimum commitment");
 

--- a/contracts/crowdfund/IArmadaCrowdfund.sol
+++ b/contracts/crowdfund/IArmadaCrowdfund.sol
@@ -41,7 +41,8 @@ struct ParticipantNode {
 }
 
 struct HopStats {
-    uint256 totalCommitted;     // aggregate USDC committed for this hop
+    uint256 totalCommitted;     // aggregate USDC committed for this hop (raw, including over-cap)
+    uint256 cappedCommitted;    // aggregate USDC committed capped at effective caps (set at finalization)
     uint32 uniqueCommitters;    // count of unique addresses that committed > 0
     uint32 whitelistCount;      // count of whitelisted addresses at this hop
 }

--- a/crowdfund-frontend/src/App.tsx
+++ b/crowdfund-frontend/src/App.tsx
@@ -35,10 +35,7 @@ export function App() {
   }
 
   const currentAddress = accounts.currentAddress
-  const isLaunchTeam = currentAddress && state.launchTeamAddress
-    ? currentAddress.toLowerCase() === state.launchTeamAddress.toLowerCase()
-    : false
-  const showAdminPanel = accounts.isAdmin || isLaunchTeam
+  const showAdminPanel = accounts.isLaunchTeam
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -51,7 +48,7 @@ export function App() {
           )}
           <ParticipantPanel state={state} crowdfund={crowdfund} />
         </div>
-        {isLocalMode() && accounts.isAdmin && <TimeControls state={state} crowdfund={crowdfund} />}
+        {isLocalMode() && accounts.isLaunchTeam && <TimeControls state={state} crowdfund={crowdfund} />}
         <ParticipantsTable state={state} crowdfund={crowdfund} />
         <EventLog events={events} />
       </main>

--- a/crowdfund-frontend/src/atoms/crowdfund.ts
+++ b/crowdfund-frontend/src/atoms/crowdfund.ts
@@ -6,7 +6,6 @@ import type { Phase, HopStats, Participant, CrowdfundEvent, CrowdfundDeployment,
 export interface CrowdfundState {
   // Contract phase and timing
   phase: Phase | null
-  adminAddress: string | null
   launchTeamAddress: string | null
   launchTeamBudget: LaunchTeamBudget | null
   windowStart: bigint
@@ -45,7 +44,6 @@ export interface CrowdfundState {
 
 const DEFAULT_STATE: CrowdfundState = {
   phase: null,
-  adminAddress: null,
   launchTeamAddress: null,
   launchTeamBudget: null,
   windowStart: 0n,

--- a/crowdfund-frontend/src/components/AdminPanel.tsx
+++ b/crowdfund-frontend/src/components/AdminPanel.tsx
@@ -31,9 +31,6 @@ export function AdminPanel({ state, crowdfund, currentAddress }: AdminPanelProps
   const [ltInviteHop, setLtInviteHop] = useState<0 | 1>(0)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const isAdmin = currentAddress && state.adminAddress
-    ? currentAddress.toLowerCase() === state.adminAddress.toLowerCase()
-    : false
   const isLaunchTeam = currentAddress && state.launchTeamAddress
     ? currentAddress.toLowerCase() === state.launchTeamAddress.toLowerCase()
     : false
@@ -44,10 +41,10 @@ export function AdminPanel({ state, crowdfund, currentAddress }: AdminPanelProps
     const treasuryAddr = crowdfund.deployment?.contracts.treasury
     if (treasuryAddr) {
       setTreasuryInput(treasuryAddr)
-    } else if (state.adminAddress) {
-      setTreasuryInput(state.adminAddress)
+    } else if (state.launchTeamAddress) {
+      setTreasuryInput(state.launchTeamAddress)
     }
-  }, [crowdfund.deployment, state.adminAddress]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [crowdfund.deployment, state.launchTeamAddress]) // eslint-disable-line react-hooks/exhaustive-deps
   const [treasuryUsdc, setTreasuryUsdc] = useState<bigint | null>(null)
   const [treasuryArm, setTreasuryArm] = useState<bigint | null>(null)
 
@@ -148,7 +145,7 @@ export function AdminPanel({ state, crowdfund, currentAddress }: AdminPanelProps
       </CardHeader>
       <CardContent className="space-y-4">
         {/* Active Phase: Add Seeds + ARM Pre-Load (admin only, before window opens) */}
-        {phase === Phase.Active && isAdmin && Number(state.windowStart) > 0 && state.blockTimestamp < Number(state.windowStart) && (
+        {phase === Phase.Active && isLaunchTeam && Number(state.windowStart) > 0 && state.blockTimestamp < Number(state.windowStart) && (
           <>
             <div className="space-y-2">
               <div className="flex items-center justify-between">
@@ -318,7 +315,7 @@ export function AdminPanel({ state, crowdfund, currentAddress }: AdminPanelProps
         })()}
 
         {/* After window ends: Finalize (admin or anyone) */}
-        {phase === Phase.Active && isAdmin && (
+        {phase === Phase.Active && isLaunchTeam && (
           <div className="space-y-2">
             <Button
               onClick={handleFinalize}
@@ -349,7 +346,7 @@ export function AdminPanel({ state, crowdfund, currentAddress }: AdminPanelProps
         )}
 
         {/* Finalized: Withdrawals (admin only) */}
-        {phase === Phase.Finalized && isAdmin && (
+        {phase === Phase.Finalized && isLaunchTeam && (
           <>
             <div className="space-y-2">
               <Label>Treasury Address</Label>

--- a/crowdfund-frontend/src/components/Header.tsx
+++ b/crowdfund-frontend/src/components/Header.tsx
@@ -23,7 +23,7 @@ interface HeaderProps {
 }
 
 export function Header({ accounts, crowdfund }: HeaderProps) {
-  const { currentAddress, isAdmin, wallet, selectAnvilAccount, connectMetaMask, disconnectMetaMask, anvilAccounts } = accounts
+  const { currentAddress, isLaunchTeam, wallet, selectAnvilAccount, connectMetaMask, disconnectMetaMask, anvilAccounts } = accounts
   const { state, mintUsdc } = crowdfund
   const local = isLocalMode()
   const [copied, setCopied] = useState(false)
@@ -132,8 +132,8 @@ export function Header({ accounts, crowdfund }: HeaderProps) {
           )}
 
           {/* Admin indicator */}
-          {isAdmin && (
-            <Badge className="bg-accent text-accent-foreground">Admin</Badge>
+          {isLaunchTeam && (
+            <Badge className="bg-accent text-accent-foreground">Launch Team</Badge>
           )}
         </div>
       </div>

--- a/crowdfund-frontend/src/config/abi.ts
+++ b/crowdfund-frontend/src/config/abi.ts
@@ -23,7 +23,6 @@ export const CROWDFUND_ABI = [
 
   // State variables (public getters)
   'function phase() view returns (uint8)',
-  'function admin() view returns (address)',
   'function launchTeam() view returns (address)',
   'function usdc() view returns (address)',
   'function armToken() view returns (address)',
@@ -40,7 +39,7 @@ export const CROWDFUND_ABI = [
   'function launchTeamInviteEnd() view returns (uint256)',
   'function participants(address, uint8) view returns (bool isWhitelisted, uint16 invitesReceived, uint256 committed, uint256 allocation, uint256 refund, bool claimed, address invitedBy, uint16 invitesSent)',
   'function participantNodes(uint256) view returns (address addr, uint8 hop)',
-  'function hopStats(uint256) view returns (uint256 totalCommitted, uint32 uniqueCommitters, uint32 whitelistCount)',
+  'function hopStats(uint256) view returns (uint256 totalCommitted, uint256 cappedCommitted, uint32 uniqueCommitters, uint32 whitelistCount)',
   'function hopConfigs(uint256) view returns (uint16 ceilingBps, uint256 capUsdc, uint8 maxInvites, uint16 maxInvitesReceived)',
   'function finalCeilings(uint256) view returns (uint256)',
   'function finalDemands(uint256) view returns (uint256)',
@@ -50,7 +49,7 @@ export const CROWDFUND_ABI = [
   'function treasuryLeftoverUsdc() view returns (uint256)',
 
   // View functions
-  'function getHopStats(uint8 hop) view returns (uint256 totalCommitted, uint32 uniqueCommitters, uint32 whitelistCount)',
+  'function getHopStats(uint8 hop) view returns (uint256 totalCommitted, uint256 cappedCommitted, uint32 uniqueCommitters, uint32 whitelistCount)',
   'function getSaleStats() view returns (uint256 totalCommitted, uint8 phase, uint256 windowStart, uint256 windowEnd)',
   'function isWhitelisted(address addr, uint8 hop) view returns (bool)',
   'function getCommitment(address addr, uint8 hop) view returns (uint256 committed)',
@@ -65,7 +64,7 @@ export const CROWDFUND_ABI = [
 
   // Events
   'event SeedAdded(address indexed seed)',
-  'event Invited(address indexed inviter, address indexed invitee, uint8 hop)',
+  'event Invited(address indexed inviter, address indexed invitee, uint8 hop, uint256 nonce)',
   'event InviteAdded(address indexed inviter, address indexed invitee, uint8 hop, uint16 newInviteCount)',
   'event Committed(address indexed participant, uint256 amount, uint256 totalForParticipant, uint8 hop)',
   'event SaleFinalized(uint256 saleSize, uint256 totalAllocUsdc, uint256 totalAllocArm, uint256 treasuryLeftoverUsdc)',

--- a/crowdfund-frontend/src/config/accounts.test.ts
+++ b/crowdfund-frontend/src/config/accounts.test.ts
@@ -21,8 +21,8 @@ describe('ANVIL_ACCOUNTS', () => {
     }
   })
 
-  it('account 0 is admin', () => {
-    expect(ANVIL_ACCOUNTS[0].role).toBe('admin')
+  it('account 0 is launchTeam', () => {
+    expect(ANVIL_ACCOUNTS[0].role).toBe('launchTeam')
     expect(ANVIL_ACCOUNTS[0].address).toBe('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266')
   })
 

--- a/crowdfund-frontend/src/config/accounts.ts
+++ b/crowdfund-frontend/src/config/accounts.ts
@@ -4,7 +4,7 @@
 export interface AnvilAccount {
   index: number
   label: string
-  role: 'admin' | 'seed' | 'hop1' | 'hop2'
+  role: 'launchTeam' | 'seed' | 'hop1' | 'hop2'
   address: string
   privateKey: string
 }
@@ -12,8 +12,8 @@ export interface AnvilAccount {
 export const ANVIL_ACCOUNTS: AnvilAccount[] = [
   {
     index: 0,
-    label: 'Admin / Deployer',
-    role: 'admin',
+    label: 'Launch Team / Deployer',
+    role: 'launchTeam',
     address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     privateKey: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
   },

--- a/crowdfund-frontend/src/hooks/useAccounts.ts
+++ b/crowdfund-frontend/src/hooks/useAccounts.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Account switching hook for both Anvil (local) and MetaMask (Sepolia).
-// ABOUTME: Provides signer, provider, address, and admin detection.
+// ABOUTME: Provides signer, provider, address, and launch team detection.
 import { useCallback, useEffect, useMemo } from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { JsonRpcProvider, Wallet, BrowserProvider, type Signer, type Provider } from 'ethers'

--- a/crowdfund-frontend/src/hooks/useAccounts.ts
+++ b/crowdfund-frontend/src/hooks/useAccounts.ts
@@ -25,7 +25,7 @@ export function useAccounts() {
     return null
   }, [wallet.mode, wallet.anvilAccount, provider])
 
-  const isAdmin = useMemo(() => {
+  const isLaunchTeam = useMemo(() => {
     if (!currentAddress || !deployment) return false
     return currentAddress.toLowerCase() === deployment.deployer.toLowerCase()
   }, [currentAddress, deployment])
@@ -140,7 +140,7 @@ export function useAccounts() {
     currentAddress,
     provider,
     signer,
-    isAdmin,
+    isLaunchTeam,
     selectAnvilAccount,
     connectMetaMask,
     disconnectMetaMask,

--- a/crowdfund-frontend/src/hooks/useCrowdfund.ts
+++ b/crowdfund-frontend/src/hooks/useCrowdfund.ts
@@ -56,7 +56,6 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
       // Batch all read calls (excluding per-hop participant data)
       const [
         phase,
-        admin,
         launchTeamAddr,
         armLoaded,
         totalCommitted,
@@ -76,7 +75,6 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
         launchTeamBudgetRaw,
       ] = await Promise.all([
         contract.phase(),
-        contract.admin(),
         contract.launchTeam(),
         contract.armLoaded(),
         contract.totalCommitted(),
@@ -173,7 +171,6 @@ export function useCrowdfund(provider: Provider, getActiveSigner: () => Promise<
 
       setState({
         phase: parsedPhase,
-        adminAddress: admin as string,
         launchTeamAddress: launchTeamAddr as string,
         launchTeamBudget: {
           hop1Remaining: Number(launchTeamBudgetRaw[0]),

--- a/crowdfund-frontend/src/types/crowdfund.ts
+++ b/crowdfund-frontend/src/types/crowdfund.ts
@@ -22,6 +22,7 @@ export interface Participant {
 
 export interface HopStats {
   totalCommitted: bigint
+  cappedCommitted: bigint
   uniqueCommitters: number
   whitelistCount: number
 }

--- a/crowdfund-frontend/src/utils/crowdfund-parse.test.ts
+++ b/crowdfund-frontend/src/utils/crowdfund-parse.test.ts
@@ -74,32 +74,35 @@ describe('parseParticipant', () => {
 
 describe('parseHopStats', () => {
   it('parses a hop stats struct', () => {
-    const result = [800_000_000_000n, 5n, 10n]
+    const result = [800_000_000_000n, 600_000_000_000n, 5n, 10n]
     const s = parseHopStats(result)
 
     expect(s.totalCommitted).toBe(800_000_000_000n)
+    expect(s.cappedCommitted).toBe(600_000_000_000n)
     expect(s.uniqueCommitters).toBe(5)
     expect(s.whitelistCount).toBe(10)
   })
 
   it('parses zero values', () => {
-    const result = [0n, 0n, 0n]
+    const result = [0n, 0n, 0n, 0n]
     const s = parseHopStats(result)
 
     expect(s.totalCommitted).toBe(0n)
+    expect(s.cappedCommitted).toBe(0n)
     expect(s.uniqueCommitters).toBe(0)
     expect(s.whitelistCount).toBe(0)
   })
 
-  it('preserves totalCommitted as bigint', () => {
-    const result = [1_200_000_000_000n, 100n, 150n]
+  it('preserves totalCommitted and cappedCommitted as bigint', () => {
+    const result = [1_200_000_000_000n, 900_000_000_000n, 100n, 150n]
     const s = parseHopStats(result)
 
     expect(typeof s.totalCommitted).toBe('bigint')
+    expect(typeof s.cappedCommitted).toBe('bigint')
   })
 
   it('converts uniqueCommitters and whitelistCount to number', () => {
-    const result = [0n, 42n, 99n]
+    const result = [0n, 0n, 42n, 99n]
     const s = parseHopStats(result)
 
     expect(typeof s.uniqueCommitters).toBe('number')

--- a/crowdfund-frontend/src/utils/crowdfund-parse.ts
+++ b/crowdfund-frontend/src/utils/crowdfund-parse.ts
@@ -20,7 +20,8 @@ export function parseParticipant(result: any): Participant {
 export function parseHopStats(result: any): HopStats {
   return {
     totalCommitted: BigInt(result[0]),
-    uniqueCommitters: Number(result[1]),
-    whitelistCount: Number(result[2]),
+    cappedCommitted: BigInt(result[1]),
+    uniqueCommitters: Number(result[2]),
+    whitelistCount: Number(result[3]),
   }
 }

--- a/docs/CROWDFUND_TEST_SCENARIOS.md
+++ b/docs/CROWDFUND_TEST_SCENARIOS.md
@@ -124,18 +124,18 @@ Exhaustive catalog of testing scenarios for ArmadaCrowdfund, organized by lifecy
 | 4.6 | Commit at `commitmentEnd + 1` | Revert: "not commitment window" | **None** |
 | 4.7 | Commit at `commitmentStart - 1` (during invitation window) | Revert: "not commitment window" | Integration |
 
-### Cap Enforcement
+### Over-Cap Acceptance (excess refunded at settlement)
 
 | # | Scenario | Expected Outcome | Coverage |
 |---|----------|-----------------|----------|
 | 4.8 | Hop-0: commit exactly $15,000 | Succeeds | Adversarial |
-| 4.9 | Hop-0: commit $15,001 | Revert: "exceeds hop cap" | Integration |
-| 4.10 | Hop-0: commit $10K then $5,001 (cumulative over cap) | Revert: "exceeds hop cap" | **None** |
+| 4.9 | Hop-0: commit $15,001 | Succeeds (excess refunded at settlement) | Integration |
+| 4.10 | Hop-0: commit $10K then $5,001 (cumulative over cap) | Succeeds (excess refunded at settlement) | **None** |
 | 4.11 | Hop-1: commit exactly $4,000 | Succeeds | **None** |
-| 4.12 | Hop-1: commit $4,001 | Revert: "exceeds hop cap" | Integration |
+| 4.12 | Hop-1: commit $4,001 | Succeeds (excess refunded at settlement) | Integration |
 | 4.13 | Hop-2: commit exactly $1,000 | Succeeds | **None** |
-| 4.14 | Hop-2: commit $1,001 | Revert: "exceeds hop cap" | Integration |
-| 4.15 | Commit 1 wei over cap (after prior commits) | Revert: "exceeds hop cap" | Adversarial |
+| 4.14 | Hop-2: commit $1,001 | Succeeds (excess refunded at settlement) | Integration |
+| 4.15 | Commit 1 wei over cap (after prior commits) | Succeeds (excess refunded at settlement) | Adversarial |
 
 ### Invalid Commits
 

--- a/scripts/crowdfund_demo.ts
+++ b/scripts/crowdfund_demo.ts
@@ -78,7 +78,6 @@ async function main() {
   const crowdfund = await ArmadaCrowdfund.deploy(
     await usdc.getAddress(),
     await armToken.getAddress(),
-    deployer.address,
     treasuryAddr.address,
     deployer.address,
     deployer.address,       // securityCouncil (demo)
@@ -144,9 +143,9 @@ async function main() {
   }
   log("INVITE", `${hop1Count} hop-1 addresses invited ${hop2Count} hop-2 addresses`);
 
-  const [, , wc0] = await crowdfund.getHopStats(0);
-  const [, , wc1] = await crowdfund.getHopStats(1);
-  const [, , wc2] = await crowdfund.getHopStats(2);
+  const [, , , wc0] = await crowdfund.getHopStats(0);
+  const [, , , wc1] = await crowdfund.getHopStats(1);
+  const [, , , wc2] = await crowdfund.getHopStats(2);
   log("STATS", `Hop 0: ${wc0} whitelisted | Hop 1: ${wc1} | Hop 2: ${wc2}`);
 
   // Commits happen concurrently — no time jump needed
@@ -183,7 +182,7 @@ async function main() {
 
   // Show per-hop breakdown
   for (let h = 0; h < 3; h++) {
-    const [tc, uc, wc] = await crowdfund.getHopStats(h);
+    const [tc, , uc, wc] = await crowdfund.getHopStats(h);
     log("STATS", `  Hop ${h}: ${uc} committers, ${fmtUsdc(tc)} total`);
   }
 
@@ -211,7 +210,6 @@ async function main() {
   const cf2 = await ArmadaCrowdfund.deploy(
     await usdc.getAddress(),
     await armToken.getAddress(),
-    deployer.address,
     treasuryAddr.address,
     deployer.address,
     deployer.address,       // securityCouncil (demo)

--- a/scripts/crowdfund_populate.ts
+++ b/scripts/crowdfund_populate.ts
@@ -346,7 +346,7 @@ async function main() {
   log("RESULT", `Phase: ${PhaseNames[finalPhase]}`);
 
   for (let h = 0; h < 3; h++) {
-    const [tc, uc, wc] = await crowdfund.getHopStats(h);
+    const [tc, , uc, wc] = await crowdfund.getHopStats(h);
     if (Number(wc) > 0) {
       log("STATS", `  Hop ${h}: ${wc} whitelisted, ${uc} committers, ${fmtUsdc(tc)} committed`);
     }

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -101,7 +101,7 @@ async function main() {
   const latestBlock = await ethers.provider.getBlock('latest');
   const openTimestamp = latestBlock!.timestamp + 60; // 1 minute after latest block
   const crowdfund = await ArmadaCrowdfund.deploy(
-    usdcAddress, armTokenAddress, deployer.address, treasuryAddress, deployer.address, deployer.address, openTimestamp, nm.override()
+    usdcAddress, armTokenAddress, treasuryAddress, deployer.address, deployer.address, openTimestamp, nm.override()
   );
   await crowdfund.deploymentTransaction()!.wait();
   const crowdfundAddress = await crowdfund.getAddress();

--- a/scripts/full_lifecycle_demo.ts
+++ b/scripts/full_lifecycle_demo.ts
@@ -185,7 +185,6 @@ async function main() {
   const crowdfund = await ArmadaCrowdfund.deploy(
     await usdc.getAddress(),
     await armToken.getAddress(),
-    deployer.address,       // admin
     await treasury.getAddress(),  // immutable treasury destination
     deployer.address,       // launchTeam
     deployer.address,       // securityCouncil (demo: deployer acts as council)
@@ -274,9 +273,9 @@ async function main() {
   }
   log("INVITE", `${hop1Count} hop-1 addresses invited ${hop2Count} hop-2 addresses`);
 
-  const [, , wc0] = await crowdfund.getHopStats(0);
-  const [, , wc1] = await crowdfund.getHopStats(1);
-  const [, , wc2] = await crowdfund.getHopStats(2);
+  const [, , , wc0] = await crowdfund.getHopStats(0);
+  const [, , , wc1] = await crowdfund.getHopStats(1);
+  const [, , , wc2] = await crowdfund.getHopStats(2);
   log("STATS", `Whitelisted \u2014 Hop 0: ${wc0} | Hop 1: ${wc1} | Hop 2: ${wc2}`);
 
   // 2d: Commitments (concurrent with invitations — no time jump needed)
@@ -311,7 +310,7 @@ async function main() {
   const totalCommitted = await crowdfund.totalCommitted();
   log("STATS", `Total committed: ${fmtUsdc(totalCommitted)}`);
   for (let h = 0; h < 3; h++) {
-    const [tc, uc] = await crowdfund.getHopStats(h);
+    const [tc, , uc] = await crowdfund.getHopStats(h);
     log("STATS", `  Hop ${h}: ${uc} committers, ${fmtUsdc(tc)}`);
   }
 

--- a/tasks/crowdfund.ts
+++ b/tasks/crowdfund.ts
@@ -161,7 +161,7 @@ task("cf-stats", "Show crowdfund statistics")
 
     console.log("\nPer-Hop Stats:");
     for (let h = 0; h < 3; h++) {
-      const [tc, uc, wc] = await crowdfund.getHopStats(h);
+      const [tc, , uc, wc] = await crowdfund.getHopStats(h);
       console.log(`  Hop ${h}: ${wc} whitelisted, ${uc} committed, $${ethers.formatUnits(tc, 6)} total`);
     }
 

--- a/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
+++ b/test-foundry/ArmadaCrowdfundArmRecovery.t.sol
@@ -28,7 +28,6 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
         crowdfund = new ArmadaCrowdfund(
             address(usdc),
             address(armToken),
-            admin,
             treasury,
             admin,
             admin,  // securityCouncil
@@ -101,7 +100,6 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
         ArmadaCrowdfund fresh = new ArmadaCrowdfund(
             address(usdc),
             address(armToken),
-            admin,
             treasury,
             admin,
             admin,  // securityCouncil
@@ -140,7 +138,6 @@ contract ArmadaCrowdfundArmRecoveryTest is Test {
         ArmadaCrowdfund fuzzCrowdfund = new ArmadaCrowdfund(
             address(usdc),
             address(armToken),
-            admin,
             treasury,
             admin,
             admin,  // securityCouncil

--- a/test-foundry/ArmadaCrowdfundRefundMode.t.sol
+++ b/test-foundry/ArmadaCrowdfundRefundMode.t.sol
@@ -32,7 +32,6 @@ contract ArmadaCrowdfundRefundModeTest is Test {
         crowdfund = new ArmadaCrowdfund(
             address(usdc),
             address(armToken),
-            admin,
             treasury,
             admin,
             admin,  // securityCouncil
@@ -180,7 +179,7 @@ contract ArmadaCrowdfundRefundModeTest is Test {
     function test_refundMode_cannotHappenAfterExpansion() public {
         // Deploy a fresh crowdfund with 100 seeds to reach ELASTIC_TRIGGER
         ArmadaCrowdfund cf2 = new ArmadaCrowdfund(
-            address(usdc), address(armToken), admin, treasury, admin, admin, block.timestamp
+            address(usdc), address(armToken), treasury, admin, admin, block.timestamp
         );
         armToken.transfer(address(cf2), ARM_FUNDING);
         cf2.loadArm();

--- a/test-foundry/CrowdfundFullInvariant.t.sol
+++ b/test-foundry/CrowdfundFullInvariant.t.sol
@@ -189,7 +189,6 @@ contract CrowdfundFullInvariantTest is Test {
         crowdfund = new ArmadaCrowdfund(
             address(usdc),
             address(armToken),
-            admin,
             address(0xBEEF), // treasury
             admin,
             admin,            // securityCouncil

--- a/test-foundry/CrowdfundInvariant.t.sol
+++ b/test-foundry/CrowdfundInvariant.t.sol
@@ -254,7 +254,6 @@ contract CrowdfundInvariantTest is Test {
         crowdfund = new ArmadaCrowdfund(
             address(usdc),
             address(armToken),
-            admin,
             address(0xBEEF), // treasury
             admin,
             admin,            // securityCouncil

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -83,7 +83,6 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
-      deployer.address,
       treasuryAddr.address,
       deployer.address,
       deployer.address,       // securityCouncil
@@ -664,7 +663,6 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       localCrowdfund = await ArmadaCrowdfund.deploy(
         await localUsdc.getAddress(),
         await localArmToken.getAddress(),
-        localDeployer.address,
         await localTreasury.getAddress(),
         localDeployer.address,
         localDeployer.address,  // securityCouncil

--- a/test/crowdfund_adversarial.ts
+++ b/test/crowdfund_adversarial.ts
@@ -67,7 +67,6 @@ describe("Crowdfund Adversarial", function () {
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
-      deployer.address,
       treasuryAddr.address,
       deployer.address,
       deployer.address,       // securityCouncil
@@ -90,14 +89,14 @@ describe("Crowdfund Adversarial", function () {
     it("unauthorized address cannot pause pre-finalization", async function () {
       await expect(
         crowdfund.connect(allSigners[1]).pause()
-      ).to.be.revertedWith("ArmadaCrowdfund: not admin or security council");
+      ).to.be.revertedWith("ArmadaCrowdfund: not launch team or security council");
     });
 
     it("unauthorized address cannot unpause pre-finalization", async function () {
       await crowdfund.pause();
       await expect(
         crowdfund.connect(allSigners[1]).unpause()
-      ).to.be.revertedWith("ArmadaCrowdfund: not admin or security council");
+      ).to.be.revertedWith("ArmadaCrowdfund: not launch team or security council");
     });
 
     it("double pause reverts", async function () {
@@ -312,17 +311,21 @@ describe("Crowdfund Adversarial", function () {
       expect(committed).to.equal(USDC(15_000));
     });
 
-    it("commit over hop cap reverts", async function () {
+    it("commit over hop cap succeeds (excess refunded at settlement)", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
       { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       await fundAndApprove(allSigners[1], USDC(15_010));
       await crowdfund.connect(allSigners[1]).commit(0, USDC(15_000));
 
-      // $10 more (meets MIN_COMMIT but exceeds hop cap)
-      await expect(
-        crowdfund.connect(allSigners[1]).commit(0, USDC(10))
-      ).to.be.revertedWith("ArmadaCrowdfund: exceeds hop cap");
+      // $10 more (meets MIN_COMMIT, exceeds hop cap — accepted for refund at settlement)
+      await crowdfund.connect(allSigners[1]).commit(0, USDC(10));
+
+      const committed = await crowdfund.getCommitment(allSigners[1].address, 0);
+      expect(committed).to.equal(USDC(15_010));
+
+      const [tc0] = await crowdfund.getHopStats(0);
+      expect(tc0).to.equal(USDC(15_010));
     });
 
     it("totalCommitted exactly at MIN_SALE finalizes (not cancel)", async function () {
@@ -444,8 +447,8 @@ describe("Crowdfund Adversarial", function () {
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
 
       // Hop-1 and hop-2 should have 0 committers
-      const [, uc1] = await crowdfund.getHopStats(1);
-      const [, uc2] = await crowdfund.getHopStats(2);
+      const [, , uc1] = await crowdfund.getHopStats(1);
+      const [, , uc2] = await crowdfund.getHopStats(2);
       expect(uc1).to.equal(0);
       expect(uc2).to.equal(0);
     });
@@ -687,22 +690,6 @@ describe("Crowdfund Adversarial", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: nothing to sweep");
     });
 
-    it("constructor rejects zero admin address", async function () {
-      const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
-      const localOpenTimestamp = (await time.latest()) + 300;
-      await expect(
-        ArmadaCrowdfund.deploy(
-          await usdc.getAddress(),
-          await armToken.getAddress(),
-          ethers.ZeroAddress,
-          treasuryAddr.address,
-          deployer.address,
-          deployer.address,
-          localOpenTimestamp
-        )
-      ).to.be.revertedWith("ArmadaCrowdfund: zero admin");
-    });
-
     it("constructor rejects zero treasury address", async function () {
       const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
       const localOpenTimestamp = (await time.latest()) + 300;
@@ -710,7 +697,6 @@ describe("Crowdfund Adversarial", function () {
         ArmadaCrowdfund.deploy(
           await usdc.getAddress(),
           await armToken.getAddress(),
-          deployer.address,
           ethers.ZeroAddress,
           deployer.address,
           deployer.address,
@@ -726,7 +712,6 @@ describe("Crowdfund Adversarial", function () {
         ArmadaCrowdfund.deploy(
           await usdc.getAddress(),
           await armToken.getAddress(),
-          deployer.address,
           treasuryAddr.address,
           deployer.address,
           ethers.ZeroAddress,

--- a/test/crowdfund_eip712.ts
+++ b/test/crowdfund_eip712.ts
@@ -1,0 +1,416 @@
+// ABOUTME: Tests for EIP-712 signed invite flow in ArmadaCrowdfund.
+// ABOUTME: Covers commitWithInvite(), revokeInviteNonce(), and related edge cases.
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+
+// Phase enum (must match IArmadaCrowdfund.sol)
+const Phase = { Active: 0, Finalized: 1, Canceled: 2 };
+
+// Time constants
+const ONE_DAY = 86400;
+const ONE_WEEK = 7 * ONE_DAY;
+
+// USDC amounts (6 decimals)
+const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
+// ARM amounts (18 decimals)
+const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
+
+describe("Crowdfund EIP-712 Invites", function () {
+  // Contracts
+  let crowdfund: any;
+  let armToken: any;
+  let usdc: any;
+
+  // Signers
+  let deployer: SignerWithAddress;
+  let seed1: SignerWithAddress;
+  let seed2: SignerWithAddress;
+  let hop1a: SignerWithAddress;
+  let hop1b: SignerWithAddress;
+  let hop1c: SignerWithAddress;
+  let hop1d: SignerWithAddress;
+  let treasury: SignerWithAddress;
+  let outsider: SignerWithAddress;
+
+  // EIP-712 domain (set after deploy)
+  let domain: {
+    name: string;
+    version: string;
+    chainId: number;
+    verifyingContract: string;
+  };
+
+  const inviteTypes = {
+    Invite: [
+      { name: "invitee", type: "address" },
+      { name: "fromHop", type: "uint8" },
+      { name: "nonce", type: "uint256" },
+      { name: "deadline", type: "uint256" },
+    ],
+  };
+
+  // Fund participants with USDC and approve crowdfund
+  async function fundAndApprove(signer: SignerWithAddress, amount: bigint) {
+    await usdc.mint(signer.address, amount);
+    await usdc.connect(signer).approve(await crowdfund.getAddress(), amount);
+  }
+
+  // Setup helper: add seeds and advance to window start
+  async function setupWithSeeds(seeds: SignerWithAddress[]) {
+    await crowdfund.addSeeds(seeds.map((s) => s.address));
+    const ws = Number(await crowdfund.windowStart());
+    if ((await time.latest()) < ws) await time.increaseTo(ws);
+  }
+
+  // Build an EIP-712 invite value object
+  function inviteValue(
+    invitee: string,
+    fromHop: number,
+    nonce: number,
+    deadline: number
+  ) {
+    return { invitee, fromHop, nonce, deadline };
+  }
+
+  // Sign an invite using EIP-712
+  async function signInvite(
+    signer: SignerWithAddress,
+    invitee: string,
+    fromHop: number,
+    nonce: number,
+    deadline: number
+  ): Promise<string> {
+    const value = inviteValue(invitee, fromHop, nonce, deadline);
+    return signer.signTypedData(domain, inviteTypes, value);
+  }
+
+  // Get a deadline far in the future
+  async function futureDeadline(): Promise<number> {
+    return (await time.latest()) + ONE_DAY;
+  }
+
+  beforeEach(async function () {
+    const allSigners = await ethers.getSigners();
+    [deployer, seed1, seed2, hop1a, hop1b, hop1c, hop1d, treasury, outsider] =
+      allSigners;
+
+    // Deploy MockUSDCV2
+    const MockUSDCV2 = await ethers.getContractFactory("MockUSDCV2");
+    usdc = await MockUSDCV2.deploy("Mock USDC", "USDC");
+    await usdc.waitForDeployment();
+
+    // Deploy ArmadaToken (12M ARM to deployer)
+    const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+    armToken = await ArmadaToken.deploy(deployer.address, deployer.address);
+    await armToken.waitForDeployment();
+    await armToken.initWhitelist([deployer.address]);
+
+    // Deploy ArmadaCrowdfund
+    const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+    const openTimestamp = (await time.latest()) + 300;
+    crowdfund = await ArmadaCrowdfund.deploy(
+      await usdc.getAddress(),
+      await armToken.getAddress(),
+      treasury.address,
+      deployer.address, // launchTeam
+      deployer.address, // securityCouncil
+      openTimestamp
+    );
+    await crowdfund.waitForDeployment();
+    await armToken.addToWhitelist(await crowdfund.getAddress());
+
+    // Fund ARM to crowdfund (enough for MAX_SALE) and load
+    const CROWDFUND_ARM_FUNDING = ARM(1_800_000);
+    await armToken.transfer(await crowdfund.getAddress(), CROWDFUND_ARM_FUNDING);
+    await crowdfund.loadArm();
+
+    // Fund potential participants with USDC
+    for (const signer of [seed1, seed2, hop1a, hop1b, hop1c, hop1d]) {
+      await fundAndApprove(signer, USDC(20_000));
+    }
+
+    // Set EIP-712 domain
+    domain = {
+      name: "ArmadaCrowdfund",
+      version: "1",
+      chainId: 31337,
+      verifyingContract: await crowdfund.getAddress(),
+    };
+  });
+
+  // ============================================================
+  // commitWithInvite
+  // ============================================================
+
+  describe("commitWithInvite", function () {
+    it("should accept a valid signed invite and commit USDC", async function () {
+      // seed1 is hop-0; signs an invite for hop1a to join at hop-1
+      await setupWithSeeds([seed1]);
+      const deadline = await futureDeadline();
+      const nonce = 1;
+
+      const signature = await signInvite(
+        seed1,
+        hop1a.address,
+        0, // fromHop
+        nonce,
+        deadline
+      );
+
+      const commitAmount = USDC(1_000);
+      const tx = await crowdfund
+        .connect(hop1a)
+        .commitWithInvite(seed1.address, 0, nonce, deadline, signature, commitAmount);
+
+      // Verify Invited event with the actual nonce (not 0)
+      await expect(tx)
+        .to.emit(crowdfund, "Invited")
+        .withArgs(seed1.address, hop1a.address, 1, nonce);
+
+      // Verify Committed event
+      await expect(tx)
+        .to.emit(crowdfund, "Committed")
+        .withArgs(hop1a.address, commitAmount, commitAmount, 1);
+
+      // Verify on-chain state
+      expect(await crowdfund.isWhitelisted(hop1a.address, 1)).to.be.true;
+      expect(await crowdfund.totalCommitted()).to.equal(commitAmount);
+      expect(await crowdfund.usedNonces(seed1.address, nonce)).to.be.true;
+    });
+
+    it("should revert when deadline has passed", async function () {
+      await setupWithSeeds([seed1]);
+      const pastDeadline = (await time.latest()) - 1;
+      const nonce = 1;
+
+      const signature = await signInvite(
+        seed1,
+        hop1a.address,
+        0,
+        nonce,
+        pastDeadline
+      );
+
+      await expect(
+        crowdfund
+          .connect(hop1a)
+          .commitWithInvite(seed1.address, 0, nonce, pastDeadline, signature, USDC(1_000))
+      ).to.be.revertedWith("ArmadaCrowdfund: invite expired");
+    });
+
+    it("should revert when nonce is zero", async function () {
+      await setupWithSeeds([seed1]);
+      const deadline = await futureDeadline();
+
+      const signature = await signInvite(seed1, hop1a.address, 0, 0, deadline);
+
+      await expect(
+        crowdfund
+          .connect(hop1a)
+          .commitWithInvite(seed1.address, 0, 0, deadline, signature, USDC(1_000))
+      ).to.be.revertedWith("ArmadaCrowdfund: zero nonce");
+    });
+
+    it("should revert when nonce is reused", async function () {
+      await setupWithSeeds([seed1]);
+      const deadline = await futureDeadline();
+      const nonce = 42;
+
+      // First use succeeds
+      const sig1 = await signInvite(seed1, hop1a.address, 0, nonce, deadline);
+      await crowdfund
+        .connect(hop1a)
+        .commitWithInvite(seed1.address, 0, nonce, deadline, sig1, USDC(1_000));
+
+      // Second use with same nonce (different invitee) should fail
+      const sig2 = await signInvite(seed1, hop1b.address, 0, nonce, deadline);
+      await expect(
+        crowdfund
+          .connect(hop1b)
+          .commitWithInvite(seed1.address, 0, nonce, deadline, sig2, USDC(1_000))
+      ).to.be.revertedWith("ArmadaCrowdfund: nonce already used");
+    });
+
+    it("should revert when nonce has been revoked", async function () {
+      await setupWithSeeds([seed1]);
+      const deadline = await futureDeadline();
+      const nonce = 7;
+
+      // Seed1 revokes the nonce before it's used
+      await crowdfund.connect(seed1).revokeInviteNonce(nonce);
+
+      const signature = await signInvite(seed1, hop1a.address, 0, nonce, deadline);
+
+      await expect(
+        crowdfund
+          .connect(hop1a)
+          .commitWithInvite(seed1.address, 0, nonce, deadline, signature, USDC(1_000))
+      ).to.be.revertedWith("ArmadaCrowdfund: nonce already used");
+    });
+
+    it("should revert with invalid signature (wrong signer)", async function () {
+      await setupWithSeeds([seed1]);
+      const deadline = await futureDeadline();
+      const nonce = 1;
+
+      // outsider signs instead of seed1
+      const signature = await signInvite(
+        outsider,
+        hop1a.address,
+        0,
+        nonce,
+        deadline
+      );
+
+      // hop1a calls with inviter=seed1, but signature is from outsider
+      await expect(
+        crowdfund
+          .connect(hop1a)
+          .commitWithInvite(seed1.address, 0, nonce, deadline, signature, USDC(1_000))
+      ).to.be.revertedWith("ArmadaCrowdfund: invalid invite signature");
+    });
+
+    it("should revert with tampered data (signature for different invitee)", async function () {
+      await setupWithSeeds([seed1]);
+      const deadline = await futureDeadline();
+      const nonce = 1;
+
+      // seed1 signs an invite for hop1a
+      const signature = await signInvite(seed1, hop1a.address, 0, nonce, deadline);
+
+      // hop1b tries to use the signature meant for hop1a
+      await expect(
+        crowdfund
+          .connect(hop1b)
+          .commitWithInvite(seed1.address, 0, nonce, deadline, signature, USDC(1_000))
+      ).to.be.revertedWith("ArmadaCrowdfund: invalid invite signature");
+    });
+
+    it("should revert when inviter budget is exhausted", async function () {
+      // seed1 has 3 invite slots (1 invitesReceived * 3 maxInvites at hop-0)
+      await setupWithSeeds([seed1]);
+      const deadline = await futureDeadline();
+
+      // Use all 3 invite slots via signed invites
+      for (let i = 0; i < 3; i++) {
+        const invitee = [hop1a, hop1b, hop1c][i];
+        const sig = await signInvite(seed1, invitee.address, 0, i + 1, deadline);
+        await crowdfund
+          .connect(invitee)
+          .commitWithInvite(seed1.address, 0, i + 1, deadline, sig, USDC(1_000));
+      }
+
+      // 4th invite should fail
+      const sig4 = await signInvite(seed1, hop1d.address, 0, 4, deadline);
+      await expect(
+        crowdfund
+          .connect(hop1d)
+          .commitWithInvite(seed1.address, 0, 4, deadline, sig4, USDC(1_000))
+      ).to.be.revertedWith("ArmadaCrowdfund: invite limit reached");
+    });
+
+    it("should revert when contract is paused", async function () {
+      await setupWithSeeds([seed1]);
+      const deadline = await futureDeadline();
+      const nonce = 1;
+
+      const signature = await signInvite(seed1, hop1a.address, 0, nonce, deadline);
+
+      // deployer is launchTeam, can pause
+      await crowdfund.pause();
+
+      await expect(
+        crowdfund
+          .connect(hop1a)
+          .commitWithInvite(seed1.address, 0, nonce, deadline, signature, USDC(1_000))
+      ).to.be.revertedWith("Pausable: paused");
+    });
+
+    it("should revert before window start", async function () {
+      // Add seeds but do NOT advance time to window start
+      await crowdfund.addSeeds([seed1.address]);
+
+      const deadline = (await time.latest()) + ONE_DAY;
+      const nonce = 1;
+
+      const signature = await signInvite(seed1, hop1a.address, 0, nonce, deadline);
+
+      await expect(
+        crowdfund
+          .connect(hop1a)
+          .commitWithInvite(seed1.address, 0, nonce, deadline, signature, USDC(1_000))
+      ).to.be.revertedWith("ArmadaCrowdfund: not active window");
+    });
+  });
+
+  // ============================================================
+  // revokeInviteNonce
+  // ============================================================
+
+  describe("revokeInviteNonce", function () {
+    it("should revoke a nonce and emit InviteNonceRevoked", async function () {
+      const nonce = 99;
+
+      const tx = await crowdfund.connect(seed1).revokeInviteNonce(nonce);
+
+      await expect(tx)
+        .to.emit(crowdfund, "InviteNonceRevoked")
+        .withArgs(seed1.address, nonce);
+
+      // Verify nonce is marked as used
+      expect(await crowdfund.usedNonces(seed1.address, nonce)).to.be.true;
+    });
+
+    it("should revert when revoking nonce zero", async function () {
+      await expect(
+        crowdfund.connect(seed1).revokeInviteNonce(0)
+      ).to.be.revertedWith("ArmadaCrowdfund: zero nonce");
+    });
+
+    it("should revert when revoking an already used nonce", async function () {
+      // Use the nonce via commitWithInvite first
+      await setupWithSeeds([seed1]);
+      const deadline = await futureDeadline();
+      const nonce = 5;
+
+      const signature = await signInvite(seed1, hop1a.address, 0, nonce, deadline);
+      await crowdfund
+        .connect(hop1a)
+        .commitWithInvite(seed1.address, 0, nonce, deadline, signature, USDC(1_000));
+
+      // Now seed1 tries to revoke the already-used nonce
+      await expect(
+        crowdfund.connect(seed1).revokeInviteNonce(nonce)
+      ).to.be.revertedWith("ArmadaCrowdfund: nonce already used");
+    });
+
+    it("should revert when revoking an already revoked nonce", async function () {
+      const nonce = 10;
+
+      await crowdfund.connect(seed1).revokeInviteNonce(nonce);
+
+      await expect(
+        crowdfund.connect(seed1).revokeInviteNonce(nonce)
+      ).to.be.revertedWith("ArmadaCrowdfund: nonce already used");
+    });
+  });
+
+  // ============================================================
+  // Direct invite() nonce=0 verification
+  // ============================================================
+
+  describe("Direct invite nonce", function () {
+    it("should emit Invited with nonce=0 for direct invite()", async function () {
+      await setupWithSeeds([seed1]);
+
+      const tx = await crowdfund.connect(seed1).invite(hop1a.address, 0);
+
+      await expect(tx)
+        .to.emit(crowdfund, "Invited")
+        .withArgs(seed1.address, hop1a.address, 1, 0);
+    });
+  });
+});

--- a/test/crowdfund_integration.ts
+++ b/test/crowdfund_integration.ts
@@ -100,7 +100,6 @@ describe("Crowdfund Integration", function () {
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
-      deployer.address,
       treasury.address,
       deployer.address,
       deployer.address,       // securityCouncil
@@ -161,7 +160,7 @@ describe("Crowdfund Integration", function () {
       expect(await crowdfund.isWhitelisted(seed1.address, 0)).to.be.true;
       expect(await crowdfund.getParticipantCount()).to.equal(1);
 
-      const [totalComm, uniqueComm, whitelistCount] = await crowdfund.getHopStats(0);
+      const [totalComm, _cappedComm, uniqueComm, whitelistCount] = await crowdfund.getHopStats(0);
       expect(whitelistCount).to.equal(1);
     });
 
@@ -173,10 +172,10 @@ describe("Crowdfund Integration", function () {
       expect(await crowdfund.getParticipantCount()).to.equal(3);
     });
 
-    it("should reject non-admin adding seeds", async function () {
+    it("should reject non-launch-team adding seeds", async function () {
       await expect(
         crowdfund.connect(seed1).addSeed(seed2.address)
-      ).to.be.revertedWith("ArmadaCrowdfund: not admin");
+      ).to.be.revertedWith("ArmadaCrowdfund: not launch team");
     });
 
     it("should reject adding zero address as seed", async function () {
@@ -224,7 +223,6 @@ describe("Crowdfund Integration", function () {
       freshCrowdfund = await ArmadaCrowdfund.deploy(
         await usdc.getAddress(),
         await freshArmToken.getAddress(),
-        deployer.address,
         treasury.address,
         deployer.address,
         deployer.address,       // securityCouncil
@@ -435,9 +433,9 @@ describe("Crowdfund Integration", function () {
       await crowdfund.connect(seed2).invite(hop1c.address, 0);
       await crowdfund.connect(hop1a).invite(hop2a.address, 1);
 
-      const [, , wc0] = await crowdfund.getHopStats(0);
-      const [, , wc1] = await crowdfund.getHopStats(1);
-      const [, , wc2] = await crowdfund.getHopStats(2);
+      const [, , , wc0] = await crowdfund.getHopStats(0);
+      const [, , , wc1] = await crowdfund.getHopStats(1);
+      const [, , , wc2] = await crowdfund.getHopStats(2);
       expect(wc0).to.equal(2);
       expect(wc1).to.equal(3);
       expect(wc2).to.equal(1);
@@ -495,31 +493,45 @@ describe("Crowdfund Integration", function () {
       expect(committed).to.equal(USDC(15_000));
     });
 
-    it("should enforce per-hop cap ($15K for hop 0)", async function () {
+    it("should accept over-cap commit ($15K for hop 0) for refund at settlement", async function () {
       await setupActive([seed1]);
 
-      await expect(
-        crowdfund.connect(seed1).commit(0, USDC(15_001))
-      ).to.be.revertedWith("ArmadaCrowdfund: exceeds hop cap");
+      await crowdfund.connect(seed1).commit(0, USDC(15_001));
+
+      // Over-cap deposits are accepted; totalCommitted includes the raw amount
+      const [tc0] = await crowdfund.getHopStats(0);
+      expect(tc0).to.equal(USDC(15_001));
+
+      // Participant's raw commitment includes the full over-cap amount
+      const committed = await crowdfund.getCommitment(seed1.address, 0);
+      expect(committed).to.equal(USDC(15_001));
     });
 
-    it("should enforce per-hop cap ($4K for hop 1)", async function () {
+    it("should accept over-cap commit ($4K for hop 1) for refund at settlement", async function () {
       await setupWithSeeds([seed1]);
       await crowdfund.connect(seed1).invite(hop1a.address, 0);
 
-      await expect(
-        crowdfund.connect(hop1a).commit(1, USDC(4_001))
-      ).to.be.revertedWith("ArmadaCrowdfund: exceeds hop cap");
+      await crowdfund.connect(hop1a).commit(1, USDC(4_001));
+
+      const [tc1] = await crowdfund.getHopStats(1);
+      expect(tc1).to.equal(USDC(4_001));
+
+      const committed = await crowdfund.getCommitment(hop1a.address, 1);
+      expect(committed).to.equal(USDC(4_001));
     });
 
-    it("should enforce per-hop cap ($1K for hop 2)", async function () {
+    it("should accept over-cap commit ($1K for hop 2) for refund at settlement", async function () {
       await setupWithSeeds([seed1]);
       await crowdfund.connect(seed1).invite(hop1a.address, 0);
       await crowdfund.connect(hop1a).invite(hop2a.address, 1);
 
-      await expect(
-        crowdfund.connect(hop2a).commit(2, USDC(1_001))
-      ).to.be.revertedWith("ArmadaCrowdfund: exceeds hop cap");
+      await crowdfund.connect(hop2a).commit(2, USDC(1_001));
+
+      const [tc2] = await crowdfund.getHopStats(2);
+      expect(tc2).to.equal(USDC(1_001));
+
+      const committed = await crowdfund.getCommitment(hop2a.address, 2);
+      expect(committed).to.equal(USDC(1_001));
     });
 
     it("should reject commit from non-whitelisted address", async function () {
@@ -567,11 +579,11 @@ describe("Crowdfund Integration", function () {
       await crowdfund.connect(seed2).commit(0, USDC(8_000));
       await crowdfund.connect(hop1a).commit(1, USDC(3_000));
 
-      const [tc0, uc0] = await crowdfund.getHopStats(0);
+      const [tc0, , uc0] = await crowdfund.getHopStats(0);
       expect(tc0).to.equal(USDC(18_000));
       expect(uc0).to.equal(2);
 
-      const [tc1, uc1] = await crowdfund.getHopStats(1);
+      const [tc1, , uc1] = await crowdfund.getHopStats(1);
       expect(tc1).to.equal(USDC(3_000));
       expect(uc1).to.equal(1);
 
@@ -583,12 +595,12 @@ describe("Crowdfund Integration", function () {
 
       // First commit: uniqueCommitters should go from 0 to 1
       await crowdfund.connect(seed1).commit(0, USDC(1_000));
-      const [, uc1] = await crowdfund.getHopStats(0);
+      const [, , uc1] = await crowdfund.getHopStats(0);
       expect(uc1).to.equal(1);
 
       // Second commit from same address: uniqueCommitters should stay at 1
       await crowdfund.connect(seed1).commit(0, USDC(1_000));
-      const [, uc2] = await crowdfund.getHopStats(0);
+      const [, , uc2] = await crowdfund.getHopStats(0);
       expect(uc2).to.equal(1);
     });
   });
@@ -822,7 +834,6 @@ describe("Crowdfund Integration", function () {
       const unfundedCrowdfund = await ArmadaCrowdfund.deploy(
         await usdc.getAddress(),
         await armToken.getAddress(),
-        deployer.address,
         treasury.address,
         deployer.address,
         deployer.address,       // securityCouncil
@@ -1295,19 +1306,18 @@ describe("Crowdfund Integration", function () {
     it("outsider cannot pause pre-finalization", async function () {
       await expect(
         crowdfund.connect(outsider).pause()
-      ).to.be.revertedWith("ArmadaCrowdfund: not admin or security council");
+      ).to.be.revertedWith("ArmadaCrowdfund: not launch team or security council");
     });
 
-    it("admin cannot pause post-finalization", async function () {
-      // Need a crowdfund where admin != securityCouncil to test this
+    it("launch team cannot pause post-finalization", async function () {
+      // Need a crowdfund where launchTeam != securityCouncil to test this
       const pauseOpenTimestamp = (await time.latest()) + 300;
       const freshCrowdfund = await (await ethers.getContractFactory("ArmadaCrowdfund")).deploy(
         await usdc.getAddress(),
         await armToken.getAddress(),
-        deployer.address,        // admin
         treasury.address,        // treasury
         deployer.address,        // launchTeam
-        outsider.address,        // securityCouncil (different from admin)
+        outsider.address,        // securityCouncil (different from launchTeam)
         pauseOpenTimestamp
       );
       const freshAddr = await freshCrowdfund.getAddress();
@@ -1336,7 +1346,7 @@ describe("Crowdfund Integration", function () {
       await time.increase(THREE_WEEKS + 1);
       await freshCrowdfund.finalize();
 
-      // Admin (deployer) cannot pause post-finalization
+      // Launch team (deployer) cannot pause post-finalization
       await expect(
         freshCrowdfund.pause()
       ).to.be.revertedWith("ArmadaCrowdfund: only security council");
@@ -1346,22 +1356,21 @@ describe("Crowdfund Integration", function () {
       expect(await freshCrowdfund.paused()).to.be.true;
     });
 
-    it("admin cannot pause post-cancel", async function () {
+    it("launch team cannot pause post-cancel", async function () {
       const cancelOpenTimestamp = (await time.latest()) + 300;
       const freshCrowdfund = await (await ethers.getContractFactory("ArmadaCrowdfund")).deploy(
         await usdc.getAddress(),
         await armToken.getAddress(),
-        deployer.address,        // admin
         treasury.address,        // treasury
         deployer.address,        // launchTeam
-        outsider.address,        // securityCouncil (different from admin)
+        outsider.address,        // securityCouncil (different from launchTeam)
         cancelOpenTimestamp
       );
 
       // Security council cancels
       await freshCrowdfund.connect(outsider).cancel();
 
-      // Admin cannot pause
+      // Launch team cannot pause
       await expect(
         freshCrowdfund.pause()
       ).to.be.revertedWith("ArmadaCrowdfund: only security council");

--- a/test/crowdfund_launch_team.ts
+++ b/test/crowdfund_launch_team.ts
@@ -22,7 +22,7 @@ describe("Launch Team & Seed Cap", function () {
   let armToken: any;
   let usdc: any;
 
-  let deployer: SignerWithAddress; // also admin and launchTeam for testing
+  let deployer: SignerWithAddress; // also launchTeam for testing
   let treasury: SignerWithAddress;
   let outsider: SignerWithAddress;
   let allSigners: SignerWithAddress[];
@@ -60,9 +60,8 @@ describe("Launch Team & Seed Cap", function () {
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
-      deployer.address,   // admin
       treasury.address,   // treasury
-      deployer.address,   // launchTeam (same as admin for local testing)
+      deployer.address,   // launchTeam
       deployer.address,   // securityCouncil
       openTimestamp        // openTimestamp
     );
@@ -323,7 +322,6 @@ describe("Launch Team & Seed Cap", function () {
       const cf = await ArmadaCrowdfund.deploy(
         await usdc.getAddress(),
         await armToken.getAddress(),
-        deployer.address,
         treasury.address,
         ltSigner.address,   // separate launch team
         deployer.address,   // securityCouncil
@@ -336,8 +334,8 @@ describe("Launch Team & Seed Cap", function () {
       await armToken.transfer(await cf.getAddress(), ARM(1_800_000));
       await cf.loadArm();
 
-      // Add launchTeam as a seed (admin can do this)
-      await cf.addSeed(ltSigner.address);
+      // Add launchTeam as a seed (launch team calls addSeed)
+      await cf.connect(ltSigner).addSeed(ltSigner.address);
       { const ws = Number(await cf.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // Fund the launch team address
@@ -435,7 +433,6 @@ describe("Launch Team & Seed Cap", function () {
         ArmadaCrowdfund.deploy(
           await usdc.getAddress(),
           await armToken.getAddress(),
-          deployer.address,
           treasury.address,
           ethers.ZeroAddress,
           deployer.address,

--- a/test/crowdfund_multinode.ts
+++ b/test/crowdfund_multinode.ts
@@ -55,7 +55,6 @@ describe("Crowdfund Multi-Node", function () {
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
-      deployer.address,
       treasury.address,
       deployer.address,
       deployer.address,       // securityCouncil
@@ -152,15 +151,20 @@ describe("Crowdfund Multi-Node", function () {
       expect(await crowdfund.getCommitment(alice.address, 1)).to.equal(USDC(8_000));
     });
 
-    it("should reject commitment exceeding scaled cap", async function () {
+    it("should accept commitment exceeding scaled cap (excess refunded at settlement)", async function () {
       await setupWithSeeds([seed1]);
 
       // One invite → cap = 1 * $4000 = $4000
       await crowdfund.connect(seed1).invite(alice.address, 0);
 
-      await expect(
-        crowdfund.connect(alice).commit(1, USDC(4_001))
-      ).to.be.revertedWith("ArmadaCrowdfund: exceeds hop cap");
+      await crowdfund.connect(alice).commit(1, USDC(4_001));
+
+      // Over-cap deposits are accepted; raw commitment includes the full amount
+      const committed = await crowdfund.getCommitment(alice.address, 1);
+      expect(committed).to.equal(USDC(4_001));
+
+      const [tc1] = await crowdfund.getHopStats(1);
+      expect(tc1).to.equal(USDC(4_001));
     });
 
     it("should scale outgoing invite budget with invitesReceived", async function () {
@@ -370,8 +374,8 @@ describe("Crowdfund Multi-Node", function () {
       await crowdfund.connect(seed1).commit(1, USDC(100));
 
       // Each hop should show 1 unique committer
-      const [, committers0] = await crowdfund.getHopStats(0);
-      const [, committers1] = await crowdfund.getHopStats(1);
+      const [, , committers0] = await crowdfund.getHopStats(0);
+      const [, , committers1] = await crowdfund.getHopStats(1);
       expect(committers0).to.equal(1);
       expect(committers1).to.equal(1);
     });

--- a/test/crowdfund_settlement.ts
+++ b/test/crowdfund_settlement.ts
@@ -79,7 +79,6 @@ describe("Crowdfund Settlement Rework", function () {
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
-      deployer.address,
       treasury.address,
       deployer.address,         // launchTeam
       securityCouncil.address,  // securityCouncil

--- a/test/gas_benchmark.ts
+++ b/test/gas_benchmark.ts
@@ -63,7 +63,6 @@ describe("Gas Benchmarks", function () {
         const crowdfund = await ArmadaCrowdfund.deploy(
           await usdc.getAddress(),
           await armToken.getAddress(),
-          deployer.address,
           deployer.address, // treasury
           deployer.address, // launchTeam
           deployer.address, // securityCouncil
@@ -173,7 +172,6 @@ describe("Gas Benchmarks", function () {
         const crowdfund = await ArmadaCrowdfund.deploy(
           await usdc.getAddress(),
           await armToken.getAddress(),
-          deployer.address,
           deployer.address, // treasury
           deployer.address, // launchTeam
           deployer.address, // securityCouncil
@@ -218,7 +216,6 @@ describe("Gas Benchmarks", function () {
       const crowdfund = await ArmadaCrowdfund.deploy(
         await usdc.getAddress(),
         await armToken.getAddress(),
-        deployer.address,
         deployer.address, // treasury
         deployer.address, // launchTeam
         deployer.address, // securityCouncil
@@ -475,7 +472,6 @@ describe("Gas Benchmarks", function () {
       const crowdfund = await ArmadaCrowdfund.deploy(
         await usdc.getAddress(),
         await armToken.getAddress(),
-        deployer.address,
         deployer.address, // treasury
         deployer.address, // launchTeam
         deployer.address, // securityCouncil

--- a/test/governance_quiet_period.ts
+++ b/test/governance_quiet_period.ts
@@ -76,7 +76,6 @@ describe("Governance Quiet Period (T6.1)", function () {
     crowdfund = await ArmadaCrowdfund.deploy(
       await usdc.getAddress(),
       await armToken.getAddress(),
-      deployer.address,
       treasuryAddr.address,
       deployer.address,
       deployer.address, // securityCouncil


### PR DESCRIPTION
## Summary

- **Task 3 — Merge admin into launchTeam**: Removes `admin` immutable and constructor parameter. `launchTeam` absorbs seed management (`addSeed`/`addSeeds`) and pre-finalization pause/unpause duties. Security council role unchanged.
- **Task 5 — Accept over-cap deposits, refund at settlement**: Removes hard cap rejection in `commit()`. Adds `_computeCappedDemand()` which iterates all participant nodes at finalization to compute exact capped demand per spec. `cappedDemand` used for MIN_SALE check, elastic expansion trigger, and deadline fallback refund. Over-cap excess refunded at settlement.
- **Task 7 — EIP-712 signed invite links**: Adds `commitWithInvite()` combining off-chain signed invite + USDC commitment in one tx. Supports EOA and EIP-1271 smart wallets via `SignatureChecker`. Adds `revokeInviteNonce()` and nonce field on `Invited` event.

## Test plan

- [x] `npm run test:all` — 703 passing (15 new EIP-712 tests), 0 failing
- [x] `npm run test:forge` — 363 passing, 0 failing
- [x] Hardhat + Foundry compilation clean
- [ ] Review constructor parameter changes across all deploy call sites (33 files updated)
- [ ] Review `commitWithInvite()` for correct invite budget accounting and signature verification
- [ ] Review `_computeCappedDemand()` gas cost with max participants (~1000 nodes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)