### PR TITLE
Remove treasury claims system (align with spec)

### DIFF
--- a/contracts/governance/ArmadaTreasuryGov.sol
+++ b/contracts/governance/ArmadaTreasuryGov.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// ABOUTME: Governance-controlled treasury with claims, steward budget, and aggregate outflow rate limits.
+// ABOUTME: Governance-controlled treasury with steward budget and aggregate outflow rate limits.
 // ABOUTME: Outflow limits enforce a rolling-window cap per token to defend against governance capture.
 pragma solidity ^0.8.17;
 
@@ -8,10 +8,10 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./EmergencyPausable.sol";
 
-/// @title ArmadaTreasuryGov — Governance-controlled treasury with claims mechanism
+/// @title ArmadaTreasuryGov — Governance-controlled treasury
 /// @notice Owned by TimelockController (immutable). Supports direct distributions,
-///         claims (deferred exercise), steward operational budget, and aggregate
-///         outflow rate limits per token over a rolling window.
+///         steward operational budget, and aggregate outflow rate limits per token
+///         over a rolling window.
 contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
     using SafeERC20 for IERC20;
 

--- a/contracts/governance/ArmadaTreasuryGov.sol
+++ b/contracts/governance/ArmadaTreasuryGov.sol
@@ -17,14 +17,6 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
 
     // ============ Types ============
 
-    struct Claim {
-        address token;
-        address beneficiary;
-        uint256 amount;
-        uint256 exercised;
-        uint256 createdAt;
-    }
-
     /// @notice Per-token outflow rate limit configuration.
     /// The effective limit is: max(percentageOfBalance, limitAbsolute),
     /// then max(result, floorAbsolute). The floor is immutable once set.
@@ -45,10 +37,6 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
     // ============ State ============
 
     address public immutable owner; // TimelockController address (set once at deployment, cannot be changed)
-    // Claims system
-    uint256 public claimCount;
-    mapping(uint256 => Claim) public claims;
-    mapping(address => uint256[]) private _beneficiaryClaims;
 
     // Per-token steward budget table (governance-managed via Extended proposals).
     // Each authorized token has an absolute spending limit per rolling window.
@@ -81,8 +69,6 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
     // ============ Events ============
 
     event DirectDistribution(address indexed token, address indexed recipient, uint256 amount);
-    event ClaimCreated(uint256 indexed claimId, address indexed beneficiary, address token, uint256 amount);
-    event ClaimExercised(uint256 indexed claimId, address indexed beneficiary, uint256 amount);
     event StewardSpent(address indexed token, address indexed recipient, uint256 amount, uint256 budgetRemaining);
     event StewardBudgetTokenAdded(address indexed token, uint256 limit, uint256 window);
     event StewardBudgetTokenUpdated(address indexed token, uint256 limit, uint256 window);
@@ -121,50 +107,6 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
         _checkAndRecordOutflow(token, amount);
         IERC20(token).safeTransfer(recipient, amount);
         emit DirectDistribution(token, recipient, amount);
-    }
-
-    /// @notice Create a claim: right to receive tokens, exercisable by beneficiary
-    /// @param token Token address
-    /// @param beneficiary Address that can exercise the claim
-    /// @param amount Total claimable amount
-    function createClaim(
-        address token,
-        address beneficiary,
-        uint256 amount
-    ) external onlyOwner returns (uint256) {
-        require(beneficiary != address(0), "ArmadaTreasuryGov: zero address");
-        require(amount > 0, "ArmadaTreasuryGov: zero amount");
-
-        uint256 claimId = ++claimCount;
-        claims[claimId] = Claim({
-            token: token,
-            beneficiary: beneficiary,
-            amount: amount,
-            exercised: 0,
-            createdAt: block.timestamp
-        });
-        _beneficiaryClaims[beneficiary].push(claimId);
-
-        emit ClaimCreated(claimId, beneficiary, token, amount);
-        return claimId;
-    }
-
-    // ============ Claim Functions ============
-
-    /// @notice Exercise a claim — beneficiary receives tokens at their discretion
-    /// @param claimId Claim to exercise
-    /// @param amount Amount to exercise (can be partial)
-    function exerciseClaim(uint256 claimId, uint256 amount) external nonReentrant whenNotPaused {
-        Claim storage c = claims[claimId];
-        require(c.beneficiary == msg.sender, "ArmadaTreasuryGov: not beneficiary");
-        require(amount > 0, "ArmadaTreasuryGov: zero amount");
-        require(c.exercised + amount <= c.amount, "ArmadaTreasuryGov: exceeds claim");
-
-        c.exercised += amount;
-        _checkAndRecordOutflow(c.token, amount);
-        IERC20(c.token).safeTransfer(c.beneficiary, amount);
-
-        emit ClaimExercised(claimId, c.beneficiary, amount);
     }
 
     // ============ Steward Spending (executed by timelock via governor) ============
