### PR TITLE
feat(governance): implement RevenueLock for team/airdrop token release

### DIFF
--- a/config/networks.ts
+++ b/config/networks.ts
@@ -66,13 +66,15 @@ export interface NetworkConfig {
   /**
    * ARM token distribution (12M total supply).
    * All values are whole-token counts (no decimals). The deployer retains the remainder.
-   *   Treasury:  10.2M — protocol treasury (65%) + parked team (15%) + parked airdrop (5%)
-   *   Crowdfund: 1.8M  — backs MAX_SALE at $1/ARM
+   *   Treasury:    7.8M — protocol treasury (65%)
+   *   Crowdfund:   1.8M — backs MAX_SALE at $1/ARM
+   *   RevenueLock: 2.4M — team (15%) + airdrop (5%), revenue-gated release
    *   Deployer remainder: 0
    */
   armDistribution: {
     treasury: string;
     crowdfund: string;
+    revenueLock: string;
   };
   /** CCTP finality mode: "fast" (confirmed, ~8-20s) or "standard" (finalized, ~15-19min) */
   cctpFinalityMode: "fast" | "standard";
@@ -196,8 +198,9 @@ export function getNetworkConfig(): NetworkConfig {
     ethUsdcPrice: numEnv("ETH_USDC_PRICE", 2000),
     treasuryAddress: process.env.TREASURY_ADDRESS ?? "",
     armDistribution: {
-      treasury: optionalEnv("ARM_TREASURY_ALLOCATION", "10200000"),
+      treasury: optionalEnv("ARM_TREASURY_ALLOCATION", "7800000"),
       crowdfund: optionalEnv("ARM_CROWDFUND_ALLOCATION", "1800000"),
+      revenueLock: optionalEnv("ARM_REVENUE_LOCK_ALLOCATION", "2400000"),
     },
     cctpFinalityMode: optionalEnv("CCTP_FINALITY_MODE", "fast") as "fast" | "standard",
   };

--- a/contracts/governance/ArmadaToken.sol
+++ b/contracts/governance/ArmadaToken.sol
@@ -37,6 +37,12 @@ contract ArmadaToken is ERC20Votes {
     mapping(address => bool) public noDelegation;
     bool public noDelegationSet;
 
+    // ============ Authorized Delegator State ============
+
+    /// @notice Contracts authorized to call delegateOnBehalf (e.g. RevenueLock, Crowdfund).
+    mapping(address => bool) public authorizedDelegator;
+    bool public authorizedDelegatorsInitialized;
+
     // ============ Events ============
 
     event WhitelistAdded(address indexed account);
@@ -44,6 +50,7 @@ contract ArmadaToken is ERC20Votes {
     event TransferableSet(bool transferable);
     event WindDownContractSet(address indexed windDownContract);
     event NoDelegationSet(address indexed account);
+    event AuthorizedDelegatorsInitialized(address[] delegators);
 
     // ============ Constructor ============
 
@@ -95,6 +102,19 @@ contract ArmadaToken is ERC20Votes {
         emit NoDelegationSet(account);
     }
 
+    /// @notice Set contracts authorized to call delegateOnBehalf. Callable once by deployer.
+    ///         Follows the same one-time pattern as initWhitelist.
+    function initAuthorizedDelegators(address[] calldata delegators) external {
+        require(msg.sender == tokenDeployer, "ArmadaToken: not deployer");
+        require(!authorizedDelegatorsInitialized, "ArmadaToken: delegators already initialized");
+        authorizedDelegatorsInitialized = true;
+        for (uint256 i = 0; i < delegators.length; i++) {
+            require(delegators[i] != address(0), "ArmadaToken: zero address");
+            authorizedDelegator[delegators[i]] = true;
+        }
+        emit AuthorizedDelegatorsInitialized(delegators);
+    }
+
     // ============ Governance Functions ============
 
     /// @notice Add an address to the transfer whitelist. Timelock-only, add-only (no removal).
@@ -110,6 +130,15 @@ contract ArmadaToken is ERC20Votes {
         require(msg.sender == windDownContract, "ArmadaToken: not wind-down contract");
         transferable = _transferable;
         emit TransferableSet(_transferable);
+    }
+
+    /// @notice Delegate voting power on behalf of another address. Only callable by
+    ///         authorized contracts (e.g. RevenueLock, Crowdfund) for atomic transfer+delegation.
+    /// @param delegator The address whose voting power is being delegated
+    /// @param delegatee The address to receive the voting power
+    function delegateOnBehalf(address delegator, address delegatee) external {
+        require(authorizedDelegator[msg.sender], "ArmadaToken: not authorized delegator");
+        _delegate(delegator, delegatee);
     }
 
     // ============ Transfer Restriction ============

--- a/contracts/governance/RevenueLock.sol
+++ b/contracts/governance/RevenueLock.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Revenue-gated token release contract for team and airdrop ARM allocations.
+// ABOUTME: Releases ARM to beneficiaries as cumulative protocol revenue milestones are reached.
+pragma solidity ^0.8.17;
+
+// Minimal interfaces for cross-contract calls
+interface IRevenueCounterRevenueLock {
+    function recognizedRevenueUsd() external view returns (uint256);
+}
+
+interface IArmadaTokenRevenueLock {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+    function delegateOnBehalf(address delegator, address delegatee) external;
+}
+
+/// @title RevenueLock — Revenue-gated token release for team and airdrop ARM
+/// @notice Holds ARM for beneficiaries and releases it as cumulative protocol revenue
+///         milestones are reached. Immutable after deployment: no admin, no upgradeability,
+///         no sweep. Released ARM is atomically delegated via delegateOnBehalf.
+contract RevenueLock {
+
+    // ============ Constants ============
+
+    /// @notice Number of milestones in the unlock schedule
+    uint256 private constant NUM_MILESTONES = 6;
+
+    /// @notice Maximum basis points (100%)
+    uint256 private constant BPS_100 = 10000;
+
+    // ============ Immutable References ============
+
+    /// @notice ARM governance token
+    IArmadaTokenRevenueLock public immutable armToken;
+
+    /// @notice Revenue counter (reads cumulative recognized revenue)
+    IRevenueCounterRevenueLock public immutable revenueCounter;
+
+    /// @notice Total ARM allocated across all beneficiaries
+    uint256 public immutable totalAllocation;
+
+    // ============ State ============
+
+    /// @notice Per-beneficiary total allocation
+    mapping(address => uint256) public allocation;
+
+    /// @notice Per-beneficiary cumulative released amount
+    mapping(address => uint256) public released;
+
+    /// @notice Ordered list of beneficiaries (for enumeration)
+    address[] internal _beneficiaries;
+
+    // ============ Events ============
+
+    event Released(
+        address indexed beneficiary,
+        uint256 amount,
+        address delegatee,
+        uint256 cumulativeReleased
+    );
+
+    // ============ Constructor ============
+
+    /// @param _armToken ARM token address (must whitelist this contract for transfers)
+    /// @param _revenueCounter RevenueCounter UUPS proxy address
+    /// @param beneficiaries Array of beneficiary addresses
+    /// @param amounts Array of allocation amounts (18-decimal ARM), parallel to beneficiaries
+    constructor(
+        address _armToken,
+        address _revenueCounter,
+        address[] memory beneficiaries,
+        uint256[] memory amounts
+    ) {
+        require(_armToken != address(0), "RevenueLock: zero armToken");
+        require(_revenueCounter != address(0), "RevenueLock: zero revenueCounter");
+        require(beneficiaries.length > 0, "RevenueLock: empty beneficiaries");
+        require(beneficiaries.length == amounts.length, "RevenueLock: length mismatch");
+
+        armToken = IArmadaTokenRevenueLock(_armToken);
+        revenueCounter = IRevenueCounterRevenueLock(_revenueCounter);
+
+        uint256 total = 0;
+        for (uint256 i = 0; i < beneficiaries.length; i++) {
+            require(beneficiaries[i] != address(0), "RevenueLock: zero beneficiary");
+            require(amounts[i] > 0, "RevenueLock: zero amount");
+            require(allocation[beneficiaries[i]] == 0, "RevenueLock: duplicate beneficiary");
+
+            allocation[beneficiaries[i]] = amounts[i];
+            _beneficiaries.push(beneficiaries[i]);
+            total += amounts[i];
+        }
+
+        totalAllocation = total;
+    }
+
+    // ============ Release ============
+
+    /// @notice Release unlocked ARM to the caller and delegate their voting power.
+    /// @param delegatee Address to receive the caller's voting power delegation.
+    ///        Self-delegation is valid. Cannot be address(0).
+    function release(address delegatee) external {
+        require(delegatee != address(0), "RevenueLock: zero delegatee");
+        uint256 alloc = allocation[msg.sender];
+        require(alloc > 0, "RevenueLock: not a beneficiary");
+
+        uint256 unlockBps = unlockPercentage();
+        uint256 entitled = (alloc * unlockBps) / BPS_100;
+        uint256 alreadyReleased = released[msg.sender];
+        uint256 amount = entitled - alreadyReleased;
+        require(amount > 0, "RevenueLock: nothing to release");
+
+        released[msg.sender] = alreadyReleased + amount;
+
+        require(armToken.transfer(msg.sender, amount), "RevenueLock: transfer failed");
+        armToken.delegateOnBehalf(msg.sender, delegatee);
+
+        emit Released(msg.sender, amount, delegatee, released[msg.sender]);
+    }
+
+    // ============ View Functions ============
+
+    /// @notice Amount currently available for a beneficiary to release.
+    function releasable(address beneficiary) external view returns (uint256) {
+        uint256 alloc = allocation[beneficiary];
+        if (alloc == 0) return 0;
+        uint256 entitled = (alloc * unlockPercentage()) / BPS_100;
+        uint256 alreadyReleased = released[beneficiary];
+        if (entitled <= alreadyReleased) return 0;
+        return entitled - alreadyReleased;
+    }
+
+    /// @notice Current unlock percentage in basis points (0 = 0%, 10000 = 100%).
+    ///         Step function based on cumulative protocol revenue milestones.
+    function unlockPercentage() public view returns (uint256) {
+        uint256 revenue = revenueCounter.recognizedRevenueUsd();
+        return _unlockBpsForRevenue(revenue);
+    }
+
+    /// @notice Current cumulative recognized revenue from the RevenueCounter.
+    function currentRevenue() external view returns (uint256) {
+        return revenueCounter.recognizedRevenueUsd();
+    }
+
+    /// @notice Number of beneficiaries in the list.
+    function beneficiaryCount() external view returns (uint256) {
+        return _beneficiaries.length;
+    }
+
+    // ============ Internal ============
+
+    /// @dev Step function: returns the unlock bps for a given cumulative revenue.
+    ///      No interpolation — jumps at each threshold.
+    function _unlockBpsForRevenue(uint256 revenue) internal pure returns (uint256) {
+        // Milestones checked in descending order for early return at highest reached
+        if (revenue >= 1_000_000e18) return 10000; // 100%
+        if (revenue >= 500_000e18)   return 8000;  // 80%
+        if (revenue >= 250_000e18)   return 6000;  // 60%
+        if (revenue >= 100_000e18)   return 4000;  // 40%
+        if (revenue >= 50_000e18)    return 2500;  // 25%
+        if (revenue >= 10_000e18)    return 1000;  // 10%
+        return 0;
+    }
+}

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -11,12 +11,13 @@
  * - ArmadaGovernor
  * - TreasurySteward
  * - RevenueCounter (UUPS proxy)
+ * - RevenueLock (immutable, team + airdrop token release)
  * - ShieldPauseController
  * - ArmadaRedemption
  * - ArmadaWindDown
  *
  * Post-deploy configuration:
- * - ARM token: setNoDelegation, initWhitelist, setWindDownContract
+ * - ARM token: setNoDelegation, initWhitelist, initAuthorizedDelegators, setWindDownContract
  * - Treasury: initOutflowConfig, setWindDownContract
  * - Governor: setWindDownContract
  * - ShieldPauseController: setWindDownContract
@@ -51,6 +52,7 @@ interface GovernanceDeployment {
     steward: string;
     revenueCounter: string;
     revenueCounterImpl: string;
+    revenueLock: string;
     shieldPauseController: string;
     redemption: string;
     windDown: string;
@@ -171,8 +173,32 @@ async function main() {
   const revenueCounterAddress = await revenueCounterProxy.getAddress();
   console.log(`   RevenueCounter (proxy): ${revenueCounterAddress}`);
 
-  // 7. Deploy ShieldPauseController
-  console.log("7. Deploying ShieldPauseController...");
+  // 7. Deploy RevenueLock (immutable — holds team + airdrop ARM)
+  console.log("7. Deploying RevenueLock...");
+  // TODO: Replace placeholder beneficiaries with finalized mainnet list (see issue #144)
+  const revenueLockAllocation = ethers.parseUnits(config.armDistribution.revenueLock, 18);
+  // Local dev: use Anvil default accounts as placeholder beneficiaries
+  const revenueLockBeneficiaries = [
+    "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", // Anvil account #1
+    "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC", // Anvil account #2
+    "0x90F79bf6EB2c4f870365E785982E1f101E93b906", // Anvil account #3
+  ];
+  const revenueLockAmounts = [
+    ethers.parseUnits("1200000", 18), // team member 1
+    ethers.parseUnits("800000", 18),  // team member 2 / Knowable Safe placeholder
+    ethers.parseUnits("400000", 18),  // airdrop placeholder
+  ];
+  const RevenueLock = await ethers.getContractFactory("RevenueLock");
+  const revenueLockContract = await RevenueLock.deploy(
+    armTokenAddress, revenueCounterAddress,
+    revenueLockBeneficiaries, revenueLockAmounts, nm.override()
+  );
+  await revenueLockContract.deploymentTransaction()!.wait();
+  const revenueLockAddress = await revenueLockContract.getAddress();
+  console.log(`   RevenueLock: ${revenueLockAddress}`);
+
+  // 8. Deploy ShieldPauseController
+  console.log("8. Deploying ShieldPauseController...");
   const ShieldPauseController = await ethers.getContractFactory("ShieldPauseController");
   const shieldPause = await ShieldPauseController.deploy(
     governorAddress, timelockAddress, nm.override()
@@ -181,17 +207,16 @@ async function main() {
   const shieldPauseAddress = await shieldPause.getAddress();
   console.log(`   ShieldPauseController: ${shieldPauseAddress}`);
 
-  // 8. Deploy ArmadaRedemption
-  // TODO: revenueLock and crowdfund addresses should come from config once those contracts exist
-  const revenueLockAddress = ethers.ZeroAddress; // placeholder — set before mainnet
+  // 9. Deploy ArmadaRedemption
+  // TODO: crowdfund address should come from config once that contract is deployed
   const crowdfundAddress = ethers.ZeroAddress;   // placeholder — set before mainnet
-  console.log("8. Deploying ArmadaRedemption...");
+  console.log("9. Deploying ArmadaRedemption...");
   const ArmadaRedemption = await ethers.getContractFactory("ArmadaRedemption");
   // NOTE: Redemption requires non-zero addresses for all constructor params.
   //       On local dev, we use placeholder addresses. On mainnet, these must be real.
   //       Skipping deployment if placeholders are zero (can't deploy with zero addresses).
   let redemptionAddress = ethers.ZeroAddress;
-  if (revenueLockAddress !== ethers.ZeroAddress && crowdfundAddress !== ethers.ZeroAddress) {
+  if (crowdfundAddress !== ethers.ZeroAddress) {
     const redemption = await ArmadaRedemption.deploy(
       armTokenAddress, treasuryAddress, revenueLockAddress, crowdfundAddress, nm.override()
     );
@@ -199,13 +224,13 @@ async function main() {
     redemptionAddress = await redemption.getAddress();
     console.log(`   ArmadaRedemption: ${redemptionAddress}`);
   } else {
-    console.log("   ArmadaRedemption: SKIPPED (revenueLock/crowdfund addresses not set)");
+    console.log("   ArmadaRedemption: SKIPPED (crowdfund address not set)");
   }
 
-  // 9. Deploy ArmadaWindDown
+  // 10. Deploy ArmadaWindDown
   let windDownAddress = ethers.ZeroAddress;
   if (redemptionAddress !== ethers.ZeroAddress) {
-    console.log("9. Deploying ArmadaWindDown...");
+    console.log("10. Deploying ArmadaWindDown...");
     const windDownDeadline = Math.floor(new Date("2026-12-31T00:00:00Z").getTime() / 1000);
     const revenueThreshold = ethers.parseUnits("10000", 18); // $10k in 18-decimal USD
     const ArmadaWindDown = await ethers.getContractFactory("ArmadaWindDown");
@@ -218,13 +243,13 @@ async function main() {
     windDownAddress = await windDownContract.getAddress();
     console.log(`   ArmadaWindDown: ${windDownAddress}`);
   } else {
-    console.log("9. ArmadaWindDown: SKIPPED (redemption not deployed)");
+    console.log("10. ArmadaWindDown: SKIPPED (redemption not deployed)");
   }
 
   // ============ Post-deploy configuration ============
 
-  // 10. Configure timelock roles
-  console.log("10. Configuring timelock roles...");
+  // 11. Configure timelock roles
+  console.log("11. Configuring timelock roles...");
   const PROPOSER_ROLE = await timelock.PROPOSER_ROLE();
   const EXECUTOR_ROLE = await timelock.EXECUTOR_ROLE();
   const ADMIN_ROLE = await timelock.TIMELOCK_ADMIN_ROLE();
@@ -237,15 +262,19 @@ async function main() {
   await (await timelock.grantRole(CANCELLER_ROLE, governorAddress, nm.override())).wait();
   console.log("   Granted CANCELLER_ROLE to governor (for SC veto)");
 
-  // 11. Configure ARM token (one-time setters)
-  console.log("11. Configuring ARM token...");
+  // 12. Configure ARM token (one-time setters)
+  console.log("12. Configuring ARM token...");
   await (await armToken.setNoDelegation(treasuryAddress, nm.override())).wait();
   console.log(`   setNoDelegation: ${treasuryAddress} (treasury)`);
 
-  // Whitelist: treasury, deployer (for initial distribution), crowdfund (if applicable)
-  const whitelistAddresses = [deployer.address, treasuryAddress];
+  // Whitelist: deployer, treasury, revenueLock (for release transfers)
+  const whitelistAddresses = [deployer.address, treasuryAddress, revenueLockAddress];
   await (await armToken.initWhitelist(whitelistAddresses, nm.override())).wait();
   console.log(`   initWhitelist: ${whitelistAddresses.length} addresses`);
+
+  // Authorize RevenueLock for delegateOnBehalf
+  await (await armToken.initAuthorizedDelegators([revenueLockAddress], nm.override())).wait();
+  console.log(`   initAuthorizedDelegators: [${revenueLockAddress}] (RevenueLock)`);
   // Set wind-down contract on ARM token (deployer-only one-time setter)
   if (windDownAddress !== ethers.ZeroAddress) {
     await (await armToken.setWindDownContract(windDownAddress, nm.override())).wait();
@@ -254,28 +283,30 @@ async function main() {
     console.log("   setWindDownContract: DEFERRED (wind-down not deployed)");
   }
 
-  // 12. Distribute ARM tokens
+  // 13. Distribute ARM tokens
   const treasuryAllocation = ethers.parseUnits(config.armDistribution.treasury, 18);
-  console.log("12. Distributing ARM tokens...");
+  console.log("13. Distributing ARM tokens...");
   await (await armToken.transfer(treasuryAddress, treasuryAllocation, nm.override())).wait();
   console.log(`   Sent ${config.armDistribution.treasury} ARM to treasury`);
+  await (await armToken.transfer(revenueLockAddress, revenueLockAllocation, nm.override())).wait();
+  console.log(`   Sent ${config.armDistribution.revenueLock} ARM to RevenueLock`);
 
-  // 13. Initialize treasury outflow limits
+  // 14. Initialize treasury outflow limits
   // TODO: These defaults should be moved to config/networks.ts when finalized
-  console.log("13. Initializing treasury outflow limits...");
+  console.log("14. Initializing treasury outflow limits...");
   // Outflow limits are configured per-token via governance after deployment.
   // The deployer (as initial owner/timelock admin) cannot call initOutflowConfig directly
   // because the treasury's owner is the timelock. Outflow config will be set via the
   // first governance proposal after ARM delegation and governance activation.
   console.log("   Outflow limits will be configured via governance proposal post-launch");
 
-  // 14. Wire wind-down contract to governor, treasury, and pause controller
+  // 15. Wire wind-down contract to governor, treasury, and pause controller
   // These are timelock-only calls. Since deployer is still timelock admin at this point,
   // we call them directly via the timelock's schedule/execute pattern.
   // NOTE: On local dev with zero timelock delay, we can call via the timelock directly.
   // On mainnet, these would need to be governance proposals.
   if (windDownAddress !== ethers.ZeroAddress) {
-    console.log("14. Wiring wind-down contract...");
+    console.log("15. Wiring wind-down contract...");
     // Governor: setWindDownContract (timelock-only)
     // NOTE: On local with deployer as timelock admin, these go through the timelock.
     // For simplicity in local dev, we schedule+execute immediately.
@@ -285,11 +316,11 @@ async function main() {
     console.log(`   TODO: treasury.setWindDownContract(${windDownAddress})`);
     console.log(`   TODO: shieldPause.setWindDownContract(${windDownAddress})`);
   } else {
-    console.log("14. Wind-down wiring: SKIPPED (wind-down not deployed)");
+    console.log("15. Wind-down wiring: SKIPPED (wind-down not deployed)");
   }
 
-  // 15. Renounce timelock admin (last step — deployer relinquishes admin role)
-  console.log("15. Renouncing timelock admin...");
+  // 16. Renounce timelock admin (last step — deployer relinquishes admin role)
+  console.log("16. Renouncing timelock admin...");
   await (await timelock.renounceRole(ADMIN_ROLE, deployer.address, nm.override())).wait();
   console.log("   Renounced TIMELOCK_ADMIN_ROLE from deployer");
 
@@ -306,6 +337,7 @@ async function main() {
       steward: stewardAddress,
       revenueCounter: revenueCounterAddress,
       revenueCounterImpl: revenueCounterImplAddress,
+      revenueLock: revenueLockAddress,
       shieldPauseController: shieldPauseAddress,
       redemption: redemptionAddress,
       windDown: windDownAddress,
@@ -331,7 +363,7 @@ async function main() {
   if (windDownAddress !== ethers.ZeroAddress) {
     console.log("  6. Wire wind-down to governor, treasury, pause controller (via governance proposals)");
   } else {
-    console.log("  6. Deploy ArmadaRedemption + ArmadaWindDown when revenueLock/crowdfund are ready");
+    console.log("  6. Deploy ArmadaRedemption + ArmadaWindDown when crowdfund is ready");
     console.log("  7. Wire wind-down to all consumers after deployment");
   }
 }

--- a/test-foundry/ArmadaTokenDelegateOnBehalf.t.sol
+++ b/test-foundry/ArmadaTokenDelegateOnBehalf.t.sol
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Foundry tests for ArmadaToken.delegateOnBehalf and initAuthorizedDelegators.
+// ABOUTME: Covers authorization setup, on-behalf delegation, voting power transfer, and guard interactions.
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+
+contract ArmadaTokenDelegateOnBehalfTest is Test {
+    // Mirror events
+    event AuthorizedDelegatorsInitialized(address[] delegators);
+    event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate);
+
+    ArmadaToken public armToken;
+    TimelockController public timelock;
+
+    address public deployer = address(this);
+    address public alice = address(0xA11CE);
+    address public bob = address(0xB0B);
+    address public carol = address(0xCA401);
+    address public authorizedContract = address(0xAC01);
+    address public unauthorizedCaller = address(0xBAD);
+    address public treasuryAddr = address(0x7EA5);
+
+    uint256 constant TOTAL_SUPPLY = 12_000_000 * 1e18;
+
+    function setUp() public {
+        // Deploy timelock
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        timelock = new TimelockController(2 days, proposers, executors, deployer);
+
+        // Deploy ARM token (deployer receives full supply)
+        armToken = new ArmadaToken(deployer, address(timelock));
+
+        // Whitelist deployer + alice + bob so transfers work
+        address[] memory whitelist = new address[](4);
+        whitelist[0] = deployer;
+        whitelist[1] = alice;
+        whitelist[2] = bob;
+        whitelist[3] = carol;
+        armToken.initWhitelist(whitelist);
+
+        // Set treasury as noDelegation
+        armToken.setNoDelegation(treasuryAddr);
+
+        // Distribute tokens
+        armToken.transfer(alice, 2_000_000 * 1e18);
+        armToken.transfer(bob, 1_000_000 * 1e18);
+        armToken.transfer(carol, 500_000 * 1e18);
+
+        // Mine a block so getPastVotes works
+        vm.roll(block.number + 1);
+    }
+
+    // ============ initAuthorizedDelegators ============
+
+    function test_initAuthorizedDelegators_succeeds() public {
+        address[] memory delegators = new address[](2);
+        delegators[0] = authorizedContract;
+        delegators[1] = address(0xAC02);
+
+        vm.expectEmit(false, false, false, true);
+        emit AuthorizedDelegatorsInitialized(delegators);
+
+        armToken.initAuthorizedDelegators(delegators);
+
+        assertTrue(armToken.authorizedDelegator(authorizedContract));
+        assertTrue(armToken.authorizedDelegator(address(0xAC02)));
+        assertFalse(armToken.authorizedDelegator(unauthorizedCaller));
+        assertTrue(armToken.authorizedDelegatorsInitialized());
+    }
+
+    function test_initAuthorizedDelegators_notDeployer_reverts() public {
+        address[] memory delegators = new address[](1);
+        delegators[0] = authorizedContract;
+
+        vm.prank(alice);
+        vm.expectRevert("ArmadaToken: not deployer");
+        armToken.initAuthorizedDelegators(delegators);
+    }
+
+    function test_initAuthorizedDelegators_calledTwice_reverts() public {
+        address[] memory delegators = new address[](1);
+        delegators[0] = authorizedContract;
+
+        armToken.initAuthorizedDelegators(delegators);
+
+        vm.expectRevert("ArmadaToken: delegators already initialized");
+        armToken.initAuthorizedDelegators(delegators);
+    }
+
+    function test_initAuthorizedDelegators_zeroAddress_reverts() public {
+        address[] memory delegators = new address[](2);
+        delegators[0] = authorizedContract;
+        delegators[1] = address(0);
+
+        vm.expectRevert("ArmadaToken: zero address");
+        armToken.initAuthorizedDelegators(delegators);
+    }
+
+    // ============ delegateOnBehalf ============
+
+    function test_delegateOnBehalf_authorized_succeeds() public {
+        // Setup: authorize the contract
+        address[] memory delegators = new address[](1);
+        delegators[0] = authorizedContract;
+        armToken.initAuthorizedDelegators(delegators);
+
+        // Alice has tokens but hasn't delegated yet — zero voting power
+        assertEq(armToken.getVotes(alice), 0);
+        assertEq(armToken.getVotes(bob), 0);
+
+        // Authorized contract delegates alice's tokens to bob
+        vm.prank(authorizedContract);
+        armToken.delegateOnBehalf(alice, bob);
+
+        // Bob now has alice's voting power
+        assertEq(armToken.getVotes(bob), 2_000_000 * 1e18);
+        assertEq(armToken.delegates(alice), bob);
+    }
+
+    function test_delegateOnBehalf_unauthorized_reverts() public {
+        // No authorized delegators set up
+        vm.prank(unauthorizedCaller);
+        vm.expectRevert("ArmadaToken: not authorized delegator");
+        armToken.delegateOnBehalf(alice, bob);
+    }
+
+    function test_delegateOnBehalf_unauthorizedAfterInit_reverts() public {
+        // Setup: authorize a different contract
+        address[] memory delegators = new address[](1);
+        delegators[0] = authorizedContract;
+        armToken.initAuthorizedDelegators(delegators);
+
+        // Unauthorized caller still blocked
+        vm.prank(unauthorizedCaller);
+        vm.expectRevert("ArmadaToken: not authorized delegator");
+        armToken.delegateOnBehalf(alice, bob);
+    }
+
+    function test_delegateOnBehalf_noDelegation_reverts() public {
+        // Setup: authorize the contract
+        address[] memory delegators = new address[](1);
+        delegators[0] = authorizedContract;
+        armToken.initAuthorizedDelegators(delegators);
+
+        // Try to delegate on behalf of treasury (noDelegation address)
+        vm.prank(authorizedContract);
+        vm.expectRevert("ArmadaToken: delegation blocked");
+        armToken.delegateOnBehalf(treasuryAddr, bob);
+    }
+
+    function test_delegateOnBehalf_emitsDelegateChanged() public {
+        // Setup
+        address[] memory delegators = new address[](1);
+        delegators[0] = authorizedContract;
+        armToken.initAuthorizedDelegators(delegators);
+
+        // Expect the OZ DelegateChanged event
+        vm.expectEmit(true, true, true, false);
+        emit DelegateChanged(alice, address(0), bob);
+
+        vm.prank(authorizedContract);
+        armToken.delegateOnBehalf(alice, bob);
+    }
+
+    function test_delegateOnBehalf_changesDelegatee() public {
+        // Setup
+        address[] memory delegators = new address[](1);
+        delegators[0] = authorizedContract;
+        armToken.initAuthorizedDelegators(delegators);
+
+        // First delegation: alice -> bob
+        vm.prank(authorizedContract);
+        armToken.delegateOnBehalf(alice, bob);
+        assertEq(armToken.delegates(alice), bob);
+        assertEq(armToken.getVotes(bob), 2_000_000 * 1e18);
+
+        // Second delegation: alice -> carol
+        vm.prank(authorizedContract);
+        armToken.delegateOnBehalf(alice, carol);
+        assertEq(armToken.delegates(alice), carol);
+        assertEq(armToken.getVotes(carol), 2_000_000 * 1e18);
+        assertEq(armToken.getVotes(bob), 0);
+    }
+
+    function test_delegateOnBehalf_selfDelegation() public {
+        // Setup
+        address[] memory delegators = new address[](1);
+        delegators[0] = authorizedContract;
+        armToken.initAuthorizedDelegators(delegators);
+
+        // Self-delegation is valid per spec
+        vm.prank(authorizedContract);
+        armToken.delegateOnBehalf(alice, alice);
+        assertEq(armToken.delegates(alice), alice);
+        assertEq(armToken.getVotes(alice), 2_000_000 * 1e18);
+    }
+}

--- a/test-foundry/RevenueLock.t.sol
+++ b/test-foundry/RevenueLock.t.sol
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Foundry unit and fuzz tests for RevenueLock — constructor validation, release mechanics, and view functions.
+// ABOUTME: Covers milestone step function, atomic delegation, multi-beneficiary release, and edge cases.
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/RevenueLock.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+
+/// @dev Mock RevenueCounter for testing (same pattern as ArmadaWindDown.t.sol)
+contract MockRevenueCounterRL {
+    uint256 public recognizedRevenueUsd;
+
+    function setRevenue(uint256 _revenue) external {
+        recognizedRevenueUsd = _revenue;
+    }
+}
+
+contract RevenueLockTest is Test {
+    // Mirror events
+    event Released(address indexed beneficiary, uint256 amount, address delegatee, uint256 cumulativeReleased);
+
+    RevenueLock public revenueLock;
+    ArmadaToken public armToken;
+    MockRevenueCounterRL public revenueCounter;
+    TimelockController public timelock;
+
+    address public deployer = address(this);
+    address public beneficiaryA = address(0xA11CE);
+    address public beneficiaryB = address(0xB0B);
+    address public beneficiaryC = address(0xCA401);
+    address public delegateeX = address(0xDE1E);
+    address public delegateeY = address(0xDE2E);
+    address public nonBeneficiary = address(0xBAD);
+
+    uint256 constant TOTAL_SUPPLY = 12_000_000 * 1e18;
+    uint256 constant ALLOC_A = 1_200_000 * 1e18; // 10% of supply
+    uint256 constant ALLOC_B = 800_000 * 1e18;   // ~6.7%
+    uint256 constant ALLOC_C = 400_000 * 1e18;   // ~3.3%
+    uint256 constant TOTAL_LOCK = ALLOC_A + ALLOC_B + ALLOC_C; // 2,400,000 ARM
+
+    function setUp() public {
+        // Deploy mock revenue counter
+        revenueCounter = new MockRevenueCounterRL();
+
+        // Deploy timelock
+        address[] memory empty = new address[](0);
+        timelock = new TimelockController(2 days, empty, empty, deployer);
+
+        // Deploy ARM token
+        armToken = new ArmadaToken(deployer, address(timelock));
+
+        // Setup beneficiary arrays
+        address[] memory beneficiaries = new address[](3);
+        beneficiaries[0] = beneficiaryA;
+        beneficiaries[1] = beneficiaryB;
+        beneficiaries[2] = beneficiaryC;
+
+        uint256[] memory amounts = new uint256[](3);
+        amounts[0] = ALLOC_A;
+        amounts[1] = ALLOC_B;
+        amounts[2] = ALLOC_C;
+
+        // Deploy RevenueLock
+        revenueLock = new RevenueLock(
+            address(armToken),
+            address(revenueCounter),
+            beneficiaries,
+            amounts
+        );
+
+        // Whitelist RevenueLock + beneficiaries for transfers
+        address[] memory whitelist = new address[](5);
+        whitelist[0] = deployer;
+        whitelist[1] = address(revenueLock);
+        whitelist[2] = beneficiaryA;
+        whitelist[3] = beneficiaryB;
+        whitelist[4] = beneficiaryC;
+        armToken.initWhitelist(whitelist);
+
+        // Authorize RevenueLock for delegateOnBehalf
+        address[] memory delegators = new address[](1);
+        delegators[0] = address(revenueLock);
+        armToken.initAuthorizedDelegators(delegators);
+
+        // Fund RevenueLock with ARM
+        armToken.transfer(address(revenueLock), TOTAL_LOCK);
+
+        // Mine a block so getPastVotes works
+        vm.roll(block.number + 1);
+    }
+
+    // ============ Constructor Tests ============
+
+    function test_constructor_setsImmutables() public {
+        assertEq(address(revenueLock.armToken()), address(armToken));
+        assertEq(address(revenueLock.revenueCounter()), address(revenueCounter));
+        assertEq(revenueLock.totalAllocation(), TOTAL_LOCK);
+        assertEq(revenueLock.beneficiaryCount(), 3);
+    }
+
+    function test_constructor_setsAllocations() public {
+        assertEq(revenueLock.allocation(beneficiaryA), ALLOC_A);
+        assertEq(revenueLock.allocation(beneficiaryB), ALLOC_B);
+        assertEq(revenueLock.allocation(beneficiaryC), ALLOC_C);
+    }
+
+    function test_constructor_initialReleasedIsZero() public {
+        assertEq(revenueLock.released(beneficiaryA), 0);
+        assertEq(revenueLock.released(beneficiaryB), 0);
+        assertEq(revenueLock.released(beneficiaryC), 0);
+    }
+
+    function test_constructor_zeroArmToken_reverts() public {
+        address[] memory b = new address[](1);
+        b[0] = beneficiaryA;
+        uint256[] memory a = new uint256[](1);
+        a[0] = 1e18;
+
+        vm.expectRevert("RevenueLock: zero armToken");
+        new RevenueLock(address(0), address(revenueCounter), b, a);
+    }
+
+    function test_constructor_zeroRevenueCounter_reverts() public {
+        address[] memory b = new address[](1);
+        b[0] = beneficiaryA;
+        uint256[] memory a = new uint256[](1);
+        a[0] = 1e18;
+
+        vm.expectRevert("RevenueLock: zero revenueCounter");
+        new RevenueLock(address(armToken), address(0), b, a);
+    }
+
+    function test_constructor_emptyBeneficiaries_reverts() public {
+        address[] memory b = new address[](0);
+        uint256[] memory a = new uint256[](0);
+
+        vm.expectRevert("RevenueLock: empty beneficiaries");
+        new RevenueLock(address(armToken), address(revenueCounter), b, a);
+    }
+
+    function test_constructor_lengthMismatch_reverts() public {
+        address[] memory b = new address[](2);
+        b[0] = beneficiaryA;
+        b[1] = beneficiaryB;
+        uint256[] memory a = new uint256[](1);
+        a[0] = 1e18;
+
+        vm.expectRevert("RevenueLock: length mismatch");
+        new RevenueLock(address(armToken), address(revenueCounter), b, a);
+    }
+
+    function test_constructor_zeroBeneficiaryAddress_reverts() public {
+        address[] memory b = new address[](1);
+        b[0] = address(0);
+        uint256[] memory a = new uint256[](1);
+        a[0] = 1e18;
+
+        vm.expectRevert("RevenueLock: zero beneficiary");
+        new RevenueLock(address(armToken), address(revenueCounter), b, a);
+    }
+
+    function test_constructor_zeroAmount_reverts() public {
+        address[] memory b = new address[](1);
+        b[0] = beneficiaryA;
+        uint256[] memory a = new uint256[](1);
+        a[0] = 0;
+
+        vm.expectRevert("RevenueLock: zero amount");
+        new RevenueLock(address(armToken), address(revenueCounter), b, a);
+    }
+
+    function test_constructor_duplicateBeneficiary_reverts() public {
+        address[] memory b = new address[](2);
+        b[0] = beneficiaryA;
+        b[1] = beneficiaryA;
+        uint256[] memory a = new uint256[](2);
+        a[0] = 1e18;
+        a[1] = 1e18;
+
+        vm.expectRevert("RevenueLock: duplicate beneficiary");
+        new RevenueLock(address(armToken), address(revenueCounter), b, a);
+    }
+
+    // ============ View Function Tests ============
+
+    function test_allocation_unknownAddress_returnsZero() public {
+        assertEq(revenueLock.allocation(nonBeneficiary), 0);
+    }
+
+    function test_unlockPercentage_zeroRevenue() public {
+        assertEq(revenueLock.unlockPercentage(), 0);
+    }
+
+    function test_unlockPercentage_belowFirstMilestone() public {
+        revenueCounter.setRevenue(9_999e18);
+        assertEq(revenueLock.unlockPercentage(), 0);
+    }
+
+    function test_unlockPercentage_atFirstMilestone() public {
+        revenueCounter.setRevenue(10_000e18);
+        assertEq(revenueLock.unlockPercentage(), 1000); // 10%
+    }
+
+    function test_unlockPercentage_betweenMilestones() public {
+        revenueCounter.setRevenue(49_999e18);
+        assertEq(revenueLock.unlockPercentage(), 1000); // still 10%, step function
+    }
+
+    function test_unlockPercentage_atSecondMilestone() public {
+        revenueCounter.setRevenue(50_000e18);
+        assertEq(revenueLock.unlockPercentage(), 2500); // 25%
+    }
+
+    function test_unlockPercentage_atThirdMilestone() public {
+        revenueCounter.setRevenue(100_000e18);
+        assertEq(revenueLock.unlockPercentage(), 4000); // 40%
+    }
+
+    function test_unlockPercentage_atFourthMilestone() public {
+        revenueCounter.setRevenue(250_000e18);
+        assertEq(revenueLock.unlockPercentage(), 6000); // 60%
+    }
+
+    function test_unlockPercentage_atFifthMilestone() public {
+        revenueCounter.setRevenue(500_000e18);
+        assertEq(revenueLock.unlockPercentage(), 8000); // 80%
+    }
+
+    function test_unlockPercentage_atSixthMilestone() public {
+        revenueCounter.setRevenue(1_000_000e18);
+        assertEq(revenueLock.unlockPercentage(), 10000); // 100%
+    }
+
+    function test_unlockPercentage_aboveMaxMilestone() public {
+        revenueCounter.setRevenue(5_000_000e18);
+        assertEq(revenueLock.unlockPercentage(), 10000); // still 100%
+    }
+
+    function test_currentRevenue_readsCounter() public {
+        revenueCounter.setRevenue(42e18);
+        assertEq(revenueLock.currentRevenue(), 42e18);
+    }
+
+    function test_releasable_zeroRevenue() public {
+        assertEq(revenueLock.releasable(beneficiaryA), 0);
+    }
+
+    function test_releasable_nonBeneficiary() public {
+        revenueCounter.setRevenue(1_000_000e18);
+        assertEq(revenueLock.releasable(nonBeneficiary), 0);
+    }
+
+    function test_releasable_atFirstMilestone() public {
+        revenueCounter.setRevenue(10_000e18);
+        // 10% of ALLOC_A = 120,000 ARM
+        assertEq(revenueLock.releasable(beneficiaryA), ALLOC_A * 1000 / 10000);
+    }
+
+    // ============ Release Tests ============
+
+    function test_release_nonBeneficiary_reverts() public {
+        revenueCounter.setRevenue(10_000e18);
+        vm.prank(nonBeneficiary);
+        vm.expectRevert("RevenueLock: not a beneficiary");
+        revenueLock.release(delegateeX);
+    }
+
+    function test_release_zeroDelegatee_reverts() public {
+        revenueCounter.setRevenue(10_000e18);
+        vm.prank(beneficiaryA);
+        vm.expectRevert("RevenueLock: zero delegatee");
+        revenueLock.release(address(0));
+    }
+
+    function test_release_zeroRevenue_reverts() public {
+        vm.prank(beneficiaryA);
+        vm.expectRevert("RevenueLock: nothing to release");
+        revenueLock.release(delegateeX);
+    }
+
+    function test_release_atFirstMilestone_transfers10Percent() public {
+        revenueCounter.setRevenue(10_000e18);
+
+        uint256 expected = ALLOC_A * 1000 / 10000; // 10%
+        uint256 balBefore = armToken.balanceOf(beneficiaryA);
+
+        vm.prank(beneficiaryA);
+        revenueLock.release(delegateeX);
+
+        assertEq(armToken.balanceOf(beneficiaryA), balBefore + expected);
+        assertEq(revenueLock.released(beneficiaryA), expected);
+    }
+
+    function test_release_delegatesToSpecifiedAddress() public {
+        revenueCounter.setRevenue(10_000e18);
+
+        vm.prank(beneficiaryA);
+        revenueLock.release(delegateeX);
+
+        assertEq(armToken.delegates(beneficiaryA), delegateeX);
+    }
+
+    function test_release_secondCallAtSameMilestone_reverts() public {
+        revenueCounter.setRevenue(10_000e18);
+
+        vm.prank(beneficiaryA);
+        revenueLock.release(delegateeX);
+
+        vm.prank(beneficiaryA);
+        vm.expectRevert("RevenueLock: nothing to release");
+        revenueLock.release(delegateeX);
+    }
+
+    function test_release_atSecondMilestone_transfersDelta() public {
+        // First release at 10%
+        revenueCounter.setRevenue(10_000e18);
+        vm.prank(beneficiaryA);
+        revenueLock.release(delegateeX);
+        uint256 firstRelease = ALLOC_A * 1000 / 10000;
+
+        // Revenue increases to $50k (25%)
+        revenueCounter.setRevenue(50_000e18);
+        uint256 balBefore = armToken.balanceOf(beneficiaryA);
+
+        vm.prank(beneficiaryA);
+        revenueLock.release(delegateeX);
+
+        uint256 secondRelease = (ALLOC_A * 2500 / 10000) - firstRelease;
+        assertEq(armToken.balanceOf(beneficiaryA), balBefore + secondRelease);
+        assertEq(revenueLock.released(beneficiaryA), firstRelease + secondRelease);
+    }
+
+    function test_release_atFullUnlock_transfersEverything() public {
+        revenueCounter.setRevenue(1_000_000e18);
+
+        vm.prank(beneficiaryA);
+        revenueLock.release(delegateeX);
+
+        assertEq(revenueLock.released(beneficiaryA), ALLOC_A);
+        assertEq(armToken.balanceOf(beneficiaryA), ALLOC_A);
+        assertEq(revenueLock.releasable(beneficiaryA), 0);
+    }
+
+    function test_release_emitsEvent() public {
+        revenueCounter.setRevenue(10_000e18);
+        uint256 expectedAmount = ALLOC_A * 1000 / 10000;
+
+        vm.expectEmit(true, false, false, true);
+        emit Released(beneficiaryA, expectedAmount, delegateeX, expectedAmount);
+
+        vm.prank(beneficiaryA);
+        revenueLock.release(delegateeX);
+    }
+
+    function test_release_multipleBeneficiariesIndependent() public {
+        revenueCounter.setRevenue(100_000e18); // 40% unlock
+
+        // Beneficiary A releases
+        vm.prank(beneficiaryA);
+        revenueLock.release(delegateeX);
+        assertEq(revenueLock.released(beneficiaryA), ALLOC_A * 4000 / 10000);
+
+        // Beneficiary B releases independently
+        vm.prank(beneficiaryB);
+        revenueLock.release(delegateeY);
+        assertEq(revenueLock.released(beneficiaryB), ALLOC_B * 4000 / 10000);
+
+        // Beneficiary C hasn't released — still zero
+        assertEq(revenueLock.released(beneficiaryC), 0);
+        assertEq(revenueLock.releasable(beneficiaryC), ALLOC_C * 4000 / 10000);
+    }
+
+    function test_release_changesDelegatee() public {
+        revenueCounter.setRevenue(10_000e18);
+
+        // First release: delegate to X
+        vm.prank(beneficiaryA);
+        revenueLock.release(delegateeX);
+        assertEq(armToken.delegates(beneficiaryA), delegateeX);
+
+        // Increase revenue, release again with different delegatee
+        revenueCounter.setRevenue(50_000e18);
+        vm.prank(beneficiaryA);
+        revenueLock.release(delegateeY);
+        assertEq(armToken.delegates(beneficiaryA), delegateeY);
+    }
+
+    function test_release_selfDelegation() public {
+        revenueCounter.setRevenue(10_000e18);
+
+        vm.prank(beneficiaryA);
+        revenueLock.release(beneficiaryA);
+
+        assertEq(armToken.delegates(beneficiaryA), beneficiaryA);
+        uint256 expectedVotes = ALLOC_A * 1000 / 10000;
+        assertEq(armToken.getVotes(beneficiaryA), expectedVotes);
+    }
+
+    function test_release_fullLifecycle_allMilestones() public {
+        uint256[6] memory thresholds = [uint256(10_000e18), 50_000e18, 100_000e18, 250_000e18, 500_000e18, 1_000_000e18];
+        uint256[6] memory bps = [uint256(1000), 2500, 4000, 6000, 8000, 10000];
+
+        uint256 prevReleased = 0;
+
+        for (uint256 i = 0; i < 6; i++) {
+            revenueCounter.setRevenue(thresholds[i]);
+            uint256 entitled = ALLOC_A * bps[i] / 10000;
+            uint256 expectedDelta = entitled - prevReleased;
+
+            vm.prank(beneficiaryA);
+            revenueLock.release(delegateeX);
+
+            assertEq(revenueLock.released(beneficiaryA), entitled, "wrong cumulative release");
+            prevReleased = entitled;
+        }
+
+        // Fully released
+        assertEq(revenueLock.released(beneficiaryA), ALLOC_A);
+        assertEq(revenueLock.releasable(beneficiaryA), 0);
+    }
+
+    function test_supplyConservation_afterReleases() public {
+        revenueCounter.setRevenue(250_000e18); // 60%
+
+        vm.prank(beneficiaryA);
+        revenueLock.release(delegateeX);
+        vm.prank(beneficiaryB);
+        revenueLock.release(delegateeX);
+
+        uint256 lockBalance = armToken.balanceOf(address(revenueLock));
+        uint256 totalReleased = revenueLock.released(beneficiaryA)
+            + revenueLock.released(beneficiaryB)
+            + revenueLock.released(beneficiaryC);
+
+        assertEq(lockBalance + totalReleased, TOTAL_LOCK, "supply conservation violated");
+    }
+
+    // ============ Fuzz Tests ============
+
+    function testFuzz_unlockPercentage_monotonic(uint256 rev1, uint256 rev2) public {
+        rev1 = bound(rev1, 0, 10_000_000e18);
+        rev2 = bound(rev2, rev1, 10_000_000e18);
+
+        revenueCounter.setRevenue(rev1);
+        uint256 pct1 = revenueLock.unlockPercentage();
+
+        revenueCounter.setRevenue(rev2);
+        uint256 pct2 = revenueLock.unlockPercentage();
+
+        assertGe(pct2, pct1, "unlock percentage not monotonic");
+    }
+
+    function testFuzz_release_neverExceedsAllocation(uint256 revenue) public {
+        revenue = bound(revenue, 0, 10_000_000e18);
+        revenueCounter.setRevenue(revenue);
+
+        uint256 releasableA = revenueLock.releasable(beneficiaryA);
+        assertLe(releasableA, ALLOC_A, "releasable exceeds allocation");
+
+        if (releasableA > 0) {
+            vm.prank(beneficiaryA);
+            revenueLock.release(delegateeX);
+            assertLe(revenueLock.released(beneficiaryA), ALLOC_A, "released exceeds allocation");
+        }
+    }
+
+    function testFuzz_unlockPercentage_stepFunction(uint256 revenue) public {
+        revenue = bound(revenue, 0, 10_000_000e18);
+        revenueCounter.setRevenue(revenue);
+        uint256 pct = revenueLock.unlockPercentage();
+
+        // Must be one of the valid step values
+        assertTrue(
+            pct == 0 || pct == 1000 || pct == 2500 || pct == 4000 ||
+            pct == 6000 || pct == 8000 || pct == 10000,
+            "unlock percentage not a valid step value"
+        );
+    }
+}

--- a/test-foundry/RevenueLockInvariant.t.sol
+++ b/test-foundry/RevenueLockInvariant.t.sol
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Foundry invariant tests for RevenueLock — supply conservation, no over-release, vote inertness.
+// ABOUTME: Uses a stateful handler to fuzz release() calls across beneficiaries and revenue levels.
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/RevenueLock.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+
+/// @dev Mock RevenueCounter for invariant testing
+contract MockRevenueCounterInv {
+    uint256 public recognizedRevenueUsd;
+
+    function setRevenue(uint256 _revenue) external {
+        recognizedRevenueUsd = _revenue;
+    }
+}
+
+/// @dev Handler contract for stateful fuzzing of RevenueLock
+contract RevenueLockHandler is Test {
+    RevenueLock public revenueLock;
+    ArmadaToken public armToken;
+    MockRevenueCounterInv public revenueCounter;
+    address[] public beneficiaries;
+    address[] public delegatees;
+
+    // Ghost variables for tracking
+    uint256 public ghost_releaseCount;
+    uint256 public ghost_revertCount;
+
+    constructor(
+        RevenueLock _revenueLock,
+        ArmadaToken _armToken,
+        MockRevenueCounterInv _revenueCounter,
+        address[] memory _beneficiaries,
+        address[] memory _delegatees
+    ) {
+        revenueLock = _revenueLock;
+        armToken = _armToken;
+        revenueCounter = _revenueCounter;
+        beneficiaries = _beneficiaries;
+        delegatees = _delegatees;
+    }
+
+    /// @dev Fuzzed: set revenue to an arbitrary amount
+    function setRevenue(uint256 revenue) external {
+        revenue = bound(revenue, 0, 5_000_000e18);
+        revenueCounter.setRevenue(revenue);
+    }
+
+    /// @dev Fuzzed: a random beneficiary calls release with a random delegatee
+    function release(uint256 beneficiaryIdx, uint256 delegateeIdx) external {
+        beneficiaryIdx = bound(beneficiaryIdx, 0, beneficiaries.length - 1);
+        delegateeIdx = bound(delegateeIdx, 0, delegatees.length - 1);
+
+        address beneficiary = beneficiaries[beneficiaryIdx];
+        address delegatee = delegatees[delegateeIdx];
+
+        vm.prank(beneficiary);
+        try revenueLock.release(delegatee) {
+            ghost_releaseCount++;
+        } catch {
+            ghost_revertCount++;
+        }
+    }
+}
+
+contract RevenueLockInvariantTest is Test {
+    RevenueLock public revenueLock;
+    ArmadaToken public armToken;
+    MockRevenueCounterInv public revenueCounter;
+    TimelockController public timelock;
+    RevenueLockHandler public handler;
+
+    address public deployer = address(this);
+    address[] public beneficiaries;
+    address[] public delegatees;
+    uint256[] public amounts;
+
+    uint256 constant TOTAL_LOCK = 2_400_000 * 1e18;
+
+    function setUp() public {
+        // Deploy mock revenue counter
+        revenueCounter = new MockRevenueCounterInv();
+
+        // Deploy timelock
+        address[] memory empty = new address[](0);
+        timelock = new TimelockController(2 days, empty, empty, deployer);
+
+        // Deploy ARM token
+        armToken = new ArmadaToken(deployer, address(timelock));
+
+        // Setup beneficiaries (5 actors)
+        beneficiaries.push(address(0xB001));
+        beneficiaries.push(address(0xB002));
+        beneficiaries.push(address(0xB003));
+        beneficiaries.push(address(0xB004));
+        beneficiaries.push(address(0xB005));
+
+        amounts.push(800_000 * 1e18);
+        amounts.push(600_000 * 1e18);
+        amounts.push(400_000 * 1e18);
+        amounts.push(300_000 * 1e18);
+        amounts.push(300_000 * 1e18);
+
+        // Setup delegatees
+        delegatees.push(address(0xD001));
+        delegatees.push(address(0xD002));
+        delegatees.push(address(0xD003));
+
+        // Deploy RevenueLock
+        revenueLock = new RevenueLock(
+            address(armToken),
+            address(revenueCounter),
+            beneficiaries,
+            amounts
+        );
+
+        // Whitelist all relevant addresses
+        address[] memory whitelist = new address[](7);
+        whitelist[0] = deployer;
+        whitelist[1] = address(revenueLock);
+        for (uint256 i = 0; i < 5; i++) {
+            whitelist[i + 2] = beneficiaries[i];
+        }
+        armToken.initWhitelist(whitelist);
+
+        // Authorize RevenueLock for delegateOnBehalf
+        address[] memory authDelegators = new address[](1);
+        authDelegators[0] = address(revenueLock);
+        armToken.initAuthorizedDelegators(authDelegators);
+
+        // Fund RevenueLock
+        armToken.transfer(address(revenueLock), TOTAL_LOCK);
+
+        // Deploy handler
+        handler = new RevenueLockHandler(
+            revenueLock,
+            armToken,
+            revenueCounter,
+            beneficiaries,
+            delegatees
+        );
+
+        // Target only the handler
+        targetContract(address(handler));
+
+        // Mine blocks so getPastVotes works
+        vm.roll(block.number + 5);
+        vm.warp(block.timestamp + 1 hours);
+    }
+
+    /// @notice INV-RL1: ARM.balanceOf(revenueLock) + sum(released) == totalAllocation
+    function invariant_supplyConservation() public {
+        uint256 lockBalance = armToken.balanceOf(address(revenueLock));
+        uint256 totalReleased = 0;
+        for (uint256 i = 0; i < beneficiaries.length; i++) {
+            totalReleased += revenueLock.released(beneficiaries[i]);
+        }
+        assertEq(lockBalance + totalReleased, TOTAL_LOCK, "INV-RL1: supply conservation");
+    }
+
+    /// @notice INV-RL2: released[b] <= allocation[b] for all beneficiaries
+    function invariant_noOverRelease() public {
+        for (uint256 i = 0; i < beneficiaries.length; i++) {
+            assertLe(
+                revenueLock.released(beneficiaries[i]),
+                revenueLock.allocation(beneficiaries[i]),
+                "INV-RL2: over-release"
+            );
+        }
+    }
+
+    /// @notice INV-RL3: RevenueLock contract itself has no delegatee (vote-inert)
+    function invariant_voteInertness() public {
+        assertEq(
+            armToken.delegates(address(revenueLock)),
+            address(0),
+            "INV-RL3: RevenueLock should never delegate"
+        );
+    }
+
+    /// @notice INV-RL4: Any beneficiary that has released > 0 must have a delegatee set
+    function invariant_releasedArmIsDelegated() public {
+        for (uint256 i = 0; i < beneficiaries.length; i++) {
+            if (revenueLock.released(beneficiaries[i]) > 0) {
+                assertTrue(
+                    armToken.delegates(beneficiaries[i]) != address(0),
+                    "INV-RL4: released ARM must be delegated"
+                );
+            }
+        }
+    }
+}

--- a/test/revenue_lock.ts
+++ b/test/revenue_lock.ts
@@ -1,0 +1,426 @@
+// ABOUTME: Hardhat integration tests for RevenueLock — full stack with real ArmadaToken and RevenueCounter.
+// ABOUTME: Covers milestone-based release lifecycle, atomic delegation, multi-beneficiary independence, and view accuracy.
+
+/**
+ * RevenueLock Integration Tests
+ *
+ * RevenueLock is an immutable contract that holds team and airdrop ARM tokens
+ * and releases them to beneficiaries as cumulative protocol revenue milestones
+ * are reached. It reads RevenueCounter.recognizedRevenueUsd() and uses a step
+ * function to determine the unlock percentage.
+ *
+ * These tests deploy the full governance stack (ArmadaToken, TimelockController,
+ * RevenueCounter proxy) and verify end-to-end release mechanics.
+ */
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { mine } from "@nomicfoundation/hardhat-network-helpers";
+import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+
+describe("RevenueLock", function () {
+  let revenueLock: any;
+  let armToken: any;
+  let revenueCounter: any;
+  let mockFeeCollector: any;
+  let timelock: any;
+
+  let deployer: SignerWithAddress;
+  let beneficiaryA: SignerWithAddress;
+  let beneficiaryB: SignerWithAddress;
+  let beneficiaryC: SignerWithAddress;
+  let delegateeX: SignerWithAddress;
+  let delegateeY: SignerWithAddress;
+  let nonBeneficiary: SignerWithAddress;
+
+  const TOTAL_SUPPLY = ethers.parseUnits("12000000", 18);
+  const ALLOC_A = ethers.parseUnits("1200000", 18);
+  const ALLOC_B = ethers.parseUnits("800000", 18);
+  const ALLOC_C = ethers.parseUnits("400000", 18);
+  const TOTAL_LOCK = ALLOC_A + ALLOC_B + ALLOC_C; // 2,400,000 ARM
+
+  // Revenue thresholds in 18-decimal USD
+  const REV_10K = ethers.parseUnits("10000", 18);
+  const REV_50K = ethers.parseUnits("50000", 18);
+  const REV_100K = ethers.parseUnits("100000", 18);
+  const REV_250K = ethers.parseUnits("250000", 18);
+  const REV_500K = ethers.parseUnits("500000", 18);
+  const REV_1M = ethers.parseUnits("1000000", 18);
+
+  async function deployAll() {
+    [deployer, beneficiaryA, beneficiaryB, beneficiaryC, delegateeX, delegateeY, nonBeneficiary] =
+      await ethers.getSigners();
+
+    // 1. Deploy TimelockController
+    const TimelockController = await ethers.getContractFactory("TimelockController");
+    timelock = await TimelockController.deploy(
+      2 * 24 * 60 * 60, // 2 days
+      [],
+      [],
+      deployer.address
+    );
+    await timelock.waitForDeployment();
+
+    // 2. Deploy ArmadaToken
+    const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+    armToken = await ArmadaToken.deploy(deployer.address, await timelock.getAddress());
+    await armToken.waitForDeployment();
+
+    // 3. Deploy RevenueCounter behind UUPS proxy
+    const MockFeeCollector = await ethers.getContractFactory("MockFeeCollector");
+    mockFeeCollector = await MockFeeCollector.deploy();
+    await mockFeeCollector.waitForDeployment();
+
+    const RevenueCounter = await ethers.getContractFactory("RevenueCounter");
+    const rcImpl = await RevenueCounter.deploy();
+    await rcImpl.waitForDeployment();
+
+    const initData = RevenueCounter.interface.encodeFunctionData("initialize", [deployer.address]);
+    const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
+    const rcProxy = await ERC1967Proxy.deploy(await rcImpl.getAddress(), initData);
+    await rcProxy.waitForDeployment();
+    revenueCounter = RevenueCounter.attach(await rcProxy.getAddress());
+
+    // Set fee collector on revenue counter
+    await revenueCounter.setFeeCollector(await mockFeeCollector.getAddress());
+
+    // 4. Deploy RevenueLock
+    const RevenueLock = await ethers.getContractFactory("RevenueLock");
+    revenueLock = await RevenueLock.deploy(
+      await armToken.getAddress(),
+      await revenueCounter.getAddress(),
+      [beneficiaryA.address, beneficiaryB.address, beneficiaryC.address],
+      [ALLOC_A, ALLOC_B, ALLOC_C]
+    );
+    await revenueLock.waitForDeployment();
+
+    // 5. Configure ArmadaToken
+    // Whitelist: deployer, revenueLock, all beneficiaries
+    await armToken.initWhitelist([
+      deployer.address,
+      await revenueLock.getAddress(),
+      beneficiaryA.address,
+      beneficiaryB.address,
+      beneficiaryC.address,
+    ]);
+
+    // Authorize RevenueLock for delegateOnBehalf
+    await armToken.initAuthorizedDelegators([await revenueLock.getAddress()]);
+
+    // 6. Fund RevenueLock with ARM
+    await armToken.transfer(await revenueLock.getAddress(), TOTAL_LOCK);
+
+    // Mine a block so voting checkpoints work
+    await mine(1);
+  }
+
+  beforeEach(async function () {
+    await deployAll();
+  });
+
+  // ============================================================
+  // 1. Setup Verification
+  // ============================================================
+
+  describe("Setup", function () {
+    it("should have correct allocations", async function () {
+      expect(await revenueLock.allocation(beneficiaryA.address)).to.equal(ALLOC_A);
+      expect(await revenueLock.allocation(beneficiaryB.address)).to.equal(ALLOC_B);
+      expect(await revenueLock.allocation(beneficiaryC.address)).to.equal(ALLOC_C);
+    });
+
+    it("should have correct total allocation", async function () {
+      expect(await revenueLock.totalAllocation()).to.equal(TOTAL_LOCK);
+    });
+
+    it("should hold the full ARM balance", async function () {
+      expect(await armToken.balanceOf(await revenueLock.getAddress())).to.equal(TOTAL_LOCK);
+    });
+
+    it("should have 3 beneficiaries", async function () {
+      expect(await revenueLock.beneficiaryCount()).to.equal(3);
+    });
+
+    it("should have zero released for all beneficiaries", async function () {
+      expect(await revenueLock.released(beneficiaryA.address)).to.equal(0);
+      expect(await revenueLock.released(beneficiaryB.address)).to.equal(0);
+      expect(await revenueLock.released(beneficiaryC.address)).to.equal(0);
+    });
+  });
+
+  // ============================================================
+  // 2. View Functions
+  // ============================================================
+
+  describe("View Functions", function () {
+    it("unlockPercentage returns 0 at zero revenue", async function () {
+      expect(await revenueLock.unlockPercentage()).to.equal(0);
+    });
+
+    it("unlockPercentage returns correct bps at each milestone", async function () {
+      const milestones = [
+        { revenue: REV_10K, expectedBps: 1000n },
+        { revenue: REV_50K, expectedBps: 2500n },
+        { revenue: REV_100K, expectedBps: 4000n },
+        { revenue: REV_250K, expectedBps: 6000n },
+        { revenue: REV_500K, expectedBps: 8000n },
+        { revenue: REV_1M, expectedBps: 10000n },
+      ];
+
+      for (const { revenue, expectedBps } of milestones) {
+        // Use attestRevenue (deployer is owner)
+        await revenueCounter.attestRevenue(revenue);
+        expect(await revenueLock.unlockPercentage()).to.equal(expectedBps);
+      }
+    });
+
+    it("releasable returns correct amount at 10% unlock", async function () {
+      await revenueCounter.attestRevenue(REV_10K);
+      const expected = (ALLOC_A * 1000n) / 10000n;
+      expect(await revenueLock.releasable(beneficiaryA.address)).to.equal(expected);
+    });
+
+    it("releasable returns 0 for non-beneficiary", async function () {
+      await revenueCounter.attestRevenue(REV_1M);
+      expect(await revenueLock.releasable(nonBeneficiary.address)).to.equal(0);
+    });
+
+    it("currentRevenue reads from RevenueCounter", async function () {
+      await revenueCounter.attestRevenue(REV_50K);
+      expect(await revenueLock.currentRevenue()).to.equal(REV_50K);
+    });
+  });
+
+  // ============================================================
+  // 3. Release Mechanics
+  // ============================================================
+
+  describe("Release", function () {
+    it("reverts when revenue is zero", async function () {
+      await expect(
+        revenueLock.connect(beneficiaryA).release(delegateeX.address)
+      ).to.be.revertedWith("RevenueLock: nothing to release");
+    });
+
+    it("reverts for non-beneficiary", async function () {
+      await revenueCounter.attestRevenue(REV_10K);
+      await expect(
+        revenueLock.connect(nonBeneficiary).release(delegateeX.address)
+      ).to.be.revertedWith("RevenueLock: not a beneficiary");
+    });
+
+    it("reverts for zero delegatee", async function () {
+      await revenueCounter.attestRevenue(REV_10K);
+      await expect(
+        revenueLock.connect(beneficiaryA).release(ethers.ZeroAddress)
+      ).to.be.revertedWith("RevenueLock: zero delegatee");
+    });
+
+    it("releases 10% at $10k milestone", async function () {
+      await revenueCounter.attestRevenue(REV_10K);
+      const expected = (ALLOC_A * 1000n) / 10000n;
+
+      await revenueLock.connect(beneficiaryA).release(delegateeX.address);
+
+      expect(await armToken.balanceOf(beneficiaryA.address)).to.equal(expected);
+      expect(await revenueLock.released(beneficiaryA.address)).to.equal(expected);
+    });
+
+    it("sets delegation atomically on release", async function () {
+      await revenueCounter.attestRevenue(REV_10K);
+
+      await revenueLock.connect(beneficiaryA).release(delegateeX.address);
+
+      expect(await armToken.delegates(beneficiaryA.address)).to.equal(delegateeX.address);
+    });
+
+    it("delegatee receives voting power after release", async function () {
+      await revenueCounter.attestRevenue(REV_10K);
+      await revenueLock.connect(beneficiaryA).release(delegateeX.address);
+
+      // Mine a block so getPastVotes captures the checkpoint
+      await mine(1);
+
+      const expected = (ALLOC_A * 1000n) / 10000n;
+      expect(await armToken.getVotes(delegateeX.address)).to.equal(expected);
+    });
+
+    it("reverts on second call at same milestone (nothing new)", async function () {
+      await revenueCounter.attestRevenue(REV_10K);
+      await revenueLock.connect(beneficiaryA).release(delegateeX.address);
+
+      await expect(
+        revenueLock.connect(beneficiaryA).release(delegateeX.address)
+      ).to.be.revertedWith("RevenueLock: nothing to release");
+    });
+
+    it("releases delta at next milestone", async function () {
+      // First release at 10%
+      await revenueCounter.attestRevenue(REV_10K);
+      await revenueLock.connect(beneficiaryA).release(delegateeX.address);
+      const firstRelease = (ALLOC_A * 1000n) / 10000n;
+
+      // Second release at 25%
+      await revenueCounter.attestRevenue(REV_50K);
+      await revenueLock.connect(beneficiaryA).release(delegateeX.address);
+      const totalEntitled = (ALLOC_A * 2500n) / 10000n;
+      const secondRelease = totalEntitled - firstRelease;
+
+      expect(await armToken.balanceOf(beneficiaryA.address)).to.equal(firstRelease + secondRelease);
+      expect(await revenueLock.released(beneficiaryA.address)).to.equal(totalEntitled);
+    });
+
+    it("releases full allocation at $1M", async function () {
+      await revenueCounter.attestRevenue(REV_1M);
+      await revenueLock.connect(beneficiaryA).release(delegateeX.address);
+
+      expect(await revenueLock.released(beneficiaryA.address)).to.equal(ALLOC_A);
+      expect(await armToken.balanceOf(beneficiaryA.address)).to.equal(ALLOC_A);
+      expect(await revenueLock.releasable(beneficiaryA.address)).to.equal(0);
+    });
+
+    it("emits Released event", async function () {
+      await revenueCounter.attestRevenue(REV_10K);
+      const expected = (ALLOC_A * 1000n) / 10000n;
+
+      await expect(revenueLock.connect(beneficiaryA).release(delegateeX.address))
+        .to.emit(revenueLock, "Released")
+        .withArgs(beneficiaryA.address, expected, delegateeX.address, expected);
+    });
+
+    it("changes delegatee on subsequent release", async function () {
+      await revenueCounter.attestRevenue(REV_10K);
+      await revenueLock.connect(beneficiaryA).release(delegateeX.address);
+      expect(await armToken.delegates(beneficiaryA.address)).to.equal(delegateeX.address);
+
+      await revenueCounter.attestRevenue(REV_50K);
+      await revenueLock.connect(beneficiaryA).release(delegateeY.address);
+      expect(await armToken.delegates(beneficiaryA.address)).to.equal(delegateeY.address);
+    });
+  });
+
+  // ============================================================
+  // 4. Multi-Beneficiary Independence
+  // ============================================================
+
+  describe("Multi-Beneficiary", function () {
+    it("beneficiaries release independently", async function () {
+      await revenueCounter.attestRevenue(REV_100K); // 40% unlock
+
+      // Only A releases
+      await revenueLock.connect(beneficiaryA).release(delegateeX.address);
+      const expectedA = (ALLOC_A * 4000n) / 10000n;
+      expect(await revenueLock.released(beneficiaryA.address)).to.equal(expectedA);
+
+      // B and C haven't released
+      expect(await revenueLock.released(beneficiaryB.address)).to.equal(0);
+      expect(await revenueLock.released(beneficiaryC.address)).to.equal(0);
+
+      // B releases later
+      await revenueLock.connect(beneficiaryB).release(delegateeY.address);
+      const expectedB = (ALLOC_B * 4000n) / 10000n;
+      expect(await revenueLock.released(beneficiaryB.address)).to.equal(expectedB);
+    });
+
+    it("late beneficiary gets full entitled amount on first release", async function () {
+      // Revenue reaches $250k (60%) — beneficiary C hasn't released at any prior milestone
+      await revenueCounter.attestRevenue(REV_250K);
+
+      await revenueLock.connect(beneficiaryC).release(delegateeX.address);
+      const expected = (ALLOC_C * 6000n) / 10000n;
+      expect(await revenueLock.released(beneficiaryC.address)).to.equal(expected);
+    });
+  });
+
+  // ============================================================
+  // 5. Supply Conservation
+  // ============================================================
+
+  describe("Supply Conservation", function () {
+    it("ARM balance + released == totalAllocation after partial releases", async function () {
+      await revenueCounter.attestRevenue(REV_250K); // 60%
+
+      await revenueLock.connect(beneficiaryA).release(delegateeX.address);
+      await revenueLock.connect(beneficiaryB).release(delegateeX.address);
+      // C doesn't release
+
+      const lockBalance = await armToken.balanceOf(await revenueLock.getAddress());
+      const releasedA = await revenueLock.released(beneficiaryA.address);
+      const releasedB = await revenueLock.released(beneficiaryB.address);
+      const releasedC = await revenueLock.released(beneficiaryC.address);
+
+      expect(lockBalance + releasedA + releasedB + releasedC).to.equal(TOTAL_LOCK);
+    });
+
+    it("ARM balance is zero after all beneficiaries fully release", async function () {
+      await revenueCounter.attestRevenue(REV_1M);
+
+      await revenueLock.connect(beneficiaryA).release(delegateeX.address);
+      await revenueLock.connect(beneficiaryB).release(delegateeX.address);
+      await revenueLock.connect(beneficiaryC).release(delegateeX.address);
+
+      expect(await armToken.balanceOf(await revenueLock.getAddress())).to.equal(0);
+    });
+  });
+
+  // ============================================================
+  // 6. Revenue Counter Integration
+  // ============================================================
+
+  describe("Revenue Counter Integration", function () {
+    it("works with syncStablecoinRevenue path", async function () {
+      // Simulate USDC fees via fee collector (6 decimals → 18 decimals in counter)
+      // $10,000 in USDC = 10_000 * 1e6
+      await mockFeeCollector.setCumulativeFees(ethers.parseUnits("10000", 6));
+      await revenueCounter.syncStablecoinRevenue();
+
+      // Revenue counter should now show $10k in 18 decimals
+      expect(await revenueCounter.recognizedRevenueUsd()).to.equal(REV_10K);
+
+      // RevenueLock should see 10% unlock
+      expect(await revenueLock.unlockPercentage()).to.equal(1000n);
+
+      // Release should work
+      await revenueLock.connect(beneficiaryA).release(delegateeX.address);
+      const expected = (ALLOC_A * 1000n) / 10000n;
+      expect(await revenueLock.released(beneficiaryA.address)).to.equal(expected);
+    });
+  });
+
+  // ============================================================
+  // 7. Full Lifecycle
+  // ============================================================
+
+  describe("Full Lifecycle", function () {
+    it("walks through all 6 milestones for one beneficiary", async function () {
+      const milestones = [
+        { revenue: REV_10K, bps: 1000n },
+        { revenue: REV_50K, bps: 2500n },
+        { revenue: REV_100K, bps: 4000n },
+        { revenue: REV_250K, bps: 6000n },
+        { revenue: REV_500K, bps: 8000n },
+        { revenue: REV_1M, bps: 10000n },
+      ];
+
+      let prevReleased = 0n;
+
+      for (const { revenue, bps } of milestones) {
+        await revenueCounter.attestRevenue(revenue);
+
+        const entitled = (ALLOC_A * bps) / 10000n;
+        const expectedDelta = entitled - prevReleased;
+
+        expect(await revenueLock.releasable(beneficiaryA.address)).to.equal(expectedDelta);
+
+        await revenueLock.connect(beneficiaryA).release(delegateeX.address);
+
+        expect(await revenueLock.released(beneficiaryA.address)).to.equal(entitled);
+        prevReleased = entitled;
+      }
+
+      // Fully released
+      expect(await revenueLock.released(beneficiaryA.address)).to.equal(ALLOC_A);
+      expect(await revenueLock.releasable(beneficiaryA.address)).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements the `RevenueLock` contract from the REVENUE_LOCK.md spec (closes #46)
- Immutable contract holding 2.4M ARM (team 15% + airdrop 5%) with 6-milestone revenue-gated release
- Adds `delegateOnBehalf()` to `ArmadaToken` for atomic transfer+delegation on release
- Updates deployment script and config to wire RevenueLock into the governance stack

### Milestone Schedule (step function, no interpolation)

| Cumulative Revenue | Unlock |
|----|---|
| $10k | 10% |
| $50k | 25% |
| $100k | 40% |
| $250k | 60% |
| $500k | 80% |
| $1M | 100% |

### Key Design Decisions

- **Basis points** (0-10000) for unlock math precision
- **Immutable, non-upgradeable** — no admin, no proxy, no sweep
- **Pull-based release** — beneficiaries call `release(delegatee)` when milestones are reached
- **Atomic delegation** — released ARM enters circulation already delegated via `delegateOnBehalf`
- **Anvil placeholder beneficiaries** for local dev (mainnet list tracked in #144)

### Files Changed

| File | Change |
|------|--------|
| `contracts/governance/RevenueLock.sol` | New — core contract |
| `contracts/governance/ArmadaToken.sol` | Added `delegateOnBehalf()`, `initAuthorizedDelegators()` |
| `config/networks.ts` | Treasury 10.2M→7.8M, added `revenueLock: 2.4M` |
| `scripts/deploy_governance.ts` | RevenueLock deployment, whitelist, authorized delegator setup |
| `test-foundry/ArmadaTokenDelegateOnBehalf.t.sol` | 11 Foundry tests |
| `test-foundry/RevenueLock.t.sol` | 42 Foundry unit/fuzz tests |
| `test-foundry/RevenueLockInvariant.t.sol` | 4 invariant tests (256 runs, 12.8k calls each) |
| `test/revenue_lock.ts` | 27 Hardhat integration tests |

## Test plan

- [x] `forge test` — 434 tests pass (0 failures), including 57 new tests
- [x] `npx hardhat test test/revenue_lock.ts` — 27 tests pass
- [x] `npx hardhat test test/revenue_counter.ts` — 21 existing tests pass (regression check)
- [ ] Verify `npm run setup` deploys RevenueLock and wires it correctly (requires Anvil chains)
- [ ] Review invariant test coverage for edge cases

### Related Issues

- #143 — Crowdfund: add atomic delegation via `delegateOnBehalf` on claim (follow-up)
- #144 — Finalize mainnet beneficiary list for RevenueLock deployment (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)