### PR TITLE
fix: permanently disable shields after wind-down

### DIFF
--- a/contracts/governance/ShieldPauseController.sol
+++ b/contracts/governance/ShieldPauseController.sol
@@ -75,8 +75,11 @@ contract ShieldPauseController is IShieldPauseController {
 
     // ============ View Functions ============
 
-    /// @notice Returns true only if paused AND the pause has not expired
+    /// @notice Returns true if shields are paused.
+    ///         Post-wind-down: permanently true (withdraw-only mode per spec).
+    ///         Pre-wind-down: true only during an active SC pause (24h auto-expiry).
     function shieldsPaused() external view override returns (bool) {
+        if (windDownActive) return true;
         return _paused && block.timestamp < pauseExpiry;
     }
 
@@ -123,7 +126,8 @@ contract ShieldPauseController is IShieldPauseController {
 
     // ============ Wind-Down Functions ============
 
-    /// @notice Called by the wind-down contract to activate post-wind-down pause restrictions
+    /// @notice Called by the wind-down contract to activate withdraw-only mode.
+    ///         Shields are permanently disabled; unshields remain available indefinitely.
     function setWindDownActive() external {
         require(msg.sender == windDownContract, "ShieldPauseController: not wind-down contract");
         require(windDownContract != address(0), "ShieldPauseController: wind-down not set");

--- a/test-foundry/ShieldPauseController.t.sol
+++ b/test-foundry/ShieldPauseController.t.sol
@@ -256,6 +256,21 @@ contract ShieldPauseControllerTest is Test, GovernorDeployHelper {
         assertTrue(pauseController.shieldsPaused());
     }
 
+    function test_postWindDown_shieldsPermanentlyPaused() public {
+        // Setup wind-down
+        vm.prank(address(timelock));
+        pauseController.setWindDownContract(windDown);
+        vm.prank(windDown);
+        pauseController.setWindDownActive();
+
+        // Shields permanently paused without any SC action
+        assertTrue(pauseController.shieldsPaused());
+
+        // Still paused after arbitrary time
+        vm.warp(block.timestamp + 365 days);
+        assertTrue(pauseController.shieldsPaused());
+    }
+
     function test_postWindDown_secondPauseReverts() public {
         // Setup wind-down
         vm.prank(address(timelock));
@@ -263,15 +278,15 @@ contract ShieldPauseControllerTest is Test, GovernorDeployHelper {
         vm.prank(windDown);
         pauseController.setWindDownActive();
 
-        // First pause
+        // First SC pause succeeds
         vm.prank(securityCouncil);
         pauseController.pauseShields();
 
-        // Expire the pause
+        // After SC pause expiry, shields remain paused due to wind-down
         vm.warp(block.timestamp + TWENTY_FOUR_HOURS);
-        assertFalse(pauseController.shieldsPaused());
+        assertTrue(pauseController.shieldsPaused());
 
-        // Second pause reverts
+        // Second SC pause reverts
         vm.prank(securityCouncil);
         vm.expectRevert("ShieldPauseController: post-wind-down pause already used");
         pauseController.pauseShields();

--- a/test/winddown_redemption_integration.ts
+++ b/test/winddown_redemption_integration.ts
@@ -373,16 +373,25 @@ describe("Wind-Down & Redemption Integration", function () {
       expect(await shieldPauseController.windDownActive()).to.be.true;
     });
 
+    it("shields permanently paused after wind-down (withdraw-only mode)", async function () {
+      // Wind-down makes shieldsPaused() return true permanently
+      expect(await shieldPauseController.shieldsPaused()).to.be.true;
+
+      // Still true even though no SC pause was triggered — wind-down alone is sufficient
+      await time.increase(TWENTY_FOUR_HOURS + 1);
+      expect(await shieldPauseController.shieldsPaused()).to.be.true;
+    });
+
     it("post-wind-down: SC gets exactly one pause", async function () {
-      // First pause succeeds
+      // SC pause still succeeds (useful if SC needs to signal an issue)
       await shieldPauseController.connect(carol).pauseShields();
       expect(await shieldPauseController.shieldsPaused()).to.be.true;
 
-      // Wait for expiry
+      // After SC pause expiry, shields remain paused due to wind-down
       await time.increase(TWENTY_FOUR_HOURS + 1);
-      expect(await shieldPauseController.shieldsPaused()).to.be.false;
+      expect(await shieldPauseController.shieldsPaused()).to.be.true;
 
-      // Second pause reverts
+      // Second SC pause still reverts (single-use post-wind-down)
       await expect(
         shieldPauseController.connect(carol).pauseShields()
       ).to.be.revertedWith("ShieldPauseController: post-wind-down pause already used");
@@ -669,19 +678,23 @@ describe("Wind-Down & Redemption Integration", function () {
       await time.increaseTo(windDownDeadline + 1);
       await windDown.triggerWindDown();
 
+      // Shields are permanently paused due to wind-down (withdraw-only mode)
+      expect(await shieldPauseController.shieldsPaused()).to.be.true;
+
       // SC gets one pause post-wind-down
       await shieldPauseController.connect(carol).pauseShields();
       expect(await shieldPauseController.shieldsPaused()).to.be.true;
 
-      // Wait for expiry
+      // After SC pause expiry, shields remain paused (wind-down is permanent)
       await time.increase(TWENTY_FOUR_HOURS + 1);
+      expect(await shieldPauseController.shieldsPaused()).to.be.true;
 
       // Cannot pause again
       await expect(
         shieldPauseController.connect(carol).pauseShields()
       ).to.be.revertedWith("ShieldPauseController: post-wind-down pause already used");
 
-      // Sweep and redeem still works
+      // Sweep and redeem still works (unshields unaffected)
       await windDown.sweepToken(await usdc.getAddress());
       await armToken.connect(alice).approve(await redemption.getAddress(), ethers.MaxUint256);
 


### PR DESCRIPTION
## Summary
- `ShieldPauseController.shieldsPaused()` now returns `true` permanently when `windDownActive` is set, implementing the spec's "withdraw-only mode" (shields disabled, unshields available indefinitely)
- Previously the `windDownActive` flag only restricted the SC to a single pause — shields could still be called after the 24h SC pause expired
- Added new Foundry test (`test_postWindDown_shieldsPermanentlyPaused`) and Hardhat test for permanent shield disable
- Updated existing post-wind-down tests to expect permanent pause behavior

Partial fix for #48 — addresses the `setWithdrawOnly()` acceptance criterion. Other criteria (automated trigger, pro-rata redemption, sweep, etc.) were already implemented.

## Test plan
- [x] Foundry: `forge test --match-contract ShieldPauseControllerTest` — 25/25 pass
- [x] Foundry: `forge test --match-contract ArmadaWindDown` — 28/28 pass
- [x] Hardhat: `npx hardhat test test/winddown_redemption_integration.ts` — 35/35 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)