### PR TITLE
fix: governance hardening — #102, #104, #105

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -642,6 +642,15 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
             );
         }
 
+        // Defense-in-depth: verify steward calldata would not classify as Extended.
+        // Currently safe because stewardSpend is not an extended selector, but this
+        // guard protects against future selector additions that could allow sensitive
+        // operations to bypass Extended classification via the pass-by-default path.
+        require(
+            _classifyProposal(ProposalType.Standard, targets, calldatas) != ProposalType.Extended,
+            "ArmadaGovernor: steward calldata classified as extended"
+        );
+
         uint256 proposalId = ++proposalCount;
         _initProposal(proposalId, ProposalType.Steward, description);
 

--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -988,12 +988,23 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         emit ProposalExecuted(proposalId);
     }
 
-    /// @notice Cancel a proposal (proposer only, while Pending)
+    /// @notice Cancel a proposal. Standard/Extended: proposer only, while Pending.
+    /// Steward proposals: proposer only, while Pending or Active (steward proposals
+    /// skip Pending due to zero voting delay, so Active is the earliest cancellable state).
     function cancel(uint256 proposalId) external {
         Proposal storage p = _proposals[proposalId];
         require(p.id != 0, "ArmadaGovernor: unknown proposal");
         require(msg.sender == p.proposer, "ArmadaGovernor: not proposer");
-        require(state(proposalId) == ProposalState.Pending, "ArmadaGovernor: not pending");
+
+        ProposalState currentState = state(proposalId);
+        if (p.proposalType == ProposalType.Steward) {
+            require(
+                currentState == ProposalState.Pending || currentState == ProposalState.Active,
+                "ArmadaGovernor: not pending or active"
+            );
+        } else {
+            require(currentState == ProposalState.Pending, "ArmadaGovernor: not pending");
+        }
 
         p.canceled = true;
 

--- a/contracts/governance/ArmadaTreasuryGov.sol
+++ b/contracts/governance/ArmadaTreasuryGov.sol
@@ -200,6 +200,7 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
     ) external onlyOwner {
         require(!_outflowConfigs[token].initialized, "ArmadaTreasuryGov: outflow already initialized");
         require(windowDuration >= 1 days, "ArmadaTreasuryGov: window too short");
+        require(limitBps > 0, "ArmadaTreasuryGov: zero bps");
         require(limitBps <= 10000, "ArmadaTreasuryGov: bps out of range");
         require(limitAbsolute >= floorAbsolute, "ArmadaTreasuryGov: absolute below floor");
 
@@ -225,6 +226,7 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
     /// @notice Update the percentage-based outflow limit for a token.
     function setOutflowLimitBps(address token, uint256 newBps) external onlyOwner {
         require(_outflowConfigs[token].initialized, "ArmadaTreasuryGov: outflow not initialized");
+        require(newBps > 0, "ArmadaTreasuryGov: zero bps");
         require(newBps <= 10000, "ArmadaTreasuryGov: bps out of range");
         _outflowConfigs[token].limitBps = newBps;
         emit OutflowLimitBpsUpdated(token, newBps);

--- a/test-foundry/GovernorSteward.t.sol
+++ b/test-foundry/GovernorSteward.t.sol
@@ -345,6 +345,65 @@ contract GovernorStewardTest is Test, GovernorDeployHelper {
     }
 
     // ══════════════════════════════════════════════════════════════════════
+    // Steward proposal cancellation (#105)
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_cancel_stewardProposalDuringActive() public {
+        uint256 proposalId = _proposeStewardSpend(alice, 100 * 1e6);
+
+        // Steward proposals go straight to Active (votingDelay == 0)
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Active));
+
+        // Steward should be able to cancel their own Active proposal
+        vm.prank(stewardPerson);
+        governor.cancel(proposalId);
+
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Canceled));
+    }
+
+    function test_cancel_stewardProposalRejectsNonProposer() public {
+        uint256 proposalId = _proposeStewardSpend(alice, 100 * 1e6);
+
+        // Non-proposer should not be able to cancel
+        vm.prank(alice);
+        vm.expectRevert("ArmadaGovernor: not proposer");
+        governor.cancel(proposalId);
+    }
+
+    function test_cancel_standardProposalStillRequiresPending() public {
+        // Standard proposals should still only be cancellable while Pending
+        vm.prank(alice);
+        armToken.delegate(alice);
+        vm.roll(block.number + 1);
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(treasury);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "distribute(address,address,uint256)",
+            address(usdc), bob, 100
+        );
+
+        vm.prank(alice);
+        uint256 proposalId = governor.propose(
+            ProposalType.Standard, targets, values, calldatas, "standard proposal"
+        );
+
+        // Should be Pending (48h delay)
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Pending));
+
+        // Advance past voting delay into Active
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Active));
+
+        // Cancel should fail — standard proposals can't cancel during Active
+        vm.prank(alice);
+        vm.expectRevert("ArmadaGovernor: not pending");
+        governor.cancel(proposalId);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
     // Wind-down blocks steward proposals
     // ══════════════════════════════════════════════════════════════════════
 

