### PR TITLE
feat(fees): add ArmadaFeeModule with volume tiers and integrator support

### DIFF
--- a/contracts/fees/ArmadaFeeModule.sol
+++ b/contracts/fees/ArmadaFeeModule.sol
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: UUPS-upgradeable fee oracle that centralizes shield fee calculation, integrator tracking,
+// ABOUTME: and cumulative protocol revenue accounting. Oracle-only — does NOT hold tokens.
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "./IArmadaFeeModule.sol";
+
+contract ArmadaFeeModule is Initializable, UUPSUpgradeable, OwnableUpgradeable, IArmadaFeeModule {
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // CONSTANTS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    uint256 public constant BPS_DENOMINATOR = 10000;
+    uint256 public constant MAX_TIERS = 10;
+    uint256 public constant MAX_BPS = 1000; // 10% max for any fee component
+    uint256 public constant MIN_YIELD_FEE_BPS = 100;  // 1%
+    uint256 public constant MAX_YIELD_FEE_BPS = 5000;  // 50%
+    uint256 public constant MAX_INTEGRATOR_FEE_BPS = 500; // 5% max integrator base fee
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // STORAGE
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Base Armada protocol take in basis points (default 50 = 0.5%)
+    uint256 public override baseArmadaTakeBps;
+
+    /// @notice Yield fee in basis points (default 1500 = 15%)
+    uint256 public override yieldFeeBps;
+
+    /// @notice Volume tiers (sorted descending by threshold). Max 10.
+    Tier[] internal _tiers;
+
+    /// @notice Per-integrator registration and stats
+    mapping(address => IntegratorInfo) internal _integrators;
+
+    /// @notice Governance-assigned custom terms for specific integrators
+    mapping(address => CustomTerms) internal _customTerms;
+
+    /// @notice Cumulative Armada protocol fees (shield + yield). Monotonically non-decreasing.
+    uint256 public override cumulativeArmadaFees;
+
+    /// @notice Cumulative integrator fees (analytics only, not protocol revenue).
+    uint256 public override cumulativeIntegratorFees;
+
+    /// @notice Treasury address where protocol fees are sent
+    address public override treasury;
+
+    /// @notice Authorized caller for recordShieldFee
+    address public override privacyPool;
+
+    /// @notice Authorized caller for recordYieldFee
+    address public override yieldVault;
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // INITIALIZER
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @param _owner Governance address (timelock)
+    /// @param _treasury ArmadaTreasuryGov address
+    /// @param _privacyPool PrivacyPool address (authorized recordShieldFee caller)
+    /// @param _yieldVault ArmadaYieldVault address (authorized recordYieldFee caller)
+    function initialize(
+        address _owner,
+        address _treasury,
+        address _privacyPool,
+        address _yieldVault
+    ) external initializer {
+        require(_owner != address(0), "ArmadaFeeModule: zero owner");
+        require(_treasury != address(0), "ArmadaFeeModule: zero treasury");
+        require(_privacyPool != address(0), "ArmadaFeeModule: zero privacyPool");
+        require(_yieldVault != address(0), "ArmadaFeeModule: zero yieldVault");
+
+        __Ownable_init();
+        __UUPSUpgradeable_init();
+        _transferOwnership(_owner);
+
+        treasury = _treasury;
+        privacyPool = _privacyPool;
+        yieldVault = _yieldVault;
+
+        // Defaults per spec
+        baseArmadaTakeBps = 50;    // 0.50%
+        yieldFeeBps = 1500;        // 15%
+
+        // Default tier: $250k volume → 40 bps armada take
+        _tiers.push(Tier({volumeThreshold: 250_000e6, armadaTakeBps: 40}));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // FEE CALCULATION
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @inheritdoc IArmadaFeeModule
+    function calculateShieldFee(
+        address integrator,
+        uint256 amount
+    ) external view override returns (uint256 armadaTake, uint256 integratorFee, uint256 totalFee) {
+        if (amount == 0) return (0, 0, 0);
+
+        uint256 effectiveTakeBps = _getEffectiveArmadaTake(integrator);
+
+        // Inclusive fee: armadaTake = amount * effectiveTakeBps / 10000
+        armadaTake = (amount * effectiveTakeBps) / BPS_DENOMINATOR;
+
+        // Integrator fee
+        if (integrator != address(0) && _integrators[integrator].registered) {
+            uint256 bonus = _getBonus(integrator);
+            uint256 integratorTotalBps = _integrators[integrator].baseFee + bonus;
+            integratorFee = (amount * integratorTotalBps) / BPS_DENOMINATOR;
+        }
+
+        totalFee = armadaTake + integratorFee;
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function getYieldFeeBps() external view override returns (uint256) {
+        return yieldFeeBps;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // FEE RECORDING
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @inheritdoc IArmadaFeeModule
+    function recordShieldFee(
+        address integrator,
+        uint256 amount,
+        uint256 armadaTakePaid,
+        uint256 integratorFeePaid
+    ) external override {
+        require(msg.sender == privacyPool, "ArmadaFeeModule: only privacy pool");
+
+        cumulativeArmadaFees += armadaTakePaid;
+
+        if (integrator != address(0) && _integrators[integrator].registered) {
+            _integrators[integrator].cumulativeVolume += amount;
+            _integrators[integrator].cumulativeEarnings += integratorFeePaid;
+            cumulativeIntegratorFees += integratorFeePaid;
+        }
+
+        emit ShieldFeeRecorded(integrator, amount, armadaTakePaid, integratorFeePaid);
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function recordYieldFee(uint256 amount) external override {
+        require(msg.sender == yieldVault, "ArmadaFeeModule: only yield vault");
+
+        cumulativeArmadaFees += amount;
+
+        emit YieldFeeRecorded(amount);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // IFeeCollector
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @inheritdoc IFeeCollector
+    function cumulativeFeesCollected() external view override returns (uint256) {
+        return cumulativeArmadaFees;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // INTEGRATOR SELF-SERVICE
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @inheritdoc IArmadaFeeModule
+    function setIntegratorFee(uint256 feeBps) external override {
+        require(feeBps <= MAX_INTEGRATOR_FEE_BPS, "ArmadaFeeModule: integrator fee too high");
+
+        IntegratorInfo storage info = _integrators[msg.sender];
+        info.baseFee = feeBps;
+        info.registered = true;
+
+        emit IntegratorRegistered(msg.sender, feeBps);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GOVERNANCE SETTERS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @inheritdoc IArmadaFeeModule
+    function setBaseArmadaTake(uint256 bps) external override onlyOwner {
+        require(bps <= MAX_BPS, "ArmadaFeeModule: take too high");
+        emit BaseArmadaTakeUpdated(baseArmadaTakeBps, bps);
+        baseArmadaTakeBps = bps;
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function addTier(uint256 threshold, uint256 takeBps) external override onlyOwner {
+        require(_tiers.length < MAX_TIERS, "ArmadaFeeModule: max tiers reached");
+        require(takeBps <= MAX_BPS, "ArmadaFeeModule: tier take too high");
+        require(threshold > 0, "ArmadaFeeModule: zero threshold");
+
+        _tiers.push(Tier({volumeThreshold: threshold, armadaTakeBps: takeBps}));
+        emit TierAdded(_tiers.length - 1, threshold, takeBps);
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function setTier(uint256 index, uint256 threshold, uint256 takeBps) external override onlyOwner {
+        require(index < _tiers.length, "ArmadaFeeModule: invalid tier index");
+        require(takeBps <= MAX_BPS, "ArmadaFeeModule: tier take too high");
+        require(threshold > 0, "ArmadaFeeModule: zero threshold");
+
+        _tiers[index] = Tier({volumeThreshold: threshold, armadaTakeBps: takeBps});
+        emit TierUpdated(index, threshold, takeBps);
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function removeTier(uint256 index) external override onlyOwner {
+        require(index < _tiers.length, "ArmadaFeeModule: invalid tier index");
+
+        // Swap with last and pop
+        uint256 lastIndex = _tiers.length - 1;
+        if (index != lastIndex) {
+            _tiers[index] = _tiers[lastIndex];
+        }
+        _tiers.pop();
+
+        emit TierRemoved(index);
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function setYieldFee(uint256 bps) external override onlyOwner {
+        require(bps >= MIN_YIELD_FEE_BPS, "ArmadaFeeModule: below min yield fee");
+        require(bps <= MAX_YIELD_FEE_BPS, "ArmadaFeeModule: above max yield fee");
+        emit YieldFeeUpdated(yieldFeeBps, bps);
+        yieldFeeBps = bps;
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function setIntegratorTerms(
+        address integrator,
+        uint256 takeBps,
+        uint256 threshold,
+        bool active
+    ) external override onlyOwner {
+        require(integrator != address(0), "ArmadaFeeModule: zero integrator");
+        require(takeBps <= MAX_BPS, "ArmadaFeeModule: custom take too high");
+
+        _customTerms[integrator] = CustomTerms({
+            customArmadaTakeBps: takeBps,
+            customVolumeThreshold: threshold,
+            active: active
+        });
+
+        emit IntegratorTermsSet(integrator, takeBps, threshold, active);
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function setTreasury(address _treasury) external override onlyOwner {
+        require(_treasury != address(0), "ArmadaFeeModule: zero treasury");
+        emit TreasuryUpdated(treasury, _treasury);
+        treasury = _treasury;
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function setPrivacyPool(address _privacyPool) external override onlyOwner {
+        require(_privacyPool != address(0), "ArmadaFeeModule: zero privacy pool");
+        emit PrivacyPoolUpdated(privacyPool, _privacyPool);
+        privacyPool = _privacyPool;
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function setYieldVault(address _yieldVault) external override onlyOwner {
+        require(_yieldVault != address(0), "ArmadaFeeModule: zero yield vault");
+        emit YieldVaultUpdated(yieldVault, _yieldVault);
+        yieldVault = _yieldVault;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // QUERY VIEWS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @inheritdoc IArmadaFeeModule
+    function getIntegratorInfo(address integrator) external view override returns (IntegratorInfo memory) {
+        return _integrators[integrator];
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function getIntegratorTerms(address integrator) external view override returns (CustomTerms memory) {
+        return _customTerms[integrator];
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function getTiers() external view override returns (Tier[] memory) {
+        return _tiers;
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function getTierCount() external view override returns (uint256) {
+        return _tiers.length;
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function getArmadaTake(address integrator) external view override returns (uint256) {
+        return _getEffectiveArmadaTake(integrator);
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function getUserFee(address integrator) external view override returns (uint256) {
+        uint256 take = _getEffectiveArmadaTake(integrator);
+        if (integrator == address(0) || !_integrators[integrator].registered) {
+            return take;
+        }
+        uint256 bonus = _getBonus(integrator);
+        return take + _integrators[integrator].baseFee + bonus;
+    }
+
+    /// @inheritdoc IArmadaFeeModule
+    function getIntegratorBonus(address integrator) external view override returns (uint256) {
+        return _getBonus(integrator);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // INTERNAL
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Get the effective Armada take bps for a given integrator, considering
+    ///         custom terms and volume tiers.
+    function _getEffectiveArmadaTake(address integrator) internal view returns (uint256) {
+        // No integrator — base rate
+        if (integrator == address(0)) {
+            return baseArmadaTakeBps;
+        }
+
+        // Custom terms override everything
+        if (_customTerms[integrator].active) {
+            return _customTerms[integrator].customArmadaTakeBps;
+        }
+
+        // Registered integrator — check volume tiers
+        if (_integrators[integrator].registered) {
+            uint256 volume = _integrators[integrator].cumulativeVolume;
+            return _getTieredTake(volume);
+        }
+
+        // Unregistered address passed as integrator — base rate
+        return baseArmadaTakeBps;
+    }
+
+    /// @notice Look up the Armada take bps for a given cumulative volume.
+    ///         Tiers are checked from index 0 to N. The matching tier with
+    ///         the highest threshold that is <= volume wins. If no tier matches,
+    ///         returns baseArmadaTakeBps.
+    function _getTieredTake(uint256 volume) internal view returns (uint256) {
+        uint256 len = _tiers.length;
+        if (len == 0) return baseArmadaTakeBps;
+
+        uint256 bestThreshold = 0;
+        uint256 bestTake = baseArmadaTakeBps;
+
+        for (uint256 i = 0; i < len; i++) {
+            if (volume >= _tiers[i].volumeThreshold && _tiers[i].volumeThreshold > bestThreshold) {
+                bestThreshold = _tiers[i].volumeThreshold;
+                bestTake = _tiers[i].armadaTakeBps;
+            }
+        }
+
+        return bestTake;
+    }
+
+    /// @notice Calculate the bonus bps an integrator earns from the volume tier discount.
+    ///         bonus = baseArmadaTakeBps - effectiveTakeBps (when volume exceeds a tier threshold).
+    function _getBonus(address integrator) internal view returns (uint256) {
+        uint256 effectiveTake = _getEffectiveArmadaTake(integrator);
+        if (effectiveTake >= baseArmadaTakeBps) {
+            return 0;
+        }
+        return baseArmadaTakeBps - effectiveTake;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // UUPS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @dev Only the owner (timelock) can authorize upgrades.
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+}

--- a/contracts/fees/IArmadaFeeModule.sol
+++ b/contracts/fees/IArmadaFeeModule.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Interface for the centralized fee oracle that calculates shield fees and tracks revenue.
+// ABOUTME: Supports volume-tiered Armada take, integrator fees, yield fee reporting, and IFeeCollector.
+pragma solidity ^0.8.17;
+
+import "../governance/IFeeCollector.sol";
+
+/// @title IArmadaFeeModule — Centralized fee oracle for shield and yield fees
+/// @notice Calculates fee rates, tracks integrator volume/earnings, and exposes cumulative
+///         protocol revenue via IFeeCollector for RevenueCounter integration.
+interface IArmadaFeeModule is IFeeCollector {
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // STRUCTS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Volume tier: when an integrator's cumulative volume exceeds the threshold,
+    ///         the Armada take drops to the specified bps.
+    struct Tier {
+        uint256 volumeThreshold;
+        uint256 armadaTakeBps;
+    }
+
+    /// @notice Per-integrator registration and cumulative stats.
+    struct IntegratorInfo {
+        uint256 baseFee;
+        uint256 cumulativeVolume;
+        uint256 cumulativeEarnings;
+        bool registered;
+    }
+
+    /// @notice Governance-assigned custom terms for a specific integrator.
+    struct CustomTerms {
+        uint256 customArmadaTakeBps;
+        uint256 customVolumeThreshold;
+        bool active;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // EVENTS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    event IntegratorRegistered(address indexed integrator, uint256 baseFee);
+    event ShieldFeeRecorded(address indexed integrator, uint256 amount, uint256 armadaTake, uint256 integratorFee);
+    event YieldFeeRecorded(uint256 amount);
+    event BaseArmadaTakeUpdated(uint256 oldBps, uint256 newBps);
+    event TierAdded(uint256 index, uint256 volumeThreshold, uint256 armadaTakeBps);
+    event TierUpdated(uint256 index, uint256 volumeThreshold, uint256 armadaTakeBps);
+    event TierRemoved(uint256 index);
+    event YieldFeeUpdated(uint256 oldBps, uint256 newBps);
+    event IntegratorTermsSet(address indexed integrator, uint256 takeBps, uint256 threshold, bool active);
+    event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury);
+    event PrivacyPoolUpdated(address indexed oldPool, address indexed newPool);
+    event YieldVaultUpdated(address indexed oldVault, address indexed newVault);
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // FEE CALCULATION (VIEW)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Calculate shield fee breakdown for a given integrator and amount.
+    /// @param integrator Integrator address (address(0) for no integrator)
+    /// @param amount Gross shield amount (inclusive — fees deducted from this)
+    /// @return armadaTake Protocol fee portion
+    /// @return integratorFee Integrator fee portion
+    /// @return totalFee armadaTake + integratorFee
+    function calculateShieldFee(
+        address integrator,
+        uint256 amount
+    ) external view returns (uint256 armadaTake, uint256 integratorFee, uint256 totalFee);
+
+    /// @notice Returns the current yield fee rate in basis points.
+    function getYieldFeeBps() external view returns (uint256);
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // FEE RECORDING (AUTHORIZED CALLERS)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Record a shield fee after payment. Called by PrivacyPool only.
+    /// @param integrator Integrator address (address(0) for no integrator)
+    /// @param amount Gross shield amount
+    /// @param armadaTakePaid Armada protocol fee actually paid
+    /// @param integratorFeePaid Integrator fee actually paid
+    function recordShieldFee(
+        address integrator,
+        uint256 amount,
+        uint256 armadaTakePaid,
+        uint256 integratorFeePaid
+    ) external;
+
+    /// @notice Record a yield fee after payment. Called by ArmadaYieldVault only.
+    /// @param amount Yield fee amount paid to treasury
+    function recordYieldFee(uint256 amount) external;
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // INTEGRATOR SELF-SERVICE
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Register as an integrator or update base fee. Permissionless.
+    /// @param feeBps Base fee in basis points charged to users via this integrator
+    function setIntegratorFee(uint256 feeBps) external;
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // GOVERNANCE SETTERS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    function setBaseArmadaTake(uint256 bps) external;
+    function addTier(uint256 threshold, uint256 takeBps) external;
+    function setTier(uint256 index, uint256 threshold, uint256 takeBps) external;
+    function removeTier(uint256 index) external;
+    function setYieldFee(uint256 bps) external;
+    function setIntegratorTerms(address integrator, uint256 takeBps, uint256 threshold, bool active) external;
+    function setTreasury(address _treasury) external;
+    function setPrivacyPool(address _privacyPool) external;
+    function setYieldVault(address _yieldVault) external;
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // QUERY VIEWS
+    // ══════════════════════════════════════════════════════════════════════════
+
+    function baseArmadaTakeBps() external view returns (uint256);
+    function yieldFeeBps() external view returns (uint256);
+    function treasury() external view returns (address);
+    function privacyPool() external view returns (address);
+    function yieldVault() external view returns (address);
+    function cumulativeArmadaFees() external view returns (uint256);
+    function cumulativeIntegratorFees() external view returns (uint256);
+
+    function getIntegratorInfo(address integrator) external view returns (IntegratorInfo memory);
+    function getIntegratorTerms(address integrator) external view returns (CustomTerms memory);
+    function getTiers() external view returns (Tier[] memory);
+    function getTierCount() external view returns (uint256);
+
+    /// @notice Get the effective Armada take for a given integrator (considers volume + custom terms).
+    function getArmadaTake(address integrator) external view returns (uint256);
+
+    /// @notice Get the total user-facing fee for a given integrator (armada take + integrator base + bonus).
+    function getUserFee(address integrator) external view returns (uint256);
+
+    /// @notice Get the bonus bps an integrator earns from volume tier discounts.
+    function getIntegratorBonus(address integrator) external view returns (uint256);
+}

--- a/contracts/privacy-pool/PrivacyPool.sol
+++ b/contracts/privacy-pool/PrivacyPool.sol
@@ -99,9 +99,10 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
     /**
      * @notice Shield tokens into the privacy pool (local, same chain)
      * @param _shieldRequests Array of shield requests
+     * @param integrator Integrator address for fee split (address(0) for no integrator)
      */
-    function shield(ShieldRequest[] calldata _shieldRequests) external override {
-        _delegatecall(shieldModule, abi.encodeCall(IShieldModule.shield, (_shieldRequests)));
+    function shield(ShieldRequest[] calldata _shieldRequests, address integrator) external override {
+        _delegatecall(shieldModule, abi.encodeCall(IShieldModule.shield, (_shieldRequests, integrator)));
     }
 
     /**
@@ -355,6 +356,16 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
         require(msg.sender == owner, "PrivacyPool: Only owner");
         shieldPauseContract = _shieldPauseContract;
         emit ShieldPauseContractSet(_shieldPauseContract);
+    }
+
+    /**
+     * @notice Set the fee module address (ArmadaFeeModule proxy)
+     * @param _feeModule Address of the fee module (or address(0) to use legacy fees)
+     */
+    function setFeeModule(address _feeModule) external override {
+        require(msg.sender == owner, "PrivacyPool: Only owner");
+        feeModule = _feeModule;
+        emit FeeModuleSet(_feeModule);
     }
 
     // ══════════════════════════════════════════════════════════════════════════

--- a/contracts/privacy-pool/PrivacyPool.sol
+++ b/contracts/privacy-pool/PrivacyPool.sol
@@ -360,7 +360,7 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
 
     /**
      * @notice Set the fee module address (ArmadaFeeModule proxy)
-     * @param _feeModule Address of the fee module (or address(0) to use legacy fees)
+     * @param _feeModule Address of the fee module (or address(0) to use flat fee fallback)
      */
     function setFeeModule(address _feeModule) external override {
         require(msg.sender == owner, "PrivacyPool: Only owner");

--- a/contracts/privacy-pool/PrivacyPoolClient.sol
+++ b/contracts/privacy-pool/PrivacyPoolClient.sol
@@ -119,6 +119,7 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
      * @param shieldKey Shield key for decryption by recipient
      * @param destinationCaller Address allowed to call receiveMessage on Hub (bytes32).
      *        Use bytes32(0) to allow any relayer, or specify a relayer address for MEV protection.
+     * @param integrator Integrator address for fee split (address(0) for no integrator)
      * @return nonce CCTP message nonce
      */
     function crossChainShield(
@@ -128,7 +129,8 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
         bytes32 npk,
         bytes32[3] calldata encryptedBundle,
         bytes32 shieldKey,
-        bytes32 destinationCaller
+        bytes32 destinationCaller,
+        address integrator
     ) external override returns (uint64) {
         require(amount > 0, "PrivacyPoolClient: Amount must be > 0");
         require(maxFee < amount, "PrivacyPoolClient: Fee exceeds amount");
@@ -142,7 +144,7 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
         IERC20(usdc).safeApprove(tokenMessenger, amount);
 
         // Encode shield payload and execute CCTP burn in helper (avoids stack-too-deep)
-        _executeCCTPShield(amount, maxFee, minFinalityThreshold, npk, encryptedBundle, shieldKey, destinationCaller);
+        _executeCCTPShield(amount, maxFee, minFinalityThreshold, npk, encryptedBundle, shieldKey, destinationCaller, integrator);
 
         emit CrossChainShieldInitiated(msg.sender, amount, npk, 0);
 
@@ -258,13 +260,15 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
         bytes32 npk,
         bytes32[3] calldata encryptedBundle,
         bytes32 shieldKey,
-        bytes32 destinationCaller
+        bytes32 destinationCaller,
+        address integrator
     ) internal {
         bytes memory hookData = CCTPPayloadLib.encodeShield(ShieldData({
             npk: npk,
             value: uint120(amount),
             encryptedBundle: encryptedBundle,
-            shieldKey: shieldKey
+            shieldKey: shieldKey,
+            integrator: integrator
         }));
 
         ITokenMessengerV2(tokenMessenger).depositForBurnWithHook(

--- a/contracts/privacy-pool/interfaces/IPrivacyPool.sol
+++ b/contracts/privacy-pool/interfaces/IPrivacyPool.sol
@@ -26,6 +26,9 @@ interface IPrivacyPool is IMessageHandlerV2 {
     /// @notice Emitted when shield pause controller contract is set
     event ShieldPauseContractSet(address indexed shieldPauseContract);
 
+    /// @notice Emitted when fee module is set
+    event FeeModuleSet(address indexed feeModule);
+
     // ══════════════════════════════════════════════════════════════════════════
     // INITIALIZATION
     // ══════════════════════════════════════════════════════════════════════════
@@ -61,8 +64,9 @@ interface IPrivacyPool is IMessageHandlerV2 {
     /**
      * @notice Shield tokens into the privacy pool (local, same chain)
      * @param _shieldRequests Array of shield requests
+     * @param integrator Integrator address for fee split (address(0) for no integrator)
      */
-    function shield(ShieldRequest[] calldata _shieldRequests) external;
+    function shield(ShieldRequest[] calldata _shieldRequests, address integrator) external;
 
     /**
      * @notice Execute private transactions (transfers and/or unshields)
@@ -142,6 +146,12 @@ interface IPrivacyPool is IMessageHandlerV2 {
      * @param privileged True to exempt from fees
      */
     function setPrivilegedShieldCaller(address caller, bool privileged) external;
+
+    /**
+     * @notice Set the fee module address (ArmadaFeeModule proxy)
+     * @param _feeModule Address of the fee module (or address(0) to use legacy fees)
+     */
+    function setFeeModule(address _feeModule) external;
 
     /**
      * @notice Set the CCTP Hook Router address

--- a/contracts/privacy-pool/interfaces/IPrivacyPool.sol
+++ b/contracts/privacy-pool/interfaces/IPrivacyPool.sol
@@ -149,7 +149,7 @@ interface IPrivacyPool is IMessageHandlerV2 {
 
     /**
      * @notice Set the fee module address (ArmadaFeeModule proxy)
-     * @param _feeModule Address of the fee module (or address(0) to use legacy fees)
+     * @param _feeModule Address of the fee module (or address(0) to use flat fee fallback)
      */
     function setFeeModule(address _feeModule) external;
 

--- a/contracts/privacy-pool/interfaces/IPrivacyPoolClient.sol
+++ b/contracts/privacy-pool/interfaces/IPrivacyPoolClient.sol
@@ -87,6 +87,7 @@ interface IPrivacyPoolClient is IMessageHandlerV2 {
      * @param shieldKey Shield key for decryption
      * @param destinationCaller Address allowed to call receiveMessage on Hub (bytes32).
      *        Use bytes32(0) to allow any relayer, or specify a relayer address for MEV protection.
+     * @param integrator Integrator address for fee split (address(0) for no integrator)
      * @return nonce CCTP message nonce
      */
     function crossChainShield(
@@ -96,7 +97,8 @@ interface IPrivacyPoolClient is IMessageHandlerV2 {
         bytes32 npk,
         bytes32[3] calldata encryptedBundle,
         bytes32 shieldKey,
-        bytes32 destinationCaller
+        bytes32 destinationCaller,
+        address integrator
     ) external returns (uint64 nonce);
 
     // ══════════════════════════════════════════════════════════════════════════

--- a/contracts/privacy-pool/interfaces/IShieldModule.sol
+++ b/contracts/privacy-pool/interfaces/IShieldModule.sol
@@ -30,8 +30,9 @@ interface IShieldModule {
      * @notice Shield tokens locally (user on Hub chain)
      * @dev Transfers tokens from sender, creates commitments, inserts into merkle tree
      * @param _shieldRequests Array of shield requests to process
+     * @param integrator Integrator address for fee split (address(0) for no integrator)
      */
-    function shield(ShieldRequest[] calldata _shieldRequests) external;
+    function shield(ShieldRequest[] calldata _shieldRequests, address integrator) external;
 
     /**
      * @notice Process an incoming cross-chain shield from a Client

--- a/contracts/privacy-pool/modules/ShieldModule.sol
+++ b/contracts/privacy-pool/modules/ShieldModule.sol
@@ -10,6 +10,7 @@ import "../interfaces/IMerkleModule.sol";
 import "../types/CCTPTypes.sol";
 import "../../railgun/logic/Poseidon.sol";
 import "../../governance/IShieldPauseController.sol";
+import "../../fees/IArmadaFeeModule.sol";
 
 /**
  * @title ShieldModule
@@ -33,8 +34,9 @@ contract ShieldModule is PrivacyPoolStorage, IShieldModule {
      *      Fees are deducted from the shielded amount.
      *
      * @param _shieldRequests Array of shield requests to process
+     * @param integrator Integrator address for fee split (address(0) for no integrator)
      */
-    function shield(ShieldRequest[] calldata _shieldRequests) external override onlyDelegatecall {
+    function shield(ShieldRequest[] calldata _shieldRequests, address integrator) external override onlyDelegatecall {
         _requireShieldsNotPaused();
         uint256 numRequests = _shieldRequests.length;
         require(numRequests > 0, "ShieldModule: No requests");
@@ -51,7 +53,7 @@ contract ShieldModule is PrivacyPoolStorage, IShieldModule {
             _validateCommitmentPreimage(_shieldRequests[i].preimage);
 
             // Transfer tokens in and calculate fee-adjusted commitment
-            (commitments[i], fees[i]) = _transferTokenIn(_shieldRequests[i].preimage);
+            (commitments[i], fees[i]) = _transferTokenIn(_shieldRequests[i].preimage, integrator);
 
             // Hash commitment for merkle tree
             insertionLeaves[i] = _hashCommitment(commitments[i]);
@@ -116,15 +118,16 @@ contract ShieldModule is PrivacyPoolStorage, IShieldModule {
 
         // Process as internal shield
         // Note: Tokens already in contract from CCTP mint, so we use _processInternalShield
-        _processInternalShield(requests[0]);
+        _processInternalShield(requests[0], data.integrator);
     }
 
     /**
      * @notice Process a shield where tokens are already in the contract
      * @dev Used for cross-chain shields where CCTP has already minted tokens to us
      * @param _request The shield request to process
+     * @param integrator Integrator address for fee split (address(0) for no integrator)
      */
-    function _processInternalShield(ShieldRequest memory _request) internal {
+    function _processInternalShield(ShieldRequest memory _request, address integrator) internal {
         // Validate the commitment preimage
         _validateCommitmentPreimageMemory(_request.preimage);
 
@@ -132,14 +135,38 @@ contract ShieldModule is PrivacyPoolStorage, IShieldModule {
         uint256 fee = 0;
         CommitmentPreimage memory adjustedPreimage = _request.preimage;
 
-        if (shieldFee > 0 && !privilegedShieldCallers[msg.sender]) {
-            (uint120 base, uint120 feeAmount) = _getFee(_request.preimage.value, true, shieldFee);
-            adjustedPreimage.value = base;
-            fee = feeAmount;
+        if (!privilegedShieldCallers[msg.sender]) {
+            if (feeModule != address(0)) {
+                // Fee module path: centralized fee calculation with integrator support
+                uint256 amount = uint256(_request.preimage.value);
+                (uint256 armadaTake, uint256 integratorFee, uint256 totalFee) =
+                    IArmadaFeeModule(feeModule).calculateShieldFee(integrator, amount);
 
-            // Transfer fee to treasury
-            if (feeAmount > 0 && treasury != address(0)) {
-                IERC20(usdc).safeTransfer(treasury, feeAmount);
+                adjustedPreimage.value = uint120(amount - totalFee);
+                fee = totalFee;
+
+                // Transfer armada take to treasury
+                if (armadaTake > 0 && treasury != address(0)) {
+                    IERC20(usdc).safeTransfer(treasury, armadaTake);
+                }
+
+                // Transfer integrator fee directly to integrator
+                if (integratorFee > 0 && integrator != address(0)) {
+                    IERC20(usdc).safeTransfer(integrator, integratorFee);
+                }
+
+                // Record fee in fee module
+                IArmadaFeeModule(feeModule).recordShieldFee(integrator, amount, armadaTake, integratorFee);
+            } else if (shieldFee > 0) {
+                // Legacy flat fee path (backward compat when feeModule == address(0))
+                (uint120 base, uint120 feeAmount) = _getFee(_request.preimage.value, true, shieldFee);
+                adjustedPreimage.value = base;
+                fee = feeAmount;
+
+                // Transfer fee to treasury
+                if (feeAmount > 0 && treasury != address(0)) {
+                    IERC20(usdc).safeTransfer(treasury, feeAmount);
+                }
             }
         }
 
@@ -205,44 +232,84 @@ contract ShieldModule is PrivacyPoolStorage, IShieldModule {
     /**
      * @notice Transfer tokens into the contract and calculate fee-adjusted commitment
      * @param _note The commitment preimage (with original value)
+     * @param integrator Integrator address for fee split (address(0) for no integrator)
      * @return adjustedNote The fee-adjusted commitment preimage
      * @return fee The fee amount
      */
     function _transferTokenIn(
-        CommitmentPreimage calldata _note
+        CommitmentPreimage calldata _note,
+        address integrator
     ) internal returns (CommitmentPreimage memory adjustedNote, uint256 fee) {
         require(_note.token.tokenType == TokenType.ERC20, "ShieldModule: Only ERC20 supported");
 
         IERC20 token = IERC20(_note.token.tokenAddress);
 
-        // Privileged callers (e.g. yield adapter) bypass shield fee
-        uint120 base;
-        uint120 feeAmount;
         if (privilegedShieldCallers[msg.sender]) {
-            base = _note.value;
-            feeAmount = 0;
+            // Privileged callers (e.g. yield adapter) bypass all fees
+            adjustedNote = CommitmentPreimage({
+                npk: _note.npk,
+                token: _note.token,
+                value: _note.value
+            });
+            fee = 0;
+
+            // Transfer full amount to this contract
+            uint256 balanceBefore = token.balanceOf(address(this));
+            token.safeTransferFrom(msg.sender, address(this), _note.value);
+            uint256 balanceAfter = token.balanceOf(address(this));
+            require(balanceAfter - balanceBefore == _note.value, "ShieldModule: Transfer failed");
+        } else if (feeModule != address(0)) {
+            // Fee module path: centralized fee calculation with integrator support
+            uint256 amount = uint256(_note.value);
+            (uint256 armadaTake, uint256 integratorFee, uint256 totalFee) =
+                IArmadaFeeModule(feeModule).calculateShieldFee(integrator, amount);
+
+            uint120 base = uint120(amount - totalFee);
+            adjustedNote = CommitmentPreimage({
+                npk: _note.npk,
+                token: _note.token,
+                value: base
+            });
+            fee = totalFee;
+
+            // Transfer base amount to this contract
+            uint256 balanceBefore = token.balanceOf(address(this));
+            token.safeTransferFrom(msg.sender, address(this), base);
+            uint256 balanceAfter = token.balanceOf(address(this));
+            require(balanceAfter - balanceBefore == base, "ShieldModule: Transfer failed");
+
+            // Transfer armada take to treasury
+            if (armadaTake > 0 && treasury != address(0)) {
+                token.safeTransferFrom(msg.sender, treasury, armadaTake);
+            }
+
+            // Transfer integrator fee directly to integrator
+            if (integratorFee > 0 && integrator != address(0)) {
+                token.safeTransferFrom(msg.sender, integrator, integratorFee);
+            }
+
+            // Record fee in fee module
+            IArmadaFeeModule(feeModule).recordShieldFee(integrator, amount, armadaTake, integratorFee);
         } else {
-            (base, feeAmount) = _getFee(_note.value, true, shieldFee);
-        }
+            // Legacy flat fee path (backward compat when feeModule == address(0))
+            (uint120 base, uint120 feeAmount) = _getFee(_note.value, true, shieldFee);
+            adjustedNote = CommitmentPreimage({
+                npk: _note.npk,
+                token: _note.token,
+                value: base
+            });
+            fee = feeAmount;
 
-        // Create adjusted preimage with fee-reduced value
-        adjustedNote = CommitmentPreimage({
-            npk: _note.npk,
-            token: _note.token,
-            value: base
-        });
-        fee = feeAmount;
+            // Transfer base amount to this contract
+            uint256 balanceBefore = token.balanceOf(address(this));
+            token.safeTransferFrom(msg.sender, address(this), base);
+            uint256 balanceAfter = token.balanceOf(address(this));
+            require(balanceAfter - balanceBefore == base, "ShieldModule: Transfer failed");
 
-        // Transfer base amount to this contract
-        uint256 balanceBefore = token.balanceOf(address(this));
-        token.safeTransferFrom(msg.sender, address(this), base);
-        uint256 balanceAfter = token.balanceOf(address(this));
-
-        require(balanceAfter - balanceBefore == base, "ShieldModule: Transfer failed");
-
-        // Transfer fee to treasury
-        if (feeAmount > 0 && treasury != address(0)) {
-            token.safeTransferFrom(msg.sender, treasury, feeAmount);
+            // Transfer fee to treasury
+            if (feeAmount > 0 && treasury != address(0)) {
+                token.safeTransferFrom(msg.sender, treasury, feeAmount);
+            }
         }
     }
 

--- a/contracts/privacy-pool/modules/ShieldModule.sol
+++ b/contracts/privacy-pool/modules/ShieldModule.sol
@@ -158,7 +158,7 @@ contract ShieldModule is PrivacyPoolStorage, IShieldModule {
                 // Record fee in fee module
                 IArmadaFeeModule(feeModule).recordShieldFee(integrator, amount, armadaTake, integratorFee);
             } else if (shieldFee > 0) {
-                // Legacy flat fee path (backward compat when feeModule == address(0))
+                // Flat fee fallback path (used when feeModule == address(0))
                 (uint120 base, uint120 feeAmount) = _getFee(_request.preimage.value, true, shieldFee);
                 adjustedPreimage.value = base;
                 fee = feeAmount;
@@ -291,7 +291,7 @@ contract ShieldModule is PrivacyPoolStorage, IShieldModule {
             // Record fee in fee module
             IArmadaFeeModule(feeModule).recordShieldFee(integrator, amount, armadaTake, integratorFee);
         } else {
-            // Legacy flat fee path (backward compat when feeModule == address(0))
+            // Flat fee fallback path (used when feeModule == address(0))
             (uint120 base, uint120 feeAmount) = _getFee(_note.value, true, shieldFee);
             adjustedNote = CommitmentPreimage({
                 npk: _note.npk,

--- a/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
+++ b/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
@@ -171,11 +171,15 @@ abstract contract PrivacyPoolStorage {
     ///      to check if shields are paused. When address(0), shields are never paused.
     address public shieldPauseContract;
 
+    /// @notice Fee module address (ArmadaFeeModule proxy) for centralized fee calculation.
+    /// @dev When address(0), ShieldModule falls back to legacy flat shieldFee logic.
+    address public feeModule;
+
     // ══════════════════════════════════════════════════════════════════════════
     // RESERVED FOR FUTURE USE
     // ══════════════════════════════════════════════════════════════════════════
 
     /// @dev Reserved storage slots for future upgrades
     ///      When adding new state variables above, decrement this gap
-    uint256[47] private __gap;
+    uint256[46] private __gap;
 }

--- a/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
+++ b/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
@@ -172,7 +172,7 @@ abstract contract PrivacyPoolStorage {
     address public shieldPauseContract;
 
     /// @notice Fee module address (ArmadaFeeModule proxy) for centralized fee calculation.
-    /// @dev When address(0), ShieldModule falls back to legacy flat shieldFee logic.
+    /// @dev When address(0), ShieldModule falls back to the flat shieldFee calculation.
     address public feeModule;
 
     // ══════════════════════════════════════════════════════════════════════════

--- a/contracts/privacy-pool/types/CCTPTypes.sol
+++ b/contracts/privacy-pool/types/CCTPTypes.sol
@@ -37,12 +37,14 @@ struct CCTPPayload {
  * @param value Amount being shielded (gross amount before CCTP fee deduction)
  * @param encryptedBundle Shield ciphertext encrypted bundle [3 x bytes32]
  * @param shieldKey Public key for shared secret derivation
+ * @param integrator Integrator address for fee split (address(0) for no integrator)
  */
 struct ShieldData {
     bytes32 npk;
     uint120 value;
     bytes32[3] encryptedBundle;
     bytes32 shieldKey;
+    address integrator;
 }
 
 /**

--- a/contracts/test/ShieldForwarder.sol
+++ b/contracts/test/ShieldForwarder.sol
@@ -18,10 +18,10 @@ contract ShieldForwarder {
 
     function approveAndShield(address token, uint256 amount, ShieldRequest[] calldata _requests) external {
         IERC20(token).approve(address(privacyPool), amount);
-        privacyPool.shield(_requests);
+        privacyPool.shield(_requests, address(0));
     }
 
     function shield(ShieldRequest[] calldata _requests) external {
-        privacyPool.shield(_requests);
+        privacyPool.shield(_requests, address(0));
     }
 }

--- a/contracts/yield/ArmadaYieldAdapter.sol
+++ b/contracts/yield/ArmadaYieldAdapter.sol
@@ -240,7 +240,7 @@ contract ArmadaYieldAdapter is ReentrancyGuard {
 
         // 8. Shield ayUSDC to user's npk
         shareToken.approve(privacyPool, shares);
-        IPrivacyPool(privacyPool).shield(shieldRequests);
+        IPrivacyPool(privacyPool).shield(shieldRequests, address(0));
 
         emit LendAndShield(_npk, amount, shares);
     }
@@ -317,7 +317,7 @@ contract ArmadaYieldAdapter is ReentrancyGuard {
 
         // 8. Shield USDC to user's npk
         usdc.approve(privacyPool, assets);
-        IPrivacyPool(privacyPool).shield(shieldRequests);
+        IPrivacyPool(privacyPool).shield(shieldRequests, address(0));
 
         emit RedeemAndShield(_npk, shares, assets);
     }

--- a/contracts/yield/ArmadaYieldVault.sol
+++ b/contracts/yield/ArmadaYieldVault.sol
@@ -327,7 +327,7 @@ contract ArmadaYieldVault is ERC20, ReentrancyGuard {
                 // Record yield fee in centralized fee module for RevenueCounter
                 IArmadaFeeModule(feeModule).recordYieldFee(yieldFee);
             } else {
-                // Legacy path: record fee in treasury for tracking
+                // Fallback path: record fee in treasury for tracking
                 IArmadaTreasury(treasury).recordFee(address(underlying), owner_, yieldFee);
             }
         }

--- a/contracts/yield/ArmadaYieldVault.sol
+++ b/contracts/yield/ArmadaYieldVault.sol
@@ -6,6 +6,8 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
+import "../fees/IArmadaFeeModule.sol";
+
 /**
  * @title IArmadaTreasury
  * @notice Interface for ArmadaTreasury fee recording
@@ -90,6 +92,10 @@ contract ArmadaYieldVault is ERC20, ReentrancyGuard {
     /// @notice Privileged adapter (can bypass fees)
     address public adapter;
 
+    /// @notice Fee module address (ArmadaFeeModule proxy) for centralized yield fee config.
+    /// @dev When address(0), uses local yieldFeeBps. When set, reads fee from fee module.
+    address public feeModule;
+
     /// @notice Total principal deposited (for yield calculation)
     uint256 public totalPrincipal;
 
@@ -125,6 +131,7 @@ contract ArmadaYieldVault is ERC20, ReentrancyGuard {
     event AdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
     event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
     event YieldFeeUpdated(uint256 oldFeeBps, uint256 newFeeBps);
+    event FeeModuleUpdated(address indexed oldModule, address indexed newModule);
 
     // ============ Modifiers ============
 
@@ -193,13 +200,24 @@ contract ArmadaYieldVault is ERC20, ReentrancyGuard {
 
     /**
      * @notice Update yield fee basis points. Governance-only (via timelock).
+     * @dev Reverts when feeModule is set — governance should use fee module instead.
      * @param _feeBps New yield fee in basis points (bounded by MIN/MAX)
      */
     function setYieldFeeBps(uint256 _feeBps) external onlyOwner {
+        require(feeModule == address(0), "ArmadaYieldVault: use fee module");
         require(_feeBps >= MIN_YIELD_FEE_BPS, "ArmadaYieldVault: below min fee");
         require(_feeBps <= MAX_YIELD_FEE_BPS, "ArmadaYieldVault: above max fee");
         emit YieldFeeUpdated(yieldFeeBps, _feeBps);
         yieldFeeBps = _feeBps;
+    }
+
+    /**
+     * @notice Set the fee module address (ArmadaFeeModule proxy)
+     * @param _feeModule Address of the fee module (or address(0) to use local yieldFeeBps)
+     */
+    function setFeeModule(address _feeModule) external onlyOwner {
+        emit FeeModuleUpdated(feeModule, _feeModule);
+        feeModule = _feeModule;
     }
 
     // ============ Core Functions ============
@@ -293,7 +311,11 @@ contract ArmadaYieldVault is ERC20, ReentrancyGuard {
         uint256 yieldFee = 0;
         if (grossAssets > principalPortion) {
             uint256 yield_ = grossAssets - principalPortion;
-            yieldFee = (yield_ * yieldFeeBps) / BPS_DENOMINATOR;
+            // Read yield fee rate from fee module when set, otherwise use local yieldFeeBps
+            uint256 effectiveFeeBps = feeModule != address(0)
+                ? IArmadaFeeModule(feeModule).getYieldFeeBps()
+                : yieldFeeBps;
+            yieldFee = (yield_ * effectiveFeeBps) / BPS_DENOMINATOR;
         }
 
         assets = grossAssets - yieldFee;
@@ -301,8 +323,13 @@ contract ArmadaYieldVault is ERC20, ReentrancyGuard {
         // Transfer fee to treasury and record it
         if (yieldFee > 0) {
             underlying.safeTransfer(treasury, yieldFee);
-            // Record fee in treasury for tracking
-            IArmadaTreasury(treasury).recordFee(address(underlying), owner_, yieldFee);
+            if (feeModule != address(0)) {
+                // Record yield fee in centralized fee module for RevenueCounter
+                IArmadaFeeModule(feeModule).recordYieldFee(yieldFee);
+            } else {
+                // Legacy path: record fee in treasury for tracking
+                IArmadaTreasury(treasury).recordFee(address(underlying), owner_, yieldFee);
+            }
         }
 
         // Transfer assets to receiver
@@ -376,7 +403,10 @@ contract ArmadaYieldVault is ERC20, ReentrancyGuard {
         // Calculate fee
         if (grossAssets > principalPortion) {
             uint256 yield_ = grossAssets - principalPortion;
-            uint256 yieldFee = (yield_ * yieldFeeBps) / BPS_DENOMINATOR;
+            uint256 effectiveFeeBps = feeModule != address(0)
+                ? IArmadaFeeModule(feeModule).getYieldFeeBps()
+                : yieldFeeBps;
+            uint256 yieldFee = (yield_ * effectiveFeeBps) / BPS_DENOMINATOR;
             assets = grossAssets - yieldFee;
         } else {
             assets = grossAssets;

--- a/scripts/deploy_fee_module.ts
+++ b/scripts/deploy_fee_module.ts
@@ -1,0 +1,171 @@
+// ABOUTME: Deployment script for ArmadaFeeModule (UUPS proxy) and wiring to PrivacyPool, YieldVault, and RevenueCounter.
+// ABOUTME: Registers governance extended selectors for fee module setters on ArmadaGovernor.
+
+/**
+ * Deploy ArmadaFeeModule
+ *
+ * Deploys:
+ * - ArmadaFeeModule implementation
+ * - ERC1967Proxy with initialize() calldata
+ *
+ * Post-deploy configuration:
+ * - PrivacyPool.setFeeModule(feeModuleProxy)
+ * - ArmadaYieldVault.setFeeModule(feeModuleProxy)
+ * - RevenueCounter.setFeeCollector(feeModuleProxy)
+ * - Register extended selectors on ArmadaGovernor
+ *
+ * Prerequisites: Governance, PrivacyPool, and YieldVault must be deployed.
+ *
+ * Usage (local):
+ *   npx hardhat run scripts/deploy_fee_module.ts --network hub
+ */
+
+import { ethers } from "hardhat";
+import * as fs from "fs";
+import * as path from "path";
+import { createNonceManager } from "./deploy-utils";
+
+// Fee module governance selectors to register as Extended proposals
+const FEE_MODULE_EXTENDED_SELECTORS = [
+  "setBaseArmadaTake(uint256)",
+  "addTier(uint256,uint256)",
+  "setTier(uint256,uint256,uint256)",
+  "removeTier(uint256)",
+  "setYieldFee(uint256)",
+  "setIntegratorTerms(address,uint256,uint256,bool)",
+];
+
+function loadDeployment(filename: string): any | null {
+  const deploymentsDir = path.join(__dirname, "..", "deployments");
+  const filePath = path.join(deploymentsDir, filename);
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+}
+
+function saveDeployment(filename: string, data: any): void {
+  const deploymentsDir = path.join(__dirname, "..", "deployments");
+  if (!fs.existsSync(deploymentsDir)) {
+    fs.mkdirSync(deploymentsDir, { recursive: true });
+  }
+  const filePath = path.join(deploymentsDir, filename);
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+async function main() {
+  const network = await ethers.provider.getNetwork();
+  const chainId = Number(network.chainId);
+  const [deployer] = await ethers.getSigners();
+  const nm = await createNonceManager(deployer);
+
+  console.log(`\n=== Deploying ArmadaFeeModule on chain ${chainId} ===`);
+  console.log(`Deployer: ${deployer.address}`);
+
+  // Load existing deployments
+  const isSepolia = chainId !== 31337 && chainId !== 1337;
+  const hubFile = isSepolia ? "hub-sepolia-v3.json" : "hub-v3.json";
+  const govFile = isSepolia ? "governance-sepolia.json" : "governance.json";
+
+  const hubDeployment = loadDeployment(hubFile);
+  const govDeployment = loadDeployment(govFile);
+
+  if (!hubDeployment) throw new Error(`Hub deployment not found: ${hubFile}`);
+  if (!govDeployment) throw new Error(`Governance deployment not found: ${govFile}`);
+
+  const privacyPoolAddress = hubDeployment.hubPrivacyPool;
+  const yieldVaultAddress = hubDeployment.yieldVault;
+  const treasuryAddress = govDeployment.treasury;
+  const timelockAddress = govDeployment.timelock;
+  const governorAddress = govDeployment.governor;
+  const revenueCounterAddress = govDeployment.revenueCounter;
+
+  console.log(`PrivacyPool: ${privacyPoolAddress}`);
+  console.log(`YieldVault:  ${yieldVaultAddress}`);
+  console.log(`Treasury:    ${treasuryAddress}`);
+  console.log(`Timelock:    ${timelockAddress}`);
+
+  // 1. Deploy ArmadaFeeModule implementation
+  console.log("\n--- Deploying ArmadaFeeModule implementation ---");
+  const ArmadaFeeModule = await ethers.getContractFactory("ArmadaFeeModule");
+  const feeModuleImpl = await ArmadaFeeModule.deploy(nm.override());
+  await feeModuleImpl.deploymentTransaction()!.wait();
+  const feeModuleImplAddress = await feeModuleImpl.getAddress();
+  console.log(`   ArmadaFeeModule (impl): ${feeModuleImplAddress}`);
+
+  // 2. Deploy ERC1967Proxy with initialize() calldata
+  // For local dev: owner = deployer (direct control). For testnet/prod: owner = timelock.
+  const ownerAddress = isSepolia ? timelockAddress : deployer.address;
+
+  const initData = ArmadaFeeModule.interface.encodeFunctionData("initialize", [
+    ownerAddress,
+    treasuryAddress,
+    privacyPoolAddress,
+    yieldVaultAddress,
+  ]);
+
+  const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
+  const feeModuleProxy = await ERC1967Proxy.deploy(
+    feeModuleImplAddress, initData, nm.override()
+  );
+  await feeModuleProxy.deploymentTransaction()!.wait();
+  const feeModuleProxyAddress = await feeModuleProxy.getAddress();
+  console.log(`   ArmadaFeeModule (proxy): ${feeModuleProxyAddress}`);
+
+  // 3. Wire fee module into PrivacyPool
+  console.log("\n--- Wiring fee module into PrivacyPool ---");
+  const privacyPool = await ethers.getContractAt("PrivacyPool", privacyPoolAddress);
+  const setFeeModuleTx1 = await privacyPool.setFeeModule(feeModuleProxyAddress, nm.override());
+  await setFeeModuleTx1.wait();
+  console.log(`   PrivacyPool.setFeeModule() done`);
+
+  // 4. Wire fee module into ArmadaYieldVault
+  console.log("--- Wiring fee module into ArmadaYieldVault ---");
+  const yieldVault = await ethers.getContractAt("ArmadaYieldVault", yieldVaultAddress);
+  const setFeeModuleTx2 = await yieldVault.setFeeModule(feeModuleProxyAddress, nm.override());
+  await setFeeModuleTx2.wait();
+  console.log(`   ArmadaYieldVault.setFeeModule() done`);
+
+  // 5. Update RevenueCounter to use fee module as fee collector
+  if (revenueCounterAddress) {
+    console.log("--- Updating RevenueCounter fee collector ---");
+    const revenueCounter = await ethers.getContractAt("RevenueCounter", revenueCounterAddress);
+    const setCollectorTx = await revenueCounter.setFeeCollector(feeModuleProxyAddress, nm.override());
+    await setCollectorTx.wait();
+    console.log(`   RevenueCounter.setFeeCollector() done`);
+  }
+
+  // 6. Register extended selectors on governor (local only — testnet uses governance proposals)
+  if (!isSepolia && governorAddress) {
+    console.log("--- Registering extended selectors on ArmadaGovernor ---");
+    const governor = await ethers.getContractAt("ArmadaGovernor", governorAddress);
+    for (const sig of FEE_MODULE_EXTENDED_SELECTORS) {
+      const selector = ethers.id(sig).slice(0, 10);
+      const tx = await governor.addExtendedSelector(selector, nm.override());
+      await tx.wait();
+      console.log(`   Registered: ${sig} → ${selector}`);
+    }
+  }
+
+  // 7. Save to deployment manifest
+  const feeModuleDeployment = {
+    feeModuleImpl: feeModuleImplAddress,
+    feeModuleProxy: feeModuleProxyAddress,
+    owner: ownerAddress,
+    treasury: treasuryAddress,
+    privacyPool: privacyPoolAddress,
+    yieldVault: yieldVaultAddress,
+    chainId,
+    deployedAt: new Date().toISOString(),
+  };
+
+  const feeFile = isSepolia ? "fee-module-sepolia.json" : "fee-module.json";
+  saveDeployment(feeFile, feeModuleDeployment);
+  console.log(`\nDeployment saved to deployments/${feeFile}`);
+  console.log("=== ArmadaFeeModule deployment complete ===\n");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/test_sepolia.ts
+++ b/scripts/test_sepolia.ts
@@ -466,7 +466,8 @@ async function testCrossChainShield(config: ReturnType<typeof getNetworkConfig>,
     shieldKey,
     ethers.ZeroHash, // any relayer can relay
     fees2
-  );
+  ,
+  ethers.ZeroAddress);
   info(`Tx: ${shieldTx.hash}`);
   const receipt = await waitForTx(shieldTx);
   passed(`Cross-chain shield initiated in block ${receipt.blockNumber}`);

--- a/test-foundry/ArmadaFeeModule.t.sol
+++ b/test-foundry/ArmadaFeeModule.t.sol
@@ -1,0 +1,534 @@
+// ABOUTME: Foundry unit tests for ArmadaFeeModule covering fee calculation, tier matching,
+// ABOUTME: integrator registration, governance setters, access control, and IFeeCollector.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/fees/ArmadaFeeModule.sol";
+import "../contracts/fees/IArmadaFeeModule.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract ArmadaFeeModuleTest is Test {
+    ArmadaFeeModule public feeModule;
+
+    address public owner = address(this);
+    address public treasury = address(0xFEE);
+    address public privacyPool = address(0xBEEF);
+    address public yieldVault = address(0xCAFE);
+    address public alice = address(0xA11CE);
+    address public bob = address(0xB0B);
+    address public integrator1 = address(0x1111);
+    address public integrator2 = address(0x2222);
+    address public nonOwner = address(0xBAD);
+
+    // Events (for expectEmit)
+    event IntegratorRegistered(address indexed integrator, uint256 baseFee);
+    event ShieldFeeRecorded(address indexed integrator, uint256 amount, uint256 armadaTake, uint256 integratorFee);
+    event YieldFeeRecorded(uint256 amount);
+    event BaseArmadaTakeUpdated(uint256 oldBps, uint256 newBps);
+    event TierAdded(uint256 index, uint256 volumeThreshold, uint256 armadaTakeBps);
+    event TierUpdated(uint256 index, uint256 volumeThreshold, uint256 armadaTakeBps);
+    event TierRemoved(uint256 index);
+    event YieldFeeUpdated(uint256 oldBps, uint256 newBps);
+    event IntegratorTermsSet(address indexed integrator, uint256 takeBps, uint256 threshold, bool active);
+
+    function setUp() public {
+        // Deploy implementation + proxy
+        ArmadaFeeModule impl = new ArmadaFeeModule();
+        bytes memory initData = abi.encodeCall(
+            ArmadaFeeModule.initialize,
+            (owner, treasury, privacyPool, yieldVault)
+        );
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        feeModule = ArmadaFeeModule(address(proxy));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Initialization
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_initialize_setsDefaults() public view {
+        assertEq(feeModule.baseArmadaTakeBps(), 50);
+        assertEq(feeModule.yieldFeeBps(), 1500);
+        assertEq(feeModule.treasury(), treasury);
+        assertEq(feeModule.privacyPool(), privacyPool);
+        assertEq(feeModule.yieldVault(), yieldVault);
+        assertEq(feeModule.getTierCount(), 1);
+
+        IArmadaFeeModule.Tier[] memory tiers = feeModule.getTiers();
+        assertEq(tiers[0].volumeThreshold, 250_000e6);
+        assertEq(tiers[0].armadaTakeBps, 40);
+    }
+
+    function test_initialize_cannotReinitialize() public {
+        vm.expectRevert("Initializable: contract is already initialized");
+        feeModule.initialize(owner, treasury, privacyPool, yieldVault);
+    }
+
+    function test_initialize_revertsOnZeroAddress() public {
+        ArmadaFeeModule impl = new ArmadaFeeModule();
+        bytes memory badInit = abi.encodeCall(
+            ArmadaFeeModule.initialize,
+            (address(0), treasury, privacyPool, yieldVault)
+        );
+        vm.expectRevert("ArmadaFeeModule: zero owner");
+        new ERC1967Proxy(address(impl), badInit);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Fee Calculation — No Integrator
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_calculateShieldFee_noIntegrator() public view {
+        (uint256 armadaTake, uint256 integratorFee, uint256 totalFee) =
+            feeModule.calculateShieldFee(address(0), 10_000e6);
+
+        // 50 bps of 10,000 USDC = 50 USDC
+        assertEq(armadaTake, 50e6);
+        assertEq(integratorFee, 0);
+        assertEq(totalFee, 50e6);
+    }
+
+    function test_calculateShieldFee_zeroAmount() public view {
+        (uint256 armadaTake, uint256 integratorFee, uint256 totalFee) =
+            feeModule.calculateShieldFee(address(0), 0);
+
+        assertEq(armadaTake, 0);
+        assertEq(integratorFee, 0);
+        assertEq(totalFee, 0);
+    }
+
+    function test_calculateShieldFee_unregisteredIntegrator() public view {
+        // Unregistered address passed as integrator uses base rate, no integrator fee
+        (uint256 armadaTake, uint256 integratorFee, uint256 totalFee) =
+            feeModule.calculateShieldFee(integrator1, 10_000e6);
+
+        assertEq(armadaTake, 50e6);
+        assertEq(integratorFee, 0);
+        assertEq(totalFee, 50e6);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Fee Calculation — With Integrator
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_calculateShieldFee_withIntegrator_belowTier() public {
+        // Register integrator with 30 bps base fee
+        vm.prank(integrator1);
+        feeModule.setIntegratorFee(30);
+
+        (uint256 armadaTake, uint256 integratorFee, uint256 totalFee) =
+            feeModule.calculateShieldFee(integrator1, 10_000e6);
+
+        // Armada take: 50 bps = 50 USDC (below tier threshold, no discount)
+        // Integrator fee: 30 bps + 0 bonus = 30 USDC
+        // Total: 80 USDC
+        assertEq(armadaTake, 50e6);
+        assertEq(integratorFee, 30e6);
+        assertEq(totalFee, 80e6);
+    }
+
+    function test_calculateShieldFee_withIntegrator_aboveTier() public {
+        // Register integrator with 30 bps base fee
+        vm.prank(integrator1);
+        feeModule.setIntegratorFee(30);
+
+        // Push integrator volume above $250k tier
+        vm.prank(privacyPool);
+        feeModule.recordShieldFee(integrator1, 300_000e6, 150e6, 90e6);
+
+        (uint256 armadaTake, uint256 integratorFee, uint256 totalFee) =
+            feeModule.calculateShieldFee(integrator1, 10_000e6);
+
+        // Armada take: 40 bps (tier 1) = 40 USDC
+        // Bonus: 50 - 40 = 10 bps
+        // Integrator fee: (30 + 10) bps = 40 bps = 40 USDC
+        // Total: 80 USDC
+        assertEq(armadaTake, 40e6);
+        assertEq(integratorFee, 40e6);
+        assertEq(totalFee, 80e6);
+    }
+
+    function test_calculateShieldFee_withCustomTerms() public {
+        // Register integrator
+        vm.prank(integrator1);
+        feeModule.setIntegratorFee(30);
+
+        // Set custom terms: 20 bps armada take, 100k threshold
+        feeModule.setIntegratorTerms(integrator1, 20, 100_000e6, true);
+
+        (uint256 armadaTake, uint256 integratorFee, uint256 totalFee) =
+            feeModule.calculateShieldFee(integrator1, 10_000e6);
+
+        // Custom terms: 20 bps armada take = 20 USDC
+        // Bonus: 50 - 20 = 30 bps (custom takes override tiers)
+        // Integrator fee: (30 + 30) bps = 60 USDC
+        // Total: 80 USDC
+        assertEq(armadaTake, 20e6);
+        assertEq(integratorFee, 60e6);
+        assertEq(totalFee, 80e6);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Tier Matching
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_tierMatching_multipleTiers() public {
+        // Add second tier: $1M → 30 bps
+        feeModule.addTier(1_000_000e6, 30);
+
+        vm.prank(integrator1);
+        feeModule.setIntegratorFee(20);
+
+        // Below both tiers
+        (uint256 take1, , ) = feeModule.calculateShieldFee(integrator1, 1000e6);
+        assertEq(take1, (1000e6 * 50) / 10000); // base rate
+
+        // Push volume above $250k
+        vm.prank(privacyPool);
+        feeModule.recordShieldFee(integrator1, 300_000e6, 0, 0);
+
+        (uint256 take2, , ) = feeModule.calculateShieldFee(integrator1, 1000e6);
+        assertEq(take2, (1000e6 * 40) / 10000); // tier 1: 40 bps
+
+        // Push volume above $1M
+        vm.prank(privacyPool);
+        feeModule.recordShieldFee(integrator1, 800_000e6, 0, 0);
+
+        (uint256 take3, , ) = feeModule.calculateShieldFee(integrator1, 1000e6);
+        assertEq(take3, (1000e6 * 30) / 10000); // tier 2: 30 bps
+    }
+
+    function test_tierMatching_edgeCaseAtBoundary() public {
+        vm.prank(integrator1);
+        feeModule.setIntegratorFee(10);
+
+        // Volume exactly at threshold
+        vm.prank(privacyPool);
+        feeModule.recordShieldFee(integrator1, 250_000e6, 0, 0);
+
+        uint256 take = feeModule.getArmadaTake(integrator1);
+        assertEq(take, 40); // Should match tier 1
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Integrator Registration
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_setIntegratorFee_permissionless() public {
+        vm.prank(integrator1);
+        vm.expectEmit(true, false, false, true);
+        emit IntegratorRegistered(integrator1, 50);
+        feeModule.setIntegratorFee(50);
+
+        IArmadaFeeModule.IntegratorInfo memory info = feeModule.getIntegratorInfo(integrator1);
+        assertTrue(info.registered);
+        assertEq(info.baseFee, 50);
+    }
+
+    function test_setIntegratorFee_revertsAboveMax() public {
+        vm.prank(integrator1);
+        vm.expectRevert("ArmadaFeeModule: integrator fee too high");
+        feeModule.setIntegratorFee(501); // MAX_INTEGRATOR_FEE_BPS = 500
+    }
+
+    function test_setIntegratorFee_canUpdateFee() public {
+        vm.startPrank(integrator1);
+        feeModule.setIntegratorFee(30);
+        feeModule.setIntegratorFee(50);
+        vm.stopPrank();
+
+        assertEq(feeModule.getIntegratorInfo(integrator1).baseFee, 50);
+    }
+
+    function test_volumeAccumulation() public {
+        vm.prank(integrator1);
+        feeModule.setIntegratorFee(30);
+
+        vm.startPrank(privacyPool);
+        feeModule.recordShieldFee(integrator1, 100_000e6, 50e6, 30e6);
+        feeModule.recordShieldFee(integrator1, 200_000e6, 100e6, 60e6);
+        vm.stopPrank();
+
+        IArmadaFeeModule.IntegratorInfo memory info = feeModule.getIntegratorInfo(integrator1);
+        assertEq(info.cumulativeVolume, 300_000e6);
+        assertEq(info.cumulativeEarnings, 90e6);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Governance Setters
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_setBaseArmadaTake_onlyOwner() public {
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        feeModule.setBaseArmadaTake(60);
+    }
+
+    function test_setBaseArmadaTake_updates() public {
+        vm.expectEmit(false, false, false, true);
+        emit BaseArmadaTakeUpdated(50, 60);
+        feeModule.setBaseArmadaTake(60);
+        assertEq(feeModule.baseArmadaTakeBps(), 60);
+    }
+
+    function test_setBaseArmadaTake_revertsAboveMax() public {
+        vm.expectRevert("ArmadaFeeModule: take too high");
+        feeModule.setBaseArmadaTake(1001); // MAX_BPS = 1000
+    }
+
+    function test_addTier() public {
+        vm.expectEmit(false, false, false, true);
+        emit TierAdded(1, 500_000e6, 35);
+        feeModule.addTier(500_000e6, 35);
+        assertEq(feeModule.getTierCount(), 2);
+    }
+
+    function test_addTier_revertsAtMaxTiers() public {
+        // Already have 1 tier, add 9 more to reach limit
+        for (uint256 i = 0; i < 9; i++) {
+            feeModule.addTier((i + 2) * 100_000e6, 40);
+        }
+        assertEq(feeModule.getTierCount(), 10);
+
+        vm.expectRevert("ArmadaFeeModule: max tiers reached");
+        feeModule.addTier(2_000_000e6, 30);
+    }
+
+    function test_setTier_updates() public {
+        feeModule.setTier(0, 300_000e6, 35);
+        IArmadaFeeModule.Tier[] memory tiers = feeModule.getTiers();
+        assertEq(tiers[0].volumeThreshold, 300_000e6);
+        assertEq(tiers[0].armadaTakeBps, 35);
+    }
+
+    function test_removeTier() public {
+        feeModule.addTier(500_000e6, 35);
+        assertEq(feeModule.getTierCount(), 2);
+
+        feeModule.removeTier(0);
+        assertEq(feeModule.getTierCount(), 1);
+        // The last tier was swapped into position 0
+        IArmadaFeeModule.Tier[] memory tiers = feeModule.getTiers();
+        assertEq(tiers[0].volumeThreshold, 500_000e6);
+    }
+
+    function test_setYieldFee_bounds() public {
+        // Below min
+        vm.expectRevert("ArmadaFeeModule: below min yield fee");
+        feeModule.setYieldFee(99);
+
+        // Above max
+        vm.expectRevert("ArmadaFeeModule: above max yield fee");
+        feeModule.setYieldFee(5001);
+
+        // Valid
+        feeModule.setYieldFee(2000);
+        assertEq(feeModule.yieldFeeBps(), 2000);
+    }
+
+    function test_setIntegratorTerms() public {
+        vm.expectEmit(true, false, false, true);
+        emit IntegratorTermsSet(integrator1, 25, 100_000e6, true);
+        feeModule.setIntegratorTerms(integrator1, 25, 100_000e6, true);
+
+        IArmadaFeeModule.CustomTerms memory terms = feeModule.getIntegratorTerms(integrator1);
+        assertTrue(terms.active);
+        assertEq(terms.customArmadaTakeBps, 25);
+        assertEq(terms.customVolumeThreshold, 100_000e6);
+    }
+
+    function test_setIntegratorTerms_revertsOnZeroAddress() public {
+        vm.expectRevert("ArmadaFeeModule: zero integrator");
+        feeModule.setIntegratorTerms(address(0), 25, 100_000e6, true);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // IFeeCollector — Monotonic Cumulative Counter
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_cumulativeFeesCollected_monotonic() public {
+        assertEq(feeModule.cumulativeFeesCollected(), 0);
+
+        vm.prank(privacyPool);
+        feeModule.recordShieldFee(address(0), 10_000e6, 5e6, 0);
+        assertEq(feeModule.cumulativeFeesCollected(), 5e6);
+
+        vm.prank(yieldVault);
+        feeModule.recordYieldFee(10e6);
+        assertEq(feeModule.cumulativeFeesCollected(), 15e6);
+    }
+
+    function test_cumulativeFeesCollected_excludesIntegratorFees() public {
+        vm.prank(integrator1);
+        feeModule.setIntegratorFee(30);
+
+        vm.prank(privacyPool);
+        feeModule.recordShieldFee(integrator1, 10_000e6, 5e6, 3e6);
+
+        // Only armada take (5e6) is protocol revenue
+        assertEq(feeModule.cumulativeFeesCollected(), 5e6);
+        // Integrator fees tracked separately
+        assertEq(feeModule.cumulativeIntegratorFees(), 3e6);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Access Control
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_recordShieldFee_onlyPrivacyPool() public {
+        vm.prank(alice);
+        vm.expectRevert("ArmadaFeeModule: only privacy pool");
+        feeModule.recordShieldFee(address(0), 10_000e6, 5e6, 0);
+    }
+
+    function test_recordYieldFee_onlyYieldVault() public {
+        vm.prank(alice);
+        vm.expectRevert("ArmadaFeeModule: only yield vault");
+        feeModule.recordYieldFee(10e6);
+    }
+
+    function test_governanceSetters_onlyOwner() public {
+        vm.startPrank(nonOwner);
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        feeModule.setBaseArmadaTake(60);
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        feeModule.addTier(500_000e6, 35);
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        feeModule.setTier(0, 300_000e6, 35);
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        feeModule.removeTier(0);
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        feeModule.setYieldFee(2000);
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        feeModule.setIntegratorTerms(integrator1, 25, 100_000e6, true);
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        feeModule.setTreasury(alice);
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        feeModule.setPrivacyPool(alice);
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        feeModule.setYieldVault(alice);
+
+        vm.stopPrank();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Query Views
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_getUserFee_noIntegrator() public view {
+        uint256 fee = feeModule.getUserFee(address(0));
+        assertEq(fee, 50); // base armada take only
+    }
+
+    function test_getUserFee_withIntegrator() public {
+        vm.prank(integrator1);
+        feeModule.setIntegratorFee(30);
+
+        uint256 fee = feeModule.getUserFee(integrator1);
+        assertEq(fee, 80); // 50 (armada) + 30 (integrator base) + 0 (no bonus yet)
+    }
+
+    function test_getIntegratorBonus_belowTier() public {
+        vm.prank(integrator1);
+        feeModule.setIntegratorFee(30);
+
+        assertEq(feeModule.getIntegratorBonus(integrator1), 0);
+    }
+
+    function test_getIntegratorBonus_aboveTier() public {
+        vm.prank(integrator1);
+        feeModule.setIntegratorFee(30);
+
+        // Push above tier
+        vm.prank(privacyPool);
+        feeModule.recordShieldFee(integrator1, 300_000e6, 0, 0);
+
+        // Bonus = 50 (base) - 40 (tier 1) = 10
+        assertEq(feeModule.getIntegratorBonus(integrator1), 10);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Fuzz Tests
+    // ══════════════════════════════════════════════════════════════════════
+
+    function testFuzz_calculateShieldFee_totalNeverExceedsAmount(uint256 amount) public view {
+        amount = bound(amount, 0, 1_000_000_000e6); // up to $1B
+
+        (, , uint256 totalFee) = feeModule.calculateShieldFee(address(0), amount);
+        assertLe(totalFee, amount);
+    }
+
+    function testFuzz_calculateShieldFee_withIntegrator_totalNeverExceedsAmount(
+        uint256 amount,
+        uint256 integratorFee
+    ) public {
+        amount = bound(amount, 0, 1_000_000_000e6);
+        integratorFee = bound(integratorFee, 0, 500);
+
+        vm.prank(integrator1);
+        feeModule.setIntegratorFee(integratorFee);
+
+        (, , uint256 totalFee) = feeModule.calculateShieldFee(integrator1, amount);
+        assertLe(totalFee, amount);
+    }
+
+    function testFuzz_setBaseArmadaTake_withinBounds(uint256 bps) public {
+        bps = bound(bps, 0, 1000);
+        feeModule.setBaseArmadaTake(bps);
+        assertEq(feeModule.baseArmadaTakeBps(), bps);
+    }
+
+    function testFuzz_setYieldFee_withinBounds(uint256 bps) public {
+        bps = bound(bps, 100, 5000);
+        feeModule.setYieldFee(bps);
+        assertEq(feeModule.yieldFeeBps(), bps);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Address Setter Views
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_setTreasury_updates() public {
+        address newTreasury = address(0xDEAD);
+        feeModule.setTreasury(newTreasury);
+        assertEq(feeModule.treasury(), newTreasury);
+    }
+
+    function test_setPrivacyPool_updates() public {
+        address newPool = address(0xDEAD);
+        feeModule.setPrivacyPool(newPool);
+        assertEq(feeModule.privacyPool(), newPool);
+    }
+
+    function test_setYieldVault_updates() public {
+        address newVault = address(0xDEAD);
+        feeModule.setYieldVault(newVault);
+        assertEq(feeModule.yieldVault(), newVault);
+    }
+
+    function test_setTreasury_revertsZero() public {
+        vm.expectRevert("ArmadaFeeModule: zero treasury");
+        feeModule.setTreasury(address(0));
+    }
+
+    function test_setPrivacyPool_revertsZero() public {
+        vm.expectRevert("ArmadaFeeModule: zero privacy pool");
+        feeModule.setPrivacyPool(address(0));
+    }
+
+    function test_setYieldVault_revertsZero() public {
+        vm.expectRevert("ArmadaFeeModule: zero yield vault");
+        feeModule.setYieldVault(address(0));
+    }
+}

--- a/test-foundry/ArmadaFeeModuleInvariant.t.sol
+++ b/test-foundry/ArmadaFeeModuleInvariant.t.sol
@@ -1,0 +1,141 @@
+// ABOUTME: Foundry invariant tests for ArmadaFeeModule verifying monotonic counters,
+// ABOUTME: fee bounds, and tier array size constraints under random state transitions.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/fees/ArmadaFeeModule.sol";
+import "../contracts/fees/IArmadaFeeModule.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/// @title ArmadaFeeModuleHandler — Target for invariant testing
+/// @notice Exposes bounded actions that the fuzzer can call to exercise ArmadaFeeModule state transitions.
+contract ArmadaFeeModuleHandler is Test {
+    ArmadaFeeModule public feeModule;
+    address public owner;
+    address public privacyPool;
+    address public yieldVault;
+    address public integrator;
+
+    uint256 public ghost_totalArmadaFees;
+    uint256 public ghost_totalIntegratorVolume;
+
+    constructor(ArmadaFeeModule _feeModule, address _owner, address _privacyPool, address _yieldVault, address _integrator) {
+        feeModule = _feeModule;
+        owner = _owner;
+        privacyPool = _privacyPool;
+        yieldVault = _yieldVault;
+        integrator = _integrator;
+    }
+
+    function recordShieldFee(uint256 amount, uint256 armadaTake) public {
+        amount = bound(amount, 1e6, 10_000_000e6);
+        armadaTake = bound(armadaTake, 0, amount);
+        uint256 integratorFee = bound(amount / 100, 0, amount - armadaTake);
+
+        vm.prank(privacyPool);
+        feeModule.recordShieldFee(integrator, amount, armadaTake, integratorFee);
+
+        ghost_totalArmadaFees += armadaTake;
+        ghost_totalIntegratorVolume += amount;
+    }
+
+    function recordYieldFee(uint256 amount) public {
+        amount = bound(amount, 1, 1_000_000e6);
+
+        vm.prank(yieldVault);
+        feeModule.recordYieldFee(amount);
+
+        ghost_totalArmadaFees += amount;
+    }
+
+    function addTier(uint256 threshold, uint256 takeBps) public {
+        threshold = bound(threshold, 1, 100_000_000e6);
+        takeBps = bound(takeBps, 0, 1000);
+
+        if (feeModule.getTierCount() >= 10) return; // silently skip at max
+
+        vm.prank(owner);
+        feeModule.addTier(threshold, takeBps);
+    }
+
+    function removeTier(uint256 index) public {
+        uint256 count = feeModule.getTierCount();
+        if (count == 0) return;
+        index = bound(index, 0, count - 1);
+
+        vm.prank(owner);
+        feeModule.removeTier(index);
+    }
+
+    function calculateFee(uint256 amount) public view returns (uint256 totalFee) {
+        amount = bound(amount, 0, 10_000_000_000e6);
+        (, , totalFee) = feeModule.calculateShieldFee(address(0), amount);
+    }
+}
+
+/// @title ArmadaFeeModuleInvariantTest — Invariant property tests
+contract ArmadaFeeModuleInvariantTest is Test {
+    ArmadaFeeModule public feeModule;
+    ArmadaFeeModuleHandler public handler;
+
+    address public owner = address(this);
+    address public treasury = address(0xFEE);
+    address public privacyPool = address(0xBEEF);
+    address public yieldVault = address(0xCAFE);
+    address public integrator = address(0x1111);
+
+    function setUp() public {
+        // Deploy proxy
+        ArmadaFeeModule impl = new ArmadaFeeModule();
+        bytes memory initData = abi.encodeCall(
+            ArmadaFeeModule.initialize,
+            (owner, treasury, privacyPool, yieldVault)
+        );
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        feeModule = ArmadaFeeModule(address(proxy));
+
+        // Register integrator
+        vm.prank(integrator);
+        feeModule.setIntegratorFee(30);
+
+        // Create handler
+        handler = new ArmadaFeeModuleHandler(feeModule, owner, privacyPool, yieldVault, integrator);
+
+        // Target only the handler
+        targetContract(address(handler));
+    }
+
+    /// @notice cumulativeArmadaFees is monotonically non-decreasing
+    function invariant_cumulativeArmadaFees_monotonic() public view {
+        assertGe(feeModule.cumulativeArmadaFees(), 0);
+        assertEq(feeModule.cumulativeArmadaFees(), handler.ghost_totalArmadaFees());
+    }
+
+    /// @notice cumulativeFeesCollected matches cumulativeArmadaFees
+    function invariant_feeCollector_consistency() public view {
+        assertEq(feeModule.cumulativeFeesCollected(), feeModule.cumulativeArmadaFees());
+    }
+
+    /// @notice integrator cumulative volume is monotonically non-decreasing
+    function invariant_integratorVolume_monotonic() public view {
+        IArmadaFeeModule.IntegratorInfo memory info = feeModule.getIntegratorInfo(integrator);
+        assertEq(info.cumulativeVolume, handler.ghost_totalIntegratorVolume());
+    }
+
+    /// @notice Tiers array never exceeds MAX_TIERS (10)
+    function invariant_tiers_length_bounded() public view {
+        assertLe(feeModule.getTierCount(), 10);
+    }
+
+    /// @notice totalFee from calculateShieldFee never exceeds input amount
+    function invariant_fee_never_exceeds_amount() public view {
+        uint256 amount = 1_000_000e6;
+        (, , uint256 totalFee) = feeModule.calculateShieldFee(address(0), amount);
+        assertLe(totalFee, amount);
+
+        (, , uint256 totalFee2) = feeModule.calculateShieldFee(integrator, amount);
+        assertLe(totalFee2, amount);
+    }
+}

--- a/test-foundry/OnlyDelegatecall.t.sol
+++ b/test-foundry/OnlyDelegatecall.t.sol
@@ -36,7 +36,7 @@ contract OnlyDelegatecallTest is Test {
     function test_shieldModule_shield_revertsOnDirectCall() public {
         ShieldRequest[] memory requests = new ShieldRequest[](0);
         vm.expectRevert(bytes(EXPECTED_REVERT));
-        shieldModule.shield(requests);
+        shieldModule.shield(requests, address(0));
     }
 
     function test_shieldModule_processIncomingShield_revertsOnDirectCall() public {
@@ -44,7 +44,8 @@ contract OnlyDelegatecallTest is Test {
             npk: bytes32(0),
             value: 100,
             encryptedBundle: [bytes32(0), bytes32(0), bytes32(0)],
-            shieldKey: bytes32(0)
+            shieldKey: bytes32(0),
+            integrator: address(0)
         });
         vm.expectRevert(bytes(EXPECTED_REVERT));
         shieldModule.processIncomingShield(100, data);

--- a/test-foundry/PrivacyPoolFullInvariant.t.sol
+++ b/test-foundry/PrivacyPoolFullInvariant.t.sol
@@ -97,7 +97,7 @@ contract PrivacyPoolFullHandler is Test {
         vm.startPrank(shielder);
         usdc.approve(address(pool), amount);
 
-        try pool.shield(requests) {
+        try pool.shield(requests, address(0)) {
             ghost_totalShieldedGross += amount;
             ghost_totalInsertions += 1;
             ghost_shieldCallCount++;
@@ -144,7 +144,7 @@ contract PrivacyPoolFullHandler is Test {
         vm.startPrank(shielder);
         usdc.approve(address(pool), totalNeeded);
 
-        try pool.shield(requests) {
+        try pool.shield(requests, address(0)) {
             ghost_totalShieldedGross += totalNeeded;
             ghost_totalInsertions += count;
             ghost_shieldCallCount++;

--- a/test/fast_finality.ts
+++ b/test/fast_finality.ts
@@ -348,7 +348,8 @@ describe("CCTP V2 Fast Finality", function () {
         params.encryptedBundle,
         params.shieldKey,
         ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -368,7 +369,8 @@ describe("CCTP V2 Fast Finality", function () {
         params.encryptedBundle,
         params.shieldKey,
         ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -391,7 +393,8 @@ describe("CCTP V2 Fast Finality", function () {
         params.encryptedBundle,
         params.shieldKey,
         ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -432,7 +435,8 @@ describe("CCTP V2 Fast Finality", function () {
         params.encryptedBundle,
         params.shieldKey,
         ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -453,7 +457,8 @@ describe("CCTP V2 Fast Finality", function () {
           params.encryptedBundle,
           params.shieldKey,
           ethers.ZeroHash
-        )
+        ,
+        ethers.ZeroAddress)
       ).to.be.revertedWith("PrivacyPoolClient: Invalid finality threshold");
     });
 
@@ -470,7 +475,8 @@ describe("CCTP V2 Fast Finality", function () {
           params.encryptedBundle,
           params.shieldKey,
           ethers.ZeroHash
-        )
+        ,
+        ethers.ZeroAddress)
       ).to.be.revertedWith("PrivacyPoolClient: Invalid finality threshold");
     });
   });
@@ -498,7 +504,8 @@ describe("CCTP V2 Fast Finality", function () {
         params.encryptedBundle,
         params.shieldKey,
         ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -526,7 +533,8 @@ describe("CCTP V2 Fast Finality", function () {
         params.encryptedBundle,
         params.shieldKey,
         ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -560,7 +568,8 @@ describe("CCTP V2 Fast Finality", function () {
         params.encryptedBundle,
         params.shieldKey,
         ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -641,7 +650,8 @@ describe("CCTP V2 Fast Finality", function () {
         params.encryptedBundle,
         params.shieldKey,
         ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -663,7 +673,8 @@ describe("CCTP V2 Fast Finality", function () {
         params.encryptedBundle,
         params.shieldKey,
         ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -698,7 +709,8 @@ describe("CCTP V2 Fast Finality", function () {
         params.encryptedBundle,
         params.shieldKey,
         ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -721,7 +733,8 @@ describe("CCTP V2 Fast Finality", function () {
         params.encryptedBundle,
         params.shieldKey,
         ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -749,7 +762,8 @@ describe("CCTP V2 Fast Finality", function () {
         params.encryptedBundle,
         params.shieldKey,
         ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 

--- a/test/fee_module_integration.ts
+++ b/test/fee_module_integration.ts
@@ -1,0 +1,572 @@
+/**
+ * Fee Module Integration Tests
+ *
+ * Tests ArmadaFeeModule wired into the live PrivacyPool (ShieldModule) and
+ * ArmadaYieldVault on a local Hardhat/Anvil chain. Covers:
+ *   1. Local shield with fee module (no integrator)
+ *   2. Local shield with registered integrator — fee split
+ *   3. Cross-chain shield with fee module
+ *   4. Flat fee fallback when feeModule == address(0)
+ *   5. Yield vault reads fee from module and records via recordYieldFee
+ *   6. Privileged callers (adapter) bypass fee module
+ */
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { Contract, Signer } from "ethers";
+import * as fs from "fs";
+import * as path from "path";
+// @ts-ignore - circomlibjs doesn't have types
+import { buildPoseidon } from "circomlibjs";
+
+const poseidonBytecode = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "lib", "poseidon_bytecode.json"), "utf-8")
+);
+
+import {
+  loadVerificationKeys,
+  TESTING_ARTIFACT_CONFIGS,
+} from "../lib/artifacts";
+
+const DOMAINS = { hub: 100, client: 101 };
+const SNARK_SCALAR_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
+const BPS_DENOMINATOR = 10000n;
+
+describe("Fee Module Integration", function () {
+  // Core contracts
+  let hubUsdc: Contract;
+  let hubTokenMessenger: Contract;
+  let hubMessageTransmitter: Contract;
+  let hubHookRouter: Contract;
+  let privacyPool: Contract;
+  let shieldModule: Contract;
+  let feeModule: Contract;
+
+  // Client chain (for cross-chain tests)
+  let clientUsdc: Contract;
+  let clientTokenMessenger: Contract;
+  let clientMessageTransmitter: Contract;
+  let clientHookRouter: Contract;
+  let privacyPoolClient: Contract;
+
+  // Yield contracts
+  let mockAaveSpoke: Contract;
+  let armadaTreasury: Contract;
+  let armadaYieldVault: Contract;
+  let armadaYieldAdapter: Contract;
+
+  // Signers
+  let deployer: Signer;
+  let alice: Signer;
+  let integrator: Signer;
+  let relayer: Signer;
+
+  // Addresses
+  let deployerAddress: string;
+  let aliceAddress: string;
+  let integratorAddress: string;
+  let relayerAddress: string;
+  let privacyPoolAddress: string;
+  let clientAddress: string;
+  let treasuryAddress: string;
+  let feeModuleAddress: string;
+  let usdcAddress: string;
+  let vaultAddress: string;
+  let adapterAddress: string;
+
+  let poseidon: any;
+  let F: any;
+
+  before(async function () {
+    [deployer, alice, integrator, relayer] = await ethers.getSigners();
+    deployerAddress = await deployer.getAddress();
+    aliceAddress = await alice.getAddress();
+    integratorAddress = await integrator.getAddress();
+    relayerAddress = await relayer.getAddress();
+
+    poseidon = await buildPoseidon();
+    F = poseidon.F;
+
+    // ── Deploy Hub chain ──
+    const MockUSDCV2 = await ethers.getContractFactory("MockUSDCV2");
+    hubUsdc = await MockUSDCV2.deploy("Mock USDC", "USDC");
+    usdcAddress = await hubUsdc.getAddress();
+
+    const MockMessageTransmitterV2 = await ethers.getContractFactory("MockMessageTransmitterV2");
+    hubMessageTransmitter = await MockMessageTransmitterV2.deploy(DOMAINS.hub, relayerAddress);
+
+    const MockTokenMessengerV2 = await ethers.getContractFactory("MockTokenMessengerV2");
+    hubTokenMessenger = await MockTokenMessengerV2.deploy(
+      await hubMessageTransmitter.getAddress(),
+      usdcAddress,
+      DOMAINS.hub
+    );
+    await hubMessageTransmitter.setTokenMessenger(await hubTokenMessenger.getAddress());
+    await hubUsdc.addMinter(await hubTokenMessenger.getAddress());
+
+    // Poseidon libraries
+    const poseidonT3Tx = await deployer.sendTransaction({ data: poseidonBytecode.PoseidonT3.bytecode });
+    const poseidonT3Address = (await poseidonT3Tx.wait())!.contractAddress!;
+    const poseidonT4Tx = await deployer.sendTransaction({ data: poseidonBytecode.PoseidonT4.bytecode });
+    const poseidonT4Address = (await poseidonT4Tx.wait())!.contractAddress!;
+
+    // Modules
+    const merkleModule = await (
+      await ethers.getContractFactory("MerkleModule", { libraries: { PoseidonT3: poseidonT3Address } })
+    ).deploy();
+    const verifierModule = await (await ethers.getContractFactory("VerifierModule")).deploy();
+    shieldModule = await (
+      await ethers.getContractFactory("ShieldModule", { libraries: { PoseidonT4: poseidonT4Address } })
+    ).deploy();
+    const transactModule = await (
+      await ethers.getContractFactory("TransactModule", { libraries: { PoseidonT4: poseidonT4Address } })
+    ).deploy();
+
+    // PrivacyPool
+    const PrivacyPool = await ethers.getContractFactory("PrivacyPool");
+    privacyPool = await PrivacyPool.deploy();
+    privacyPoolAddress = await privacyPool.getAddress();
+
+    await privacyPool.initialize(
+      await shieldModule.getAddress(),
+      await transactModule.getAddress(),
+      await merkleModule.getAddress(),
+      await verifierModule.getAddress(),
+      await hubTokenMessenger.getAddress(),
+      await hubMessageTransmitter.getAddress(),
+      usdcAddress,
+      DOMAINS.hub,
+      deployerAddress
+    );
+
+    await loadVerificationKeys(privacyPool, TESTING_ARTIFACT_CONFIGS, false);
+    await privacyPool.setTestingMode(true);
+
+    // Treasury
+    const ArmadaTreasury = await ethers.getContractFactory("ArmadaTreasury");
+    armadaTreasury = await ArmadaTreasury.deploy();
+    treasuryAddress = await armadaTreasury.getAddress();
+    await privacyPool.setTreasury(treasuryAddress);
+    await privacyPool.setShieldFee(50); // 0.50% flat fee (for fallback tests)
+
+    // ── Deploy ArmadaFeeModule behind UUPS proxy ──
+    const ArmadaFeeModule = await ethers.getContractFactory("ArmadaFeeModule");
+    const feeModuleImpl = await ArmadaFeeModule.deploy();
+    await feeModuleImpl.waitForDeployment();
+
+    // Yield vault (needed for fee module init)
+    const MockAaveSpoke = await ethers.getContractFactory("MockAaveSpoke");
+    mockAaveSpoke = await MockAaveSpoke.deploy();
+    await hubUsdc.addMinter(await mockAaveSpoke.getAddress());
+    await mockAaveSpoke.addReserve(usdcAddress, 500, true);
+
+    const ArmadaYieldVault = await ethers.getContractFactory("ArmadaYieldVault");
+    armadaYieldVault = await ArmadaYieldVault.deploy(
+      await mockAaveSpoke.getAddress(),
+      0,
+      treasuryAddress,
+      "Armada Yield USDC",
+      "ayUSDC"
+    );
+    vaultAddress = await armadaYieldVault.getAddress();
+
+    // Deploy proxy
+    const initData = ArmadaFeeModule.interface.encodeFunctionData("initialize", [
+      deployerAddress,      // owner
+      treasuryAddress,      // treasury
+      privacyPoolAddress,   // privacyPool
+      vaultAddress,         // yieldVault
+    ]);
+    const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
+    const feeModuleProxy = await ERC1967Proxy.deploy(await feeModuleImpl.getAddress(), initData);
+    await feeModuleProxy.waitForDeployment();
+    feeModuleAddress = await feeModuleProxy.getAddress();
+    feeModule = ArmadaFeeModule.attach(feeModuleAddress);
+
+    // Wire fee module into PrivacyPool and YieldVault
+    await privacyPool.setFeeModule(feeModuleAddress);
+    await armadaYieldVault.setFeeModule(feeModuleAddress);
+
+    // ── Deploy yield adapter ──
+    const MockAdapterRegistry = await ethers.getContractFactory("MockAdapterRegistry");
+    const mockRegistry = await MockAdapterRegistry.deploy();
+    const ArmadaYieldAdapter = await ethers.getContractFactory("ArmadaYieldAdapter");
+    armadaYieldAdapter = await ArmadaYieldAdapter.deploy(
+      usdcAddress,
+      vaultAddress,
+      await mockRegistry.getAddress()
+    );
+    adapterAddress = await armadaYieldAdapter.getAddress();
+    await mockRegistry.setAuthorized(adapterAddress, true);
+    await armadaYieldVault.setAdapter(adapterAddress);
+    await armadaYieldAdapter.setPrivacyPool(privacyPoolAddress);
+    await privacyPool.setPrivilegedShieldCaller(adapterAddress, true);
+
+    // ── Deploy Client chain ──
+    clientUsdc = await MockUSDCV2.deploy("Mock USDC", "USDC");
+    clientMessageTransmitter = await MockMessageTransmitterV2.deploy(DOMAINS.client, relayerAddress);
+    clientTokenMessenger = await MockTokenMessengerV2.deploy(
+      await clientMessageTransmitter.getAddress(),
+      await clientUsdc.getAddress(),
+      DOMAINS.client
+    );
+    await clientMessageTransmitter.setTokenMessenger(await clientTokenMessenger.getAddress());
+    await clientUsdc.addMinter(await clientTokenMessenger.getAddress());
+
+    const PrivacyPoolClient = await ethers.getContractFactory("PrivacyPoolClient");
+    privacyPoolClient = await PrivacyPoolClient.deploy();
+    clientAddress = await privacyPoolClient.getAddress();
+
+    await privacyPoolClient.initialize(
+      await clientTokenMessenger.getAddress(),
+      await clientMessageTransmitter.getAddress(),
+      await clientUsdc.getAddress(),
+      DOMAINS.client,
+      DOMAINS.hub,
+      ethers.ZeroHash,
+      deployerAddress
+    );
+
+    // Hook routers
+    const CCTPHookRouter = await ethers.getContractFactory("CCTPHookRouter");
+    hubHookRouter = await CCTPHookRouter.deploy(await hubMessageTransmitter.getAddress());
+    clientHookRouter = await CCTPHookRouter.deploy(await clientMessageTransmitter.getAddress());
+
+    // Link hub ↔ client
+    const hubPoolBytes32 = ethers.zeroPadValue(privacyPoolAddress, 32);
+    const clientBytes32 = ethers.zeroPadValue(clientAddress, 32);
+    await privacyPool.setRemotePool(DOMAINS.client, clientBytes32);
+    await privacyPoolClient.setHubPool(DOMAINS.hub, hubPoolBytes32);
+
+    const hubTmBytes32 = ethers.zeroPadValue(await hubTokenMessenger.getAddress(), 32);
+    const clientTmBytes32 = ethers.zeroPadValue(await clientTokenMessenger.getAddress(), 32);
+    await hubTokenMessenger.setRemoteTokenMessenger(DOMAINS.client, clientTmBytes32);
+    await clientTokenMessenger.setRemoteTokenMessenger(DOMAINS.hub, hubTmBytes32);
+
+    await privacyPool.setHookRouter(await hubHookRouter.getAddress());
+    await privacyPoolClient.setHookRouter(await clientHookRouter.getAddress());
+    await hubMessageTransmitter.connect(relayer).setRelayer(await hubHookRouter.getAddress());
+    await clientMessageTransmitter.connect(relayer).setRelayer(await clientHookRouter.getAddress());
+
+    // Fund Alice
+    await hubUsdc.mint(aliceAddress, ethers.parseUnits("100000", 6));
+    await clientUsdc.mint(aliceAddress, ethers.parseUnits("100000", 6));
+  });
+
+  after(async function () {
+    await privacyPool.setTestingMode(false);
+  });
+
+  // ── Helpers ──
+
+  function validNpk(seed: string = "test-npk"): string {
+    const raw = BigInt(ethers.keccak256(ethers.toUtf8Bytes(seed)));
+    return ethers.zeroPadValue(ethers.toBeHex(raw % SNARK_SCALAR_FIELD), 32);
+  }
+
+  function makeShieldRequest(amount: bigint, npkSeed?: string) {
+    return {
+      preimage: {
+        npk: validNpk(npkSeed ?? `shield-${Date.now()}-${Math.random()}`),
+        token: { tokenType: 0, tokenAddress: usdcAddress, tokenSubID: 0 },
+        value: amount,
+      },
+      ciphertext: {
+        encryptedBundle: [
+          ethers.keccak256(ethers.toUtf8Bytes("enc1")),
+          ethers.keccak256(ethers.toUtf8Bytes("enc2")),
+          ethers.keccak256(ethers.toUtf8Bytes("enc3")),
+        ],
+        shieldKey: ethers.keccak256(ethers.toUtf8Bytes("key")),
+      },
+    };
+  }
+
+  // ── Tests ──
+
+  describe("Local shield with fee module (no integrator)", function () {
+    const SHIELD_AMOUNT = ethers.parseUnits("1000", 6); // 1000 USDC
+
+    it("should deduct armada take and send to treasury", async function () {
+      await hubUsdc.connect(alice).approve(privacyPoolAddress, SHIELD_AMOUNT);
+
+      const treasuryBefore = await hubUsdc.balanceOf(treasuryAddress);
+      const poolBefore = await hubUsdc.balanceOf(privacyPoolAddress);
+
+      await privacyPool.connect(alice).shield([makeShieldRequest(SHIELD_AMOUNT)], ethers.ZeroAddress);
+
+      // Default baseArmadaTakeBps = 50 (0.50%)
+      const expectedArmadaTake = SHIELD_AMOUNT * 50n / BPS_DENOMINATOR;
+      const expectedBase = SHIELD_AMOUNT - expectedArmadaTake;
+
+      const treasuryAfter = await hubUsdc.balanceOf(treasuryAddress);
+      const poolAfter = await hubUsdc.balanceOf(privacyPoolAddress);
+
+      expect(treasuryAfter - treasuryBefore).to.equal(expectedArmadaTake);
+      expect(poolAfter - poolBefore).to.equal(expectedBase);
+    });
+
+    it("should record fee in fee module cumulative counters", async function () {
+      const cumulativeBefore = await feeModule.cumulativeArmadaFees();
+
+      await hubUsdc.connect(alice).approve(privacyPoolAddress, SHIELD_AMOUNT);
+      await privacyPool.connect(alice).shield([makeShieldRequest(SHIELD_AMOUNT)], ethers.ZeroAddress);
+
+      const expectedArmadaTake = SHIELD_AMOUNT * 50n / BPS_DENOMINATOR;
+      const cumulativeAfter = await feeModule.cumulativeArmadaFees();
+
+      expect(cumulativeAfter - cumulativeBefore).to.equal(expectedArmadaTake);
+    });
+
+    it("should expose cumulative fees via IFeeCollector", async function () {
+      const cumulative = await feeModule.cumulativeFeesCollected();
+      const armadaFees = await feeModule.cumulativeArmadaFees();
+      expect(cumulative).to.equal(armadaFees);
+    });
+  });
+
+  describe("Local shield with registered integrator", function () {
+    const SHIELD_AMOUNT = ethers.parseUnits("1000", 6);
+    const INTEGRATOR_FEE_BPS = 100n; // 1%
+
+    before(async function () {
+      // Integrator self-registers with 1% base fee
+      await feeModule.connect(integrator).setIntegratorFee(INTEGRATOR_FEE_BPS);
+    });
+
+    it("should split fees between treasury and integrator", async function () {
+      await hubUsdc.connect(alice).approve(privacyPoolAddress, SHIELD_AMOUNT);
+
+      const treasuryBefore = await hubUsdc.balanceOf(treasuryAddress);
+      const integratorBefore = await hubUsdc.balanceOf(integratorAddress);
+      const poolBefore = await hubUsdc.balanceOf(privacyPoolAddress);
+
+      await privacyPool.connect(alice).shield([makeShieldRequest(SHIELD_AMOUNT)], integratorAddress);
+
+      // baseArmadaTakeBps = 50, integrator baseFee = 100
+      // No tier discount yet (volume below $250k threshold) so bonus = 0
+      const expectedArmadaTake = SHIELD_AMOUNT * 50n / BPS_DENOMINATOR;
+      const expectedIntegratorFee = SHIELD_AMOUNT * INTEGRATOR_FEE_BPS / BPS_DENOMINATOR;
+      const expectedBase = SHIELD_AMOUNT - expectedArmadaTake - expectedIntegratorFee;
+
+      const treasuryAfter = await hubUsdc.balanceOf(treasuryAddress);
+      const integratorAfter = await hubUsdc.balanceOf(integratorAddress);
+      const poolAfter = await hubUsdc.balanceOf(privacyPoolAddress);
+
+      expect(treasuryAfter - treasuryBefore).to.equal(expectedArmadaTake);
+      expect(integratorAfter - integratorBefore).to.equal(expectedIntegratorFee);
+      expect(poolAfter - poolBefore).to.equal(expectedBase);
+    });
+
+    it("should update integrator cumulative volume and earnings", async function () {
+      const infoBefore = await feeModule.getIntegratorInfo(integratorAddress);
+
+      await hubUsdc.connect(alice).approve(privacyPoolAddress, SHIELD_AMOUNT);
+      await privacyPool.connect(alice).shield([makeShieldRequest(SHIELD_AMOUNT)], integratorAddress);
+
+      const infoAfter = await feeModule.getIntegratorInfo(integratorAddress);
+
+      expect(infoAfter.cumulativeVolume - infoBefore.cumulativeVolume).to.equal(SHIELD_AMOUNT);
+      expect(infoAfter.cumulativeEarnings).to.be.gt(infoBefore.cumulativeEarnings);
+    });
+  });
+
+  describe("Cross-chain shield with fee module", function () {
+    const SHIELD_AMOUNT = ethers.parseUnits("500", 6);
+
+    it("should deduct fees from CCTP-minted amount on hub", async function () {
+      await clientUsdc.connect(alice).approve(clientAddress, SHIELD_AMOUNT);
+
+      const npk = validNpk("cross-chain-fee-module");
+      const encryptedBundle: [string, string, string] = [
+        ethers.keccak256(ethers.toUtf8Bytes("cc-enc1")),
+        ethers.keccak256(ethers.toUtf8Bytes("cc-enc2")),
+        ethers.keccak256(ethers.toUtf8Bytes("cc-enc3")),
+      ];
+      const shieldKey = ethers.keccak256(ethers.toUtf8Bytes("cc-key"));
+
+      // Initiate cross-chain shield (no CCTP fee for simplicity)
+      const tx = await privacyPoolClient.connect(alice).crossChainShield(
+        SHIELD_AMOUNT,
+        0,    // maxFee
+        0,    // minFinalityThreshold
+        npk,
+        encryptedBundle,
+        shieldKey,
+        ethers.ZeroHash,
+        ethers.ZeroAddress  // no integrator
+      );
+      const receipt = await tx.wait();
+
+      // Extract CCTP message
+      const transmitterInterface = clientMessageTransmitter.interface;
+      let encodedMessage: string | undefined;
+      for (const log of receipt!.logs) {
+        try {
+          const parsed = transmitterInterface.parseLog(log);
+          if (parsed?.name === "MessageSent") {
+            encodedMessage = parsed.args.message;
+            break;
+          }
+        } catch { /* not from this contract */ }
+      }
+      expect(encodedMessage).to.not.be.undefined;
+
+      // Record balances before relay
+      const poolBefore = await hubUsdc.balanceOf(privacyPoolAddress);
+      const treasuryBefore = await hubUsdc.balanceOf(treasuryAddress);
+      const cumulativeBefore = await feeModule.cumulativeArmadaFees();
+
+      // Relay to hub
+      await hubHookRouter.connect(relayer).relayWithHook(encodedMessage!, "0x");
+
+      // Fee module applies 50 bps armada take to CCTP-minted amount
+      const expectedArmadaTake = SHIELD_AMOUNT * 50n / BPS_DENOMINATOR;
+      const expectedBase = SHIELD_AMOUNT - expectedArmadaTake;
+
+      const poolAfter = await hubUsdc.balanceOf(privacyPoolAddress);
+      const treasuryAfter = await hubUsdc.balanceOf(treasuryAddress);
+      const cumulativeAfter = await feeModule.cumulativeArmadaFees();
+
+      expect(poolAfter - poolBefore).to.equal(expectedBase);
+      expect(treasuryAfter - treasuryBefore).to.equal(expectedArmadaTake);
+      expect(cumulativeAfter - cumulativeBefore).to.equal(expectedArmadaTake);
+    });
+  });
+
+  describe("Flat fee fallback (feeModule == address(0))", function () {
+    const SHIELD_AMOUNT = ethers.parseUnits("100", 6);
+
+    it("should use flat shieldFee when fee module is cleared", async function () {
+      // Temporarily clear fee module
+      await privacyPool.setFeeModule(ethers.ZeroAddress);
+
+      await hubUsdc.connect(alice).approve(privacyPoolAddress, SHIELD_AMOUNT);
+
+      const treasuryBefore = await hubUsdc.balanceOf(treasuryAddress);
+      const poolBefore = await hubUsdc.balanceOf(privacyPoolAddress);
+
+      await privacyPool.connect(alice).shield([makeShieldRequest(SHIELD_AMOUNT)], ethers.ZeroAddress);
+
+      // Flat fee: 50 bps
+      const expectedFee = SHIELD_AMOUNT * 50n / BPS_DENOMINATOR;
+      const expectedBase = SHIELD_AMOUNT - expectedFee;
+
+      const treasuryAfter = await hubUsdc.balanceOf(treasuryAddress);
+      const poolAfter = await hubUsdc.balanceOf(privacyPoolAddress);
+
+      expect(treasuryAfter - treasuryBefore).to.equal(expectedFee);
+      expect(poolAfter - poolBefore).to.equal(expectedBase);
+
+      // Restore fee module
+      await privacyPool.setFeeModule(feeModuleAddress);
+    });
+  });
+
+  describe("Yield vault fee module integration", function () {
+    it("should read yield fee from fee module", async function () {
+      const feeModuleYieldBps = await feeModule.getYieldFeeBps();
+      // Default is 1500 (15%)
+      expect(feeModuleYieldBps).to.equal(1500n);
+    });
+
+    it("should block setYieldFeeBps when fee module is set", async function () {
+      await expect(
+        armadaYieldVault.setYieldFeeBps(2000)
+      ).to.be.revertedWith("ArmadaYieldVault: use fee module");
+    });
+
+    it("should record yield fee via recordYieldFee on redeem", async function () {
+      // Deposit USDC into vault to generate shares
+      const depositAmount = ethers.parseUnits("10000", 6);
+      await hubUsdc.mint(deployerAddress, depositAmount);
+      await hubUsdc.approve(vaultAddress, depositAmount);
+      await armadaYieldVault.deposit(depositAmount, deployerAddress);
+
+      // Simulate yield accrual by minting extra USDC to the Aave spoke
+      const yieldAmount = ethers.parseUnits("1000", 6);
+      await hubUsdc.mint(await mockAaveSpoke.getAddress(), yieldAmount);
+
+      const shares = await armadaYieldVault.balanceOf(deployerAddress);
+      expect(shares).to.be.gt(0n);
+
+      const cumulativeBefore = await feeModule.cumulativeArmadaFees();
+
+      // Redeem all shares
+      await armadaYieldVault.redeem(shares, deployerAddress, deployerAddress);
+
+      const cumulativeAfter = await feeModule.cumulativeArmadaFees();
+      // Yield fee should have been recorded (15% of yield)
+      expect(cumulativeAfter).to.be.gt(cumulativeBefore);
+    });
+  });
+
+  describe("Privileged caller bypasses fee module", function () {
+    it("adapter shields without fee even with fee module active", async function () {
+      // Seed the pool with shielded USDC first
+      const seedAmount = ethers.parseUnits("5000", 6);
+      await hubUsdc.connect(alice).approve(privacyPoolAddress, seedAmount);
+      await privacyPool.connect(alice).shield([makeShieldRequest(seedAmount)], ethers.ZeroAddress);
+
+      const merkleRoot = await privacyPool.merkleRoot();
+      const amount = ethers.parseUnits("1000", 6);
+
+      // Build a lendAndShield transaction (testing mode bypasses SNARK)
+      const npk = validNpk("adapter-fee-test");
+      const encryptedBundle: [string, string, string] = [
+        ethers.keccak256(ethers.toUtf8Bytes("adapt-enc1")),
+        ethers.keccak256(ethers.toUtf8Bytes("adapt-enc2")),
+        ethers.keccak256(ethers.toUtf8Bytes("adapt-enc3")),
+      ];
+      const shieldKey = ethers.keccak256(ethers.toUtf8Bytes("adapt-key"));
+
+      const adaptParamsEncoded = ethers.AbiCoder.defaultAbiCoder().encode(
+        ["bytes32", "bytes32[3]", "bytes32"],
+        [npk, encryptedBundle, shieldKey]
+      );
+      const adaptParams = ethers.keccak256(adaptParamsEncoded);
+
+      const unshieldNpk = ethers.zeroPadValue(adapterAddress, 32);
+      const tokenId = BigInt(usdcAddress);
+      const commitmentHash = poseidon([F.e(BigInt(unshieldNpk)), F.e(tokenId), F.e(BigInt(amount))]);
+      const commitmentHashBytes32 = ethers.zeroPadValue(
+        ethers.toBeHex(BigInt(F.toString(commitmentHash))),
+        32
+      );
+
+      const chainId = (await ethers.provider.getNetwork()).chainId;
+      const transaction = {
+        proof: { a: { x: 0, y: 0 }, b: { x: [0, 0], y: [0, 0] }, c: { x: 0, y: 0 } },
+        merkleRoot,
+        nullifiers: [ethers.keccak256(ethers.toUtf8Bytes("null-adapter-fee"))],
+        commitments: [commitmentHashBytes32],
+        boundParams: {
+          treeNumber: 0,
+          minGasPrice: 0,
+          unshield: 1,
+          chainID: chainId,
+          adaptContract: adapterAddress,
+          adaptParams,
+          commitmentCiphertext: [],
+        },
+        unshieldPreimage: {
+          npk: unshieldNpk,
+          token: { tokenType: 0, tokenAddress: usdcAddress, tokenSubID: 0 },
+          value: amount,
+        },
+      };
+
+      const treasuryBefore = await hubUsdc.balanceOf(treasuryAddress);
+      const cumulativeBefore = await feeModule.cumulativeArmadaFees();
+
+      await armadaYieldAdapter.lendAndShield(transaction, npk, { encryptedBundle, shieldKey });
+
+      const treasuryAfter = await hubUsdc.balanceOf(treasuryAddress);
+      const cumulativeAfter = await feeModule.cumulativeArmadaFees();
+
+      // No shield fee charged — adapter is privileged
+      expect(treasuryAfter).to.equal(treasuryBefore);
+      expect(cumulativeAfter).to.equal(cumulativeBefore);
+    });
+  });
+});

--- a/test/privacy_pool_adversarial.ts
+++ b/test/privacy_pool_adversarial.ts
@@ -234,7 +234,7 @@ describe("Privacy Pool Adversarial", function () {
     const usdcAddr = await hubUsdc.getAddress();
     await hubUsdc.mint(aliceAddress, amount);
     await hubUsdc.connect(alice).approve(privacyPoolAddress, amount);
-    await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount)]);
+    await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount)], ethers.ZeroAddress);
     return await privacyPool.merkleRoot();
   }
 
@@ -354,7 +354,7 @@ describe("Privacy Pool Adversarial", function () {
       const poolBefore = await hubUsdc.balanceOf(privacyPoolAddress);
 
       const usdcAddr = await hubUsdc.getAddress();
-      await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount)]);
+      await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount)], ethers.ZeroAddress);
 
       const treasuryAfter = await hubUsdc.balanceOf(deployerAddress);
       const poolAfter = await hubUsdc.balanceOf(privacyPoolAddress);
@@ -551,7 +551,7 @@ describe("Privacy Pool Adversarial", function () {
       const req = makeShieldRequest(usdcAddr, 0n);
 
       await expect(
-        privacyPool.connect(alice).shield([req])
+        privacyPool.connect(alice).shield([req], ethers.ZeroAddress)
       ).to.be.revertedWith("ShieldModule: Invalid value");
     });
 
@@ -566,7 +566,7 @@ describe("Privacy Pool Adversarial", function () {
       const req = makeShieldRequest(usdcAddr, amount, invalidNpk);
 
       await expect(
-        privacyPool.connect(alice).shield([req])
+        privacyPool.connect(alice).shield([req], ethers.ZeroAddress)
       ).to.be.revertedWith("ShieldModule: Invalid npk");
     });
 
@@ -580,7 +580,7 @@ describe("Privacy Pool Adversarial", function () {
       const req = makeShieldRequest(usdcAddr, amount, invalidNpk);
 
       await expect(
-        privacyPool.connect(alice).shield([req])
+        privacyPool.connect(alice).shield([req], ethers.ZeroAddress)
       ).to.be.revertedWith("ShieldModule: Invalid npk");
     });
 
@@ -880,7 +880,8 @@ describe("Privacy Pool Adversarial", function () {
           0, 0, 0, validNpk(),
           [ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash],
           ethers.ZeroHash, ethers.ZeroHash
-        )
+        ,
+        ethers.ZeroAddress)
       ).to.be.revertedWith("PrivacyPoolClient: Amount must be > 0");
     });
 
@@ -891,7 +892,8 @@ describe("Privacy Pool Adversarial", function () {
           amount, amount, 0, validNpk(),
           [ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash],
           ethers.ZeroHash, ethers.ZeroHash
-        )
+        ,
+        ethers.ZeroAddress)
       ).to.be.revertedWith("PrivacyPoolClient: Fee exceeds amount");
     });
 
@@ -917,7 +919,8 @@ describe("Privacy Pool Adversarial", function () {
           amount, 0, 0, validNpk(),
           [ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash],
           ethers.ZeroHash, ethers.ZeroHash
-        )
+        ,
+        ethers.ZeroAddress)
       ).to.be.revertedWith("PrivacyPoolClient: Hub not configured");
     });
   });

--- a/test/privacy_pool_gas.ts
+++ b/test/privacy_pool_gas.ts
@@ -234,7 +234,7 @@ describe("Privacy Pool Gas Profiling", function () {
     const usdcAddr = await hubUsdc.getAddress();
     await hubUsdc.mint(aliceAddress, amount);
     await hubUsdc.connect(alice).approve(privacyPoolAddress, amount);
-    await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount, npkSeed)]);
+    await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount, npkSeed)], ethers.ZeroAddress);
     return await privacyPool.merkleRoot();
   }
 
@@ -257,7 +257,7 @@ describe("Privacy Pool Gas Profiling", function () {
           makeShieldRequest(usdcAddr, AMOUNT_PER_SHIELD, `shield-gas-${count}-${i}`)
         );
 
-        const tx = await privacyPool.connect(alice).shield(requests);
+        const tx = await privacyPool.connect(alice).shield(requests, ethers.ZeroAddress);
         const receipt = await tx.wait();
         const gasUsed = Number(receipt!.gasUsed);
 
@@ -368,7 +368,8 @@ describe("Privacy Pool Gas Profiling", function () {
 
       const tx = await privacyPoolClient.connect(alice).crossChainShield(
         amount, 0, 0, npk, encBundle, shieldKey, ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
       recordGas("crossChainShield (client-side)", Number(receipt!.gasUsed));
 
@@ -450,7 +451,7 @@ describe("Privacy Pool Gas Profiling", function () {
       await hubUsdc.mint(aliceAddress, amount);
       await hubUsdc.connect(alice).approve(privacyPoolAddress, amount);
 
-      const tx = await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount, "merkle-near-empty")]);
+      const tx = await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount, "merkle-near-empty")], ethers.ZeroAddress);
       const receipt = await tx.wait();
       recordGas("shield (near-empty tree)", Number(receipt!.gasUsed));
     });
@@ -469,7 +470,7 @@ describe("Privacy Pool Gas Profiling", function () {
         const requests = Array.from({ length: batchSize }, (_, j) =>
           makeShieldRequest(usdcAddr, batchAmount, `fill-50-${i}-${j}`)
         );
-        await privacyPool.connect(alice).shield(requests);
+        await privacyPool.connect(alice).shield(requests, ethers.ZeroAddress);
       }
 
       // Now measure a single shield at this fill level
@@ -477,7 +478,7 @@ describe("Privacy Pool Gas Profiling", function () {
       await hubUsdc.mint(aliceAddress, amount);
       await hubUsdc.connect(alice).approve(privacyPoolAddress, amount);
 
-      const tx = await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount, "merkle-after-50")]);
+      const tx = await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount, "merkle-after-50")], ethers.ZeroAddress);
       const receipt = await tx.wait();
       recordGas("shield (after ~50 leaves)", Number(receipt!.gasUsed));
     });

--- a/test/privacy_pool_hardening.ts
+++ b/test/privacy_pool_hardening.ts
@@ -250,7 +250,7 @@ describe("Privacy Pool Integration Hardening", function () {
     const usdcAddr = await hubUsdc.getAddress();
     await hubUsdc.mint(signerAddr, amount);
     await hubUsdc.connect(signer).approve(privacyPoolAddress, amount);
-    await privacyPool.connect(signer).shield([makeShieldRequest(usdcAddr, amount, npkSeed)]);
+    await privacyPool.connect(signer).shield([makeShieldRequest(usdcAddr, amount, npkSeed)], ethers.ZeroAddress);
     return await privacyPool.merkleRoot();
   }
 
@@ -272,7 +272,7 @@ describe("Privacy Pool Integration Hardening", function () {
       const requests = Array.from({ length: SHIELD_COUNT }, (_, i) =>
         makeShieldRequest(usdcAddr, SHIELD_EACH, `lifecycle-${i}`)
       );
-      await privacyPool.connect(alice).shield(requests);
+      await privacyPool.connect(alice).shield(requests, ethers.ZeroAddress);
 
       const root = await privacyPool.merkleRoot();
       const nextLeaf = await privacyPool.nextLeafIndex();
@@ -336,7 +336,7 @@ describe("Privacy Pool Integration Hardening", function () {
 
       await hubUsdc.mint(aliceAddress, AMOUNT);
       await hubUsdc.connect(alice).approve(privacyPoolAddress, AMOUNT);
-      await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, AMOUNT, "fee-test")]);
+      await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, AMOUNT, "fee-test")], ethers.ZeroAddress);
 
       const treasuryAfter = await hubUsdc.balanceOf(treasuryAddress);
       const poolAfter = await hubUsdc.balanceOf(privacyPoolAddress);
@@ -372,13 +372,13 @@ describe("Privacy Pool Integration Hardening", function () {
       const rootBefore = await privacyPool.merkleRoot();
 
       // All three users shield
-      await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, AMOUNT, "concurrent-alice")]);
+      await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, AMOUNT, "concurrent-alice")], ethers.ZeroAddress);
       const rootAfterAlice = await privacyPool.merkleRoot();
 
-      await privacyPool.connect(bob).shield([makeShieldRequest(usdcAddr, AMOUNT, "concurrent-bob")]);
+      await privacyPool.connect(bob).shield([makeShieldRequest(usdcAddr, AMOUNT, "concurrent-bob")], ethers.ZeroAddress);
       const rootAfterBob = await privacyPool.merkleRoot();
 
-      await privacyPool.connect(charlie).shield([makeShieldRequest(usdcAddr, AMOUNT, "concurrent-charlie")]);
+      await privacyPool.connect(charlie).shield([makeShieldRequest(usdcAddr, AMOUNT, "concurrent-charlie")], ethers.ZeroAddress);
       const rootAfterCharlie = await privacyPool.merkleRoot();
 
       // Each should produce a unique root
@@ -443,7 +443,8 @@ describe("Privacy Pool Integration Hardening", function () {
 
       const clientTx = await privacyPoolClient.connect(alice).crossChainShield(
         SHIELD_AMOUNT, 0, 0, npk, encBundle, shieldKey, ethers.ZeroHash
-      );
+      ,
+      ethers.ZeroAddress);
       const clientReceipt = await clientTx.wait();
 
       // Step 2: Relay to Hub — extract full MessageV2 from MessageSent(bytes) event

--- a/test/privacy_pool_integration.ts
+++ b/test/privacy_pool_integration.ts
@@ -327,7 +327,7 @@ describe("Privacy Pool Integration", function () {
 
       // Execute shield
       const treasuryBalanceBefore = await hubUsdc.balanceOf(treasuryAddress);
-      const tx = await privacyPool.connect(alice).shield([shieldRequest]);
+      const tx = await privacyPool.connect(alice).shield([shieldRequest], ethers.ZeroAddress);
       await tx.wait();
 
       // 50 bps fee: base = 100 - (100 * 50 / 10000) = 99.50 USDC, fee = 0.50 USDC
@@ -383,7 +383,8 @@ describe("Privacy Pool Integration", function () {
         encryptedBundle,
         shieldKey,
         ethers.ZeroHash  // destinationCaller = 0 (any relayer can submit)
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
 
       // Check event was emitted
@@ -428,7 +429,8 @@ describe("Privacy Pool Integration", function () {
         encryptedBundle,
         shieldKey,
         ethers.ZeroHash  // destinationCaller = 0 (any relayer)
-      );
+      ,
+      ethers.ZeroAddress);
       const receipt = await tx.wait();
 
       // Extract MessageSent(bytes) event — contains the full encoded MessageV2
@@ -526,7 +528,7 @@ describe("Privacy Pool Integration", function () {
         },
       };
 
-      await privacyPool.connect(alice).shield([shieldRequest]);
+      await privacyPool.connect(alice).shield([shieldRequest], ethers.ZeroAddress);
     });
 
     after(async function () {

--- a/test/shielded_yield_integration.ts
+++ b/test/shielded_yield_integration.ts
@@ -259,7 +259,7 @@ describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
 
   async function shieldAndGetRoot(amount: bigint): Promise<string> {
     await hubUsdc.connect(alice).approve(privacyPoolAddress, amount);
-    await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddress, amount)]);
+    await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddress, amount)], ethers.ZeroAddress);
     return await privacyPool.merkleRoot();
   }
 

--- a/test/winddown_redemption_integration.ts
+++ b/test/winddown_redemption_integration.ts
@@ -833,7 +833,7 @@ describe("Wind-Down Pool Withdraw-Only Mode", function () {
     const usdcAddr = await hubUsdc.getAddress();
     await hubUsdc.mint(aliceAddress, amount);
     await hubUsdc.connect(alice).approve(privacyPoolAddress, amount);
-    await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount)]);
+    await privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount)], ethers.ZeroAddress);
     return await privacyPool.merkleRoot();
   }
 
@@ -1029,7 +1029,7 @@ describe("Wind-Down Pool Withdraw-Only Mode", function () {
       await hubUsdc.connect(alice).approve(privacyPoolAddress, amount);
 
       await expect(
-        privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount)])
+        privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount)], ethers.ZeroAddress)
       ).to.not.be.reverted;
     });
 
@@ -1099,7 +1099,7 @@ describe("Wind-Down Pool Withdraw-Only Mode", function () {
       await hubUsdc.connect(alice).approve(privacyPoolAddress, amount);
 
       await expect(
-        privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount)])
+        privacyPool.connect(alice).shield([makeShieldRequest(usdcAddr, amount)], ethers.ZeroAddress)
       ).to.be.revertedWith("ShieldModule: shields paused");
     });
 

--- a/usdc-v2-frontend/src/services/shield/shieldContractService.ts
+++ b/usdc-v2-frontend/src/services/shield/shieldContractService.ts
@@ -234,7 +234,7 @@ export async function executeDirectShield(
     },
   }
 
-  const tx = await pool.shield([shieldRequest])
+  const tx = await pool.shield([shieldRequest], ethers.ZeroAddress)
 
   console.log('[shield-contract] Direct shield submitted:', tx.hash)
 
@@ -313,6 +313,7 @@ export async function executeCrossChainShield(
     params.encryptedBundle,
     params.shieldKey,
     destinationCaller,
+    ethers.ZeroAddress, // integrator: no integrator for direct user shields
   )
 
   console.log('[shield-contract] Cross-chain shield submitted:', tx.hash)


### PR DESCRIPTION
## Summary

- Adds `ArmadaFeeModule` — a UUPS-upgradeable fee oracle that centralizes shield fee calculation, integrator volume tracking, and cumulative protocol revenue accounting (replaces scattered flat-bps logic)
- Wires fee module into `ShieldModule` (local + cross-chain shields) and `ArmadaYieldVault` (yield fee on redemption), with legacy fallback when `feeModule == address(0)`
- Threads `integrator` address through `shield()`, `crossChainShield()`, and `ShieldData` for fee-split support
- Implements `IFeeCollector` for seamless `RevenueCounter` integration

Closes ship-armada/armada-poc#109

## Changes

### New files
| File | Purpose |
|------|---------|
| `contracts/fees/IArmadaFeeModule.sol` | Interface |
| `contracts/fees/ArmadaFeeModule.sol` | UUPS implementation |
| `scripts/deploy_fee_module.ts` | Deployment + wiring script |
| `test-foundry/ArmadaFeeModule.t.sol` | 44 unit tests (calc, tiers, integrators, access control, fuzz) |
| `test-foundry/ArmadaFeeModuleInvariant.t.sol` | 5 invariant tests (monotonic counters, fee bounds) |

### Modified files
- `PrivacyPoolStorage`: added `feeModule` slot, decremented `__gap`
- `ShieldModule`: fee module integration in `_transferTokenIn` + `_processInternalShield`
- `PrivacyPool` + `IPrivacyPool`: `shield(requests, integrator)`, `setFeeModule()`
- `CCTPTypes`: `integrator` field in `ShieldData`
- `PrivacyPoolClient` + interface: `integrator` param on `crossChainShield()`
- `ArmadaYieldVault`: reads yield fee from module, calls `recordYieldFee()`, blocks local `setYieldFeeBps` when module set
- All callers updated (adapter, forwarder, tests, frontend)

## Out of scope (tracked separately)
- Unshield fee removal (#153)
- ArmadaTreasury → ArmadaTreasuryGov migration (#154)
- Deprecate legacy fee setters (#155)
- Relayer fee calculator update (#156)

## Test plan

- [x] `npx hardhat compile` — 116 contracts, 0 errors
- [x] `forge build` — 0 errors
- [x] `forge test` — **529 tests passed, 0 failed** (44 new unit + 5 new invariant)
- [ ] `npm run test:all` — Hardhat integration tests (requires Anvil chains)
- [ ] Manual: shield with/without integrator, verify fee splits
- [ ] Verify RevenueCounter.syncStablecoinRevenue() reads from fee module


🤖 Generated with [Claude Code](https://claude.com/claude-code)