### PR TITLE
Register ArmadaFeeModule extended selectors (#145)

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -318,6 +318,13 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         // Revenue definition expansion (on RevenueCounter)
         extendedSelectors[bytes4(keccak256("setFeeCollector(address)"))] = true;
 
+        // ArmadaFeeModule — fee parameters (per governance spec: all fee changes → Extended)
+        extendedSelectors[bytes4(keccak256("setBaseArmadaTake(uint256)"))] = true;
+        extendedSelectors[bytes4(keccak256("addTier(uint256,uint256)"))] = true;
+        extendedSelectors[bytes4(keccak256("setTier(uint256,uint256,uint256)"))] = true;
+        extendedSelectors[bytes4(keccak256("removeTier(uint256)"))] = true;
+        extendedSelectors[bytes4(keccak256("setYieldFee(uint256)"))] = true;
+        extendedSelectors[bytes4(keccak256("setIntegratorTerms(address,uint256,uint256,bool)"))] = true;
 
         // Treasury outflow limit parameters
         extendedSelectors[bytes4(keccak256("setOutflowWindow(address,uint256)"))] = true;

--- a/test-foundry/GovernorClassificationBondWindDown.t.sol
+++ b/test-foundry/GovernorClassificationBondWindDown.t.sol
@@ -380,6 +380,82 @@ contract GovernorClassificationBondWindDownTest is Test, GovernorDeployHelper {
     }
 
     // ═══════════════════════════════════════════════════════════════
+    // ARMADA FEE MODULE SELECTOR CLASSIFICATION
+    // ═══════════════════════════════════════════════════════════════
+
+    function test_classify_setBaseArmadaTake_forcesExtended() public {
+        bytes memory data = abi.encodeWithSelector(
+            bytes4(keccak256("setBaseArmadaTake(uint256)")),
+            uint256(500)
+        );
+        uint256 proposalId = _proposeWithCalldata(alice, ProposalType.Standard, address(governor), data);
+
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Extended));
+    }
+
+    function test_classify_addTier_forcesExtended() public {
+        bytes memory data = abi.encodeWithSelector(
+            bytes4(keccak256("addTier(uint256,uint256)")),
+            uint256(1_000_000e6),
+            uint256(300)
+        );
+        uint256 proposalId = _proposeWithCalldata(alice, ProposalType.Standard, address(governor), data);
+
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Extended));
+    }
+
+    function test_classify_setTier_forcesExtended() public {
+        bytes memory data = abi.encodeWithSelector(
+            bytes4(keccak256("setTier(uint256,uint256,uint256)")),
+            uint256(0),
+            uint256(500_000e6),
+            uint256(400)
+        );
+        uint256 proposalId = _proposeWithCalldata(alice, ProposalType.Standard, address(governor), data);
+
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Extended));
+    }
+
+    function test_classify_removeTier_forcesExtended() public {
+        bytes memory data = abi.encodeWithSelector(
+            bytes4(keccak256("removeTier(uint256)")),
+            uint256(0)
+        );
+        uint256 proposalId = _proposeWithCalldata(alice, ProposalType.Standard, address(governor), data);
+
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Extended));
+    }
+
+    function test_classify_setYieldFee_forcesExtended() public {
+        bytes memory data = abi.encodeWithSelector(
+            bytes4(keccak256("setYieldFee(uint256)")),
+            uint256(1000)
+        );
+        uint256 proposalId = _proposeWithCalldata(alice, ProposalType.Standard, address(governor), data);
+
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Extended));
+    }
+
+    function test_classify_setIntegratorTerms_forcesExtended() public {
+        bytes memory data = abi.encodeWithSelector(
+            bytes4(keccak256("setIntegratorTerms(address,uint256,uint256,bool)")),
+            address(0x1234),
+            uint256(200),
+            uint256(100_000e6),
+            true
+        );
+        uint256 proposalId = _proposeWithCalldata(alice, ProposalType.Standard, address(governor), data);
+
+        (,ProposalType pType,,,,,,, ) = governor.getProposal(proposalId);
+        assertEq(uint256(pType), uint256(ProposalType.Extended));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
     // SECURITY COUNCIL STATE
     // ═══════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

- Register 6 ArmadaFeeModule setter selectors as Extended in `ArmadaGovernor._registerExtendedSelectors()`: `setBaseArmadaTake`, `addTier`, `setTier`, `removeTier`, `setYieldFee`, `setIntegratorTerms`
- Add 6 Foundry classification tests confirming Standard proposals with these selectors are auto-upgraded to Extended

Closes #145

## Design decisions

- **Not registered as Extended:** `setTreasury`, `setPrivacyPool`, `setYieldVault` — these are administrative setters, not fee parameters per the governance spec
- **`setTreasury` immutability:** Filed #170 to evaluate removing `setTreasury` entirely (treasury address changes can be routed through UUPS upgrades, which are already Extended-classified)
- **Old selectors preserved:** `setShieldFee`, `setUnshieldFee`, `setYieldFeeBps` remain registered — they still exist on PrivacyPool/YieldVault

## Test plan

- [x] `npm run test:forge` — 535 tests pass (includes 6 new classification tests)
- [x] `npm run test:governance` — 117 Hardhat governance tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)