### PR TITLE
fix: align crowdfund contract with spec (8 gap fixes)

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -120,7 +120,6 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable, EIP712 {
 
     event SeedAdded(address indexed seed);
     event Invited(address indexed inviter, address indexed invitee, uint8 hop, uint256 nonce);
-    event InviteAdded(address indexed inviter, address indexed invitee, uint8 hop, uint16 newInviteCount);
     event Committed(address indexed participant, uint8 hop, uint256 amount);
     event Finalized(uint256 saleSize, uint256 allocatedArm, uint256 netProceeds, bool refundMode);
     event Cancelled();
@@ -227,7 +226,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable, EIP712 {
     /// @param inviterHop Which of the caller's hop-level nodes is doing the inviting
     function invite(address invitee, uint8 inviterHop) external whenNotPaused {
         require(phase == Phase.Active, "ArmadaCrowdfund: not active");
-        require(block.timestamp < windowEnd, "ArmadaCrowdfund: window closed");
+        require(armLoaded, "ArmadaCrowdfund: ARM not loaded");
+        require(block.timestamp <= windowEnd, "ArmadaCrowdfund: window closed");
 
         Participant storage inviter = participants[msg.sender][inviterHop];
         require(inviter.isWhitelisted, "ArmadaCrowdfund: not whitelisted");
@@ -250,8 +250,6 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable, EIP712 {
             inviteeNode.invitedBy = msg.sender;
             participantNodes.push(ParticipantNode(invitee, inviteeHop));
             hopStats[inviteeHop].whitelistCount++;
-
-            emit Invited(msg.sender, invitee, inviteeHop, 0);
         } else {
             // Subsequent invite — increment counter (scales cap + outgoing budget)
             require(
@@ -259,11 +257,10 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable, EIP712 {
                 "ArmadaCrowdfund: max invites received"
             );
             inviteeNode.invitesReceived++;
-
-            emit InviteAdded(msg.sender, invitee, inviteeHop, inviteeNode.invitesReceived);
         }
 
         inviter.invitesSent++;
+        emit Invited(msg.sender, invitee, inviteeHop, 0);
     }
 
     /// @notice Launch team issues a direct invite at hop-1 or hop-2 (week 1 only).
@@ -275,8 +272,8 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable, EIP712 {
         require(msg.sender == launchTeam, "ArmadaCrowdfund: not launch team");
         require(phase == Phase.Active, "ArmadaCrowdfund: not active");
         require(
-            block.timestamp < launchTeamInviteEnd,
-            "ArmadaCrowdfund: launch team invite window closed"
+            block.timestamp >= windowStart && block.timestamp < launchTeamInviteEnd,
+            "ArmadaCrowdfund: outside week-1 window"
         );
         require(fromHop == 0 || fromHop == 1, "ArmadaCrowdfund: invalid hop for launch team");
         require(invitee != address(0), "ArmadaCrowdfund: zero address");
@@ -299,17 +296,15 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable, EIP712 {
             inviteeNode.invitedBy = msg.sender;
             participantNodes.push(ParticipantNode(invitee, inviteeHop));
             hopStats[inviteeHop].whitelistCount++;
-
-            emit Invited(msg.sender, invitee, inviteeHop, 0);
         } else {
             require(
                 inviteeNode.invitesReceived < hopConfigs[inviteeHop].maxInvitesReceived,
                 "ArmadaCrowdfund: max invites received"
             );
             inviteeNode.invitesReceived++;
-
-            emit InviteAdded(msg.sender, invitee, inviteeHop, inviteeNode.invitesReceived);
         }
+
+        emit Invited(msg.sender, invitee, inviteeHop, 0);
     }
 
     // ============ Commitment Phase ============
@@ -411,17 +406,15 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable, EIP712 {
             inviteeNode.invitedBy = inviter;
             participantNodes.push(ParticipantNode(msg.sender, inviteeHop));
             hopStats[inviteeHop].whitelistCount++;
-
-            emit Invited(inviter, msg.sender, inviteeHop, nonce);
         } else {
             require(
                 inviteeNode.invitesReceived < hopConfigs[inviteeHop].maxInvitesReceived,
                 "ArmadaCrowdfund: max invites received"
             );
             inviteeNode.invitesReceived++;
-            emit InviteAdded(inviter, msg.sender, inviteeHop, inviteeNode.invitesReceived);
         }
         inviterNode.invitesSent++;
+        emit Invited(inviter, msg.sender, inviteeHop, nonce);
 
         // --- USDC escrow ---
         require(msg.sender != launchTeam, "ArmadaCrowdfund: launch team cannot commit");
@@ -505,7 +498,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable, EIP712 {
             refundMode = true;
             phase = Phase.Finalized;
             finalizedAt = block.timestamp;
-            emit Finalized(0, 0, 0, true);
+            emit Finalized(saleSize, 0, 0, true);
             return;
         }
 
@@ -581,15 +574,17 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable, EIP712 {
         bool fullRefund = false;
 
         if (phase == Phase.Finalized && !refundMode) {
-            // Path 1: Normal post-finalization pro-rata refund
-            require(block.timestamp <= claimDeadline, "ArmadaCrowdfund: claim deadline passed");
+            // Path 1: Normal post-finalization pro-rata refund (no expiry — spec: "refunds do not expire")
             normalRefund = true;
         } else if (refundMode || phase == Phase.Canceled) {
             // Paths 2 & 3: Full deposit refund (no deadline — participants must always recover USDC)
             fullRefund = true;
         } else if (block.timestamp > windowEnd && phase != Phase.Finalized) {
-            // Path 4: Deadline fallback — window expired without finalization
-            _computeCappedDemand();
+            // Path 4: Deadline fallback — window expired without finalization.
+            // Compute capped demand once; subsequent calls reuse the cached value.
+            if (cappedDemand == 0) {
+                _computeCappedDemand();
+            }
             if (cappedDemand < MIN_SALE) {
                 fullRefund = true;
             }
@@ -828,13 +823,13 @@ contract ArmadaCrowdfund is ReentrancyGuard, Pausable, EIP712 {
 
     // ============ Internal ============
 
-    /// @dev Enforces that seeds can only be added before the invite period ends (requires ARM loaded).
+    /// @dev Enforces that seeds can only be added during week 1 (requires ARM loaded).
     function _requireArmLoadedAndPreInviteEnd() internal view {
         require(phase == Phase.Active, "ArmadaCrowdfund: not active");
         require(armLoaded, "ArmadaCrowdfund: ARM not loaded");
         require(
-            block.timestamp < launchTeamInviteEnd,
-            "ArmadaCrowdfund: seeds only before invite period ends"
+            block.timestamp >= windowStart && block.timestamp < launchTeamInviteEnd,
+            "ArmadaCrowdfund: outside week-1 window"
         );
     }
 

--- a/contracts/crowdfund/IArmadaCrowdfund.sol
+++ b/contracts/crowdfund/IArmadaCrowdfund.sol
@@ -11,7 +11,7 @@ pragma solidity ^0.8.17;
 enum Phase {
     Active,         // Invites + commits happen concurrently (3-week window)
     Finalized,      // Allocations computed, claims open
-    Canceled        // Below minimum raise, full refunds
+    Canceled        // Security Council cancel or permanent shutdown; full refunds
 }
 
 // ========== Structs ==========

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -145,8 +145,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       // === CROWDFUND PHASE ===
 
       // 1. Add seeds and start invitations
-      await crowdfund.addSeeds(seeds.map(s => s.address));
       { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+      await crowdfund.addSeeds(seeds.map(s => s.address));
 
       // 2. Seeds invite hop-1 addresses
       for (let i = 0; i < 3 && i < hop1Addrs.length; i++) {
@@ -249,8 +249,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
   describe("Token Supply Consistency", function () {
     async function runCrowdfundAndClaim() {
-      await crowdfund.addSeeds(seeds.map(s => s.address));
       { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+      await crowdfund.addSeeds(seeds.map(s => s.address));
 
       for (const seed of seeds) {
         const amount = USDC(15_000);
@@ -357,8 +357,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
   describe("Adversarial Cross-Contract", function () {
     async function setupCrowdfundAndGovernance() {
       // Run crowdfund
-      await crowdfund.addSeeds(seeds.map(s => s.address));
       { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+      await crowdfund.addSeeds(seeds.map(s => s.address));
 
       for (const seed of seeds) {
         const amount = USDC(15_000);
@@ -542,8 +542,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
     it("unclaimed crowdfund participant cannot vote (no ARM, no delegation, no voting power)", async function () {
       // Run crowdfund but DON'T claim
-      await crowdfund.addSeeds(seeds.map(s => s.address));
       { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+      await crowdfund.addSeeds(seeds.map(s => s.address));
 
       for (const seed of seeds) {
         const amount = USDC(15_000);
@@ -731,8 +731,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
     it("quorum denominator shifts as participants claim ARM from crowdfund", async function () {
       // Run crowdfund lifecycle
-      await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
       { const ws = Number(await localCrowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+      await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
@@ -791,8 +791,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
     it("finalize pushes USDC proceeds to treasury contract", async function () {
       // Run crowdfund
-      await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
       { const ws = Number(await localCrowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+      await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
@@ -821,8 +821,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
     it("withdrawUnallocatedArm sends ARM to treasury contract", async function () {
       // Run crowdfund
-      await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
       { const ws = Number(await localCrowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+      await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);
@@ -846,8 +846,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
     it("full lifecycle: crowdfund → claim → delegate → propose → vote → execute", async function () {
       // Run crowdfund
-      await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
       { const ws = Number(await localCrowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+      await localCrowdfund.addSeeds(localSeeds.map(s => s.address));
 
       for (const seed of localSeeds) {
         const amount = USDC(15_000);

--- a/test/crowdfund_adversarial.ts
+++ b/test/crowdfund_adversarial.ts
@@ -80,6 +80,7 @@ describe("Crowdfund Adversarial", function () {
     const CROWDFUND_ARM_FUNDING = ARM(1_800_000);
     await armToken.transfer(await crowdfund.getAddress(), CROWDFUND_ARM_FUNDING);
     await crowdfund.loadArm();
+    await time.increaseTo(await crowdfund.windowStart());
   });
 
   // ============================================================
@@ -122,7 +123,7 @@ describe("Crowdfund Adversarial", function () {
     it("sum of allocations + refunds == totalCommitted (70 seeds, pro-rata)", async function () {
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       // All commit at max cap = 70 * $15K = $1.05M > MIN_SALE
       for (const s of seeds) {
@@ -188,7 +189,7 @@ describe("Crowdfund Adversarial", function () {
       // Setup: 70 seeds → each invites up to 3 hop-1 addresses
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       // Seeds invite hop-1 addresses (use signers 71-140)
       const hop1Addrs = allSigners.slice(71, 141);
@@ -239,7 +240,7 @@ describe("Crowdfund Adversarial", function () {
     it("contract ARM balance covers all allocations after finalization", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -260,7 +261,7 @@ describe("Crowdfund Adversarial", function () {
     it("after all claims, contract balances are non-negative", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -305,7 +306,7 @@ describe("Crowdfund Adversarial", function () {
   describe("Boundary Conditions", function () {
     it("commit exactly at hop cap succeeds", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       await fundAndApprove(allSigners[1], USDC(15_000));
       await crowdfund.connect(allSigners[1]).commit(0, USDC(15_000));
@@ -316,7 +317,7 @@ describe("Crowdfund Adversarial", function () {
 
     it("commit over hop cap succeeds (excess refunded at settlement)", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       await fundAndApprove(allSigners[1], USDC(15_010));
       await crowdfund.connect(allSigners[1]).commit(0, USDC(15_000));
@@ -339,7 +340,7 @@ describe("Crowdfund Adversarial", function () {
       // Let's use 66 seeds at $15K ($990K) + 1 seed at $10K ($10K) = $1,000,000
       const seeds = allSigners.slice(1, 68); // 67 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       // 66 seeds at $15K
       for (let i = 0; i < 66; i++) {
@@ -363,7 +364,7 @@ describe("Crowdfund Adversarial", function () {
       // 66 seeds at $15K = $990K. 1 seed at $9,999.999999 = $999,999.999999 < $1M
       const seeds = allSigners.slice(1, 68);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (let i = 0; i < 66; i++) {
         await fundAndApprove(seeds[i], USDC(15_000));
@@ -391,7 +392,7 @@ describe("Crowdfund Adversarial", function () {
       // Need 100 seeds at $15K each = $1,500,000
       const seeds = allSigners.slice(1, 101); // 100 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -412,7 +413,7 @@ describe("Crowdfund Adversarial", function () {
       // 99 seeds at $15K = $1,485,000. 1 seed at $14,999.999999
       const seeds = allSigners.slice(1, 101);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (let i = 0; i < 99; i++) {
         await fundAndApprove(seeds[i], USDC(15_000));
@@ -438,7 +439,7 @@ describe("Crowdfund Adversarial", function () {
       // there's no demand at those hops, unallocated capacity becomes treasury leftover.
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -459,7 +460,7 @@ describe("Crowdfund Adversarial", function () {
     it("finalize with all whitelisted but 0 committers reverts", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       // Nobody commits — just fast-forward through the active window
       await time.increase(THREE_WEEKS + 1);
@@ -472,7 +473,7 @@ describe("Crowdfund Adversarial", function () {
 
     it("commit below MIN_COMMIT ($10 USDC) reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       await fundAndApprove(allSigners[1], USDC(10));
 
@@ -495,7 +496,7 @@ describe("Crowdfund Adversarial", function () {
     it("seed self-invite creates a hop-1 node (permitted in multi-node model)", async function () {
       const seed = allSigners[1];
       await crowdfund.addSeeds([seed.address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       // Seed invites self — creates (seed, 1) node
       await crowdfund.connect(seed).invite(seed.address, 0);
@@ -507,11 +508,11 @@ describe("Crowdfund Adversarial", function () {
       const seed = allSigners[1];
       const invitee = allSigners[2];
       await crowdfund.addSeeds([seed.address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       const windowEnd = await crowdfund.windowEnd();
-      // Warp to exactly windowEnd — invite should fail (strict <)
-      await time.increaseTo(windowEnd);
+      // Warp past windowEnd — invite should fail
+      await time.increaseTo(windowEnd + 1n);
       await expect(
         crowdfund.connect(seed).invite(invitee.address, 0)
       ).to.be.revertedWith("ArmadaCrowdfund: window closed");
@@ -521,7 +522,7 @@ describe("Crowdfund Adversarial", function () {
       const seed = allSigners[1];
       const invitee = allSigners[2];
       await crowdfund.addSeeds([seed.address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       const windowEnd = await crowdfund.windowEnd();
       // Warp to 2 seconds before windowEnd — next tx executes at windowEnd - 1
@@ -535,7 +536,7 @@ describe("Crowdfund Adversarial", function () {
     it("commit succeeds at window start", async function () {
       const seed = allSigners[1];
       await crowdfund.addSeeds([seed.address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       await fundAndApprove(seed, USDC(100));
       await crowdfund.connect(seed).commit(0, USDC(100));
@@ -550,19 +551,41 @@ describe("Crowdfund Adversarial", function () {
   // ============================================================
 
   describe("Access Control & State Machine", function () {
-    it("commit before window start reverts", async function () {
-      await crowdfund.addSeeds([allSigners[1].address]);
+    it("commit outside active window reverts", async function () {
+      // Deploy a fresh crowdfund to test outside-window behavior.
+      // The shared beforeEach advances to windowStart, so we need an independent instance.
+      const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+      const futureOpen = (await time.latest()) + 600;
+      const freshCf = await ArmadaCrowdfund.deploy(
+        await usdc.getAddress(),
+        await armToken.getAddress(),
+        treasuryAddr.address,
+        deployer.address,
+        deployer.address,
+        futureOpen,
+        false
+      );
+      await freshCf.waitForDeployment();
+      await armToken.addToWhitelist(await freshCf.getAddress());
+      await armToken.transfer(await freshCf.getAddress(), ARM(1_800_000));
+      await freshCf.loadArm();
 
-      // Active window hasn't started yet
+      // Advance to windowStart so addSeeds works
+      await time.increaseTo(await freshCf.windowStart());
+      await freshCf.addSeeds([allSigners[1].address]);
+
+      // Advance past windowEnd so commit reverts
+      await time.increase(THREE_WEEKS + 1);
       await fundAndApprove(allSigners[1], USDC(15_000));
+      await usdc.connect(allSigners[1]).approve(await freshCf.getAddress(), USDC(15_000));
       await expect(
-        crowdfund.connect(allSigners[1]).commit(0, USDC(15_000))
+        freshCf.connect(allSigners[1]).commit(0, USDC(15_000))
       ).to.be.revertedWith("ArmadaCrowdfund: not active window");
     });
 
     it("invite after window ends reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       await time.increase(THREE_WEEKS + 1); // past active window
 
       await expect(
@@ -573,7 +596,7 @@ describe("Crowdfund Adversarial", function () {
     it("finalize before window ends reverts", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       await expect(
         crowdfund.finalize()
@@ -582,18 +605,18 @@ describe("Crowdfund Adversarial", function () {
 
     it("addSeeds after week 1 of active window reverts", async function () {
       await crowdfund.addSeeds([allSigners[1].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       await time.increase(ONE_WEEK + 1); // past launch team invite period
 
       await expect(
         crowdfund.addSeeds([allSigners[2].address])
-      ).to.be.revertedWith("ArmadaCrowdfund: seeds only before invite period ends");
+      ).to.be.revertedWith("ArmadaCrowdfund: outside week-1 window");
     });
 
     it("claim reverts when below minimum (should use claimRefund)", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       await fundAndApprove(seeds[0], USDC(15_000));
       await crowdfund.connect(seeds[0]).commit(0, USDC(15_000));
@@ -616,7 +639,7 @@ describe("Crowdfund Adversarial", function () {
     it("claimRefund when phase is Finalized (not refundMode) returns pro-rata refund", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -643,7 +666,7 @@ describe("Crowdfund Adversarial", function () {
     it("non-admin can finalize (permissionless)", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -659,7 +682,7 @@ describe("Crowdfund Adversarial", function () {
     it("non-admin can sweep unallocated ARM (permissionless)", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -675,7 +698,7 @@ describe("Crowdfund Adversarial", function () {
     it("withdrawUnallocatedArm second call reverts when nothing to sweep", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -733,7 +756,7 @@ describe("Crowdfund Adversarial", function () {
     it("non-participant cannot claim", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -755,7 +778,7 @@ describe("Crowdfund Adversarial", function () {
     it("whitelisted-but-uncommitted participant cannot claim", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       // Only first 69 seeds commit, seeds[69] does not
       for (let i = 0; i < 69; i++) {
@@ -791,7 +814,7 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 54); // 53 seeds (indices 1-53)
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       // Each of the first 52 seeds invites one hop-1 participant (signers 54-105)
       const hop1Invitees: SignerWithAddress[] = [];
@@ -843,7 +866,7 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 69); // 68 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -891,7 +914,7 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 71); // 70 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -925,7 +948,7 @@ describe("Crowdfund Adversarial", function () {
 
       const seeds = allSigners.slice(1, 54); // 53 seeds
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       const hop1Invitees: SignerWithAddress[] = [];
       for (let i = 0; i < 52; i++) {
@@ -971,7 +994,7 @@ describe("Crowdfund Adversarial", function () {
       // Deploy the attacker contract
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
@@ -998,7 +1021,7 @@ describe("Crowdfund Adversarial", function () {
     it("claimRefund() is protected by nonReentrant", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       await fundAndApprove(seeds[0], USDC(15_000));
       await crowdfund.connect(seeds[0]).commit(0, USDC(15_000));
@@ -1021,7 +1044,7 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of seeds) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -1044,7 +1067,7 @@ describe("Crowdfund Adversarial", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of seeds) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -1063,7 +1086,7 @@ describe("Crowdfund Adversarial", function () {
     it("commit() is protected by nonReentrant", async function () {
       // Verify commit guard by confirming correct behavior under normal conditions
       await crowdfund.addSeeds([allSigners[1].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       await fundAndApprove(allSigners[1], USDC(15_000));
       await crowdfund.connect(allSigners[1]).commit(0, USDC(10_000));

--- a/test/crowdfund_eager_allocation.ts
+++ b/test/crowdfund_eager_allocation.ts
@@ -42,6 +42,7 @@ describe("Eager Allocation at Finalization", function () {
     await armToken.addToWhitelist(await crowdfund.getAddress());
     await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
     await crowdfund.loadArm();
+    await time.increaseTo(await crowdfund.windowStart());
     return crowdfund;
   }
 
@@ -50,10 +51,6 @@ describe("Eager Allocation at Finalization", function () {
   async function setupFinalizableScenario(crowdfund: any, seedCount: number) {
     const seeds = allSigners.slice(5, 5 + seedCount);
     await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
-    {
-      const ws = Number(await crowdfund.windowStart());
-      if ((await time.latest()) < ws) await time.increaseTo(ws);
-    }
 
     // Seeds commit at hop 0
     for (const s of seeds) {
@@ -288,10 +285,7 @@ describe("Eager Allocation at Finalization", function () {
       // No hop-1 demand → totalAllocUsdc = $798K < $1M MIN_SALE → refundMode.
       const seeds = allSigners.slice(5, 85);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      {
-        const ws = Number(await crowdfund.windowStart());
-        if ((await time.latest()) < ws) await time.increaseTo(ws);
-      }
+
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000), crowdfund);
         await crowdfund.connect(s).commit(0, USDC(15_000));
@@ -488,10 +482,7 @@ describe("Eager Allocation at Finalization", function () {
       // Create refundMode scenario
       const seeds = allSigners.slice(5, 85);
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      {
-        const ws = Number(await crowdfund.windowStart());
-        if ((await time.latest()) < ws) await time.increaseTo(ws);
-      }
+
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000), crowdfund);
         await crowdfund.connect(s).commit(0, USDC(15_000));

--- a/test/crowdfund_eip712.ts
+++ b/test/crowdfund_eip712.ts
@@ -60,9 +60,9 @@ describe("Crowdfund EIP-712 Invites", function () {
 
   // Setup helper: add seeds and advance to window start
   async function setupWithSeeds(seeds: SignerWithAddress[]) {
-    await crowdfund.addSeeds(seeds.map((s) => s.address));
     const ws = Number(await crowdfund.windowStart());
     if ((await time.latest()) < ws) await time.increaseTo(ws);
+    await crowdfund.addSeeds(seeds.map((s) => s.address));
   }
 
   // Build an EIP-712 invite value object
@@ -127,6 +127,7 @@ describe("Crowdfund EIP-712 Invites", function () {
     const CROWDFUND_ARM_FUNDING = ARM(1_800_000);
     await armToken.transfer(await crowdfund.getAddress(), CROWDFUND_ARM_FUNDING);
     await crowdfund.loadArm();
+    await time.increaseTo(await crowdfund.windowStart());
 
     // Fund potential participants with USDC
     for (const signer of [seed1, seed2, hop1a, hop1b, hop1c, hop1d]) {
@@ -330,14 +331,17 @@ describe("Crowdfund EIP-712 Invites", function () {
       ).to.be.revertedWith("Pausable: paused");
     });
 
-    it("should revert before window start", async function () {
-      // Add seeds but do NOT advance time to window start
+    it("should revert after window end", async function () {
       await crowdfund.addSeeds([seed1.address]);
 
-      const deadline = (await time.latest()) + ONE_DAY;
+      const deadline = (await time.latest()) + 30 * ONE_DAY;
       const nonce = 1;
 
       const signature = await signInvite(seed1, hop1a.address, 0, nonce, deadline);
+
+      // Advance past window end
+      const THREE_WEEKS = 21 * ONE_DAY;
+      await time.increase(THREE_WEEKS + 1);
 
       await expect(
         crowdfund

--- a/test/crowdfund_integration.ts
+++ b/test/crowdfund_integration.ts
@@ -55,13 +55,12 @@ describe("Crowdfund Integration", function () {
     await usdc.connect(signer).approve(await crowdfund.getAddress(), amount);
   }
 
-  // Setup helper: add seeds and start the 3-week active window
+  // Setup helper: register seed addresses in the crowdfund
   async function setupWithSeeds(seeds: SignerWithAddress[]) {
     await crowdfund.addSeeds(seeds.map(s => s.address));
   }
 
-  // Setup through active phase: seeds added and time advanced to window start.
-  // Commits are permitted once the active window opens.
+  // Setup helper: register seeds (time advancement to windowStart handled by beforeEach)
   async function setupActive(seeds: SignerWithAddress[]) {
     await setupWithSeeds(seeds);
   }

--- a/test/crowdfund_integration.ts
+++ b/test/crowdfund_integration.ts
@@ -58,7 +58,6 @@ describe("Crowdfund Integration", function () {
   // Setup helper: add seeds and start the 3-week active window
   async function setupWithSeeds(seeds: SignerWithAddress[]) {
     await crowdfund.addSeeds(seeds.map(s => s.address));
-    { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
   }
 
   // Setup through active phase: seeds added and time advanced to window start.
@@ -114,6 +113,7 @@ describe("Crowdfund Integration", function () {
     const maxArm = CROWDFUND_ARM_FUNDING;
     await armToken.transfer(await crowdfund.getAddress(), maxArm);
     await crowdfund.loadArm();
+    await time.increaseTo(await crowdfund.windowStart());
 
     // Fund all potential participants with USDC
     for (const signer of [seed1, seed2, seed3, hop1a, hop1b, hop1c, hop2a, hop2b]) {
@@ -194,12 +194,12 @@ describe("Crowdfund Integration", function () {
 
     it("should reject adding seeds after week 1 of active window", async function () {
       await crowdfund.addSeed(seed1.address);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       // Seeds allowed during week 1; fast-forward past launchTeamInviteEnd
       await time.increase(ONE_WEEK + 1);
       await expect(
         crowdfund.addSeed(seed2.address)
-      ).to.be.revertedWith("ArmadaCrowdfund: seeds only before invite period ends");
+      ).to.be.revertedWith("ArmadaCrowdfund: outside week-1 window");
     });
   });
 
@@ -304,7 +304,10 @@ describe("Crowdfund Integration", function () {
       await freshCrowdfund.loadArm();
       expect(await freshCrowdfund.armLoaded()).to.be.true;
 
-      // 4. Add seeds — works now that ARM is loaded
+      // 4. Advance to window start
+      await time.increaseTo(await freshCrowdfund.windowStart());
+
+      // 5. Add seeds — works now that ARM is loaded and window is open
       await freshCrowdfund.addSeed(seed1.address);
       expect(await freshCrowdfund.isWhitelisted(seed1.address, 0)).to.be.true;
       expect(await freshCrowdfund.phase()).to.equal(Phase.Active);
@@ -318,7 +321,7 @@ describe("Crowdfund Integration", function () {
   describe("Active Window — Invitations", function () {
     it("should transition to active phase", async function () {
       await crowdfund.addSeed(seed1.address);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       expect(await crowdfund.phase()).to.equal(Phase.Active);
       expect(await crowdfund.windowEnd()).to.be.gt(0);
     });
@@ -630,7 +633,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of seeds) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -670,7 +673,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       // Each seed commits $15K, 80 seeds = $1.2M (above minimum, at base trigger)
       for (const s of seeds.slice(0, 68)) {
@@ -704,7 +707,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       // 70 seeds × $15K = $1,050,000 total committed (above min, below elastic trigger)
       for (const s of seeds.slice(0, 70)) {
@@ -740,7 +743,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
@@ -768,7 +771,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       // Only 68 seeds commit — hop-0 ceiling = 70% of $1.14M (netRaise) = $798K
       // 68 * $15K = $1.02M committed (above MIN_SALE), but all in hop-0
@@ -802,7 +805,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of seeds) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -866,7 +869,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of seeds.slice(0, 70)) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -892,7 +895,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -934,7 +937,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of committers) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -966,7 +969,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of committers) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -1001,7 +1004,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of seeds.slice(0, 70)) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -1062,7 +1065,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of seeds) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -1087,10 +1090,9 @@ describe("Crowdfund Integration", function () {
         );
         await armToken.transfer(await cf.getAddress(), ARM(1_800_000));
         await cf.loadArm();
+        await time.increaseTo(await cf.windowStart());
         const s = allSigners.slice(1, 81);
         await cf.addSeeds(s.map(a => a.address));
-        const ws = Number(await cf.windowStart());
-        if ((await time.latest()) < ws) await time.increaseTo(ws);
         for (const a of s) {
           await fundAndApprove(a, USDC(15_000));
           await usdc.connect(a).approve(await cf.getAddress(), USDC(15_000));
@@ -1143,15 +1145,15 @@ describe("Crowdfund Integration", function () {
         .to.emit(crowdfund, "RefundClaimed");
     });
 
-    it("normal-path claimRefund() enforces claimDeadline", async function () {
+    it("normal-path claimRefund() succeeds after claimDeadline (refunds never expire)", async function () {
       const seeds = await setupOversubscribed();
 
       const deadline = await crowdfund.claimDeadline();
       await time.increaseTo(deadline + 1n);
 
-      await expect(
-        crowdfund.connect(seeds[0]).claimRefund()
-      ).to.be.revertedWith("ArmadaCrowdfund: claim deadline passed");
+      // Refunds do not expire per spec — should succeed even after claim deadline
+      await expect(crowdfund.connect(seeds[0]).claimRefund())
+        .to.emit(crowdfund, "RefundClaimed");
     });
   });
 
@@ -1185,7 +1187,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -1203,7 +1205,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of seeds.slice(0, 68)) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -1231,7 +1233,7 @@ describe("Crowdfund Integration", function () {
 
       // Setup
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       // Invitations (some seeds invite hop-1 participants)
       // Use remaining signers for hop-1
@@ -1271,7 +1273,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
 
       for (const s of seeds) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
@@ -1342,7 +1344,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of seeds) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -1401,7 +1403,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of seeds) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -1487,6 +1489,7 @@ describe("Crowdfund Integration", function () {
       const freshAddr = await freshCrowdfund.getAddress();
       await armToken.transfer(freshAddr, ARM(1_800_000));
       await freshCrowdfund.loadArm();
+      await time.increaseTo(await freshCrowdfund.windowStart());
 
       // Setup and finalize — must approve USDC to freshCrowdfund (not the main one)
       const seeds = allSigners.slice(1, 71);
@@ -1495,7 +1498,6 @@ describe("Crowdfund Integration", function () {
         await usdc.connect(s).approve(freshAddr, USDC(15_000));
       }
       await freshCrowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await freshCrowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
       for (const s of seeds) {
         await freshCrowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -1558,7 +1560,7 @@ describe("Crowdfund Integration", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map(s => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
       for (const s of seeds) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }

--- a/test/crowdfund_launch_team.ts
+++ b/test/crowdfund_launch_team.ts
@@ -72,6 +72,7 @@ describe("Launch Team & Seed Cap", function () {
     const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
     await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
     await crowdfund.loadArm();
+    await time.increaseTo(await crowdfund.windowStart());
   });
 
   // ============ 150-Seed Cap ============
@@ -123,7 +124,7 @@ describe("Launch Team & Seed Cap", function () {
       [, , , invitee1, invitee2, seed1] = allSigners;
       // Add a seed and start the active window
       await crowdfund.addSeed(seed1.address);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
     });
 
     it("launch team can invite to hop-1", async function () {
@@ -165,7 +166,7 @@ describe("Launch Team & Seed Cap", function () {
       await time.increase(7 * ONE_DAY + 1);
       await expect(
         crowdfund.launchTeamInvite(invitee1.address, 0)
-      ).to.be.revertedWith("ArmadaCrowdfund: launch team invite window closed");
+      ).to.be.revertedWith("ArmadaCrowdfund: outside week-1 window");
     });
 
     it("invite graph shows launch team as inviter", async function () {
@@ -209,7 +210,7 @@ describe("Launch Team & Seed Cap", function () {
   describe("Budget Exhaustion", function () {
     beforeEach(async function () {
       await crowdfund.addSeed(allSigners[3].address);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
     });
 
     it("allows exactly 60 hop-1 invites", async function () {
@@ -272,7 +273,7 @@ describe("Launch Team & Seed Cap", function () {
   describe("7-Day Invite Window Timing", function () {
     beforeEach(async function () {
       await crowdfund.addSeed(allSigners[3].address);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
     });
 
     it("launch team invite on day 6 succeeds", async function () {
@@ -285,7 +286,7 @@ describe("Launch Team & Seed Cap", function () {
       await time.increase(7 * ONE_DAY + 1);
       await expect(
         crowdfund.launchTeamInvite(allSigners[4].address, 0)
-      ).to.be.revertedWith("ArmadaCrowdfund: launch team invite window closed");
+      ).to.be.revertedWith("ArmadaCrowdfund: outside week-1 window");
     });
 
     it("launch team invite at exactly 7 days reverts (boundary)", async function () {
@@ -293,7 +294,7 @@ describe("Launch Team & Seed Cap", function () {
       await time.increase(7 * ONE_DAY);
       await expect(
         crowdfund.launchTeamInvite(allSigners[4].address, 0)
-      ).to.be.revertedWith("ArmadaCrowdfund: launch team invite window closed");
+      ).to.be.revertedWith("ArmadaCrowdfund: outside week-1 window");
     });
 
     it("regular seed invites still work after week 1", async function () {
@@ -308,7 +309,7 @@ describe("Launch Team & Seed Cap", function () {
   describe("Launch Team Cannot Commit", function () {
     beforeEach(async function () {
       await crowdfund.addSeed(allSigners[3].address);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
     });
 
     it("launch team address cannot commit USDC", async function () {
@@ -338,7 +339,7 @@ describe("Launch Team & Seed Cap", function () {
 
       // Add launchTeam as a seed (launch team calls addSeed)
       await cf.connect(ltSigner).addSeed(ltSigner.address);
-      { const ws = Number(await cf.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+      await time.increaseTo(await cf.windowStart());
 
       // Fund the launch team address
       await fundAndApprove(ltSigner, USDC(15000));
@@ -356,7 +357,7 @@ describe("Launch Team & Seed Cap", function () {
     beforeEach(async function () {
       invitee = allSigners[4];
       await crowdfund.addSeed(allSigners[3].address);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
     });
 
     it("re-invite to same (address, hop) increments invitesReceived", async function () {
@@ -419,11 +420,11 @@ describe("Launch Team & Seed Cap", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: max invites received");
     });
 
-    it("emits InviteAdded on re-invite", async function () {
+    it("emits Invited on re-invite", async function () {
       await crowdfund.launchTeamInvite(invitee.address, 0);
       await expect(crowdfund.launchTeamInvite(invitee.address, 0))
-        .to.emit(crowdfund, "InviteAdded")
-        .withArgs(deployer.address, invitee.address, 1, 2);
+        .to.emit(crowdfund, "Invited")
+        .withArgs(deployer.address, invitee.address, 1, 0);
     });
   });
 

--- a/test/crowdfund_launch_team.ts
+++ b/test/crowdfund_launch_team.ts
@@ -337,9 +337,9 @@ describe("Launch Team & Seed Cap", function () {
       await armToken.transfer(await cf.getAddress(), ARM(1_800_000));
       await cf.loadArm();
 
-      // Add launchTeam as a seed (launch team calls addSeed)
-      await cf.connect(ltSigner).addSeed(ltSigner.address);
+      // Advance to window start, then add launchTeam as a seed
       await time.increaseTo(await cf.windowStart());
+      await cf.connect(ltSigner).addSeed(ltSigner.address);
 
       // Fund the launch team address
       await fundAndApprove(ltSigner, USDC(15000));

--- a/test/crowdfund_lifecycle.ts
+++ b/test/crowdfund_lifecycle.ts
@@ -84,6 +84,7 @@ describe("Crowdfund Full Lifecycle", function () {
     await armToken.addToWhitelist(await crowdfund.getAddress());
     await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
     await crowdfund.loadArm();
+    await time.increaseTo(await crowdfund.windowStart());
     return crowdfund;
   }
 
@@ -151,9 +152,7 @@ describe("Crowdfund Full Lifecycle", function () {
       const seedEvents = parseEvents(crowdfund, addSeedsReceipt, "SeedAdded");
       expect(seedEvents.length).to.equal(70);
 
-      // Advance to window start
-      const ws = Number(await crowdfund.windowStart());
-      await time.increaseTo(ws);
+      // deployCrowdfund() already advances to windowStart
 
       // ---- Week 1: Launch team invites ----
       // 3 hop-1 invites from launch team
@@ -581,8 +580,7 @@ describe("Crowdfund Full Lifecycle", function () {
       // At MAX_SALE, hop-0 ceiling ≈ $1.197M > MIN_SALE, so no hop-1 needed.
       const seeds = allSigners.slice(5, 105); // 100 seeds
       await crowdfund.addSeeds(seeds.map((s) => s.address));
-      const ws = Number(await crowdfund.windowStart());
-      await time.increaseTo(ws);
+      // deployCrowdfund() already advances to windowStart
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000), crowdfund);
@@ -641,8 +639,7 @@ describe("Crowdfund Full Lifecycle", function () {
       // is $798K. No hop-1 demand → totalAllocUsdc = $798K < MIN_SALE → refundMode.
       const seeds = allSigners.slice(5, 85); // 80 seeds
       await crowdfund.addSeeds(seeds.map((s) => s.address));
-      const ws = Number(await crowdfund.windowStart());
-      await time.increaseTo(ws);
+      // deployCrowdfund() already advances to windowStart
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000), crowdfund);
@@ -657,10 +654,10 @@ describe("Crowdfund Full Lifecycle", function () {
       expect(await crowdfund.phase()).to.equal(Phase.Finalized);
       expect(await crowdfund.refundMode()).to.be.true;
 
-      // Finalized event: zeros + refundMode=true
+      // Finalized event: saleSize set, zero allocations, refundMode=true
       const fEvents = parseEvents(crowdfund, receipt, "Finalized");
       expect(fEvents.length).to.equal(1);
-      expect(fEvents[0].args.saleSize).to.equal(0n);
+      expect(fEvents[0].args.saleSize).to.equal(BASE_SALE);
       expect(fEvents[0].args.allocatedArm).to.equal(0n);
       expect(fEvents[0].args.netProceeds).to.equal(0n);
       expect(fEvents[0].args.refundMode).to.be.true;
@@ -719,8 +716,7 @@ describe("Crowdfund Full Lifecycle", function () {
       // Setup: 10 seeds, some commits
       const seeds = allSigners.slice(5, 15);
       await crowdfund.addSeeds(seeds.map((s) => s.address));
-      const ws = Number(await crowdfund.windowStart());
-      await time.increaseTo(ws);
+      // deployCrowdfund() already advances to windowStart
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000), crowdfund);
@@ -777,8 +773,7 @@ describe("Crowdfund Full Lifecycle", function () {
       // Small commitments well below MIN_SALE
       const seeds = allSigners.slice(5, 8); // 3 seeds
       await crowdfund.addSeeds(seeds.map((s) => s.address));
-      const ws = Number(await crowdfund.windowStart());
-      await time.increaseTo(ws);
+      // deployCrowdfund() already advances to windowStart
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000), crowdfund);
@@ -819,8 +814,7 @@ describe("Crowdfund Full Lifecycle", function () {
       // Setup: 70 seeds + hop-1 demand for successful finalization
       const seeds = allSigners.slice(5, 75);
       await crowdfund.addSeeds(seeds.map((s) => s.address));
-      const ws = Number(await crowdfund.windowStart());
-      await time.increaseTo(ws);
+      // deployCrowdfund() already advances to windowStart
 
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000), crowdfund);

--- a/test/crowdfund_multinode.ts
+++ b/test/crowdfund_multinode.ts
@@ -34,7 +34,6 @@ describe("Crowdfund Multi-Node", function () {
 
   async function setupWithSeeds(seeds: SignerWithAddress[]) {
     await crowdfund.addSeeds(seeds.map(s => s.address));
-    { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
   }
 
   beforeEach(async function () {
@@ -66,6 +65,7 @@ describe("Crowdfund Multi-Node", function () {
 
     await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
     await crowdfund.loadArm();
+    await time.increaseTo(await crowdfund.windowStart());
 
     for (const signer of [seed1, seed2, seed3, alice, bob]) {
       await fundAndApprove(signer, USDC(50_000));
@@ -206,15 +206,15 @@ describe("Crowdfund Multi-Node", function () {
       expect(await crowdfund.getInvitesReceived(alice.address, 1)).to.equal(2);
     });
 
-    it("should emit InviteAdded on re-invite (not Invited)", async function () {
+    it("should emit Invited on re-invite", async function () {
       await setupWithSeeds([seed1, seed2]);
 
       await crowdfund.connect(seed1).invite(alice.address, 0);
 
-      // Second invite should emit InviteAdded
+      // Second invite should also emit Invited (spec: every invite edge emits Invited)
       await expect(crowdfund.connect(seed2).invite(alice.address, 0))
-        .to.emit(crowdfund, "InviteAdded")
-        .withArgs(seed2.address, alice.address, 1, 2);
+        .to.emit(crowdfund, "Invited")
+        .withArgs(seed2.address, alice.address, 1, 0);
     });
 
     it("should not duplicate participantNodes entry on re-invite", async function () {
@@ -423,7 +423,6 @@ describe("Crowdfund Multi-Node", function () {
       // Use many seeds to get above MIN_SALE
       const seeds = signers.slice(1, 80);
       await crowdfund.addSeeds(seeds.map((s: SignerWithAddress) => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
 
       // seed1 self-invites to hop-1
       await crowdfund.connect(seed1).invite(seed1.address, 0);

--- a/test/crowdfund_settlement.ts
+++ b/test/crowdfund_settlement.ts
@@ -35,7 +35,7 @@ describe("Crowdfund Settlement Rework", function () {
       await fundAndApprove(s, commitUsdc);
     }
     await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
-    { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+
     for (const s of seeds) {
       await crowdfund.connect(s).commit(0, commitUsdc);
     }
@@ -90,6 +90,7 @@ describe("Crowdfund Settlement Rework", function () {
 
     await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
     await crowdfund.loadArm();
+    await time.increaseTo(await crowdfund.windowStart());
   });
 
   // ============================================================
@@ -105,7 +106,7 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("security council can cancel during Active phase", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+  
       expect(await crowdfund.phase()).to.equal(Phase.Active);
 
       await crowdfund.connect(securityCouncil).cancel();
@@ -114,7 +115,7 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("security council can cancel after window but before finalize", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+  
       await time.increase(THREE_WEEKS + 1);
 
       // Window ended, but still Active phase
@@ -146,7 +147,7 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("after cancel: commit reverts", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+  
       await fundAndApprove(allSigners[5], USDC(15_000));
 
       await crowdfund.connect(securityCouncil).cancel();
@@ -158,7 +159,7 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("after cancel: finalize reverts", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+  
       await time.increase(THREE_WEEKS + 1);
 
       await crowdfund.connect(securityCouncil).cancel();
@@ -170,7 +171,7 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("after cancel: claimRefund works", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+  
       await fundAndApprove(allSigners[5], USDC(10_000));
       await crowdfund.connect(allSigners[5]).commit(0, USDC(10_000));
 
@@ -194,7 +195,7 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("emits Cancelled event", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+  
       await fundAndApprove(allSigners[5], USDC(10_000));
       await crowdfund.connect(allSigners[5]).commit(0, USDC(10_000));
 
@@ -208,7 +209,7 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("claimRefund reverts for whitelisted address with zero commitment", async function () {
       await crowdfund.addSeeds([allSigners[5].address, allSigners[6].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+  
       // allSigners[5] commits, allSigners[6] does not
       await fundAndApprove(allSigners[5], USDC(10_000));
       await crowdfund.connect(allSigners[5]).commit(0, USDC(10_000));
@@ -273,7 +274,7 @@ describe("Crowdfund Settlement Rework", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+  
       for (const s of seeds) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -313,22 +314,23 @@ describe("Crowdfund Settlement Rework", function () {
       expect(ev.args.refundMode).to.equal(false);
     });
 
-    it("emits Finalized event with zeros in refundMode", async function () {
+    it("emits Finalized event with saleSize but zero allocations in refundMode", async function () {
       // 80 seeds at hop-0 only → enters refundMode (hop-0 ceiling < MIN_SALE)
       const seeds = allSigners.slice(5, 85);
       for (const s of seeds) {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+  
       for (const s of seeds) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
       await time.increase(THREE_WEEKS + 1);
 
+      // saleSize is BASE_SALE ($1.2M) — capped demand $1.2M < ELASTIC_TRIGGER
       await expect(crowdfund.finalize())
         .to.emit(crowdfund, "Finalized")
-        .withArgs(0, 0, 0, true);
+        .withArgs(USDC(1_200_000), 0, 0, true);
     });
   });
 
@@ -373,7 +375,7 @@ describe("Crowdfund Settlement Rework", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+  
       for (const s of seeds) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -397,7 +399,7 @@ describe("Crowdfund Settlement Rework", function () {
         await fundAndApprove(s, USDC(15_000));
       }
       await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+  
       for (const s of seeds) {
         await crowdfund.connect(s).commit(0, USDC(15_000));
       }
@@ -499,7 +501,7 @@ describe("Crowdfund Settlement Rework", function () {
 
     it("after cancel: sweeps all ARM", async function () {
       await crowdfund.addSeeds([allSigners[5].address]);
-      { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+  
 
       await crowdfund.connect(securityCouncil).cancel();
 

--- a/test/gas_benchmark.ts
+++ b/test/gas_benchmark.ts
@@ -78,8 +78,8 @@ describe("Gas Benchmarks", function () {
 
         // Add seeds — all participants are hop-0 for simplicity
         const seeds = allSigners.slice(1, count + 1);
-        await crowdfund.addSeeds(seeds.map(s => s.address));
         { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+        await crowdfund.addSeeds(seeds.map(s => s.address));
 
         // Each seed commits $15K (max hop-0 cap)
         // Total: count * $15K. Need >= $1M (MIN_SALE) for finalize() to succeed.
@@ -197,8 +197,8 @@ describe("Gas Benchmarks", function () {
       await crowdfund.loadArm();
 
       const seeds = allSigners.slice(1, count + 1);
-      await crowdfund.addSeeds(seeds.map(s => s.address));
       { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+      await crowdfund.addSeeds(seeds.map(s => s.address));
 
       const commitAmount = USDC(15_000);
       for (const s of seeds) {
@@ -280,6 +280,7 @@ describe("Gas Benchmarks", function () {
         const ARM = (n: number) => ethers.parseUnits(n.toString(), 18);
         await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
         await crowdfund.loadArm();
+        await time.increaseTo(await crowdfund.windowStart());
 
         const seeds = allSigners.slice(1, batchSize + 1);
         const tx = await crowdfund.addSeeds(seeds.map(s => s.address));
@@ -328,8 +329,8 @@ describe("Gas Benchmarks", function () {
 
       const count = 100;
       const seeds = allSigners.slice(1, count + 1);
-      await crowdfund.addSeeds(seeds.map(s => s.address));
       { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+      await crowdfund.addSeeds(seeds.map(s => s.address));
 
       for (const s of seeds) {
         await usdc.mint(s.address, USDC(15_000));
@@ -584,8 +585,8 @@ describe("Gas Benchmarks", function () {
       await crowdfund.loadArm();
 
       const seeds = allSigners.slice(1, 4);
-      await crowdfund.addSeeds(seeds.map(s => s.address));
       { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+      await crowdfund.addSeeds(seeds.map(s => s.address));
 
       // Fund all seeds
       for (const s of seeds) {

--- a/test/governance_quiet_period.ts
+++ b/test/governance_quiet_period.ts
@@ -140,8 +140,8 @@ describe("Governance Quiet Period (T6.1)", function () {
 
   // Helper: run crowdfund to finalization (normal path — above MIN_SALE)
   async function finalizeCrowdfund() {
-    await crowdfund.addSeeds(seeds.map(s => s.address));
     { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+    await crowdfund.addSeeds(seeds.map(s => s.address));
 
     for (const seed of seeds) {
       const amount = USDC(15_000);
@@ -318,8 +318,8 @@ describe("Governance Quiet Period (T6.1)", function () {
       // Hop-0 ceiling = 70% × $1.2M = $840K. Demand $1.05M > $840K → pro-rata $840K.
       // No hop-1/2 participants → totalAllocUsdc = $840K < $1M → refundMode. ✓
       const refundSeeds = seeds.slice(0, 70);
-      await crowdfund.addSeeds(refundSeeds.map(s => s.address));
       { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
+      await crowdfund.addSeeds(refundSeeds.map(s => s.address));
 
       for (const seed of refundSeeds) {
         const amount = USDC(15_000);


### PR DESCRIPTION
## Summary

- Spec-to-code audit of `ArmadaCrowdfund.sol` against `CROWDFUND_SPEC.md` found 11 discrepancies
- This PR fixes the 8 that are straightforward; the remaining 3 require design decisions and are tracked as issues

### Contract fixes
- **#3** Emit `Invited` (not `InviteAdded`) for all invites including re-invites — removed `InviteAdded` event
- **#4** Gate `addSeed`/`launchTeamInvite` to `>= windowStart` (spec: "must not be called before the window is active")
- **#5** Require `armLoaded` in `invite()` (spec: ARM loaded is a precondition for invites)
- **#6** Remove `claimDeadline` from normal refund path (spec: "refunds do not expire")
- **#8** Use `<= windowEnd` for invite deadline, matching `commit()` boundary
- **#10** Emit actual `saleSize` in refundMode `Finalized` event (was emitting 0)
- **#11** Cache `_computeCappedDemand()` in `claimRefund` Path 4 (avoid O(N) per claim)
- **#15** Fix misleading `Phase.Canceled` enum comment

### Remaining issues (design decisions needed)
- #131 — INVITE_TYPEHASH signs invitee (address-targeted) vs spec's bearer credential model (critical)
- #132 — Rounding buffer strands dust USDC in contract permanently
- #133 — Pausable gates claimRefund, giving Security Council power spec doesn't grant

## Test plan
- [x] All 134 Hardhat crowdfund tests passing
- [x] All 363 Foundry tests passing
- [x] Updated error message expectations for renamed revert strings
- [x] Updated `Finalized` event assertions for refundMode path
- [x] Converted refund-deadline test to verify refunds succeed after deadline
- [x] All test setups advance to `windowStart` before `addSeeds`

🤖 Generated with [Claude Code](https://claude.com/claude-code)