--- a/test-foundry/GovernorSteward.t.sol
+++ b/test-foundry/GovernorSteward.t.sol
@@ -467,6 +467,29 @@ contract GovernorStewardTest is Test, GovernorDeployHelper {
     }
 
     // ══════════════════════════════════════════════════════════════════════
+    // Classification guard (#102)
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_proposeStewardSpend_revertsIfCalldataClassifiesAsExtended() public {
+        // Register stewardSpend's selector as extended (simulates future expansion)
+        bytes4 stewardSpendSelector = bytes4(keccak256("stewardSpend(address,address,uint256)"));
+        vm.prank(address(timelock));
+        governor.addExtendedSelector(stewardSpendSelector);
+
+        // Steward proposal should now revert because its calldata would classify as Extended
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100 * 1e6;
+
+        vm.prank(stewardPerson);
+        vm.expectRevert("ArmadaGovernor: steward calldata classified as extended");
+        governor.proposeStewardSpend(tokens, recipients, amounts, "should fail");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
     // Budget management on treasury
     // ══════════════════════════════════════════════════════════════════════
 

--- a/test/treasury_outflow.ts
+++ b/test/treasury_outflow.ts
@@ -110,6 +110,14 @@ describe("Treasury Outflow Rate Limits", function () {
       ).to.be.revertedWith("ArmadaTreasuryGov: outflow already initialized");
     });
 
+    it("should reject zero bps in initOutflowConfig", async function () {
+      await expect(
+        treasury.initOutflowConfig(
+          await usdc.getAddress(), THIRTY_DAYS, 0, USDC(100_000), USDC(50_000)
+        )
+      ).to.be.revertedWith("ArmadaTreasuryGov: zero bps");
+    });
+
     it("should reject absolute limit below floor", async function () {
       await expect(
         treasury.initOutflowConfig(
@@ -145,6 +153,12 @@ describe("Treasury Outflow Rate Limits", function () {
       await treasury.setOutflowLimitBps(await usdc.getAddress(), 2000);
       const config = await treasury.getOutflowConfig(await usdc.getAddress());
       expect(config.limitBps).to.equal(2000);
+    });
+
+    it("should reject zero bps", async function () {
+      await expect(
+        treasury.setOutflowLimitBps(await usdc.getAddress(), 0)
+      ).to.be.revertedWith("ArmadaTreasuryGov: zero bps");
     });
 
     it("should reject bps above 10000", async function () {


### PR DESCRIPTION
## Summary

- **#102** — Add defensive `_classifyProposal` guard in `proposeStewardSpend` that reverts if generated calldata would classify as Extended, preventing sensitive operations from bypassing Extended quorum via the pass-by-default steward path
- **#104** — Reject zero `limitBps` in `initOutflowConfig` and `setOutflowLimitBps` to prevent governance from zeroing the percentage-based outflow limit
- **#105** — Allow steward to cancel proposals during Active state (steward proposals skip Pending due to zero voting delay, so Active is their earliest cancellable state). Tied-vote sub-issue was already correct in code.

Also reviewed and commented on:
- **#103** — Closed as won't-fix: append-only outflow history is correct design (bounded iteration cost, preserves correctness across window duration changes)
- **#116** — Not fixable without ArmadaToken changes (ERC20Votes has no `getPastBalanceOf`)

## Test plan

- [x] Hardhat: `test/treasury_outflow.ts` — 30/30 passing (2 new tests for zero BPS rejection)
- [x] Foundry: `GovernorSteward.t.sol` — 38/38 passing (4 new tests: classification guard, steward cancel during Active, non-proposer rejection, standard proposal unchanged)
- [x] Hardhat: `test/governance_integration.ts` — 41/41 passing (regression check)

Closes #102, closes #104, closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)