### PR TITLE
test: add 15 security-critical crowdfund coverage gap tests

### DIFF
--- a/test/crowdfund_adversarial.ts
+++ b/test/crowdfund_adversarial.ts
@@ -779,6 +779,16 @@ describe("Crowdfund Adversarial", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: no commitment");
     });
 
+    it("launch team cannot commit via commit()", async function () {
+      // deployer IS launchTeam in this file's beforeEach
+      await crowdfund.addSeeds([deployer.address]);
+      await fundAndApprove(deployer, USDC(15_000));
+
+      await expect(
+        crowdfund.connect(deployer).commit(0, USDC(1_000))
+      ).to.be.revertedWith("ArmadaCrowdfund: launch team cannot commit");
+    });
+
     it("whitelisted-but-uncommitted participant cannot claim", async function () {
       const seeds = allSigners.slice(1, 71);
       await crowdfund.addSeeds(seeds.map(s => s.address));
@@ -990,7 +1000,78 @@ describe("Crowdfund Adversarial", function () {
   });
 
   // ============================================================
-  // 5. Double-Action Guards
+  // 5. Deadline Fallback Refund (Path 4)
+  // ============================================================
+
+  describe("Deadline Fallback Refund (Path 4)", function () {
+    it("full refund when window expired, not finalized, cappedDemand < MIN_SALE", async function () {
+      // 3 seeds commit $15K each = $45K (well below MIN_SALE $1M)
+      const seeds = allSigners.slice(1, 4);
+      await crowdfund.addSeeds(seeds.map(s => s.address));
+
+      for (const s of seeds) {
+        await fundAndApprove(s, USDC(15_000));
+        await crowdfund.connect(s).commit(0, USDC(15_000));
+      }
+
+      // Advance past windowEnd — do NOT call finalize
+      await time.increase(THREE_WEEKS + 1);
+
+      const usdcBefore = await usdc.balanceOf(seeds[0].address);
+      await crowdfund.connect(seeds[0]).claimRefund();
+      const usdcAfter = await usdc.balanceOf(seeds[0].address);
+
+      expect(usdcAfter - usdcBefore).to.equal(USDC(15_000));
+    });
+
+    it("deadline fallback reverts when cappedDemand >= MIN_SALE (sale should finalize)", async function () {
+      // 70 seeds commit $15K = $1.05M, plus 51 hop-1 at $4K → cappedDemand > MIN_SALE
+      const seeds = allSigners.slice(1, 71);
+      await crowdfund.addSeeds(seeds.map(s => s.address));
+
+      for (const s of seeds) {
+        await fundAndApprove(s, USDC(15_000));
+        await crowdfund.connect(s).commit(0, USDC(15_000));
+      }
+
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 191));
+
+      // Advance past windowEnd — do NOT call finalize
+      await time.increase(THREE_WEEKS + 1);
+
+      // Path 4 correctly rejects when the sale could succeed
+      await expect(
+        crowdfund.connect(seeds[0]).claimRefund()
+      ).to.be.revertedWith("ArmadaCrowdfund: refund not available");
+    });
+
+    it("deadline fallback computes cappedDemand lazily and caches it", async function () {
+      // 3 seeds commit small amounts, advance past windowEnd
+      const seeds = allSigners.slice(1, 4);
+      await crowdfund.addSeeds(seeds.map(s => s.address));
+
+      for (const s of seeds) {
+        await fundAndApprove(s, USDC(15_000));
+        await crowdfund.connect(s).commit(0, USDC(15_000));
+      }
+
+      await time.increase(THREE_WEEKS + 1);
+
+      // First claimRefund triggers _computeCappedDemand()
+      await crowdfund.connect(seeds[0]).claimRefund();
+      const cappedDemandAfter = await crowdfund.cappedDemand();
+      expect(cappedDemandAfter).to.be.gt(0);
+
+      // Second claimRefund also succeeds (uses cached value)
+      const usdcBefore = await usdc.balanceOf(seeds[1].address);
+      await crowdfund.connect(seeds[1]).claimRefund();
+      const usdcAfter = await usdc.balanceOf(seeds[1].address);
+      expect(usdcAfter - usdcBefore).to.equal(USDC(15_000));
+    });
+  });
+
+  // ============================================================
+  // 6. Double-Action Guards
   // ============================================================
 
   describe("Double-Action Guards", function () {

--- a/test/crowdfund_eip712.ts
+++ b/test/crowdfund_eip712.ts
@@ -34,6 +34,8 @@ describe("Crowdfund EIP-712 Invites", function () {
   let hop1d: SignerWithAddress;
   let treasury: SignerWithAddress;
   let outsider: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let allSigners: SignerWithAddress[];
 
   // EIP-712 domain (set after deploy)
   let domain: {
@@ -93,8 +95,8 @@ describe("Crowdfund EIP-712 Invites", function () {
   }
 
   beforeEach(async function () {
-    const allSigners = await ethers.getSigners();
-    [deployer, seed1, seed2, hop1a, hop1b, hop1c, hop1d, treasury, outsider] =
+    allSigners = await ethers.getSigners();
+    [deployer, seed1, seed2, hop1a, hop1b, hop1c, hop1d, treasury, outsider, alice] =
       allSigners;
 
     // Deploy MockUSDCV2
@@ -130,7 +132,7 @@ describe("Crowdfund EIP-712 Invites", function () {
     await time.increaseTo(await crowdfund.windowStart());
 
     // Fund potential participants with USDC
-    for (const signer of [seed1, seed2, hop1a, hop1b, hop1c, hop1d]) {
+    for (const signer of [seed1, seed2, hop1a, hop1b, hop1c, hop1d, alice]) {
       await fundAndApprove(signer, USDC(20_000));
     }
 
@@ -348,6 +350,89 @@ describe("Crowdfund EIP-712 Invites", function () {
           .connect(hop1a)
           .commitWithInvite(seed1.address, 0, nonce, deadline, signature, USDC(1_000))
       ).to.be.revertedWith("ArmadaCrowdfund: not active window");
+    });
+
+    it("should succeed with fromHop=1 (hop-1 inviter to hop-2 invitee)", async function () {
+      // seed1 (hop-0) invites hop1a at hop-1 via direct invite
+      await setupWithSeeds([seed1]);
+      await crowdfund.connect(seed1).invite(hop1a.address, 0);
+
+      // hop1a (hop-1) signs EIP-712 invite for hop1b to join at hop-2
+      const deadline = await futureDeadline();
+      const nonce = 1;
+      const signature = await signInvite(hop1a, hop1b.address, 1, nonce, deadline);
+
+      const commitAmount = USDC(500);
+      await crowdfund
+        .connect(hop1b)
+        .commitWithInvite(hop1a.address, 1, nonce, deadline, signature, commitAmount);
+
+      // Verify hop1b is whitelisted at hop-2 with correct commitment
+      expect(await crowdfund.isWhitelisted(hop1b.address, 2)).to.be.true;
+      expect(await crowdfund.getCommitment(hop1b.address, 2)).to.equal(commitAmount);
+    });
+
+    it("should revert with fromHop=2 (hop-2 cannot invite further)", async function () {
+      // Create a hop-2 address: seed1 → hop1a (hop-1) → hop1b (hop-2)
+      await setupWithSeeds([seed1]);
+      await crowdfund.connect(seed1).invite(hop1a.address, 0);
+      await crowdfund.connect(hop1a).invite(hop1b.address, 1);
+
+      // hop1b (hop-2) signs invite with fromHop=2
+      const deadline = await futureDeadline();
+      const nonce = 1;
+      const signature = await signInvite(hop1b, hop1c.address, 2, nonce, deadline);
+
+      // Contract checks fromHop < NUM_HOPS - 1 (i.e., fromHop < 2)
+      await expect(
+        crowdfund
+          .connect(hop1c)
+          .commitWithInvite(hop1b.address, 2, nonce, deadline, signature, USDC(500))
+      ).to.be.revertedWith("ArmadaCrowdfund: max hop reached");
+    });
+
+    it("should revert when caller is launchTeam", async function () {
+      // seed1 signs invite for deployer (who is launchTeam)
+      await setupWithSeeds([seed1]);
+      const deadline = await futureDeadline();
+      const nonce = 1;
+      const signature = await signInvite(seed1, deployer.address, 0, nonce, deadline);
+
+      await fundAndApprove(deployer, USDC(1_000));
+
+      // The invite registration whitelists deployer at hop-1, then
+      // commit() fires require(msg.sender != launchTeam)
+      await expect(
+        crowdfund
+          .connect(deployer)
+          .commitWithInvite(seed1.address, 0, nonce, deadline, signature, USDC(1_000))
+      ).to.be.revertedWith("ArmadaCrowdfund: launch team cannot commit");
+    });
+
+    it("should revert when invitee already at maxInvitesReceived", async function () {
+      // Hop-1 maxInvitesReceived=10. Use 11 seeds: first 10 invite alice, 11th fails.
+      const seeds = allSigners.slice(10, 21); // 11 seeds
+      await setupWithSeeds(seeds);
+
+      // 10 seeds invite alice to hop-1 via direct invite (saturates maxInvitesReceived)
+      for (let i = 0; i < 10; i++) {
+        await crowdfund.connect(seeds[i]).invite(alice.address, 0);
+      }
+      expect(await crowdfund.getInvitesReceived(alice.address, 1)).to.equal(10);
+
+      // 11th seed signs EIP-712 invite for alice
+      const deadline = await futureDeadline();
+      const nonce = 1;
+      const signature = await signInvite(seeds[10], alice.address, 0, nonce, deadline);
+
+      await fundAndApprove(alice, USDC(1_000));
+
+      // Should revert: alice already at maxInvitesReceived for hop-1
+      await expect(
+        crowdfund
+          .connect(alice)
+          .commitWithInvite(seeds[10].address, 0, nonce, deadline, signature, USDC(1_000))
+      ).to.be.revertedWith("ArmadaCrowdfund: max invites received");
     });
   });
 

--- a/test/crowdfund_multinode.ts
+++ b/test/crowdfund_multinode.ts
@@ -192,6 +192,91 @@ describe("Crowdfund Multi-Node", function () {
   });
 
   // ============================================================
+  // Invite Stacking Economics
+  // ============================================================
+
+  describe("Invite Stacking Economics", function () {
+    it("should increment invitesReceived on each re-invite from different inviters", async function () {
+      await setupWithSeeds([seed1, seed2, seed3]);
+
+      await crowdfund.connect(seed1).invite(alice.address, 0);
+      expect(await crowdfund.getInvitesReceived(alice.address, 1)).to.equal(1);
+
+      await crowdfund.connect(seed2).invite(alice.address, 0);
+      expect(await crowdfund.getInvitesReceived(alice.address, 1)).to.equal(2);
+
+      await crowdfund.connect(seed3).invite(alice.address, 0);
+      expect(await crowdfund.getInvitesReceived(alice.address, 1)).to.equal(3);
+    });
+
+    it("should scale effective cap linearly: invitesReceived * capUsdc", async function () {
+      await setupWithSeeds([seed1, seed2, seed3]);
+
+      await crowdfund.connect(seed1).invite(alice.address, 0);
+      expect(await crowdfund.getEffectiveCap(alice.address, 1)).to.equal(USDC(4_000));
+
+      await crowdfund.connect(seed2).invite(alice.address, 0);
+      expect(await crowdfund.getEffectiveCap(alice.address, 1)).to.equal(USDC(8_000));
+
+      await crowdfund.connect(seed3).invite(alice.address, 0);
+      expect(await crowdfund.getEffectiveCap(alice.address, 1)).to.equal(USDC(12_000));
+    });
+
+    it("should scale outgoing invite budget linearly: invitesReceived * maxInvites", async function () {
+      await setupWithSeeds([seed1, seed2, seed3]);
+
+      // Hop-1 maxInvites=2, so budget = invitesReceived * 2
+      await crowdfund.connect(seed1).invite(alice.address, 0);
+      expect(await crowdfund.getInvitesRemaining(alice.address, 1)).to.equal(2);
+
+      await crowdfund.connect(seed2).invite(alice.address, 0);
+      expect(await crowdfund.getInvitesRemaining(alice.address, 1)).to.equal(4);
+
+      await crowdfund.connect(seed3).invite(alice.address, 0);
+      expect(await crowdfund.getInvitesRemaining(alice.address, 1)).to.equal(6);
+    });
+
+    it("should allow commit at stacked cap through finalization to claim", async function () {
+      const signers = await ethers.getSigners();
+
+      // 3 seeds invite alice to hop-1 (cap = 3 * $4K = $12K)
+      await setupWithSeeds([seed1, seed2, seed3]);
+      await crowdfund.connect(seed1).invite(alice.address, 0);
+      await crowdfund.connect(seed2).invite(alice.address, 0);
+      await crowdfund.connect(seed3).invite(alice.address, 0);
+
+      // Alice commits $12K at her stacked cap
+      await crowdfund.connect(alice).commit(1, USDC(12_000));
+
+      // Add enough seeds + hop-1 demand to avoid refundMode
+      const extraSeeds = signers.slice(10, 80);
+      await crowdfund.addSeeds(extraSeeds.map((s: SignerWithAddress) => s.address));
+      for (const s of extraSeeds) {
+        await fundAndApprove(s, USDC(15_000));
+        await crowdfund.connect(s).commit(0, USDC(15_000));
+      }
+
+      // Add hop-1 demand to push totalAllocUsdc above MIN_SALE
+      const hop1Pool = signers.slice(140, 191);
+      for (let i = 0; i < 51; i++) {
+        await crowdfund.connect(extraSeeds[i]).invite(hop1Pool[i].address, 0);
+        await fundAndApprove(hop1Pool[i], USDC(4_000));
+        await crowdfund.connect(hop1Pool[i]).commit(1, USDC(4_000));
+      }
+
+      await time.increase(THREE_WEEKS + 1);
+      await crowdfund.finalize();
+      expect(await crowdfund.refundMode()).to.equal(false);
+
+      // Alice claims ARM — stacking → commit → settlement → claim end-to-end
+      const armBefore = await armToken.balanceOf(alice.address);
+      await crowdfund.connect(alice).claim(ethers.ZeroAddress);
+      const armAfter = await armToken.balanceOf(alice.address);
+      expect(armAfter - armBefore).to.be.gt(0);
+    });
+  });
+
+  // ============================================================
   // Re-Invite (Subsequent Invites to Same Node)
   // ============================================================
 
@@ -296,6 +381,13 @@ describe("Crowdfund Multi-Node", function () {
       await expect(
         crowdfund.connect(hop1Addrs[20]).invite(alice.address, 1)
       ).to.be.revertedWith("ArmadaCrowdfund: max invites received");
+    });
+
+    it("hop-0 nodes always have invitesReceived=1 (cannot be re-invited)", async function () {
+      await setupWithSeeds([seed1]);
+      // Hop-0 seeds are added with invitesReceived=1; there is no mechanism to
+      // increase it because invite() targets inviterHop+1, so hop-0 can never be the target.
+      expect(await crowdfund.getInvitesReceived(seed1.address, 0)).to.equal(1);
     });
 
     it("different hops enforce different caps", async function () {

--- a/test/crowdfund_settlement.ts
+++ b/test/crowdfund_settlement.ts
@@ -416,6 +416,57 @@ describe("Crowdfund Settlement Rework", function () {
   });
 
   // ============================================================
+  // claim() Refund Mode Guard
+  // ============================================================
+
+  describe("claim() Refund Mode Guard", function () {
+    it("claim() reverts when refundMode is true", async function () {
+      // 80 seeds at hop-0 only → hop-0 ceiling $798K < MIN_SALE → refundMode = true
+      const seeds = allSigners.slice(5, 85);
+      for (const s of seeds) {
+        await fundAndApprove(s, USDC(15_000));
+      }
+      await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
+
+      for (const s of seeds) {
+        await crowdfund.connect(s).commit(0, USDC(15_000));
+      }
+      await time.increase(THREE_WEEKS + 1);
+      await crowdfund.finalize();
+
+      // Verify we're in refundMode
+      expect(await crowdfund.refundMode()).to.be.true;
+
+      // claim() should revert — if this guard were missing, users could drain ARM
+      await expect(
+        crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress)
+      ).to.be.revertedWith("ArmadaCrowdfund: sale in refund mode");
+    });
+
+    it("claimRefund() succeeds when refundMode is true (counterpart)", async function () {
+      // Same refundMode setup
+      const seeds = allSigners.slice(5, 85);
+      for (const s of seeds) {
+        await fundAndApprove(s, USDC(15_000));
+      }
+      await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
+
+      for (const s of seeds) {
+        await crowdfund.connect(s).commit(0, USDC(15_000));
+      }
+      await time.increase(THREE_WEEKS + 1);
+      await crowdfund.finalize();
+      expect(await crowdfund.refundMode()).to.be.true;
+
+      // claimRefund should return full committed amount
+      const usdcBefore = await usdc.balanceOf(seeds[0].address);
+      await crowdfund.connect(seeds[0]).claimRefund();
+      const usdcAfter = await usdc.balanceOf(seeds[0].address);
+      expect(usdcAfter - usdcBefore).to.equal(USDC(15_000));
+    });
+  });
+
+  // ============================================================
   // T4.8 — Multi-Window withdrawUnallocatedArm
   // ============================================================
 


### PR DESCRIPTION
## Summary
- **Phase 2** of the crowdfund test audit: adds 15 tests across 4 files covering security-critical contract paths that previously had zero coverage
- **Stream A** (`crowdfund_multinode.ts`): Invite stacking economics (incremental cap/budget scaling, end-to-end claim) + hop-0 belt-and-suspenders
- **Stream B** (`crowdfund_eip712.ts`): `commitWithInvite` adversarial paths — hop-1→hop-2, hop-2 rejection, launchTeam guard, maxInvitesReceived via EIP-712
- **Stream C** (`crowdfund_adversarial.ts`): Launch team commit guard + deadline fallback refund (path 4) — full refund below MIN_SALE, rejection above MIN_SALE, lazy cappedDemand caching
- **Stream D** (`crowdfund_settlement.ts`): `claim()` reverts in refundMode, `claimRefund()` succeeds in refundMode

## Test plan
- [x] `npm run test:crowdfund` — 137 passing, 1 pending (pre-existing)
- [x] Each new test verified against the contract guard it exercises
- [x] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)