### PR TITLE
test: add correctness coverage gap tests (Phase 3)

### DIFF
--- a/test-foundry/CrowdfundFullInvariant.t.sol
+++ b/test-foundry/CrowdfundFullInvariant.t.sol
@@ -31,6 +31,7 @@ contract CrowdfundFullHandler is Test {
     uint256 public ghost_totalUsdcIn;
     mapping(address => uint256) public ghost_committed;
     mapping(address => uint8) public ghost_hop;
+    uint8[] public ghost_hopForEntry;
     bool public ghost_finalized;
     bool public ghost_canceled;
     bool public ghost_refundMode;
@@ -81,6 +82,7 @@ contract CrowdfundFullHandler is Test {
             if (ghost_committed[seed] == amount) {
                 allCommitters.push(seed);
                 ghost_hop[seed] = 0;
+                ghost_hopForEntry.push(0);
             }
         } catch {}
         vm.stopPrank();
@@ -112,6 +114,7 @@ contract CrowdfundFullHandler is Test {
             if (ghost_committed[addr] == amount) {
                 allCommitters.push(addr);
                 ghost_hop[addr] = 1;
+                ghost_hopForEntry.push(1);
             }
         } catch {}
         vm.stopPrank();
@@ -143,6 +146,7 @@ contract CrowdfundFullHandler is Test {
             if (ghost_committed[addr] == amount) {
                 allCommitters.push(addr);
                 ghost_hop[addr] = 2;
+                ghost_hopForEntry.push(2);
             }
         } catch {}
         vm.stopPrank();
@@ -174,6 +178,10 @@ contract CrowdfundFullHandler is Test {
 
     function getCommitter(uint256 idx) external view returns (address) {
         return allCommitters[idx];
+    }
+
+    function getHopForEntry(uint256 idx) external view returns (uint8) {
+        return ghost_hopForEntry[idx];
     }
 }
 
@@ -315,7 +323,7 @@ contract CrowdfundFullInvariantTest is Test {
         uint256 count = handler.getCommittersCount();
         for (uint256 i = 0; i < count; i++) {
             address committer = handler.getCommitter(i);
-            uint8 hop = handler.ghost_hop(committer);
+            uint8 hop = handler.getHopForEntry(i);
             uint256 committed = crowdfund.getCommitment(committer, hop);
             uint256 effectiveCap = crowdfund.getEffectiveCap(committer, hop);
 
@@ -332,6 +340,7 @@ contract CrowdfundFullInvariantTest is Test {
 
     /// @notice After finalization, allocArm and refundUsdc from the contract are consistent
     ///         with each other and with the participant's committed amount.
+    ///         Uses per-(address, hop) tuple tracking to handle multi-hop participants.
     function invariant_allocPlusRefundEqualsCommitted() public view {
         if (!handler.ghost_finalized()) return;
         if (handler.ghost_refundMode()) return; // no allocations in refundMode
@@ -339,7 +348,7 @@ contract CrowdfundFullInvariantTest is Test {
         uint256 count = handler.getCommittersCount();
         for (uint256 i = 0; i < count; i++) {
             address committer = handler.getCommitter(i);
-            uint8 hop = handler.ghost_hop(committer);
+            uint8 hop = handler.getHopForEntry(i);
             uint256 committed = crowdfund.getCommitment(committer, hop);
 
             if (committed == 0) continue;

--- a/test-foundry/CrowdfundInvariant.t.sol
+++ b/test-foundry/CrowdfundInvariant.t.sol
@@ -39,6 +39,8 @@ contract CrowdfundHandler is Test {
     mapping(address => uint256) public ghost_committed;
     // Track each committer's hop for API calls that require it
     mapping(address => uint8) public ghost_hop;
+    // Per-(address, hop) tuple tracking for multi-hop participants
+    uint8[] public ghost_hopForEntry;
 
     constructor(
         ArmadaCrowdfund _crowdfund,
@@ -90,6 +92,7 @@ contract CrowdfundHandler is Test {
             if (ghost_committed[seed] == amount) {
                 allCommitters.push(seed);
                 ghost_hop[seed] = 0;
+                ghost_hopForEntry.push(0);
             }
         } catch {}
         vm.stopPrank();
@@ -121,6 +124,7 @@ contract CrowdfundHandler is Test {
             if (ghost_committed[addr] == amount) {
                 allCommitters.push(addr);
                 ghost_hop[addr] = 1;
+                ghost_hopForEntry.push(1);
             }
         } catch {}
         vm.stopPrank();
@@ -152,6 +156,7 @@ contract CrowdfundHandler is Test {
             if (ghost_committed[addr] == amount) {
                 allCommitters.push(addr);
                 ghost_hop[addr] = 2;
+                ghost_hopForEntry.push(2);
             }
         } catch {}
         vm.stopPrank();
@@ -244,6 +249,10 @@ contract CrowdfundHandler is Test {
 
     function getCommitter(uint256 idx) external view returns (address) {
         return allCommitters[idx];
+    }
+
+    function getHopForEntry(uint256 idx) external view returns (uint8) {
+        return ghost_hopForEntry[idx];
     }
 }
 
@@ -376,11 +385,11 @@ contract CrowdfundInvariantTest is Test {
         uint256 count = handler.getCommittersCount();
         for (uint256 i = 0; i < count; i++) {
             address committer = handler.getCommitter(i);
-            (uint256 allocArm, uint256 refundUsdc, bool claimed) = crowdfund.getAllocation(committer);
-            if (!claimed && allocArm == 0) continue; // not yet allocated
-
-            uint8 hop = handler.ghost_hop(committer);
+            uint8 hop = handler.getHopForEntry(i);
             uint256 committed = crowdfund.getCommitment(committer, hop);
+            if (committed == 0) continue;
+
+            (, uint256 refundUsdc, ) = crowdfund.getAllocationAtHop(committer, hop);
             // allocUsdc = committed - refund, which must be <= committed
             uint256 allocUsdc = committed - refundUsdc;
             assertLe(allocUsdc, committed, "Allocation exceeds commitment");
@@ -408,7 +417,7 @@ contract CrowdfundInvariantTest is Test {
         uint256 count = handler.getCommittersCount();
         for (uint256 i = 0; i < count; i++) {
             address committer = handler.getCommitter(i);
-            uint8 hop = handler.ghost_hop(committer);
+            uint8 hop = handler.getHopForEntry(i);
             uint256 committed = crowdfund.getCommitment(committer, hop);
             uint256 effectiveCap = crowdfund.getEffectiveCap(committer, hop);
 
@@ -426,6 +435,7 @@ contract CrowdfundInvariantTest is Test {
 
     /// @notice After finalization, allocArm and refundUsdc from the contract are consistent
     ///         with each other and with the participant's committed amount.
+    ///         Uses per-(address, hop) tuple tracking to handle multi-hop participants.
     function invariant_allocPlusRefundEqualsCommitted() public view {
         if (!handler.ghost_finalized()) return;
         if (handler.ghost_refundMode()) return; // no allocations in refundMode
@@ -433,7 +443,7 @@ contract CrowdfundInvariantTest is Test {
         uint256 count = handler.getCommittersCount();
         for (uint256 i = 0; i < count; i++) {
             address committer = handler.getCommitter(i);
-            uint8 hop = handler.ghost_hop(committer);
+            uint8 hop = handler.getHopForEntry(i);
             uint256 committed = crowdfund.getCommitment(committer, hop);
 
             if (committed == 0) continue;

--- a/test/crowdfund_adversarial.ts
+++ b/test/crowdfund_adversarial.ts
@@ -461,6 +461,38 @@ describe("Crowdfund Adversarial", function () {
       expect(uc2).to.equal(0);
     });
 
+    it("ELASTIC_TRIGGER boundary uses cappedDemand not totalCommitted (over-cap commits ignored)", async function () {
+      // Construct a scenario where totalCommitted >= $1.5M but cappedDemand < $1.5M.
+      // 99 seeds × $15K = $1,485K (all at cap, cappedDemand from seeds = $1,485K).
+      // 3 hop-1 participants commit $6K each (over $4K cap by $2K).
+      // totalCommitted = $1,485K + $18K = $1,503K >= ELASTIC_TRIGGER ($1.5M)
+      // cappedDemand = $1,485K + 3×$4K = $1,497K < ELASTIC_TRIGGER ($1.5M)
+      const seeds = allSigners.slice(1, 100); // 99 seeds
+      await crowdfund.addSeeds(seeds.map(s => s.address));
+
+      for (const s of seeds) {
+        await fundAndApprove(s, USDC(15_000));
+        await crowdfund.connect(s).commit(0, USDC(15_000));
+      }
+
+      // 3 hop-1 participants commit $6K each (over $4K cap)
+      for (let i = 0; i < 3; i++) {
+        const hop1Addr = allSigners[140 + i];
+        await crowdfund.connect(seeds[i]).invite(hop1Addr.address, 0);
+        await fundAndApprove(hop1Addr, USDC(6_000));
+        await crowdfund.connect(hop1Addr).commit(1, USDC(6_000));
+      }
+
+      await time.increase(THREE_WEEKS + 1);
+      await crowdfund.finalize();
+
+      const cappedDemandVal = await crowdfund.cappedDemand();
+      expect(cappedDemandVal).to.be.lt(USDC(1_500_000));
+
+      // Expansion should NOT trigger — saleSize remains BASE_SALE
+      expect(await crowdfund.saleSize()).to.equal(USDC(1_200_000));
+    });
+
     it("finalize with all whitelisted but 0 committers reverts", async function () {
       const seeds = allSigners.slice(1, 4);
       await crowdfund.addSeeds(seeds.map(s => s.address));
@@ -723,6 +755,55 @@ describe("Crowdfund Adversarial", function () {
       await expect(
         crowdfund.withdrawUnallocatedArm()
       ).to.be.revertedWith("ArmadaCrowdfund: nothing to sweep");
+    });
+
+    it("pro-rata refund amounts match getAllocation exactly for each participant", async function () {
+      const seeds = allSigners.slice(1, 71);
+      await crowdfund.addSeeds(seeds.map(s => s.address));
+
+      for (const s of seeds) {
+        await fundAndApprove(s, USDC(15_000));
+        await crowdfund.connect(s).commit(0, USDC(15_000));
+      }
+
+      await addHop1ForMinSale(seeds.slice(0, 51), allSigners.slice(140, 191));
+
+      await time.increase(THREE_WEEKS + 1);
+      await crowdfund.finalize();
+
+      // Verify exact refund amounts for 5 representative seeds
+      for (let i = 0; i < 5; i++) {
+        const [, refundUsdc] = await crowdfund.getAllocation(seeds[i].address);
+        const usdcBefore = await usdc.balanceOf(seeds[i].address);
+        await crowdfund.connect(seeds[i]).claimRefund();
+        const usdcAfter = await usdc.balanceOf(seeds[i].address);
+        expect(usdcAfter - usdcBefore).to.equal(refundUsdc);
+      }
+    });
+
+    it("withdrawUnallocatedArm reverts in Active phase", async function () {
+      await crowdfund.addSeeds([allSigners[1].address]);
+
+      await fundAndApprove(allSigners[1], USDC(15_000));
+      await crowdfund.connect(allSigners[1]).commit(0, USDC(15_000));
+
+      // Phase is still Active (window not ended, not finalized)
+      expect(await crowdfund.phase()).to.equal(Phase.Active);
+
+      await expect(
+        crowdfund.withdrawUnallocatedArm()
+      ).to.be.revertedWith("ArmadaCrowdfund: not finalized or canceled");
+    });
+
+    it("launch team cannot commit via commit()", async function () {
+      // deployer IS launchTeam in this file's beforeEach
+      await crowdfund.addSeeds([deployer.address]);
+
+      await fundAndApprove(deployer, USDC(1_000));
+
+      await expect(
+        crowdfund.connect(deployer).commit(0, USDC(1_000))
+      ).to.be.revertedWith("ArmadaCrowdfund: launch team cannot commit");
     });
 
     it("constructor rejects zero treasury address", async function () {

--- a/test/crowdfund_eager_allocation.ts
+++ b/test/crowdfund_eager_allocation.ts
@@ -495,4 +495,59 @@ describe("Eager Allocation at Finalization", function () {
         .to.be.revertedWith("ArmadaCrowdfund: refund mode");
     });
   });
+
+  // ============================================================
+  // Settlement Mode Equivalence
+  // ============================================================
+
+  describe("Settlement Mode Equivalence", function () {
+    it("phased and single-tx modes produce identical allocations for same scenario", async function () {
+      const cfSingleTx = await deployCrowdfund(false);
+      const cfPhased = await deployCrowdfund(true);
+
+      // Run identical scenarios on both instances
+      const { seeds: seedsST, hop1Invitees: hop1ST } = await setupFinalizableScenario(cfSingleTx, 70);
+      const { seeds: seedsP, hop1Invitees: hop1P } = await setupFinalizableScenario(cfPhased, 70);
+
+      await time.increase(THREE_WEEKS + 1);
+
+      // Finalize both
+      await cfSingleTx.finalize();
+      await cfPhased.finalize();
+
+      // For phased: complete settlement event emission
+      const nodeCount = Number(await cfPhased.getParticipantCount());
+      await cfPhased.emitSettlement(0, nodeCount);
+
+      // Compare allocations for all seed participants
+      for (let i = 0; i < seedsST.length; i++) {
+        const addr = seedsST[i].address;
+        const armST = await cfSingleTx.addressArmAllocation(addr);
+        const armP = await cfPhased.addressArmAllocation(addr);
+        expect(armST).to.equal(armP, `ARM allocation mismatch for seed ${i}`);
+
+        const refundST = await cfSingleTx.addressRefundAmount(addr);
+        const refundP = await cfPhased.addressRefundAmount(addr);
+        expect(refundST).to.equal(refundP, `Refund mismatch for seed ${i}`);
+      }
+
+      // Compare allocations for hop-1 participants
+      for (let i = 0; i < hop1ST.length; i++) {
+        const addr = hop1ST[i].address;
+        const armST = await cfSingleTx.addressArmAllocation(addr);
+        const armP = await cfPhased.addressArmAllocation(addr);
+        expect(armST).to.equal(armP, `ARM allocation mismatch for hop1 ${i}`);
+
+        const refundST = await cfSingleTx.addressRefundAmount(addr);
+        const refundP = await cfPhased.addressRefundAmount(addr);
+        expect(refundST).to.equal(refundP, `Refund mismatch for hop1 ${i}`);
+      }
+
+      // Compare aggregate values
+      expect(await cfSingleTx.totalAllocated()).to.equal(await cfPhased.totalAllocated());
+      expect(await cfSingleTx.totalAllocatedUsdc()).to.equal(await cfPhased.totalAllocatedUsdc());
+      expect(await cfSingleTx.saleSize()).to.equal(await cfPhased.saleSize());
+      expect(await cfSingleTx.treasuryLeftoverUsdc()).to.equal(await cfPhased.treasuryLeftoverUsdc());
+    });
+  });
 });

--- a/test/crowdfund_settlement.ts
+++ b/test/crowdfund_settlement.ts
@@ -416,6 +416,47 @@ describe("Crowdfund Settlement Rework", function () {
   });
 
   // ============================================================
+  // Full USDC Token Flow Conservation
+  // ============================================================
+
+  describe("Full USDC Token Flow Conservation", function () {
+    it("absolute USDC flow: treasury delta + sum(refunds) + residual == totalCommitted", async function () {
+      const treasuryBefore = await usdc.balanceOf(treasury.address);
+      const seeds = await setupAndFinalize(80, USDC(15_000));
+      const treasuryAfter = await usdc.balanceOf(treasury.address);
+      const treasuryDelta = treasuryAfter - treasuryBefore;
+
+      // Collect hop-1 invitees (same pattern as setupAndFinalize)
+      const hop1Pool = allSigners.slice(140, 195);
+      const inviterCount = Math.min(80, 18);
+      const hop1Invitees: HardhatEthersSigner[] = [];
+      for (let i = 0; i < inviterCount; i++) {
+        for (let j = 0; j < 3 && (i * 3 + j) < hop1Pool.length; j++) {
+          hop1Invitees.push(hop1Pool[i * 3 + j]);
+        }
+      }
+
+      // All participants claim refunds, tracking actual USDC received
+      let sumRefundsPaid = 0n;
+      const allParticipants = [...seeds, ...hop1Invitees];
+      for (const p of allParticipants) {
+        const before = await usdc.balanceOf(p.address);
+        await crowdfund.connect(p).claimRefund();
+        const after = await usdc.balanceOf(p.address);
+        sumRefundsPaid += (after - before);
+      }
+
+      const residual = await usdc.balanceOf(await crowdfund.getAddress());
+      const totalCommitted = await crowdfund.totalCommitted();
+
+      // Conservation: every USDC deposited is accounted for
+      expect(treasuryDelta + sumRefundsPaid + residual).to.equal(totalCommitted);
+      // Contract should have only dust remaining
+      expect(residual).to.be.lte(USDC(1));
+    });
+  });
+
+  // ============================================================
   // claim() Refund Mode Guard
   // ============================================================
 
@@ -548,6 +589,31 @@ describe("Crowdfund Settlement Rework", function () {
 
       expect(treasuryAfter - treasuryBefore).to.equal(armBalance);
       expect(await armToken.balanceOf(await crowdfund.getAddress())).to.equal(0);
+    });
+
+    it("after refundMode finalization: sweeps all ARM (armStillOwed = 0)", async function () {
+      // 80 seeds at hop-0 only (no hop-1 demand) → hop-0 ceiling < MIN_SALE → refundMode
+      const seeds = allSigners.slice(5, 85);
+      for (const s of seeds) {
+        await fundAndApprove(s, USDC(15_000));
+      }
+      await crowdfund.addSeeds(seeds.map((s: HardhatEthersSigner) => s.address));
+
+      for (const s of seeds) {
+        await crowdfund.connect(s).commit(0, USDC(15_000));
+      }
+      await time.increase(THREE_WEEKS + 1);
+      await crowdfund.finalize();
+
+      expect(await crowdfund.phase()).to.equal(Phase.Finalized);
+      expect(await crowdfund.refundMode()).to.be.true;
+
+      // In refundMode, armStillOwed = 0, so full ARM balance is sweepable
+      const treasuryBefore = await armToken.balanceOf(treasury.address);
+      await crowdfund.withdrawUnallocatedArm();
+      const treasuryAfter = await armToken.balanceOf(treasury.address);
+
+      expect(treasuryAfter - treasuryBefore).to.equal(ARM(1_800_000));
     });
 
     it("after cancel: sweeps all ARM", async function () {


### PR DESCRIPTION
## Summary
- **P3-1**: Absolute USDC token flow conservation test — verifies `treasury delta + sum(refunds) + residual == totalCommitted`
- **P3-2**: Settlement mode equivalence — confirms phased and single-tx modes produce identical allocations, refunds, and aggregates
- **P3-3**: ELASTIC_TRIGGER boundary — constructs divergence between `totalCommitted` and `cappedDemand` via over-cap hop-1 commits, proving expansion uses `cappedDemand`
- **P3-4**: Exact pro-rata refund assertions — verifies `claimRefund()` returns exactly `getAllocation().refundUsdc` for 5 representative participants
- **P3-5**: `withdrawUnallocatedArm` reverts in Active phase (guards against pre-settlement ARM drain)
- **P3-6**: `withdrawUnallocatedArm` in refundMode+Finalized sweeps all ARM (distinct from Cancel path)
- **P3-7**: Multi-hop ghost tracking in Foundry invariant handlers — `ghost_hopForEntry[]` parallel array ensures invariants check per-(address, hop) tuples
- **S4.1**: Launch team commit guard test

## Test plan
- [x] `npx hardhat test test/crowdfund_settlement.ts` — 36 passing
- [x] `npx hardhat test test/crowdfund_adversarial.ts` — 51 passing
- [x] `npx hardhat test test/crowdfund_eager_allocation.ts` — 20 passing
- [x] `forge test --match-contract "CrowdfundInvariant|CrowdfundFullInvariant"` — 14 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)