### PR TITLE
test: Phase 4 Foundry advanced tests

### DIFF
--- a/test-foundry/ArmadaCrowdfundRefundMode.t.sol
+++ b/test-foundry/ArmadaCrowdfundRefundMode.t.sol
@@ -212,53 +212,44 @@ contract ArmadaCrowdfundRefundModeTest is Test {
 
     // ============ Fuzz: claimRefund returns exact committed amount ============
 
-    /// @notice Fuzz: in refundMode, each participant's claimRefund returns their exact deposit
+    /// @notice Fuzz: in refundMode, each participant's claimRefund returns their exact deposit.
+    ///         All 80 seeds commit (79 at $15K, 1 at fuzzed amount) to guarantee cappedDemand
+    ///         is in [MIN_SALE, ELASTIC_TRIGGER), which always triggers refundMode at BASE_SALE
+    ///         because hop-0 ceiling ($798K) < MIN_SALE ($1M).
     function testFuzz_claimRefund_exactAmount(uint256 seedIdx, uint256 commitAmount) public {
-        // Only use first 100 seeds (already set up)
         seedIdx = bound(seedIdx, 0, seeds.length - 1);
-        commitAmount = bound(commitAmount, 10 * 1e6, 15_000 * 1e6); // MIN_COMMIT to hop-0 cap
+        commitAmount = bound(commitAmount, 10 * 1e6, 15_000 * 1e6);
 
-        // Commit the fuzzed amount from one seed
+        // All non-target seeds commit full $15K to guarantee cappedDemand >= MIN_SALE
+        for (uint256 i = 0; i < seeds.length; i++) {
+            if (i == seedIdx) continue;
+            uint256 amount = 15_000 * 1e6;
+            usdc.mint(seeds[i], amount);
+            vm.startPrank(seeds[i]);
+            usdc.approve(address(crowdfund), amount);
+            crowdfund.commit(0, amount);
+            vm.stopPrank();
+        }
+
+        // Commit the fuzzed amount from the target seed
         usdc.mint(seeds[seedIdx], commitAmount);
         vm.startPrank(seeds[seedIdx]);
         usdc.approve(address(crowdfund), commitAmount);
         crowdfund.commit(0, commitAmount);
         vm.stopPrank();
 
-        // Need enough total to pass MIN_SALE for finalize to not revert.
-        // Commit from remaining seeds to reach MIN_SALE.
-        uint256 totalSoFar = commitAmount;
-        for (uint256 i = 0; i < seeds.length && totalSoFar < MIN_SALE; i++) {
-            if (i == seedIdx) continue;
-            uint256 amount = 15_000 * 1e6;
-            if (totalSoFar + amount > 1_400_000 * 1e6) {
-                // Cap total at $1.4M to stay at BASE_SALE (below ELASTIC_TRIGGER)
-                // and maximize chance of refundMode
-                amount = 1_400_000 * 1e6 - totalSoFar;
-                if (amount < 10 * 1e6) break;
-            }
-            usdc.mint(seeds[i], amount);
-            vm.startPrank(seeds[i]);
-            usdc.approve(address(crowdfund), amount);
-            crowdfund.commit(0, amount);
-            vm.stopPrank();
-            totalSoFar += amount;
-        }
-
         vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
 
-        // Try to finalize. If refundMode triggers, verify exact refund.
-        try crowdfund.finalize() {
-            if (crowdfund.refundMode()) {
-                uint256 balBefore = usdc.balanceOf(seeds[seedIdx]);
-                vm.prank(seeds[seedIdx]);
-                crowdfund.claimRefund();
-                uint256 balAfter = usdc.balanceOf(seeds[seedIdx]);
-                assertEq(balAfter - balBefore, commitAmount, "Refund should be exact committed amount");
-            }
-        } catch {
-            // finalize reverted (below MIN_SALE) — not a refundMode scenario
-        }
+        // 80 seeds × max $15K = $1.2M cappedDemand < ELASTIC_TRIGGER ($1.5M)
+        // → saleSize = BASE_SALE → hop-0 ceiling = $798K < MIN_SALE → refundMode guaranteed
+        assertTrue(crowdfund.refundMode(), "Must be in refund mode with only hop-0 at BASE_SALE");
+
+        uint256 balBefore = usdc.balanceOf(seeds[seedIdx]);
+        vm.prank(seeds[seedIdx]);
+        crowdfund.claimRefund();
+        uint256 balAfter = usdc.balanceOf(seeds[seedIdx]);
+        assertEq(balAfter - balBefore, commitAmount, "Refund must equal exact committed amount");
     }
 
     // ============ Permissionless finalize ============

--- a/test-foundry/CrowdfundDonation.t.sol
+++ b/test-foundry/CrowdfundDonation.t.sol
@@ -1,0 +1,177 @@
+// ABOUTME: Tests that direct token donations (bypassing commit/loadArm) don't corrupt accounting.
+// ABOUTME: Verifies totalCommitted, allocation math, and ARM sweep are unaffected by donations.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/crowdfund/ArmadaCrowdfund.sol";
+import "../contracts/crowdfund/IArmadaCrowdfund.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/cctp/MockUSDCV2.sol";
+
+contract CrowdfundDonationTest is Test {
+    ArmadaCrowdfund public crowdfund;
+    MockUSDCV2 public usdc;
+    ArmadaToken public armToken;
+    address public admin;
+    address public treasury;
+
+    uint256 constant ARM_FUNDING = 1_800_000 * 1e18;
+
+    address[] public seeds;
+
+    function setUp() public {
+        admin = address(this);
+        treasury = address(0xCAFE);
+
+        usdc = new MockUSDCV2("Mock USDC", "USDC");
+        armToken = new ArmadaToken(admin, admin);
+        crowdfund = new ArmadaCrowdfund(
+            address(usdc),
+            address(armToken),
+            treasury,
+            admin,
+            admin,
+            block.timestamp,
+            false
+        );
+
+        address[] memory wl = new address[](2);
+        wl[0] = admin;
+        wl[1] = address(crowdfund);
+        armToken.initWhitelist(wl);
+
+        armToken.transfer(address(crowdfund), ARM_FUNDING);
+        crowdfund.loadArm();
+
+        // 80 seeds — enough to reach MIN_SALE threshold for finalization tests
+        for (uint256 i = 0; i < 80; i++) {
+            seeds.push(address(uint160(0xA000 + i)));
+        }
+        crowdfund.addSeeds(seeds);
+    }
+
+    /// @notice Helper: each seed commits full $15K at hop-0
+    function _allSeedsCommitFull() internal {
+        for (uint256 i = 0; i < seeds.length; i++) {
+            uint256 amount = 15_000 * 1e6;
+            usdc.mint(seeds[i], amount);
+            vm.startPrank(seeds[i]);
+            usdc.approve(address(crowdfund), amount);
+            crowdfund.commit(0, amount);
+            vm.stopPrank();
+        }
+    }
+
+    // ============ Donation Attack Tests ============
+
+    /// @notice Direct USDC transfer to contract does not change totalCommitted
+    function test_directUsdcTransfer_doesNotChangeCommitAccounting() public {
+        // One seed commits normally
+        uint256 commitAmt = 15_000 * 1e6;
+        usdc.mint(seeds[0], commitAmt);
+        vm.startPrank(seeds[0]);
+        usdc.approve(address(crowdfund), commitAmt);
+        crowdfund.commit(0, commitAmt);
+        vm.stopPrank();
+
+        uint256 totalBefore = crowdfund.totalCommitted();
+        assertEq(totalBefore, commitAmt);
+
+        // Donate USDC directly (bypassing commit)
+        uint256 donationAmt = 100_000 * 1e6;
+        usdc.mint(address(crowdfund), donationAmt);
+
+        // totalCommitted must be unaffected
+        assertEq(crowdfund.totalCommitted(), totalBefore, "totalCommitted must not change from donation");
+        // But the raw balance increased
+        assertEq(
+            usdc.balanceOf(address(crowdfund)),
+            commitAmt + donationAmt,
+            "USDC balance should reflect both commit and donation"
+        );
+    }
+
+    /// @notice Direct ARM transfer after finalization does not change allocation math
+    function test_directArmTransfer_doesNotAffectAllocationMath() public {
+        // Need a successful (non-refundMode) finalization for allocations to exist.
+        // Use 53 seeds at hop-0 + 53 hop-1 participants to exceed MIN_SALE.
+        for (uint256 i = 0; i < 53; i++) {
+            uint256 amount = 15_000 * 1e6;
+            usdc.mint(seeds[i], amount);
+            vm.startPrank(seeds[i]);
+            usdc.approve(address(crowdfund), amount);
+            crowdfund.commit(0, amount);
+            vm.stopPrank();
+        }
+
+        // Create hop-1 participants via seed invites
+        address[] memory hop1Addrs = new address[](53);
+        for (uint256 i = 0; i < 53; i++) {
+            hop1Addrs[i] = address(uint160(0xB000 + i));
+            vm.prank(seeds[i]);
+            crowdfund.invite(hop1Addrs[i], 0);
+        }
+
+        for (uint256 i = 0; i < 53; i++) {
+            uint256 amount = 4_000 * 1e6;
+            usdc.mint(hop1Addrs[i], amount);
+            vm.startPrank(hop1Addrs[i]);
+            usdc.approve(address(crowdfund), amount);
+            crowdfund.commit(1, amount);
+            vm.stopPrank();
+        }
+
+        vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
+        assertFalse(crowdfund.refundMode());
+
+        // Record allocations before ARM donation
+        uint256 totalAllocBefore = crowdfund.totalAllocated();
+        uint256 seed0AllocArm = crowdfund.addressArmAllocation(seeds[0]);
+        assertTrue(totalAllocBefore > 0, "Must have allocations");
+
+        // Donate extra ARM directly to the contract
+        uint256 extraArm = 100_000 * 1e18;
+        armToken.transfer(address(crowdfund), extraArm);
+
+        // Allocations must be unchanged
+        assertEq(crowdfund.totalAllocated(), totalAllocBefore, "totalAllocated must not change");
+        assertEq(crowdfund.addressArmAllocation(seeds[0]), seed0AllocArm, "Per-address allocation must not change");
+    }
+
+    /// @notice withdrawUnallocatedArm captures donated ARM alongside unallocated ARM
+    function test_withdrawUnallocatedArm_capturesDonatedArm() public {
+        // Use refundMode scenario: all 80 seeds commit hop-0, refundMode triggers
+        _allSeedsCommitFull();
+        vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
+        assertTrue(crowdfund.refundMode(), "Must be in refund mode");
+
+        // Donate extra ARM directly
+        uint256 extraArm = 50_000 * 1e18;
+        armToken.transfer(address(crowdfund), extraArm);
+
+        // In refundMode, armStillOwed = 0, so all ARM (funding + donation) is sweepable
+        uint256 treasuryBefore = armToken.balanceOf(treasury);
+        crowdfund.withdrawUnallocatedArm();
+        uint256 treasuryAfter = armToken.balanceOf(treasury);
+
+        assertEq(
+            treasuryAfter - treasuryBefore,
+            ARM_FUNDING + extraArm,
+            "Sweep must capture both original funding and donated ARM"
+        );
+    }
+
+    /// @notice ARM sweep still requires Finalized/Canceled phase even with USDC donation
+    function test_donatedUsdc_doesNotEnablePrematureSweep() public {
+        // Donate USDC directly while still in Active phase
+        usdc.mint(address(crowdfund), 500_000 * 1e6);
+
+        // withdrawUnallocatedArm should still revert — phase is Active
+        vm.expectRevert("ArmadaCrowdfund: not finalized or canceled");
+        crowdfund.withdrawUnallocatedArm();
+    }
+}

--- a/test-foundry/CrowdfundElasticFuzz.t.sol
+++ b/test-foundry/CrowdfundElasticFuzz.t.sol
@@ -113,6 +113,9 @@ contract CrowdfundElasticFuzzTest is Test {
         vm.warp(cf.windowEnd() + 1);
         cf.finalize();
 
+        // Assert directly on cappedDemand: must be exactly 100 × $15K, not inflated by the $20K
+        assertEq(cf.cappedDemand(), 100 * HOP0_CAP, "Over-cap commit must not inflate cappedDemand");
+
         // cappedDemand = 100 × $15K = $1,500,000 = ELASTIC_TRIGGER → MAX_SALE
         assertEq(cf.saleSize(), MAX_SALE, "Capped demand at exact trigger should use MAX_SALE");
 

--- a/test-foundry/CrowdfundElasticFuzz.t.sol
+++ b/test-foundry/CrowdfundElasticFuzz.t.sol
@@ -1,0 +1,199 @@
+// ABOUTME: Fuzz tests for the elastic expansion boundary at ELASTIC_TRIGGER ($1.5M).
+// ABOUTME: Verifies saleSize is BASE_SALE or MAX_SALE based on cappedDemand threshold.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/crowdfund/ArmadaCrowdfund.sol";
+import "../contracts/crowdfund/IArmadaCrowdfund.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/cctp/MockUSDCV2.sol";
+
+contract CrowdfundElasticFuzzTest is Test {
+    MockUSDCV2 public usdc;
+    ArmadaToken public armToken;
+    address public admin;
+    address public treasury;
+
+    uint256 constant ARM_FUNDING = 1_800_000 * 1e18;
+    uint256 constant BASE_SALE = 1_200_000 * 1e6;
+    uint256 constant MAX_SALE  = 1_800_000 * 1e6;
+    uint256 constant MIN_SALE  = 1_000_000 * 1e6;
+    uint256 constant ELASTIC_TRIGGER = 1_500_000 * 1e6;
+    uint256 constant HOP0_CAP = 15_000 * 1e6;
+    uint256 constant HOP1_CAP = 4_000 * 1e6;
+    uint256 constant HOP2_CAP = 1_000 * 1e6;
+    uint256 constant MIN_COMMIT = 10 * 1e6;
+
+    function setUp() public {
+        admin = address(this);
+        treasury = address(0xCAFE);
+
+        usdc = new MockUSDCV2("Mock USDC", "USDC");
+        armToken = new ArmadaToken(admin, admin);
+
+        address[] memory wl = new address[](1);
+        wl[0] = admin;
+        armToken.initWhitelist(wl);
+    }
+
+    /// @notice Deploy a fresh crowdfund with a given number of seeds
+    function _deployCrowdfund(uint256 numSeeds) internal returns (ArmadaCrowdfund cf, address[] memory seeds) {
+        cf = new ArmadaCrowdfund(
+            address(usdc), address(armToken), treasury, admin, admin, block.timestamp, false
+        );
+        armToken.transfer(address(cf), ARM_FUNDING);
+        cf.loadArm();
+
+        seeds = new address[](numSeeds);
+        for (uint256 i = 0; i < numSeeds; i++) {
+            seeds[i] = address(uint160(0xD000 + i));
+        }
+        cf.addSeeds(seeds);
+        return (cf, seeds);
+    }
+
+    /// @notice Helper: commit a specific amount for a seed
+    function _commitAs(ArmadaCrowdfund cf, address who, uint8 hop, uint256 amount) internal {
+        usdc.mint(who, amount);
+        vm.startPrank(who);
+        usdc.approve(address(cf), amount);
+        cf.commit(hop, amount);
+        vm.stopPrank();
+    }
+
+    // ============ Deterministic Boundary Tests ============
+
+    /// @notice 99 seeds × $15K = $1,485,000 < ELASTIC_TRIGGER → BASE_SALE
+    function test_elasticExpansion_justBelow_usesBaseSale() public {
+        (ArmadaCrowdfund cf, address[] memory seeds) = _deployCrowdfund(99);
+        for (uint256 i = 0; i < 99; i++) {
+            _commitAs(cf, seeds[i], 0, HOP0_CAP);
+        }
+
+        vm.warp(cf.windowEnd() + 1);
+        cf.finalize();
+
+        assertEq(cf.saleSize(), BASE_SALE, "Just below trigger should use BASE_SALE");
+    }
+
+    /// @notice 100 seeds × $15K = $1,500,000 = ELASTIC_TRIGGER → MAX_SALE
+    function test_elasticExpansion_atExactThreshold_usesMaxSale() public {
+        (ArmadaCrowdfund cf, address[] memory seeds) = _deployCrowdfund(100);
+        for (uint256 i = 0; i < 100; i++) {
+            _commitAs(cf, seeds[i], 0, HOP0_CAP);
+        }
+
+        vm.warp(cf.windowEnd() + 1);
+        cf.finalize();
+
+        assertEq(cf.saleSize(), MAX_SALE, "At exact trigger should use MAX_SALE");
+    }
+
+    /// @notice Over-cap commits are capped in cappedDemand calculation.
+    ///         99 seeds at $15K + 1 seed at $20K (over-cap) = cappedDemand of $1,500,000
+    ///         because the $20K is capped to $15K. Without the extra, 99 × $15K = $1,485K < trigger.
+    ///         With 100 seeds total (one over-cap), cappedDemand = 100 × $15K = $1,500K → MAX_SALE.
+    function test_elasticExpansion_overCapCommit_doesNotInflateCappedDemand() public {
+        // 99 seeds × $15K = $1,485,000.
+        // Add one more seed committing $20K (over the $15K cap).
+        // cappedDemand should be 99 × $15K + min($20K, $15K) = $1,500,000 = trigger.
+        // If over-cap inflated cappedDemand, it would be $1,505,000 — but it must not.
+        (ArmadaCrowdfund cf, address[] memory seeds) = _deployCrowdfund(100);
+        for (uint256 i = 0; i < 99; i++) {
+            _commitAs(cf, seeds[i], 0, HOP0_CAP);
+        }
+        // Last seed commits over cap — $20K exceeds $15K hop-0 cap
+        _commitAs(cf, seeds[99], 0, 20_000 * 1e6);
+
+        // totalCommitted includes the full $20K
+        assertEq(cf.totalCommitted(), 99 * HOP0_CAP + 20_000 * 1e6);
+
+        vm.warp(cf.windowEnd() + 1);
+        cf.finalize();
+
+        // cappedDemand = 100 × $15K = $1,500,000 = ELASTIC_TRIGGER → MAX_SALE
+        assertEq(cf.saleSize(), MAX_SALE, "Capped demand at exact trigger should use MAX_SALE");
+
+        // Verify that reducing to 99 seeds would have stayed below trigger
+        // (this is structural — 99 × $15K = $1,485K < $1,500K)
+        assertTrue(99 * HOP0_CAP < ELASTIC_TRIGGER, "99 seeds alone should be below trigger");
+    }
+
+    // ============ Fuzz Tests ============
+
+    /// @notice Fuzz seeds-only: varying number of seeds and commit amounts
+    function testFuzz_elasticExpansion_seedsOnly(uint256 numSeeds, uint256 commitPerSeed) public {
+        numSeeds = bound(numSeeds, 1, 150);
+        commitPerSeed = bound(commitPerSeed, MIN_COMMIT, HOP0_CAP);
+
+        uint256 expectedCappedDemand = _min(commitPerSeed, HOP0_CAP) * numSeeds;
+
+        // Skip runs where finalize would revert (below MIN_SALE)
+        vm.assume(expectedCappedDemand >= MIN_SALE);
+
+        (ArmadaCrowdfund cf, address[] memory seeds) = _deployCrowdfund(numSeeds);
+        for (uint256 i = 0; i < numSeeds; i++) {
+            _commitAs(cf, seeds[i], 0, commitPerSeed);
+        }
+
+        vm.warp(cf.windowEnd() + 1);
+        cf.finalize();
+
+        if (expectedCappedDemand >= ELASTIC_TRIGGER) {
+            assertEq(cf.saleSize(), MAX_SALE, "Above trigger must use MAX_SALE");
+        } else {
+            assertEq(cf.saleSize(), BASE_SALE, "Below trigger must use BASE_SALE");
+        }
+    }
+
+    /// @notice Fuzz mixed hops: seeds invite hop-1 participants, varying commits across hops.
+    ///         Seeds always commit full cap to guarantee MIN_SALE is reachable; hop-1 commit
+    ///         amount is fuzzed to explore the elastic trigger boundary.
+    function testFuzz_elasticExpansion_mixedHops(
+        uint256 numHop0,
+        uint256 numHop1,
+        uint256 commitH1
+    ) public {
+        // Need at least 67 seeds at $15K to reach MIN_SALE ($1,005,000 > $1M)
+        numHop0 = bound(numHop0, 67, 120);
+        numHop1 = bound(numHop1, 0, 20);
+        commitH1 = bound(commitH1, MIN_COMMIT, HOP1_CAP);
+
+        // Limit hop-1 to not exceed hop-0 count (each seed invites at most one hop-1)
+        if (numHop1 > numHop0) numHop1 = numHop0;
+
+        uint256 expectedCappedDemand =
+            HOP0_CAP * numHop0 +
+            _min(commitH1, HOP1_CAP) * numHop1;
+
+        (ArmadaCrowdfund cf, address[] memory seeds) = _deployCrowdfund(numHop0);
+
+        // Seeds commit full cap at hop-0
+        for (uint256 i = 0; i < numHop0; i++) {
+            _commitAs(cf, seeds[i], 0, HOP0_CAP);
+        }
+
+        // Seeds invite hop-1 participants, who then commit
+        for (uint256 i = 0; i < numHop1; i++) {
+            address hop1Addr = address(uint160(0xE000 + i));
+            vm.prank(seeds[i]);
+            cf.invite(hop1Addr, 0);
+            _commitAs(cf, hop1Addr, 1, commitH1);
+        }
+
+        vm.warp(cf.windowEnd() + 1);
+        cf.finalize();
+
+        if (expectedCappedDemand >= ELASTIC_TRIGGER) {
+            assertEq(cf.saleSize(), MAX_SALE, "Above trigger must use MAX_SALE");
+        } else {
+            assertEq(cf.saleSize(), BASE_SALE, "Below trigger must use BASE_SALE");
+        }
+    }
+
+    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+}

--- a/test-foundry/CrowdfundReentrancy.t.sol
+++ b/test-foundry/CrowdfundReentrancy.t.sol
@@ -1,0 +1,396 @@
+// ABOUTME: Reentrancy tests using malicious ERC20 tokens with transfer hooks.
+// ABOUTME: Verifies nonReentrant modifier blocks reentry on claim, claimRefund, and commit.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/crowdfund/ArmadaCrowdfund.sol";
+import "../contracts/crowdfund/IArmadaCrowdfund.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/cctp/MockUSDCV2.sol";
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice ERC20 that fires a callback into a target contract during transfer.
+///         Simulates ERC777-style reentrancy attacks. The callback result is captured
+///         (not propagated) so the outer transfer completes — this lets us verify that
+///         the nonReentrant guard blocked the reentry without disrupting the legitimate call.
+contract MaliciousERC20 is ERC20 {
+    address public attackTarget;
+    bytes public attackCalldata;
+    bool public attackActive;
+    bool public attackFired;
+    /// @notice Whether the reentry callback succeeded (false = blocked by nonReentrant)
+    bool public callSucceeded;
+
+    uint8 private _decimals;
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_
+    ) ERC20(name_, symbol_) {
+        _decimals = decimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    /// @notice Arm the attack. On the next transfer, the contract will call
+    ///         attackTarget with attackCalldata. The attackFired flag is set
+    ///         BEFORE the callback to prevent infinite recursion.
+    function setAttack(address target, bytes calldata data) external {
+        attackTarget = target;
+        attackCalldata = data;
+        attackActive = true;
+        attackFired = false;
+        callSucceeded = false;
+    }
+
+    function disableAttack() external {
+        attackActive = false;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal override {
+        super._transfer(from, to, amount);
+        if (attackActive && !attackFired) {
+            attackFired = true;
+            (bool success, ) = attackTarget.call(attackCalldata);
+            callSucceeded = success;
+        }
+    }
+}
+
+/// @notice Variant that propagates the reentry revert, causing the outer call to also revert.
+///         This simulates an attacker who requires reentry to succeed (all-or-nothing).
+contract MaliciousERC20Propagating is ERC20 {
+    address public attackTarget;
+    bytes public attackCalldata;
+    bool public attackActive;
+    bool public attackFired;
+
+    uint8 private _decimals;
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_
+    ) ERC20(name_, symbol_) {
+        _decimals = decimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function setAttack(address target, bytes calldata data) external {
+        attackTarget = target;
+        attackCalldata = data;
+        attackActive = true;
+        attackFired = false;
+    }
+
+    function disableAttack() external {
+        attackActive = false;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal override {
+        super._transfer(from, to, amount);
+        if (attackActive && !attackFired) {
+            attackFired = true;
+            (bool success, bytes memory ret) = attackTarget.call(attackCalldata);
+            // Propagate the revert — if reentry is blocked, the entire transfer reverts
+            if (!success) {
+                assembly {
+                    revert(add(ret, 32), mload(ret))
+                }
+            }
+        }
+    }
+}
+
+contract CrowdfundReentrancyTest is Test {
+    MockUSDCV2 public usdc;
+    ArmadaToken public armToken;
+    address public admin;
+    address public treasury;
+
+    uint256 constant ARM_FUNDING = 1_800_000 * 1e18;
+    uint256 constant HOP0_CAP = 15_000 * 1e6;
+
+    function setUp() public {
+        admin = address(this);
+        treasury = address(0xCAFE);
+
+        usdc = new MockUSDCV2("Mock USDC", "USDC");
+        armToken = new ArmadaToken(admin, admin);
+
+        address[] memory wl = new address[](1);
+        wl[0] = admin;
+        armToken.initWhitelist(wl);
+    }
+
+    // ============ Helper ============
+
+    /// @notice Build address arrays for a crowdfund with multi-hop demand.
+    ///         Does NOT add seeds — caller must loadArm() first, then addSeeds().
+    function _buildAddresses()
+        internal pure returns (address[] memory seeds, address[] memory hop1)
+    {
+        seeds = new address[](53);
+        for (uint256 i = 0; i < 53; i++) {
+            seeds[i] = address(uint160(0xA000 + i));
+        }
+        hop1 = new address[](53);
+        for (uint256 i = 0; i < 53; i++) {
+            hop1[i] = address(uint160(0xB000 + i));
+        }
+    }
+
+    // ============ Test: claim() reentry blocked (silent catch) ============
+
+    /// @notice Malicious ARM token fires callback during claim() → safeTransfer().
+    ///         The reentry attempt is caught by the malicious token (not propagated).
+    ///         Verifies: reentry failed, outer claim completed, no double-counting.
+    function test_reentrancy_claim_reentryBlocked() public {
+        MaliciousERC20 maliciousArm = new MaliciousERC20("Bad ARM", "BARM", 18);
+
+        ArmadaCrowdfund cf = new ArmadaCrowdfund(
+            address(usdc), address(maliciousArm), treasury, admin, admin, block.timestamp, false
+        );
+        maliciousArm.mint(address(cf), ARM_FUNDING);
+        cf.loadArm();
+
+        (address[] memory seeds, address[] memory hop1) = _buildAddresses();
+        cf.addSeeds(seeds);
+
+        // All seeds commit at hop-0
+        for (uint256 i = 0; i < seeds.length; i++) {
+            usdc.mint(seeds[i], HOP0_CAP);
+            vm.startPrank(seeds[i]);
+            usdc.approve(address(cf), HOP0_CAP);
+            cf.commit(0, HOP0_CAP);
+            vm.stopPrank();
+        }
+
+        // Invite and commit hop-1
+        for (uint256 i = 0; i < hop1.length; i++) {
+            vm.prank(seeds[i]);
+            cf.invite(hop1[i], 0);
+            uint256 hop1Amt = 4_000 * 1e6;
+            usdc.mint(hop1[i], hop1Amt);
+            vm.startPrank(hop1[i]);
+            usdc.approve(address(cf), hop1Amt);
+            cf.commit(1, hop1Amt);
+            vm.stopPrank();
+        }
+
+        vm.warp(cf.windowEnd() + 1);
+        cf.finalize();
+        assertFalse(cf.refundMode());
+
+        // Arm: on ARM transfer, try to call claim() again
+        maliciousArm.setAttack(
+            address(cf),
+            abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, address(0))
+        );
+
+        uint256 armBefore = maliciousArm.balanceOf(seeds[0]);
+        vm.prank(seeds[0]);
+        cf.claim(address(0));
+
+        // Reentry was attempted and blocked
+        assertTrue(maliciousArm.attackFired(), "Attack callback must have fired");
+        assertFalse(maliciousArm.callSucceeded(), "Reentry call must have been blocked");
+
+        // Verify only one claim went through (no double ARM)
+        uint256 armReceived = maliciousArm.balanceOf(seeds[0]) - armBefore;
+        uint256 expectedArm = cf.addressArmAllocation(seeds[0]);
+        assertEq(armReceived, expectedArm, "Must receive exactly one allocation, not double");
+
+        // Second claim must revert (already claimed)
+        vm.prank(seeds[0]);
+        vm.expectRevert("ArmadaCrowdfund: ARM already claimed");
+        cf.claim(address(0));
+    }
+
+    // ============ Test: claim() reentry blocked (propagating revert) ============
+
+    /// @notice Same attack but the malicious token propagates the revert.
+    ///         The entire claim() reverts. Attacker gets nothing.
+    function test_reentrancy_claim_propagatingRevert() public {
+        MaliciousERC20Propagating maliciousArm =
+            new MaliciousERC20Propagating("Bad ARM", "BARM", 18);
+
+        ArmadaCrowdfund cf = new ArmadaCrowdfund(
+            address(usdc), address(maliciousArm), treasury, admin, admin, block.timestamp, false
+        );
+        maliciousArm.mint(address(cf), ARM_FUNDING);
+        cf.loadArm();
+
+        (address[] memory seeds, address[] memory hop1) = _buildAddresses();
+        cf.addSeeds(seeds);
+
+        for (uint256 i = 0; i < seeds.length; i++) {
+            usdc.mint(seeds[i], HOP0_CAP);
+            vm.startPrank(seeds[i]);
+            usdc.approve(address(cf), HOP0_CAP);
+            cf.commit(0, HOP0_CAP);
+            vm.stopPrank();
+        }
+
+        for (uint256 i = 0; i < hop1.length; i++) {
+            vm.prank(seeds[i]);
+            cf.invite(hop1[i], 0);
+            uint256 hop1Amt = 4_000 * 1e6;
+            usdc.mint(hop1[i], hop1Amt);
+            vm.startPrank(hop1[i]);
+            usdc.approve(address(cf), hop1Amt);
+            cf.commit(1, hop1Amt);
+            vm.stopPrank();
+        }
+
+        vm.warp(cf.windowEnd() + 1);
+        cf.finalize();
+
+        maliciousArm.setAttack(
+            address(cf),
+            abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, address(0))
+        );
+
+        // Outer call reverts because reentry revert propagates through the token transfer
+        vm.prank(seeds[0]);
+        vm.expectRevert();
+        cf.claim(address(0));
+
+        // Attacker received nothing
+        assertEq(maliciousArm.balanceOf(seeds[0]), 0, "Attacker must receive nothing");
+
+        // Disable attack — legitimate claim works
+        maliciousArm.disableAttack();
+        vm.prank(seeds[0]);
+        cf.claim(address(0));
+        assertTrue(maliciousArm.balanceOf(seeds[0]) > 0, "Legitimate claim must succeed");
+    }
+
+    // ============ Test: claimRefund() reentry blocked ============
+
+    /// @notice Malicious USDC fires callback during claimRefund() → safeTransfer().
+    ///         Verifies reentry is blocked and no double-refund occurs.
+    function test_reentrancy_claimRefund_reentryBlocked() public {
+        MaliciousERC20 maliciousUsdc = new MaliciousERC20("Bad USDC", "BUSDC", 6);
+
+        ArmadaCrowdfund cf = new ArmadaCrowdfund(
+            address(maliciousUsdc),
+            address(armToken),
+            treasury,
+            admin,
+            admin,
+            block.timestamp,
+            false
+        );
+
+        armToken.transfer(address(cf), ARM_FUNDING);
+        cf.loadArm();
+
+        // 80 seeds, all hop-0 → refundMode
+        address[] memory seeds = new address[](80);
+        for (uint256 i = 0; i < 80; i++) {
+            seeds[i] = address(uint160(0xC000 + i));
+        }
+        cf.addSeeds(seeds);
+
+        for (uint256 i = 0; i < seeds.length; i++) {
+            maliciousUsdc.mint(seeds[i], HOP0_CAP);
+            vm.startPrank(seeds[i]);
+            maliciousUsdc.approve(address(cf), HOP0_CAP);
+            cf.commit(0, HOP0_CAP);
+            vm.stopPrank();
+        }
+
+        vm.warp(cf.windowEnd() + 1);
+        cf.finalize();
+        assertTrue(cf.refundMode());
+
+        // Arm: on USDC transfer, try to call claimRefund() again
+        maliciousUsdc.setAttack(
+            address(cf),
+            abi.encodeWithSelector(ArmadaCrowdfund.claimRefund.selector)
+        );
+
+        uint256 balBefore = maliciousUsdc.balanceOf(seeds[0]);
+        vm.prank(seeds[0]);
+        cf.claimRefund();
+
+        // Reentry was attempted and blocked
+        assertTrue(maliciousUsdc.attackFired(), "Attack callback must have fired");
+        assertFalse(maliciousUsdc.callSucceeded(), "Reentry call must have been blocked");
+
+        // Only one refund went through
+        uint256 refundReceived = maliciousUsdc.balanceOf(seeds[0]) - balBefore;
+        assertEq(refundReceived, HOP0_CAP, "Must receive exactly committed amount, not double");
+
+        // Second claimRefund must revert (already refunded)
+        vm.prank(seeds[0]);
+        vm.expectRevert("ArmadaCrowdfund: already refunded");
+        cf.claimRefund();
+    }
+
+    // ============ Test: commit() reentry blocked ============
+
+    /// @notice Malicious USDC fires callback during commit() → safeTransferFrom().
+    ///         The reentry attempt tries to call commit() again, which is blocked
+    ///         by nonReentrant. The outer commit completes with no double-counting.
+    function test_reentrancy_commit_reentryBlocked() public {
+        MaliciousERC20 maliciousUsdc = new MaliciousERC20("Bad USDC", "BUSDC", 6);
+
+        ArmadaCrowdfund cf = new ArmadaCrowdfund(
+            address(maliciousUsdc),
+            address(armToken),
+            treasury,
+            admin,
+            admin,
+            block.timestamp,
+            false
+        );
+
+        armToken.transfer(address(cf), ARM_FUNDING);
+        cf.loadArm();
+
+        address seed = address(uint160(0xF001));
+        address[] memory seedArr = new address[](1);
+        seedArr[0] = seed;
+        cf.addSeeds(seedArr);
+
+        uint256 commitAmt = 1_000 * 1e6;
+        maliciousUsdc.mint(seed, commitAmt * 2);
+        vm.prank(seed);
+        maliciousUsdc.approve(address(cf), commitAmt * 2);
+
+        // Arm: during transferFrom, try to call commit() again
+        maliciousUsdc.setAttack(
+            address(cf),
+            abi.encodeWithSelector(ArmadaCrowdfund.commit.selector, uint8(0), commitAmt)
+        );
+
+        vm.prank(seed);
+        cf.commit(0, commitAmt);
+
+        // Reentry was attempted and blocked
+        assertTrue(maliciousUsdc.attackFired(), "Attack callback must have fired");
+        assertFalse(maliciousUsdc.callSucceeded(), "Reentry call must have been blocked");
+
+        // Only one commit recorded (no double-counting)
+        assertEq(cf.totalCommitted(), commitAmt, "Must record exactly one commit, not double");
+    }
+}

--- a/test-foundry/CrowdfundReentrancy.t.sol
+++ b/test-foundry/CrowdfundReentrancy.t.sol
@@ -23,6 +23,8 @@ contract MaliciousERC20 is ERC20 {
     bool public attackFired;
     /// @notice Whether the reentry callback succeeded (false = blocked by nonReentrant)
     bool public callSucceeded;
+    /// @notice Revert data from a failed reentry callback (for asserting revert reason)
+    bytes public revertData;
 
     uint8 private _decimals;
 
@@ -51,6 +53,7 @@ contract MaliciousERC20 is ERC20 {
         attackActive = true;
         attackFired = false;
         callSucceeded = false;
+        revertData = "";
     }
 
     function disableAttack() external {
@@ -61,8 +64,11 @@ contract MaliciousERC20 is ERC20 {
         super._transfer(from, to, amount);
         if (attackActive && !attackFired) {
             attackFired = true;
-            (bool success, ) = attackTarget.call(attackCalldata);
+            (bool success, bytes memory ret) = attackTarget.call(attackCalldata);
             callSucceeded = success;
+            if (!success) {
+                revertData = ret;
+            }
         }
     }
 }
@@ -140,7 +146,19 @@ contract CrowdfundReentrancyTest is Test {
         armToken.initWhitelist(wl);
     }
 
-    // ============ Helper ============
+    // ============ Helpers ============
+
+    /// @notice Extract the revert reason string from raw revert data.
+    ///         Assumes Error(string) encoding: 4-byte selector + abi-encoded string.
+    function _extractRevertReason(bytes memory data) internal pure returns (string memory) {
+        require(data.length >= 4, "revert data too short");
+        // Strip the 4-byte Error(string) selector, then abi-decode the string
+        bytes memory payload = new bytes(data.length - 4);
+        for (uint256 i = 4; i < data.length; i++) {
+            payload[i - 4] = data[i];
+        }
+        return abi.decode(payload, (string));
+    }
 
     /// @notice Build address arrays for a crowdfund with multi-hop demand.
     ///         Does NOT add seeds — caller must loadArm() first, then addSeeds().
@@ -209,9 +227,14 @@ contract CrowdfundReentrancyTest is Test {
         vm.prank(seeds[0]);
         cf.claim(address(0));
 
-        // Reentry was attempted and blocked
+        // Reentry was attempted and blocked by nonReentrant specifically
         assertTrue(maliciousArm.attackFired(), "Attack callback must have fired");
         assertFalse(maliciousArm.callSucceeded(), "Reentry call must have been blocked");
+        assertEq(
+            _extractRevertReason(maliciousArm.revertData()),
+            "ReentrancyGuard: reentrant call",
+            "Reentry must be blocked by nonReentrant guard, not another check"
+        );
 
         // Verify only one claim went through (no double ARM)
         uint256 armReceived = maliciousArm.balanceOf(seeds[0]) - armBefore;
@@ -268,9 +291,10 @@ contract CrowdfundReentrancyTest is Test {
             abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, address(0))
         );
 
-        // Outer call reverts because reentry revert propagates through the token transfer
+        // Outer call reverts because reentry revert propagates through the token transfer.
+        // The propagated revert reason must be the nonReentrant guard.
         vm.prank(seeds[0]);
-        vm.expectRevert();
+        vm.expectRevert("ReentrancyGuard: reentrant call");
         cf.claim(address(0));
 
         // Attacker received nothing
@@ -332,9 +356,14 @@ contract CrowdfundReentrancyTest is Test {
         vm.prank(seeds[0]);
         cf.claimRefund();
 
-        // Reentry was attempted and blocked
+        // Reentry was attempted and blocked by nonReentrant specifically
         assertTrue(maliciousUsdc.attackFired(), "Attack callback must have fired");
         assertFalse(maliciousUsdc.callSucceeded(), "Reentry call must have been blocked");
+        assertEq(
+            _extractRevertReason(maliciousUsdc.revertData()),
+            "ReentrancyGuard: reentrant call",
+            "Reentry must be blocked by nonReentrant guard, not another check"
+        );
 
         // Only one refund went through
         uint256 refundReceived = maliciousUsdc.balanceOf(seeds[0]) - balBefore;
@@ -386,9 +415,14 @@ contract CrowdfundReentrancyTest is Test {
         vm.prank(seed);
         cf.commit(0, commitAmt);
 
-        // Reentry was attempted and blocked
+        // Reentry was attempted and blocked by nonReentrant specifically
         assertTrue(maliciousUsdc.attackFired(), "Attack callback must have fired");
         assertFalse(maliciousUsdc.callSucceeded(), "Reentry call must have been blocked");
+        assertEq(
+            _extractRevertReason(maliciousUsdc.revertData()),
+            "ReentrancyGuard: reentrant call",
+            "Reentry must be blocked by nonReentrant guard, not another check"
+        );
 
         // Only one commit recorded (no double-counting)
         assertEq(cf.totalCommitted(), commitAmt, "Must record exactly one commit, not double");


### PR DESCRIPTION
## Summary

- **G1: Reentrancy tests** — `MaliciousERC20` with transfer hooks verifies `nonReentrant` blocks reentry on `claim()`, `claimRefund()`, and `commit()`. Includes both silent-catch and propagating-revert attack variants.
- **G3: Donation attack tests** — Direct USDC/ARM transfers don't corrupt `totalCommitted`, allocations, or ARM sweep accounting.
- **G4: Elastic expansion boundary fuzz** — 3 deterministic + 2 fuzz tests around ELASTIC_TRIGGER ($1.5M) with seeds-only and mixed-hop participants.
- **G5: Fix vacuous refundMode fuzz** — Replaced `try/catch` with guaranteed refundMode. All 80 seeds commit so cappedDemand stays in [MIN_SALE, ELASTIC_TRIGGER). `assertTrue(refundMode)` is now unconditional on every fuzz run.

## New files
- `test-foundry/CrowdfundReentrancy.t.sol` (4 tests)
- `test-foundry/CrowdfundDonation.t.sol` (4 tests)
- `test-foundry/CrowdfundElasticFuzz.t.sol` (5 tests)

## Modified files
- `test-foundry/ArmadaCrowdfundRefundMode.t.sol` (G5 fix)

## Test plan
- [x] `forge test --match-contract CrowdfundReentrancyTest -vv` — 4/4 pass
- [x] `forge test --match-contract CrowdfundDonationTest -vv` — 4/4 pass
- [x] `forge test --match-contract CrowdfundElasticFuzzTest -vv` — 5/5 pass
- [x] `forge test --match-contract ArmadaCrowdfundRefundModeTest -vv` — 15/15 pass
- [x] `npm run test:forge` — 377/377 pass (full regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)