@@ -385,15 +327,6 @@ contract ArmadaTreasuryGov is ReentrancyGuard, EmergencyPausable {
 
     function getBalance(address token) external view returns (uint256) {
         return IERC20(token).balanceOf(address(this));
-    }
-
-    function getBeneficiaryClaims(address beneficiary) external view returns (uint256[] memory) {
-        return _beneficiaryClaims[beneficiary];
-    }
-
-    function getClaimRemaining(uint256 claimId) external view returns (uint256) {
-        Claim storage c = claims[claimId];
-        return c.amount - c.exercised;
     }
 
     /// @notice View the steward's current budget status for a token

--- a/docs/governance-test-scenarios.md
+++ b/docs/governance-test-scenarios.md
@@ -106,23 +106,7 @@ Scenarios marked with issue numbers (e.g., #19) reference known bugs filed on Co
 | F7 | Non-owner calls distribute | Revert: "not owner" |
 | F8 | Distribute, then check steward budget decreased | Budget is 1% of current (now lower) balance |
 
-## G. ArmadaTreasuryGov — Claims
-
-| # | Scenario | Expected Behavior |
-|---|----------|-------------------|
-| G1 | Create claim, exercise full amount at once | Beneficiary receives all tokens |
-| G2 | Create claim, exercise in 3 partial amounts | Each partial works; `getClaimRemaining` decreases |
-| G3 | Exercise more than remaining | Revert: "exceeds claim" |
-| G4 | Non-beneficiary exercises claim | Revert: "not beneficiary" |
-| G5 | Exercise 0 amount | Revert: "zero amount" |
-| G6 | Create claim with 0 amount | Revert: "zero amount" |
-| G7 | Create claim to zero address | Revert: "zero address" |
-| G8 | Create claim, then treasury gets drained, then exercise | Revert (safeTransfer fails — insufficient balance) |
-| G9 | Multiple claims for same beneficiary | All work independently |
-| G10 | Exercise claim after treasury ownership changed | Should still work (claim data is in storage) |
-| G11 | Create claim, never exercise | Sits forever (no revocation — bug #23) |
-
-## H. ArmadaTreasuryGov — Steward Budget
+## G. ArmadaTreasuryGov — Steward Budget
 
 | # | Scenario | Expected Behavior |
 |---|----------|-------------------|

--- a/governance-ui/src/components/CreateProposalForm.tsx
+++ b/governance-ui/src/components/CreateProposalForm.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Form for creating governance proposals with calldata template builders.
-// ABOUTME: Supports Standard (distribute/claim), Extended (steward election), and manual calldata types.
+// ABOUTME: Supports Standard (distribute), Extended (steward election), and manual calldata types.
 
 import { useState } from 'react'
 import { ethers } from 'ethers'
@@ -13,8 +13,6 @@ interface CreateProposalFormProps {
   onCreated: () => Promise<void>
 }
 
-type TreasuryAction = 'distribute' | 'createClaim'
-
 export function CreateProposalForm({ contracts, wallet, onCreated }: CreateProposalFormProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [proposalType, setProposalType] = useState<ProposalType>(ProposalType.Standard)
@@ -23,7 +21,6 @@ export function CreateProposalForm({ contracts, wallet, onCreated }: CreatePropo
   const [txError, setTxError] = useState<string | null>(null)
 
   // Treasury template fields
-  const [treasuryAction, setTreasuryAction] = useState<TreasuryAction>('distribute')
   const [treasuryToken, setTreasuryToken] = useState<'arm' | 'usdc'>('usdc')
   const [treasuryRecipient, setTreasuryRecipient] = useState('')
   const [treasuryAmount, setTreasuryAmount] = useState('')
@@ -51,12 +48,9 @@ export function CreateProposalForm({ contracts, wallet, onCreated }: CreatePropo
       const amount = ethers.parseUnits(treasuryAmount, decimals)
       const iface = new ethers.Interface([
         'function distribute(address token, address recipient, uint256 amount)',
-        'function createClaim(address token, address beneficiary, uint256 amount)',
       ])
 
-      const calldata = treasuryAction === 'distribute'
-        ? iface.encodeFunctionData('distribute', [tokenAddr, treasuryRecipient, amount])
-        : iface.encodeFunctionData('createClaim', [tokenAddr, treasuryRecipient, amount])
+      const calldata = iface.encodeFunctionData('distribute', [tokenAddr, treasuryRecipient, amount])
 
       return {
         targets: [deployment.contracts.treasury],
@@ -205,20 +199,6 @@ export function CreateProposalForm({ contracts, wallet, onCreated }: CreatePropo
       {proposalType === ProposalType.Standard && (
         <div className="mt-3 space-y-2">
           <div className="flex gap-2">
-            <button
-              onClick={() => setTreasuryAction('distribute')}
-              className={`rounded px-3 py-1 text-xs ${treasuryAction === 'distribute' ? 'bg-green-800 text-green-200' : 'bg-neutral-800 text-neutral-400'}`}
-            >
-              Distribute
-            </button>
-            <button
-              onClick={() => setTreasuryAction('createClaim')}
-              className={`rounded px-3 py-1 text-xs ${treasuryAction === 'createClaim' ? 'bg-purple-800 text-purple-200' : 'bg-neutral-800 text-neutral-400'}`}
-            >
-              Create Claim
-            </button>
-          </div>
-          <div className="flex gap-2">
             <select
               value={treasuryToken}
               onChange={(e) => setTreasuryToken(e.target.value as 'arm' | 'usdc')}
@@ -232,7 +212,7 @@ export function CreateProposalForm({ contracts, wallet, onCreated }: CreatePropo
             type="text"
             value={treasuryRecipient}
             onChange={(e) => setTreasuryRecipient(e.target.value)}
-            placeholder={treasuryAction === 'distribute' ? 'Recipient address' : 'Beneficiary address'}
+            placeholder="Recipient address"
             className="w-full rounded bg-neutral-800 px-3 py-2 text-sm text-neutral-200 placeholder-neutral-600"
           />
           <input

--- a/governance-ui/src/components/TreasuryPanel.tsx
+++ b/governance-ui/src/components/TreasuryPanel.tsx
@@ -1,5 +1,5 @@
-// ABOUTME: Treasury panel showing balances, claims, steward budget, and claim exercise.
-// ABOUTME: Displays treasury-held ARM/USDC, active claims, and steward budget status.
+// ABOUTME: Treasury panel showing balances and steward budget status.
+// ABOUTME: Displays treasury-held ARM/USDC and steward budget spending.
 
 import { useState } from 'react'
 import { ethers } from 'ethers'
@@ -15,10 +15,6 @@ interface TreasuryPanelProps {
 }
 
 export function TreasuryPanel({ contracts, wallet, govData }: TreasuryPanelProps) {
-  const [exerciseClaimId, setExerciseClaimId] = useState('')
-  const [exerciseAmount, setExerciseAmount] = useState('')
-  const [txStatus, setTxStatus] = useState<string | null>(null)
-  const [txError, setTxError] = useState<string | null>(null)
 
   const fmtArm = (v: bigint) => {
     const num = Number(ethers.formatUnits(v, 18))
@@ -31,35 +27,6 @@ export function TreasuryPanel({ contracts, wallet, govData }: TreasuryPanelProps
 
   const truncAddr = (addr: string) =>
     addr ? `${addr.slice(0, 10)}...${addr.slice(-6)}` : 'None'
-
-  const handleExerciseClaim = async () => {
-    if (!wallet.account || !contracts.deployment || !exerciseClaimId || !exerciseAmount) return
-    setTxStatus('Exercising claim...')
-    setTxError(null)
-    try {
-      const signer = await wallet.getSigner()
-      const treasury = new ethers.Contract(
-        contracts.deployment.contracts.treasury,
-        ['function exerciseClaim(uint256 claimId, uint256 amount)'],
-        signer,
-      )
-      // Determine decimals from claim token (check if it matches ARM or USDC)
-      const claim = govData.claims.find((c) => c.id === Number(exerciseClaimId))
-      const decimals = claim?.token.toLowerCase() === contracts.deployment.contracts.armToken.toLowerCase() ? 18 : 6
-      const amount = ethers.parseUnits(exerciseAmount, decimals)
-      const tx = await treasury.exerciseClaim(Number(exerciseClaimId), amount)
-      setTxStatus('Confirming...')
-      await tx.wait()
-      setTxStatus('Claim exercised!')
-      setExerciseClaimId('')
-      setExerciseAmount('')
-      await govData.refresh()
-      setTimeout(() => setTxStatus(null), 3000)
-    } catch (err) {
-      setTxError(err instanceof Error ? err.message : 'Failed to exercise claim')
-      setTxStatus(null)
-    }
-  }
 
   return (
     <div className="space-y-6">
@@ -103,78 +70,6 @@ export function TreasuryPanel({ contracts, wallet, govData }: TreasuryPanelProps
         </div>
       )}
 
-      {/* Claims */}
-      <div>
-        <h3 className="mb-3 text-sm font-medium text-neutral-300">
-          Claims ({govData.claimCount})
-        </h3>
-        {govData.claims.length === 0 ? (
-          <p className="text-sm text-neutral-500">No claims yet.</p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="border-b border-neutral-800 text-left text-neutral-500">
-                  <th className="pb-2 pr-3">ID</th>
-                  <th className="pb-2 pr-3">Token</th>
-                  <th className="pb-2 pr-3">Beneficiary</th>
-                  <th className="pb-2 pr-3 text-right">Total</th>
-                  <th className="pb-2 pr-3 text-right">Exercised</th>
-                  <th className="pb-2 text-right">Remaining</th>
-                </tr>
-              </thead>
-              <tbody>
-                {govData.claims.map((claim) => {
-                  const isArm = contracts.deployment
-                    ? claim.token.toLowerCase() === contracts.deployment.contracts.armToken.toLowerCase()
-                    : false
-                  const fmt = isArm ? fmtArm : fmtUsdc
-                  return (
-                    <tr key={claim.id} className="border-b border-neutral-900 text-neutral-300">
-                      <td className="py-2 pr-3 font-mono">{claim.id}</td>
-                      <td className="py-2 pr-3">{isArm ? 'ARM' : 'USDC'}</td>
-                      <td className="py-2 pr-3 font-mono">{truncAddr(claim.beneficiary)}</td>
-                      <td className="py-2 pr-3 text-right">{fmt(claim.amount)}</td>
-                      <td className="py-2 pr-3 text-right">{fmt(claim.exercised)}</td>
-                      <td className="py-2 text-right font-medium">{fmt(claim.remaining)}</td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-
-      {/* Exercise Claim */}
-      <div className="rounded border border-neutral-800 bg-neutral-900 p-4">
-        <h3 className="mb-3 text-sm font-medium text-neutral-300">Exercise Claim</h3>
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={exerciseClaimId}
-            onChange={(e) => setExerciseClaimId(e.target.value)}
-            placeholder="Claim ID"
-            className="w-24 rounded bg-neutral-800 px-3 py-2 text-sm text-neutral-200 placeholder-neutral-600"
-          />
-          <input
-            type="text"
-            value={exerciseAmount}
-            onChange={(e) => setExerciseAmount(e.target.value)}
-            placeholder="Amount"
-            className="flex-1 rounded bg-neutral-800 px-3 py-2 text-sm text-neutral-200 placeholder-neutral-600"
-          />
-          <button
-            onClick={handleExerciseClaim}
-            disabled={!wallet.account || !exerciseClaimId || !exerciseAmount}
-            className="rounded bg-green-700 px-4 py-2 text-sm font-medium text-white hover:bg-green-600 disabled:opacity-50"
-          >
-            Exercise
-          </button>
-        </div>
-        {txStatus && <div className="mt-2 text-xs text-blue-400">{txStatus}</div>}
-        {txError && <div className="mt-2 text-xs text-red-400">{txError}</div>}
-      </div>
     </div>
   )
 }

--- a/governance-ui/src/governance-abis.ts
+++ b/governance-ui/src/governance-abis.ts
@@ -51,23 +51,15 @@ export const GOVERNOR_ABI = [
 export const TREASURY_ABI = [
   // Write functions
   'function distribute(address token, address recipient, uint256 amount)',
-  'function createClaim(address token, address beneficiary, uint256 amount) returns (uint256)',
-  'function exerciseClaim(uint256 claimId, uint256 amount)',
   'function setSteward(address _steward)',
   'function stewardSpend(address token, address recipient, uint256 amount)',
   // Read functions
   'function getBalance(address token) view returns (uint256)',
-  'function claimCount() view returns (uint256)',
-  'function claims(uint256 claimId) view returns (address token, address beneficiary, uint256 amount, uint256 exercised, uint256 createdAt)',
-  'function getBeneficiaryClaims(address beneficiary) view returns (uint256[])',
-  'function getClaimRemaining(uint256 claimId) view returns (uint256)',
   'function getStewardBudget(address token) view returns (uint256 budget, uint256 spent, uint256 remaining)',
   'function steward() view returns (address)',
   'function owner() view returns (address)',
   // Events
   'event DirectDistribution(address indexed token, address indexed recipient, uint256 amount)',
-  'event ClaimCreated(uint256 indexed claimId, address indexed beneficiary, address token, uint256 amount)',
-  'event ClaimExercised(uint256 indexed claimId, address indexed beneficiary, uint256 amount)',
   'event StewardSpent(address indexed token, address indexed recipient, uint256 amount, uint256 budgetRemaining)',
   'event StewardUpdated(address indexed oldSteward, address indexed newSteward)',
   'event OwnerUpdated(address indexed oldOwner, address indexed newOwner)',

--- a/governance-ui/src/governance-types.ts
+++ b/governance-ui/src/governance-types.ts
@@ -45,17 +45,6 @@ export interface ProposalData {
   userVoteChoice: number | null
 }
 
-/** Treasury claim data from ArmadaTreasuryGov.claims() */
-export interface ClaimData {
-  id: number
-  token: string
-  beneficiary: string
-  amount: bigint
-  exercised: bigint
-  remaining: bigint
-  createdAt: bigint
-}
-
 /** Steward action data from TreasurySteward.getAction() */
 export interface StewardActionData {
   id: number

--- a/governance-ui/src/hooks/useGovernanceData.ts
+++ b/governance-ui/src/hooks/useGovernanceData.ts
@@ -4,7 +4,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { ethers } from 'ethers'
 import type { GovernanceContracts } from './useGovernanceContracts'
-import type { ProposalData, ClaimData, StewardActionData } from '../governance-types'
+import type { ProposalData, StewardActionData } from '../governance-types'
 import { ProposalState, ProposalType } from '../governance-types'
 
 const POLL_INTERVAL_MS = 10_000
@@ -27,8 +27,6 @@ export interface GovernanceData {
   treasuryUsdcBalance: bigint
   treasuryOwner: string
   treasurySteward: string
-  claimCount: number
-  claims: ClaimData[]
   stewardBudget: { budget: bigint; spent: bigint; remaining: bigint } | null
 
   // Steward
@@ -62,8 +60,6 @@ const EMPTY_DATA: GovernanceData = {
   treasuryUsdcBalance: 0n,
   treasuryOwner: '',
   treasurySteward: '',
-  claimCount: 0,
-  claims: [],
   stewardBudget: null,
   currentSteward: '',
   isStewardActive: false,
@@ -176,7 +172,6 @@ export function useGovernanceData(
       let treasuryUsdcBalance = 0n
       let treasuryOwner = ''
       let treasurySteward = ''
-      let claimCount = 0
       let stewardBudget: { budget: bigint; spent: bigint; remaining: bigint } | null = null
 
       try {
@@ -189,9 +184,6 @@ export function useGovernanceData(
         if (usdc) {
           treasuryUsdcBalance = await treasury.getBalance(await usdc.getAddress())
         }
-
-        const claimCountRaw = await treasury.claimCount()
-        claimCount = Number(claimCountRaw)
 
         if (usdc && contracts.usdcAddress) {
           try {
@@ -207,28 +199,6 @@ export function useGovernanceData(
         }
       } catch {
         // Treasury queries may fail
-      }
-
-      // Fetch claims
-      const claims: ClaimData[] = []
-      for (let i = 1; i <= claimCount; i++) {
-        try {
-          const [claimData, remaining] = await Promise.all([
-            treasury.claims(i),
-            treasury.getClaimRemaining(i),
-          ])
-          claims.push({
-            id: i,
-            token: claimData[0] as string,
-            beneficiary: claimData[1] as string,
-            amount: claimData[2] as bigint,
-            exercised: claimData[3] as bigint,
-            remaining: remaining as bigint,
-            createdAt: claimData[4] as bigint,
-          })
-        } catch {
-          // Claim may not exist
-        }
       }
 
       // Steward data
@@ -285,8 +255,6 @@ export function useGovernanceData(
         treasuryUsdcBalance,
         treasuryOwner,
         treasurySteward,
-        claimCount,
-        claims,
         stewardBudget,
         currentSteward,
         isStewardActive,

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -197,7 +197,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       expect(seed0VotingPower).to.be.gt(0);
 
       // 9. Create a governance proposal (treasury owner is already the timelock from deployment)
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
+      // Fund treasury with a small amount of USDC so the distribute call succeeds
+      await usdc.mint(await treasuryGov.getAddress(), 1);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("distribute", [await usdc.getAddress(), deployer.address, 1]);
       const proposalTx = await governor.propose(
         ProposalType.Standard,
         [await treasuryGov.getAddress()],
@@ -287,7 +289,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await mine(1);
 
       // Create proposal to check quorum
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("distribute", [await usdc.getAddress(), deployer.address, 1]);
       await governor.propose(
         ProposalType.Standard,
         [await treasuryGov.getAddress()],
@@ -339,7 +341,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await armToken.connect(pooledSeed).delegate(pooledSeed.address);
       await mine(1);
 
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("distribute", [await usdc.getAddress(), deployer.address, 1]);
       await expect(
         governor.connect(pooledSeed).propose(
           ProposalType.Standard,
@@ -391,7 +393,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // Create proposal (snapshot is taken at current block - 1)
       await mine(1);
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("distribute", [await usdc.getAddress(), deployer.address, 1]);
       await governor.propose(
         ProposalType.Standard,
         [await treasuryGov.getAddress()],
@@ -482,7 +484,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // Create proposal — snapshot is block.number - 1
       // At snapshot: Alice has voting power, Bob does not
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("distribute", [await usdc.getAddress(), deployer.address, 1]);
       await governor.propose(
         ProposalType.Standard,
         [await treasuryGov.getAddress()],
@@ -522,7 +524,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await armToken.connect(alice).delegate(alice.address);
       await mine(1);
 
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("distribute", [await usdc.getAddress(), deployer.address, 1]);
       await governor.propose(
         ProposalType.Standard,
         [await treasuryGov.getAddress()],
@@ -564,7 +566,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await armToken.delegate(deployer.address);
       await mine(1);
 
-      const dummyCalldata = treasuryGov.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
+      const dummyCalldata = treasuryGov.interface.encodeFunctionData("distribute", [await usdc.getAddress(), deployer.address, 1]);
       await governor.propose(
         ProposalType.Standard,
         [await treasuryGov.getAddress()],
@@ -708,7 +710,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await mine(1);
 
       // Create a proposal to get quorum value
-      const dummyCalldata = localTreasury.interface.encodeFunctionData("createClaim", [await localUsdc.getAddress(), localDeployer.address, 1]);
+      const dummyCalldata = localTreasury.interface.encodeFunctionData("distribute", [await localUsdc.getAddress(), localDeployer.address, 1]);
       await localGovernor.propose(
         ProposalType.Standard,
         [await localTreasury.getAddress()],
@@ -755,7 +757,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await mine(1);
 
       // Create proposal before claims
-      const dummyCalldata = localTreasury.interface.encodeFunctionData("createClaim", [await localUsdc.getAddress(), localDeployer.address, 1]);
+      const dummyCalldata = localTreasury.interface.encodeFunctionData("distribute", [await localUsdc.getAddress(), localDeployer.address, 1]);
       await localGovernor.propose(
         ProposalType.Standard,
         [await localTreasury.getAddress()],
@@ -878,8 +880,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       await mine(1);
 
-      // Propose: create a claim (demo governance action)
-      const dummyCalldata = localTreasury.interface.encodeFunctionData("createClaim", [await localUsdc.getAddress(), localDeployer.address, 1]);
+      // Fund treasury with a small amount of USDC so the distribute call succeeds
+      await localUsdc.mint(await localTreasury.getAddress(), 1);
+      const dummyCalldata = localTreasury.interface.encodeFunctionData("distribute", [await localUsdc.getAddress(), localDeployer.address, 1]);
       await localGovernor.propose(
         ProposalType.Standard,
         [await localTreasury.getAddress()],

--- a/test/governance_emergency_pause.ts
+++ b/test/governance_emergency_pause.ts
@@ -392,10 +392,6 @@ describe("Governance Emergency Pause", function () {
         await usdc.getAddress(), ethers.parseUnits("10000", USDC_DECIMALS), 30 * ONE_DAY
       );
 
-      // Create a claim for alice
-      await standaloneTreasury.createClaim(
-        await usdc.getAddress(), alice.address, ethers.parseUnits("10000", USDC_DECIMALS)
-      );
     });
 
     it("distribute reverts when paused", async function () {
@@ -403,14 +399,6 @@ describe("Governance Emergency Pause", function () {
 
       await expect(
         standaloneTreasury.distribute(await usdc.getAddress(), bob.address, ethers.parseUnits("100", USDC_DECIMALS))
-      ).to.be.revertedWith("Pausable: paused");
-    });
-
-    it("exerciseClaim reverts when paused", async function () {
-      await standaloneTreasury.connect(guardian).emergencyPause();
-
-      await expect(
-        standaloneTreasury.connect(alice).exerciseClaim(1, ethers.parseUnits("100", USDC_DECIMALS))
       ).to.be.revertedWith("Pausable: paused");
     });
 
@@ -425,17 +413,6 @@ describe("Governance Emergency Pause", function () {
       ).to.be.revertedWith("Pausable: paused");
     });
 
-    it("createClaim still works when paused (owner-only, no fund outflow)", async function () {
-      await standaloneTreasury.connect(guardian).emergencyPause();
-
-      // Creating a claim is safe — it doesn't move funds out
-      await standaloneTreasury.createClaim(
-        await usdc.getAddress(), bob.address, ethers.parseUnits("5000", USDC_DECIMALS)
-      );
-      const remaining = await standaloneTreasury.getClaimRemaining(2);
-      expect(remaining).to.equal(ethers.parseUnits("5000", USDC_DECIMALS));
-    });
-
     it("all paused functions resume after unpause", async function () {
       await standaloneTreasury.connect(guardian).emergencyPause();
       await standaloneTreasury.connect(deployer).emergencyUnpause();
@@ -444,9 +421,6 @@ describe("Governance Emergency Pause", function () {
       await standaloneTreasury.distribute(
         await usdc.getAddress(), bob.address, ethers.parseUnits("100", USDC_DECIMALS)
       );
-
-      // exerciseClaim should work
-      await standaloneTreasury.connect(alice).exerciseClaim(1, ethers.parseUnits("100", USDC_DECIMALS));
 
       // stewardSpend should work (deployer is owner/timelock in standalone setup)
       await standaloneTreasury.stewardSpend(

--- a/test/governance_integration.ts
+++ b/test/governance_integration.ts
@@ -552,80 +552,8 @@ describe("Governance Integration", function () {
   });
 
   // ============================================================
-  // 6. Treasury Claims
   // ============================================================
-
-  describe("Treasury Claims", function () {
-    it("should create and exercise a claim via governance", async function () {
-      const claimAmount = ethers.parseUnits("1000", USDC_DECIMALS);
-      const targets = [await treasury.getAddress()];
-      const values = [0n];
-      const calldatas = [treasury.interface.encodeFunctionData("createClaim", [
-        await usdc.getAddress(), carol.address, claimAmount
-      ])];
-
-      await passProposal(
-        alice,
-        [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Standard, targets, values, calldatas,
-        "Create claim for Carol"
-      );
-
-      // Carol exercises the claim
-      const claimId = 1;
-      expect(await treasury.getClaimRemaining(claimId)).to.equal(claimAmount);
-
-      await treasury.connect(carol).exerciseClaim(claimId, claimAmount);
-      expect(await usdc.balanceOf(carol.address)).to.equal(claimAmount);
-      expect(await treasury.getClaimRemaining(claimId)).to.equal(0);
-    });
-
-    it("should support partial claim exercise", async function () {
-      const claimAmount = ethers.parseUnits("1000", USDC_DECIMALS);
-      const targets = [await treasury.getAddress()];
-      const values = [0n];
-      const calldatas = [treasury.interface.encodeFunctionData("createClaim", [
-        await usdc.getAddress(), carol.address, claimAmount
-      ])];
-
-      await passProposal(
-        alice,
-        [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Standard, targets, values, calldatas,
-        "Partial claim test"
-      );
-
-      const half = claimAmount / 2n;
-      await treasury.connect(carol).exerciseClaim(1, half);
-      expect(await treasury.getClaimRemaining(1)).to.equal(half);
-
-      await treasury.connect(carol).exerciseClaim(1, half);
-      expect(await treasury.getClaimRemaining(1)).to.equal(0);
-    });
-
-    it("should reject exercise by non-beneficiary", async function () {
-      const claimAmount = ethers.parseUnits("100", USDC_DECIMALS);
-      const targets = [await treasury.getAddress()];
-      const values = [0n];
-      const calldatas = [treasury.interface.encodeFunctionData("createClaim", [
-        await usdc.getAddress(), carol.address, claimAmount
-      ])];
-
-      await passProposal(
-        alice,
-        [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
-        ProposalType.Standard, targets, values, calldatas,
-        "Non-beneficiary test"
-      );
-
-      await expect(
-        treasury.connect(dave).exerciseClaim(1, claimAmount)
-      ).to.be.revertedWith("ArmadaTreasuryGov: not beneficiary");
-    });
-  });
-
-  // ============================================================
-  // 7. Treasury Steward (governor-based flow)
+  // 6. Treasury Steward (governor-based flow)
   // ============================================================
 
   describe("Treasury Steward", function () {

--- a/test/governance_quiet_period.ts
+++ b/test/governance_quiet_period.ts
@@ -118,7 +118,7 @@ describe("Governance Quiet Period (T6.1)", function () {
   // Helper: create a basic proposal (async — resolves treasury address)
   async function propose(description = "Test proposal") {
     const treasuryAddress = await treasury.getAddress();
-    const calldata = treasury.interface.encodeFunctionData("createClaim", [await usdc.getAddress(), deployer.address, 1]);
+    const calldata = treasury.interface.encodeFunctionData("distribute", [await usdc.getAddress(), deployer.address, 1]);
     return governor.propose(
       ProposalType.Standard,
       [treasuryAddress],


### PR DESCRIPTION
## Summary
- Remove the `createClaim`/`exerciseClaim` system from `ArmadaTreasuryGov` — it was not in the governance spec (which defines only `distribute()` and steward spending as treasury outflow channels)
- Remove associated state, events, view functions, tests, frontend UI, and doc scenarios
- Replace dummy `createClaim` calldata in cross-contract/quiet-period tests with `distribute`

## Context
Issue #29 flagged that claims are irrevocable and never expire. On review, the claims mechanism was an implementation-level addition not present in GOVERNANCE_SPEC.md. Rather than adding revocation to a non-spec feature, we remove it entirely. The spec's two channels (`distribute` for immediate transfers, steward spending for operational budget) cover all intended use cases.

## Changes (11 files, -377/+23 lines)
- **Contract**: `ArmadaTreasuryGov.sol` — removed Claim struct, state vars, events, `createClaim()`, `exerciseClaim()`, view functions
- **Tests**: removed 5 claim-specific test cases, replaced 11 dummy calldata references across 4 test files
- **Frontend**: removed claims from ABIs, types, data hook, TreasuryPanel, and CreateProposalForm
- **Docs**: removed G1–G11 claims test scenarios section

## Test plan
- [x] `npx hardhat compile` — clean
- [x] Hardhat governance tests (110 passing)
- [x] Foundry fuzz/invariant tests (all passing)
- [x] Grep for claims references — zero hits outside historical reports/archive

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)