### PR TITLE
Governance spec compliance: full alignment pass

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -324,8 +324,6 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         // Revenue definition expansion (on RevenueCounter)
         extendedSelectors[bytes4(keccak256("setFeeCollector(address)"))] = true;
 
-        // Steward circuit breaker resume (on governor, via timelock)
-        extendedSelectors[this.resumeStewardChannel.selector] = true;
 
         // Treasury outflow limit parameters
         extendedSelectors[bytes4(keccak256("setOutflowWindow(address,uint256)"))] = true;
@@ -712,7 +710,7 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     }
 
     /// @notice Resume the steward channel after a circuit breaker pause.
-    /// Auto-classified as Extended (30% quorum, 14-day voting) via the timelock.
+    /// Standard proposal (20% quorum, 7-day voting) per governance spec §Circuit breaker.
     function resumeStewardChannel() external {
         require(msg.sender == address(timelock), "ArmadaGovernor: not timelock");
         require(stewardChannelPaused, "ArmadaGovernor: not paused");

--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -656,20 +656,8 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         p.values = values;
         p.calldatas = calldatas;
 
-        // Bond: required only when ARM is transferable (same as regular proposals)
-        if (armToken.transferable()) {
-            require(
-                armToken.transferFrom(msg.sender, address(this), PROPOSAL_BOND),
-                "ArmadaGovernor: bond transfer failed"
-            );
-            proposalBonds[proposalId] = BondInfo({
-                depositor: msg.sender,
-                amount: PROPOSAL_BOND,
-                unlockTime: 0,
-                claimed: false
-            });
-            emit BondPosted(proposalId, msg.sender, PROPOSAL_BOND);
-        }
+        // No bond required for steward proposals — the steward is an elected role
+        // operating within budget limits. Bonds are for standard/extended proposals only.
 
         emit ProposalCreated(
             proposalId, msg.sender, ProposalType.Steward,

--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -512,7 +512,7 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
 
         // Evaluate outcome: does the community uphold or deny the veto?
         bool quorumMet = _quorumReached(ratificationId);
-        bool majorityAgainst = quorumMet && !_voteSucceeded(ratificationId);
+        bool majorityAgainst = quorumMet && (p.againstVotes > p.forVotes);
 
         if (majorityAgainst) {
             // Community denies the veto → eject SC, store calldata hash

--- a/contracts/governance/ArmadaToken.sol
+++ b/contracts/governance/ArmadaToken.sol
@@ -126,10 +126,13 @@ contract ArmadaToken is ERC20Votes {
     }
 
     /// @notice Enable unrestricted transfers. Only callable by the wind-down contract.
+    ///         One-way: transfers cannot be re-restricted once enabled.
     function setTransferable(bool _transferable) external {
         require(msg.sender == windDownContract, "ArmadaToken: not wind-down contract");
-        transferable = _transferable;
-        emit TransferableSet(_transferable);
+        require(_transferable, "ArmadaToken: can only enable transfers");
+        require(!transferable, "ArmadaToken: transfers already enabled");
+        transferable = true;
+        emit TransferableSet(true);
     }
 
     /// @notice Delegate voting power on behalf of another address. Only callable by

--- a/contracts/governance/IShieldPauseController.sol
+++ b/contracts/governance/IShieldPauseController.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // ABOUTME: Interface for shield pause controller, consumed by PrivacyPool's ShieldModule.
-// ABOUTME: Exposes a single view function to check if shields are currently paused.
+// ABOUTME: Exposes view functions to check shield pause state and withdraw-only mode.
 pragma solidity ^0.8.17;
 
 /// @title IShieldPauseController — Minimal interface for shield pause status

--- a/contracts/governance/IShieldPauseController.sol
+++ b/contracts/governance/IShieldPauseController.sol
@@ -5,7 +5,13 @@ pragma solidity ^0.8.17;
 
 /// @title IShieldPauseController — Minimal interface for shield pause status
 /// @notice The PrivacyPool's ShieldModule checks this to determine if shields are paused.
+///         TransactModule checks withdrawOnlyMode() to block private transfers after wind-down.
 interface IShieldPauseController {
     /// @notice Returns true if shields are currently paused (accounting for auto-expiry)
     function shieldsPaused() external view returns (bool);
+
+    /// @notice Returns true if the pool is in withdraw-only mode (wind-down active).
+    ///         When true, only unshields are allowed — private transfers are blocked.
+    ///         Distinct from shieldsPaused(): SC pause does NOT activate withdraw-only mode.
+    function withdrawOnlyMode() external view returns (bool);
 }

--- a/contracts/governance/ShieldPauseController.sol
+++ b/contracts/governance/ShieldPauseController.sol
@@ -83,6 +83,13 @@ contract ShieldPauseController is IShieldPauseController {
         return _paused && block.timestamp < pauseExpiry;
     }
 
+    /// @notice Returns true if pool is in withdraw-only mode (wind-down active).
+    ///         When true, only unshields are allowed — shields and private transfers are blocked.
+    ///         SC pause does NOT activate withdraw-only mode (SC pause only affects shields).
+    function withdrawOnlyMode() external view override returns (bool) {
+        return windDownActive;
+    }
+
     // ============ Security Council Functions ============
 
     /// @notice SC triggers shield pause. Auto-expires after 24 hours.

--- a/contracts/privacy-pool/modules/TransactModule.sol
+++ b/contracts/privacy-pool/modules/TransactModule.sol
@@ -11,6 +11,7 @@ import "../interfaces/IVerifierModule.sol";
 import "../types/CCTPTypes.sol";
 import "../../cctp/ICCTPV2.sol";
 import "../../railgun/logic/Poseidon.sol";
+import "../../governance/IShieldPauseController.sol";
 
 /**
  * @title TransactModule
@@ -38,6 +39,10 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
      */
     function transact(Transaction[] calldata _transactions) external override onlyDelegatecall {
         require(_transactions.length > 0, "TransactModule: No transactions");
+
+        // In withdraw-only mode (post-wind-down), block pure private transfers.
+        // Unshield transactions are allowed — users must always be able to exit.
+        _requireNotWithdrawOnly(_transactions);
 
         // Calculate total commitments (excluding unshield outputs)
         uint256 commitmentsCount = _sumCommitments(_transactions);
@@ -424,5 +429,22 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
             return bytes32(uint256(uint160(_tokenData.tokenAddress)));
         }
         return bytes32(uint256(keccak256(abi.encode(_tokenData))) % SNARK_SCALAR_FIELD);
+    }
+
+    /**
+     * @notice Reverts if pool is in withdraw-only mode and any transaction is a pure transfer.
+     *         After wind-down, only unshields are allowed per spec §Wind-Down → Sequence step 3.
+     *         No-op if no pause contract is set or if withdraw-only mode is not active.
+     */
+    function _requireNotWithdrawOnly(Transaction[] calldata _transactions) internal view {
+        if (shieldPauseContract == address(0)) return;
+        if (!IShieldPauseController(shieldPauseContract).withdrawOnlyMode()) return;
+
+        for (uint256 i = 0; i < _transactions.length; i++) {
+            require(
+                _transactions[i].boundParams.unshield != UnshieldType.NONE,
+                "TransactModule: withdraw only"
+            );
+        }
     }
 }

--- a/test-foundry/ArmadaRedemption.t.sol
+++ b/test-foundry/ArmadaRedemption.t.sol
@@ -404,13 +404,15 @@ contract ArmadaRedemptionTest is Test {
     // ======== Wind-Down Gate ========
 
     function test_revert_redeemBeforeWindDown() public {
-        // Deploy a fresh ARM token where transferable is still false
+        // Deploy a fresh ARM token where transferable is still false (pre-wind-down)
         ArmadaToken freshArm = new ArmadaToken(deployer, address(timelock));
-
-        // Enable transfers on freshArm so we can distribute, then disable
         freshArm.setWindDownContract(windDown);
-        vm.prank(windDown);
-        freshArm.setTransferable(true);
+
+        // Whitelist deployer and alice so we can distribute tokens without enabling global transfers
+        address[] memory wl = new address[](2);
+        wl[0] = deployer;
+        wl[1] = alice;
+        freshArm.initWhitelist(wl);
 
         ArmadaRedemption freshRedemption = new ArmadaRedemption(
             address(freshArm), treasuryAddr, revenueLock, crowdfund
@@ -420,10 +422,7 @@ contract ArmadaRedemptionTest is Test {
         vm.prank(alice);
         freshArm.approve(address(freshRedemption), type(uint256).max);
 
-        // Disable transfers (simulating pre-wind-down state)
-        vm.prank(windDown);
-        freshArm.setTransferable(false);
-
+        // transferable is still false — redeem should revert
         address[] memory tokens = new address[](0);
         vm.prank(alice);
         vm.expectRevert("ArmadaRedemption: wind-down not triggered");

--- a/test-foundry/GovernorClassificationBondWindDown.t.sol
+++ b/test-foundry/GovernorClassificationBondWindDown.t.sol
@@ -287,6 +287,18 @@ contract GovernorClassificationBondWindDownTest is Test, GovernorDeployHelper {
         assertEq(uint256(pType), uint256(ProposalType.Extended));
     }
 
+    function test_classify_resumeStewardChannelIsStandard() public {
+        // resumeStewardChannel is NOT registered as an extended selector,
+        // so proposals targeting it should be classified as Standard.
+        assertFalse(governor.extendedSelectors(governor.resumeStewardChannel.selector));
+
+        bytes memory data = abi.encodeWithSelector(governor.resumeStewardChannel.selector);
+        uint256 proposalId = _proposeWithCalldata(alice, ProposalType.Standard, address(governor), data);
+
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Standard));
+    }
+
     function test_classify_addExtendedSelector() public {
         bytes4 newSelector = bytes4(keccak256("someNewFunction(uint256)"));
 

--- a/test-foundry/GovernorSteward.t.sol
+++ b/test-foundry/GovernorSteward.t.sol
@@ -51,7 +51,6 @@ contract GovernorStewardTest is Test, GovernorDeployHelper {
     address public windDown = address(0xD00D);
 
     uint256 constant TOTAL_SUPPLY = 12_000_000 * 1e18;
-    uint256 constant BOND_AMOUNT = 1_000 * 1e18;
     uint256 constant TWO_DAYS = 2 days;
     uint256 constant SEVEN_DAYS = 7 days;
     uint256 constant MAX_PAUSE = 14 days;
@@ -373,6 +372,36 @@ contract GovernorStewardTest is Test, GovernorDeployHelper {
         vm.prank(stewardPerson);
         vm.expectRevert("ArmadaGovernor: governance ended");
         governor.proposeStewardSpend(tokens, recipients, amounts, "test");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // No bond on steward proposals
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_proposeStewardSpend_noBondRequired() public {
+        // Enable ARM transfers so bonds would normally be required
+        armToken.setWindDownContract(windDown);
+        vm.prank(windDown);
+        armToken.setTransferable(true);
+
+        // Give steward some ARM so bond transfer would succeed if attempted
+        armToken.transfer(stewardPerson, 2_000 * 1e18);
+        uint256 stewardBalanceBefore = armToken.balanceOf(stewardPerson);
+
+        // Create proposal — no bond should be taken even with transferable ARM
+        uint256 proposalId = _proposeStewardSpend(alice, 100 * 1e6);
+        assertTrue(proposalId > 0);
+
+        // Steward's ARM balance should be unchanged (no bond deducted)
+        assertEq(armToken.balanceOf(stewardPerson), stewardBalanceBefore);
+    }
+
+    function test_proposeStewardSpend_noBondClaimable() public {
+        uint256 proposalId = _proposeStewardSpend(alice, 100 * 1e6);
+
+        // No bond was posted, so claimBond should revert
+        vm.expectRevert("ArmadaGovernor: no bond");
+        governor.claimBond(proposalId);
     }
 
     // ══════════════════════════════════════════════════════════════════════

--- a/test-foundry/GovernorVeto.t.sol
+++ b/test-foundry/GovernorVeto.t.sol
@@ -364,6 +364,58 @@ contract GovernorVetoTest is Test, GovernorDeployHelper {
         assertEq(governor.securityCouncil(), sc);
     }
 
+    function test_resolve_tiedVoteVetoStands() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+
+        // Tied vote: alice votes FOR (uphold), bob votes AGAINST (deny)
+        // alice has 20% of supply, bob has 15% — not equal weight.
+        // To get a true tie, give carol tokens equal to alice and have her vote AGAINST.
+        // Instead, use alice FOR and bob AGAINST with equal weight:
+        // Transfer tokens so alice and bob each have exactly 25% of supply.
+        uint256 aliceBal = armToken.balanceOf(alice);
+        uint256 bobBal = armToken.balanceOf(bob);
+        uint256 equalAmount = (aliceBal + bobBal) / 2;
+
+        // Rebalance: deployer facilitates (alice sends excess to deployer, deployer sends to bob)
+        uint256 aliceExcess = aliceBal - equalAmount;
+        vm.prank(alice);
+        armToken.transfer(deployer, aliceExcess);
+        armToken.transfer(bob, aliceExcess);
+
+        // Re-delegate to update checkpoints
+        vm.prank(alice);
+        armToken.delegate(alice);
+        vm.prank(bob);
+        armToken.delegate(bob);
+        vm.roll(block.number + 1);
+
+        // Create a fresh proposal and veto it (checkpoints are per-block)
+        uint256 proposalId2 = _createAndQueueProposal(alice);
+        vm.prank(sc);
+        governor.veto(proposalId2, keccak256("rationale2"));
+        uint256 ratId2 = governor.proposalCount();
+
+        // Now cast tied votes on the ratification
+        vm.prank(alice);
+        governor.castVote(ratId2, 1); // FOR (uphold veto)
+        vm.prank(bob);
+        governor.castVote(ratId2, 0); // AGAINST (deny veto)
+
+        // Advance past voting period
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        vm.expectEmit(true, false, false, true);
+        emit RatificationResolved(ratId2, true); // vetoUpheld = true
+
+        governor.resolveRatification(ratId2);
+
+        // SC retains seat on a tie — strict majority AGAINST is required for ejection
+        assertEq(governor.securityCouncil(), sc);
+    }
+
     function test_resolve_againstWinsSCEjected() public {
         uint256 proposalId = _createAndQueueProposal(alice);
 

--- a/test-foundry/TransactModuleWindDown.t.sol
+++ b/test-foundry/TransactModuleWindDown.t.sol
@@ -1,0 +1,294 @@
+// ABOUTME: Foundry tests for TransactModule withdraw-only mode (issue #112).
+// ABOUTME: Verifies that private transfers are blocked after wind-down while unshields remain available.
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/privacy-pool/PrivacyPool.sol";
+import "../contracts/privacy-pool/modules/ShieldModule.sol";
+import "../contracts/privacy-pool/modules/TransactModule.sol";
+import "../contracts/privacy-pool/modules/MerkleModule.sol";
+import "../contracts/privacy-pool/modules/VerifierModule.sol";
+import "../contracts/governance/ShieldPauseController.sol";
+import "../contracts/cctp/MockUSDCV2.sol";
+import "../contracts/cctp/MockCCTPV2.sol";
+
+/// @notice Minimal mock that satisfies IArmadaGovernorSC (securityCouncil() view)
+contract MockGovernorSC {
+    address public securityCouncil;
+    constructor(address _sc) { securityCouncil = _sc; }
+}
+
+/// @title TransactModuleWindDownTest — Withdraw-only mode blocks private transfers
+/// @dev Tests that after wind-down activation, transact() reverts for pure transfers
+///      but allows unshields. Covers spec §Wind-Down → Sequence step 3.
+contract TransactModuleWindDownTest is Test {
+    PrivacyPool public pool;
+    ShieldModule public shieldModule;
+    TransactModule public transactModule;
+    MerkleModule public merkleModule;
+    VerifierModule public verifierModule;
+    MockUSDCV2 public usdc;
+    MockTokenMessengerV2 public tokenMessenger;
+    MockMessageTransmitterV2 public messageTransmitter;
+    ShieldPauseController public pauseController;
+    MockGovernorSC public mockGovernor;
+
+    address public owner;
+    address public treasury;
+    address public securityCouncil = address(0x5C5C);
+    address public windDownContract = address(0xD0D0);
+
+    function setUp() public {
+        owner = address(this);
+        treasury = address(0xFEE);
+
+        // Deploy USDC + CCTP mocks
+        usdc = new MockUSDCV2("Mock USDC", "USDC");
+        messageTransmitter = new MockMessageTransmitterV2(0, owner);
+        tokenMessenger = new MockTokenMessengerV2(address(messageTransmitter), address(usdc), 0);
+        messageTransmitter.setTokenMessenger(address(tokenMessenger));
+
+        // Deploy modules
+        shieldModule = new ShieldModule();
+        transactModule = new TransactModule();
+        merkleModule = new MerkleModule();
+        verifierModule = new VerifierModule();
+
+        // Deploy and initialize pool
+        pool = new PrivacyPool();
+        pool.initialize(
+            address(shieldModule),
+            address(transactModule),
+            address(merkleModule),
+            address(verifierModule),
+            address(tokenMessenger),
+            address(messageTransmitter),
+            address(usdc),
+            0, // localDomain
+            owner
+        );
+        pool.setTestingMode(true);
+        pool.setTreasury(payable(treasury));
+
+        // Deploy ShieldPauseController
+        mockGovernor = new MockGovernorSC(securityCouncil);
+        pauseController = new ShieldPauseController(address(mockGovernor), owner);
+
+        // Wire wind-down contract to pause controller
+        pauseController.setWindDownContract(windDownContract);
+
+        // Wire pause controller to pool
+        pool.setShieldPauseContract(address(pauseController));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // HELPERS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Build a minimal Transaction with the specified UnshieldType
+    function _buildMinimalTransaction(UnshieldType unshieldType) internal view returns (Transaction memory) {
+        CommitmentCiphertext[] memory ciphertext;
+
+        if (unshieldType == UnshieldType.NONE) {
+            // Pure transfer: 1 commitment, 1 ciphertext
+            ciphertext = new CommitmentCiphertext[](1);
+            ciphertext[0] = CommitmentCiphertext({
+                ciphertext: [bytes32(0), bytes32(0), bytes32(0), bytes32(0)],
+                blindedSenderViewingKey: bytes32(0),
+                blindedReceiverViewingKey: bytes32(0),
+                annotationData: "",
+                memo: ""
+            });
+        } else {
+            // Unshield: 0 ciphertext (unshield output excluded from ciphertext)
+            ciphertext = new CommitmentCiphertext[](0);
+        }
+
+        bytes32[] memory nullifiers = new bytes32[](1);
+        nullifiers[0] = bytes32(uint256(0x1234));
+
+        bytes32[] memory commitments = new bytes32[](1);
+        commitments[0] = bytes32(uint256(0x5678));
+
+        return Transaction({
+            proof: SnarkProof({
+                a: G1Point(0, 0),
+                b: G2Point([uint256(0), uint256(0)], [uint256(0), uint256(0)]),
+                c: G1Point(0, 0)
+            }),
+            merkleRoot: bytes32(0),
+            nullifiers: nullifiers,
+            commitments: commitments,
+            boundParams: BoundParams({
+                treeNumber: 0,
+                minGasPrice: 0,
+                unshield: unshieldType,
+                chainID: uint64(block.chainid),
+                adaptContract: address(0),
+                adaptParams: bytes32(0),
+                commitmentCiphertext: ciphertext
+            }),
+            unshieldPreimage: CommitmentPreimage({
+                npk: bytes32(uint256(uint160(address(0xBEEF)))),
+                token: TokenData({
+                    tokenType: TokenType.ERC20,
+                    tokenAddress: address(usdc),
+                    tokenSubID: 0
+                }),
+                value: 1000
+            })
+        });
+    }
+
+    function _activateWindDown() internal {
+        vm.prank(windDownContract);
+        pauseController.setWindDownActive();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // TESTS: Pure transfer blocked in withdraw-only mode
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Pure private transfer reverts after wind-down (withdraw-only mode)
+    function test_pureTransfer_reverts_withdrawOnlyMode() public {
+        _activateWindDown();
+
+        Transaction[] memory txs = new Transaction[](1);
+        txs[0] = _buildMinimalTransaction(UnshieldType.NONE);
+
+        vm.expectRevert("TransactModule: withdraw only");
+        pool.transact(txs);
+    }
+
+    /// @notice Mixed batch (transfer + unshield) reverts after wind-down
+    function test_mixedBatch_reverts_withdrawOnlyMode() public {
+        _activateWindDown();
+
+        Transaction[] memory txs = new Transaction[](2);
+        txs[0] = _buildMinimalTransaction(UnshieldType.NORMAL); // unshield
+        txs[1] = _buildMinimalTransaction(UnshieldType.NONE);   // pure transfer
+
+        // Use a different nullifier to avoid double-spend revert
+        txs[1].nullifiers[0] = bytes32(uint256(0x9999));
+        txs[1].commitments[0] = bytes32(uint256(0xAAAA));
+
+        vm.expectRevert("TransactModule: withdraw only");
+        pool.transact(txs);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // TESTS: Unshields allowed in withdraw-only mode
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Unshield transaction does NOT revert with "withdraw only" after wind-down.
+    ///         It may revert for other reasons (invalid merkle root, etc.) — that's fine.
+    function test_unshield_bypasses_withdrawOnlyGuard() public {
+        _activateWindDown();
+
+        Transaction[] memory txs = new Transaction[](1);
+        txs[0] = _buildMinimalTransaction(UnshieldType.NORMAL);
+
+        try pool.transact(txs) {
+            // If it succeeds, that's fine — guard didn't block it
+        } catch Error(string memory reason) {
+            // If it reverted, ensure it's NOT the withdraw-only guard
+            assertTrue(
+                keccak256(bytes(reason)) != keccak256(bytes("TransactModule: withdraw only")),
+                "Unshield should not be blocked by withdraw-only mode"
+            );
+        }
+    }
+
+    /// @notice atomicCrossChainUnshield does NOT revert with "withdraw only" after wind-down.
+    function test_atomicCrossChainUnshield_bypasses_withdrawOnlyGuard() public {
+        _activateWindDown();
+
+        // Register a remote pool so destination validation passes
+        pool.setRemotePool(1, bytes32(uint256(uint160(address(0xBE0BE0)))));
+
+        Transaction memory tx0 = _buildMinimalTransaction(UnshieldType.NORMAL);
+
+        try pool.atomicCrossChainUnshield(tx0, 1, address(0xBEEF), bytes32(0), 0) {
+            // Success — guard didn't block
+        } catch Error(string memory reason) {
+            assertTrue(
+                keccak256(bytes(reason)) != keccak256(bytes("TransactModule: withdraw only")),
+                "Cross-chain unshield should not be blocked by withdraw-only mode"
+            );
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // TESTS: Pre-wind-down (no guard)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Pure transfer is NOT blocked by withdraw-only guard when wind-down is inactive.
+    ///         May revert for other reasons (invalid merkle root, etc.)
+    function test_pureTransfer_allowed_preWindDown() public {
+        // Do NOT activate wind-down
+
+        Transaction[] memory txs = new Transaction[](1);
+        txs[0] = _buildMinimalTransaction(UnshieldType.NONE);
+
+        try pool.transact(txs) {
+            // Success — guard didn't block
+        } catch Error(string memory reason) {
+            assertTrue(
+                keccak256(bytes(reason)) != keccak256(bytes("TransactModule: withdraw only")),
+                "Pre-wind-down transfer should not trigger withdraw-only guard"
+            );
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // TESTS: SC pause does NOT activate withdraw-only mode
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @notice SC pause blocks shields but does NOT block private transfers.
+    ///         withdraw-only mode is a wind-down-only behavior per spec.
+    function test_scPause_doesNotBlockTransfers() public {
+        // SC pauses shields (not wind-down)
+        vm.prank(securityCouncil);
+        pauseController.pauseShields();
+
+        // Shields should be paused
+        assertTrue(pauseController.shieldsPaused(), "Shields should be paused");
+        // But withdraw-only should NOT be active
+        assertFalse(pauseController.withdrawOnlyMode(), "SC pause should not activate withdraw-only");
+
+        Transaction[] memory txs = new Transaction[](1);
+        txs[0] = _buildMinimalTransaction(UnshieldType.NONE);
+
+        try pool.transact(txs) {
+            // Success — guard didn't block
+        } catch Error(string memory reason) {
+            assertTrue(
+                keccak256(bytes(reason)) != keccak256(bytes("TransactModule: withdraw only")),
+                "SC pause should not trigger withdraw-only guard on transfers"
+            );
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // TESTS: No pause controller set (graceful no-op)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @notice If shieldPauseContract is address(0), withdraw-only guard is a no-op
+    function test_noPauseController_transfersAllowed() public {
+        // Remove pause controller
+        pool.setShieldPauseContract(address(0));
+
+        Transaction[] memory txs = new Transaction[](1);
+        txs[0] = _buildMinimalTransaction(UnshieldType.NONE);
+
+        try pool.transact(txs) {
+            // Success
+        } catch Error(string memory reason) {
+            assertTrue(
+                keccak256(bytes(reason)) != keccak256(bytes("TransactModule: withdraw only")),
+                "No pause controller should not trigger withdraw-only guard"
+            );
+        }
+    }
+}

--- a/test/arm_token_votes.ts
+++ b/test/arm_token_votes.ts
@@ -257,6 +257,19 @@ describe("ArmadaToken — ERC20Votes", function () {
       ).to.be.revertedWith("ArmadaToken: not wind-down contract");
     });
 
+    it("should reject setTransferable(false) — one-way only", async function () {
+      await expect(
+        armToken.connect(windDownContract).setTransferable(false)
+      ).to.be.revertedWith("ArmadaToken: can only enable transfers");
+    });
+
+    it("should reject setTransferable(true) when already enabled", async function () {
+      await armToken.connect(windDownContract).setTransferable(true);
+      await expect(
+        armToken.connect(windDownContract).setTransferable(true)
+      ).to.be.revertedWith("ArmadaToken: transfers already enabled");
+    });
+
     it("should allow setWindDownContract only once (deployer-only)", async function () {
       // Already called in beforeEach
       await expect(

--- a/test/winddown_redemption_integration.ts
+++ b/test/winddown_redemption_integration.ts
@@ -16,6 +16,14 @@ import { ethers } from "hardhat";
 import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 import { deployGovernorProxy } from "./helpers/deploy-governor";
+import * as fs from "fs";
+import * as path from "path";
+// @ts-ignore
+import { buildPoseidon } from "circomlibjs";
+import {
+  loadVerificationKeys,
+  TESTING_ARTIFACT_CONFIGS,
+} from "../lib/artifacts";
 
 const ONE_DAY = 86400;
 const TWO_DAYS = 2 * ONE_DAY;
@@ -701,6 +709,483 @@ describe("Wind-Down & Redemption Integration", function () {
       const tokens = [await usdc.getAddress()];
       await redemption.connect(alice).redeem(ALICE_AMOUNT, tokens, false);
       expect(await usdc.balanceOf(alice.address)).to.equal(ethers.parseUnits("250000", 6));
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════
+// Wind-Down Pool Withdraw-Only Mode
+// Tests that the privacy pool enforces withdraw-only mode after wind-down:
+// shield() blocked, private transfer() blocked, unshield() always available.
+// Spec: §Wind-Down → Sequence step 3
+// ══════════════════════════════════════════════════════════════════════════
+
+const poseidonBytecode = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "lib", "poseidon_bytecode.json"), "utf-8")
+);
+
+const SNARK_SCALAR_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
+const POOL_DOMAINS = { hub: 100 };
+
+describe("Wind-Down Pool Withdraw-Only Mode", function () {
+  // Governance stack
+  let armToken: any;
+  let timelockController: any;
+  let governor: any;
+  let treasuryContract: any;
+  let shieldPauseController: any;
+  let windDown: any;
+  let redemption: any;
+  let revenueCounter: any;
+
+  // Privacy pool stack
+  let privacyPool: any;
+  let hubUsdc: any;
+
+  // Signers
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let carol: SignerWithAddress; // security council
+  let revenueLockAddr: SignerWithAddress;
+  let crowdfundAddr: SignerWithAddress;
+
+  // Poseidon
+  let poseidon: any;
+  let F: any;
+
+  let windDownDeadline: number;
+  let privacyPoolAddress: string;
+  let aliceAddress: string;
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Helpers (adapted from privacy_pool_adversarial.ts)
+  // ═══════════════════════════════════════════════════════════════════
+
+  function validNpk(): string {
+    const raw = BigInt(ethers.keccak256(ethers.toUtf8Bytes("test-npk")));
+    return ethers.zeroPadValue(ethers.toBeHex(raw % SNARK_SCALAR_FIELD), 32);
+  }
+
+  function makeShieldRequest(token: string, amount: bigint, npk?: string) {
+    return {
+      preimage: {
+        npk: npk ?? validNpk(),
+        token: { tokenType: 0, tokenAddress: token, tokenSubID: 0 },
+        value: amount,
+      },
+      ciphertext: {
+        encryptedBundle: [
+          ethers.keccak256(ethers.toUtf8Bytes("enc1")),
+          ethers.keccak256(ethers.toUtf8Bytes("enc2")),
+          ethers.keccak256(ethers.toUtf8Bytes("enc3")),
+        ],
+        shieldKey: ethers.keccak256(ethers.toUtf8Bytes("key")),
+      },
+    };
+  }
+
+  function makeTransaction(opts: {
+    merkleRoot: string;
+    nullifiers: string[];
+    commitments: string[];
+    unshield?: number;
+    unshieldPreimage?: any;
+    ciphertextCount?: number;
+  }) {
+    const unshieldType = opts.unshield ?? 0;
+    const ciphertextCount = opts.ciphertextCount ??
+      (unshieldType !== 0 ? opts.commitments.length - 1 : opts.commitments.length);
+
+    const ciphertext = Array.from({ length: ciphertextCount }, () => ({
+      ciphertext: [ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash],
+      blindedSenderViewingKey: ethers.ZeroHash,
+      blindedReceiverViewingKey: ethers.ZeroHash,
+      annotationData: "0x",
+      memo: "0x",
+    }));
+
+    return {
+      proof: { a: { x: 0, y: 0 }, b: { x: [0, 0], y: [0, 0] }, c: { x: 0, y: 0 } },
+      merkleRoot: opts.merkleRoot,
+      nullifiers: opts.nullifiers,
+      commitments: opts.commitments,
+      boundParams: {
+        treeNumber: 0,
+        minGasPrice: 0,
+        unshield: unshieldType,
+        chainID: 31337,
+        adaptContract: ethers.ZeroAddress,
+        adaptParams: ethers.ZeroHash,
+        commitmentCiphertext: ciphertext,
+      },
+      unshieldPreimage: opts.unshieldPreimage ?? {
+        npk: ethers.ZeroHash,
+        token: { tokenType: 0, tokenAddress: ethers.ZeroAddress, tokenSubID: 0 },
+        value: 0,
+      },
+    };
+  }
+
+  function computeCommitmentHash(npkBigInt: bigint, tokenId: bigint, value: bigint): string {
+    const hash = poseidon([F.e(npkBigInt), F.e(tokenId), F.e(value)]);
+    return ethers.zeroPadValue(ethers.toBeHex(BigInt(F.toString(hash))), 32);
+  }
+
+  async function shieldAndGetRoot(amount: bigint): Promise<string> {
+    const usdcAddr = await hubUsdc.getAddress();
+    await hubUsdc.mint(aliceAddress, amount);
+    await hubUsdc.connect(alice).approve(privacyPoolAddress, amount);
+    await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount)]);
+    return await privacyPool.merkleRoot();
+  }
+
+  async function asTimelock() {
+    const timelockAddr = await timelockController.getAddress();
+    await ethers.provider.send("hardhat_impersonateAccount", [timelockAddr]);
+    await deployer.sendTransaction({ to: timelockAddr, value: ethers.parseEther("1") });
+    return await ethers.getSigner(timelockAddr) as unknown as SignerWithAddress;
+  }
+
+  async function stopImpersonatingTimelock() {
+    await ethers.provider.send("hardhat_stopImpersonatingAccount", [
+      await timelockController.getAddress(),
+    ]);
+  }
+
+  async function triggerWindDown() {
+    await time.increaseTo(windDownDeadline + 1);
+    await windDown.triggerWindDown();
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Setup
+  // ═══════════════════════════════════════════════════════════════════
+
+  before(async function () {
+    [deployer, alice, bob, carol, revenueLockAddr, crowdfundAddr] = await ethers.getSigners();
+    aliceAddress = await alice.getAddress();
+
+    poseidon = await buildPoseidon();
+    F = poseidon.F;
+
+    // --- Deploy governance stack ---
+
+    const TimelockController = await ethers.getContractFactory("TimelockController");
+    timelockController = await TimelockController.deploy(TWO_DAYS, [], [], deployer.address);
+    const timelockAddr = await timelockController.getAddress();
+
+    const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+    armToken = await ArmadaToken.deploy(deployer.address, timelockAddr);
+
+    const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+    treasuryContract = await ArmadaTreasuryGov.deploy(timelockAddr, deployer.address, MAX_PAUSE_DURATION);
+
+    governor = await deployGovernorProxy(
+      await armToken.getAddress(),
+      timelockAddr,
+      await treasuryContract.getAddress(),
+      deployer.address,
+      MAX_PAUSE_DURATION,
+    );
+
+    // Deploy mock USDC
+    const MockUSDCV2 = await ethers.getContractFactory("MockUSDCV2");
+    hubUsdc = await MockUSDCV2.deploy("Mock USDC", "USDC");
+
+    // Deploy RevenueCounter behind proxy
+    const RevenueCounter = await ethers.getContractFactory("RevenueCounter");
+    const rcImpl = await RevenueCounter.deploy();
+    const initData = RevenueCounter.interface.encodeFunctionData("initialize", [timelockAddr]);
+    const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
+    const rcProxy = await ERC1967Proxy.deploy(await rcImpl.getAddress(), initData);
+    revenueCounter = RevenueCounter.attach(await rcProxy.getAddress());
+
+    // Deploy ShieldPauseController
+    const ShieldPauseController = await ethers.getContractFactory("ShieldPauseController");
+    shieldPauseController = await ShieldPauseController.deploy(
+      await governor.getAddress(),
+      timelockAddr,
+    );
+
+    // Deploy ArmadaRedemption
+    const ArmadaRedemption = await ethers.getContractFactory("ArmadaRedemption");
+    redemption = await ArmadaRedemption.deploy(
+      await armToken.getAddress(),
+      await treasuryContract.getAddress(),
+      revenueLockAddr.address,
+      crowdfundAddr.address,
+    );
+
+    // Deploy ArmadaWindDown
+    windDownDeadline = (await time.latest()) + 365 * ONE_DAY;
+    const ArmadaWindDown = await ethers.getContractFactory("ArmadaWindDown");
+    windDown = await ArmadaWindDown.deploy(
+      await armToken.getAddress(),
+      await treasuryContract.getAddress(),
+      await governor.getAddress(),
+      await redemption.getAddress(),
+      await shieldPauseController.getAddress(),
+      await revenueCounter.getAddress(),
+      timelockAddr,
+      REVENUE_THRESHOLD,
+      windDownDeadline,
+    );
+
+    // Wire governance contracts
+    await armToken.setWindDownContract(await windDown.getAddress());
+
+    const timelockSigner = await asTimelock();
+    await governor.connect(timelockSigner).setSecurityCouncil(carol.address);
+    await governor.connect(timelockSigner).setWindDownContract(await windDown.getAddress());
+    await treasuryContract.connect(timelockSigner).setWindDownContract(await windDown.getAddress());
+    await shieldPauseController.connect(timelockSigner).setWindDownContract(await windDown.getAddress());
+    await stopImpersonatingTimelock();
+
+    // Configure timelock roles
+    const PROPOSER_ROLE = await timelockController.PROPOSER_ROLE();
+    const EXECUTOR_ROLE = await timelockController.EXECUTOR_ROLE();
+    const ADMIN_ROLE = await timelockController.TIMELOCK_ADMIN_ROLE();
+    await timelockController.grantRole(PROPOSER_ROLE, await governor.getAddress());
+    await timelockController.grantRole(EXECUTOR_ROLE, await governor.getAddress());
+    await timelockController.renounceRole(ADMIN_ROLE, deployer.address);
+
+    // Distribute ARM
+    await armToken.initWhitelist([
+      deployer.address,
+      await treasuryContract.getAddress(),
+      alice.address,
+      bob.address,
+      revenueLockAddr.address,
+      crowdfundAddr.address,
+      await redemption.getAddress(),
+    ]);
+    await armToken.transfer(await treasuryContract.getAddress(), TREASURY_AMOUNT);
+    await armToken.transfer(alice.address, ALICE_AMOUNT);
+    await armToken.transfer(bob.address, BOB_AMOUNT);
+    await armToken.connect(alice).delegate(alice.address);
+
+    // --- Deploy privacy pool ---
+
+    // Deploy Poseidon libraries
+    const poseidonT3Tx = await deployer.sendTransaction({ data: poseidonBytecode.PoseidonT3.bytecode });
+    const poseidonT3Address = (await poseidonT3Tx.wait())!.contractAddress!;
+    const poseidonT4Tx = await deployer.sendTransaction({ data: poseidonBytecode.PoseidonT4.bytecode });
+    const poseidonT4Address = (await poseidonT4Tx.wait())!.contractAddress!;
+
+    // Deploy modules with Poseidon linking
+    const merkleModule = await (await ethers.getContractFactory("MerkleModule", {
+      libraries: { PoseidonT3: poseidonT3Address },
+    })).deploy();
+    const verifierModule = await (await ethers.getContractFactory("VerifierModule")).deploy();
+    const shieldModule = await (await ethers.getContractFactory("ShieldModule", {
+      libraries: { PoseidonT4: poseidonT4Address },
+    })).deploy();
+    const transactModule = await (await ethers.getContractFactory("TransactModule", {
+      libraries: { PoseidonT4: poseidonT4Address },
+    })).deploy();
+
+    // Deploy mock CCTP
+    const MockMessageTransmitterV2 = await ethers.getContractFactory("MockMessageTransmitterV2");
+    const hubMessageTransmitter = await MockMessageTransmitterV2.deploy(POOL_DOMAINS.hub, deployer.address);
+    const MockTokenMessengerV2 = await ethers.getContractFactory("MockTokenMessengerV2");
+    const hubTokenMessenger = await MockTokenMessengerV2.deploy(
+      await hubMessageTransmitter.getAddress(),
+      await hubUsdc.getAddress(),
+      POOL_DOMAINS.hub,
+    );
+    await hubMessageTransmitter.setTokenMessenger(await hubTokenMessenger.getAddress());
+    await hubUsdc.addMinter(await hubTokenMessenger.getAddress());
+
+    // Deploy and initialize PrivacyPool
+    const PrivacyPool = await ethers.getContractFactory("PrivacyPool");
+    privacyPool = await PrivacyPool.deploy();
+    privacyPoolAddress = await privacyPool.getAddress();
+
+    await privacyPool.initialize(
+      await shieldModule.getAddress(),
+      await transactModule.getAddress(),
+      await merkleModule.getAddress(),
+      await verifierModule.getAddress(),
+      await hubTokenMessenger.getAddress(),
+      await hubMessageTransmitter.getAddress(),
+      await hubUsdc.getAddress(),
+      POOL_DOMAINS.hub,
+      deployer.address,
+    );
+
+    await loadVerificationKeys(privacyPool, TESTING_ARTIFACT_CONFIGS, false);
+    await privacyPool.setTestingMode(true);
+    await privacyPool.setTreasury(deployer.address);
+    await privacyPool.setShieldPauseContract(await shieldPauseController.getAddress());
+
+    await mine(1);
+  });
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Tests: Pre-wind-down (regression)
+  // ═══════════════════════════════════════════════════════════════════
+
+  describe("Pre-wind-down: all operations allowed", function () {
+    it("shield succeeds before wind-down", async function () {
+      const amount = ethers.parseUnits("100", 6);
+      const usdcAddr = await hubUsdc.getAddress();
+      await hubUsdc.mint(aliceAddress, amount);
+      await hubUsdc.connect(alice).approve(privacyPoolAddress, amount);
+
+      await expect(
+        privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount)])
+      ).to.not.be.reverted;
+    });
+
+    it("pure private transfer succeeds before wind-down", async function () {
+      const root = await shieldAndGetRoot(ethers.parseUnits("100", 6));
+      const nullifier = ethers.keccak256(ethers.toUtf8Bytes("pre-wd-transfer-null"));
+      const commitment = ethers.keccak256(ethers.toUtf8Bytes("pre-wd-transfer-commit"));
+
+      const tx = makeTransaction({
+        merkleRoot: root,
+        nullifiers: [nullifier],
+        commitments: [commitment],
+        unshield: 0, // UnshieldType.NONE — pure transfer
+      });
+
+      // Should not revert with "withdraw only" (may succeed or fail on proof validation)
+      await expect(privacyPool.transact([tx])).to.not.be.revertedWith(
+        "TransactModule: withdraw only"
+      );
+    });
+
+    it("unshield succeeds before wind-down", async function () {
+      const shieldAmount = ethers.parseUnits("200", 6);
+      const root = await shieldAndGetRoot(shieldAmount);
+      const usdcAddr = await hubUsdc.getAddress();
+      const recipientAddr = await bob.getAddress();
+
+      const unshieldAmount = ethers.parseUnits("100", 6);
+      const npkBigInt = BigInt(recipientAddr);
+      const tokenId = BigInt(usdcAddr);
+      const commitHash = computeCommitmentHash(npkBigInt, tokenId, unshieldAmount);
+      const nullifier = ethers.keccak256(ethers.toUtf8Bytes("pre-wd-unshield-null"));
+
+      const tx = makeTransaction({
+        merkleRoot: root,
+        nullifiers: [nullifier],
+        commitments: [commitHash],
+        unshield: 1, // UnshieldType.NORMAL
+        unshieldPreimage: {
+          npk: ethers.zeroPadValue(recipientAddr, 32),
+          token: { tokenType: 0, tokenAddress: usdcAddr, tokenSubID: 0 },
+          value: unshieldAmount,
+        },
+      });
+
+      const bobBefore = await hubUsdc.balanceOf(recipientAddr);
+      await privacyPool.transact([tx]);
+      const bobAfter = await hubUsdc.balanceOf(recipientAddr);
+
+      expect(bobAfter - bobBefore).to.equal(unshieldAmount);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Tests: Post-wind-down (withdraw-only mode)
+  // ═══════════════════════════════════════════════════════════════════
+
+  describe("Post-wind-down: withdraw-only mode", function () {
+    before(async function () {
+      await triggerWindDown();
+    });
+
+    it("shield reverts after wind-down", async function () {
+      const amount = ethers.parseUnits("100", 6);
+      const usdcAddr = await hubUsdc.getAddress();
+      await hubUsdc.mint(aliceAddress, amount);
+      await hubUsdc.connect(alice).approve(privacyPoolAddress, amount);
+
+      await expect(
+        privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount)])
+      ).to.be.revertedWith("ShieldModule: shields paused");
+    });
+
+    it("pure private transfer reverts after wind-down", async function () {
+      const root = await privacyPool.merkleRoot();
+      const nullifier = ethers.keccak256(ethers.toUtf8Bytes("post-wd-transfer-null"));
+      const commitment = ethers.keccak256(ethers.toUtf8Bytes("post-wd-transfer-commit"));
+
+      const tx = makeTransaction({
+        merkleRoot: root,
+        nullifiers: [nullifier],
+        commitments: [commitment],
+        unshield: 0, // UnshieldType.NONE — pure transfer
+      });
+
+      await expect(privacyPool.transact([tx])).to.be.revertedWith(
+        "TransactModule: withdraw only"
+      );
+    });
+
+    it("mixed batch (transfer + unshield) reverts after wind-down", async function () {
+      const root = await privacyPool.merkleRoot();
+      const usdcAddr = await hubUsdc.getAddress();
+      const recipientAddr = await bob.getAddress();
+      const unshieldAmount = ethers.parseUnits("50", 6);
+      const npkBigInt = BigInt(recipientAddr);
+      const tokenId = BigInt(usdcAddr);
+      const commitHash = computeCommitmentHash(npkBigInt, tokenId, unshieldAmount);
+
+      const unshieldTx = makeTransaction({
+        merkleRoot: root,
+        nullifiers: [ethers.keccak256(ethers.toUtf8Bytes("mixed-unshield-null"))],
+        commitments: [commitHash],
+        unshield: 1,
+        unshieldPreimage: {
+          npk: ethers.zeroPadValue(recipientAddr, 32),
+          token: { tokenType: 0, tokenAddress: usdcAddr, tokenSubID: 0 },
+          value: unshieldAmount,
+        },
+      });
+
+      const transferTx = makeTransaction({
+        merkleRoot: root,
+        nullifiers: [ethers.keccak256(ethers.toUtf8Bytes("mixed-transfer-null"))],
+        commitments: [ethers.keccak256(ethers.toUtf8Bytes("mixed-transfer-commit"))],
+        unshield: 0,
+      });
+
+      await expect(privacyPool.transact([unshieldTx, transferTx])).to.be.revertedWith(
+        "TransactModule: withdraw only"
+      );
+    });
+
+    it("unshield succeeds after wind-down", async function () {
+      const root = await privacyPool.merkleRoot();
+      const usdcAddr = await hubUsdc.getAddress();
+      const recipientAddr = await bob.getAddress();
+
+      const unshieldAmount = ethers.parseUnits("50", 6);
+      const npkBigInt = BigInt(recipientAddr);
+      const tokenId = BigInt(usdcAddr);
+      const commitHash = computeCommitmentHash(npkBigInt, tokenId, unshieldAmount);
+      const nullifier = ethers.keccak256(ethers.toUtf8Bytes("post-wd-unshield-null"));
+
+      const tx = makeTransaction({
+        merkleRoot: root,
+        nullifiers: [nullifier],
+        commitments: [commitHash],
+        unshield: 1,
+        unshieldPreimage: {
+          npk: ethers.zeroPadValue(recipientAddr, 32),
+          token: { tokenType: 0, tokenAddress: usdcAddr, tokenSubID: 0 },
+          value: unshieldAmount,
+        },
+      });
+
+      const bobBefore = await hubUsdc.balanceOf(recipientAddr);
+      await privacyPool.transact([tx]);
+      const bobAfter = await hubUsdc.balanceOf(recipientAddr);
+
+      expect(bobAfter - bobBefore).to.equal(unshieldAmount);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Block private transfers in withdraw-only mode** after wind-down (#112)
- **Require strict majority AGAINST** to eject SC on ratification tie (#113)
- **Reclassify `resumeStewardChannel`** as standard proposal (spec alignment)
- **Remove bond requirement** from steward proposals (#119)
- **Make `setTransferable` one-way** to match wind-down spec (#120)

## Issues Fixed

Closes #112
Closes #113
Closes #119
Closes #120

## Test plan

- [x] `npm run test` — core privacy pool integration tests pass
- [x] `npm run test:governance` — governance lifecycle & adversarial tests pass
- [x] `npm run test:forge` — Foundry fuzz/invariant tests pass
- [ ] `npm run test:all` — full Hardhat suite
- [ ] `npm run halmos` — symbolic verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)