### PR TITLE
fix(crowdfund): align claim() with spec event semantics

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -551,7 +551,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, EIP712 {
             totalAllocArm += allocArm;
             totalRefundUsdc += hopRefund;
 
-            emit AllocatedHop(msg.sender, h, allocUsdc);
+            if (allocUsdc > 0) emit AllocatedHop(msg.sender, h, allocUsdc);
         }
 
         // ARM: only transfer if within claim deadline
@@ -570,7 +570,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, EIP712 {
             usdc.safeTransfer(msg.sender, totalRefundUsdc);
         }
 
-        emit Allocated(msg.sender, armTransferred, totalRefundUsdc, delegate);
+        emit Allocated(msg.sender, armTransferred, totalRefundUsdc, armTransferred > 0 ? delegate : address(0));
     }
 
     /// @notice Claim USDC refund — failure paths only. Three eligibility paths:

--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -557,6 +557,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, EIP712 {
         // ARM: only transfer if within claim deadline
         uint256 armTransferred = 0;
         if (block.timestamp <= claimDeadline && totalAllocArm > 0) {
+            require(delegate != address(0), "ArmadaCrowdfund: delegate required");
             armTransferred = totalAllocArm;
             totalArmTransferred += armTransferred;
             armToken.safeTransfer(msg.sender, armTransferred);

--- a/test-foundry/CrowdfundReentrancy.t.sol
+++ b/test-foundry/CrowdfundReentrancy.t.sol
@@ -220,12 +220,12 @@ contract CrowdfundReentrancyTest is Test {
         // Arm: on ARM transfer, try to call claim() again
         maliciousArm.setAttack(
             address(cf),
-            abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, address(0))
+            abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, seeds[0])
         );
 
         uint256 armBefore = maliciousArm.balanceOf(seeds[0]);
         vm.prank(seeds[0]);
-        cf.claim(address(0));
+        cf.claim(seeds[0]);
 
         // Reentry was attempted and blocked by nonReentrant specifically
         assertTrue(maliciousArm.attackFired(), "Attack callback must have fired");
@@ -244,7 +244,7 @@ contract CrowdfundReentrancyTest is Test {
         // Second claim must revert (already claimed)
         vm.prank(seeds[0]);
         vm.expectRevert("ArmadaCrowdfund: already claimed");
-        cf.claim(address(0));
+        cf.claim(seeds[0]);
     }
 
     // ============ Test: claim() reentry blocked (propagating revert) ============
@@ -288,14 +288,14 @@ contract CrowdfundReentrancyTest is Test {
 
         maliciousArm.setAttack(
             address(cf),
-            abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, address(0))
+            abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, seeds[0])
         );
 
         // Outer call reverts because reentry revert propagates through the token transfer.
         // The propagated revert reason must be the nonReentrant guard.
         vm.prank(seeds[0]);
         vm.expectRevert("ReentrancyGuard: reentrant call");
-        cf.claim(address(0));
+        cf.claim(seeds[0]);
 
         // Attacker received nothing
         assertEq(maliciousArm.balanceOf(seeds[0]), 0, "Attacker must receive nothing");
@@ -303,7 +303,7 @@ contract CrowdfundReentrancyTest is Test {
         // Disable attack — legitimate claim works
         maliciousArm.disableAttack();
         vm.prank(seeds[0]);
-        cf.claim(address(0));
+        cf.claim(seeds[0]);
         assertTrue(maliciousArm.balanceOf(seeds[0]) > 0, "Legitimate claim must succeed");
     }
 

--- a/test-foundry/CrowdfundReentrancy.t.sol
+++ b/test-foundry/CrowdfundReentrancy.t.sol
@@ -44,6 +44,9 @@ contract MaliciousERC20 is ERC20 {
         _mint(to, amount);
     }
 
+    /// @notice Stub for IArmadaTokenCrowdfund — claim() calls delegateOnBehalf after transfer.
+    function delegateOnBehalf(address, address) external {}
+
     /// @notice Arm the attack. On the next transfer, the contract will call
     ///         attackTarget with attackCalldata. The attackFired flag is set
     ///         BEFORE the callback to prevent infinite recursion.
@@ -98,6 +101,9 @@ contract MaliciousERC20Propagating is ERC20 {
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
     }
+
+    /// @notice Stub for IArmadaTokenCrowdfund — claim() calls delegateOnBehalf after transfer.
+    function delegateOnBehalf(address, address) external {}
 
     function setAttack(address target, bytes calldata data) external {
         attackTarget = target;

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -168,7 +168,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       // 6. Seeds claim their ARM
       const claimedSeeds = seeds.slice(0, 5); // claim first 5 for governance testing
       for (const seed of claimedSeeds) {
-        await crowdfund.connect(seed).claim(ethers.ZeroAddress);
+        await crowdfund.connect(seed).claim(seed.address);
       }
 
       // Verify seeds received ARM
@@ -263,7 +263,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // Claim all
       for (const seed of seeds) {
-        await crowdfund.connect(seed).claim(ethers.ZeroAddress);
+        await crowdfund.connect(seed).claim(seed.address);
       }
 
       // Skip past 7-day governance quiet period
@@ -370,7 +370,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // Claim first 10 seeds
       for (let i = 0; i < 10; i++) {
-        await crowdfund.connect(seeds[i]).claim(ethers.ZeroAddress);
+        await crowdfund.connect(seeds[i]).claim(seeds[i].address);
       }
 
       // Skip past 7-day governance quiet period
@@ -514,7 +514,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // Alice tries to claim again — should revert
       await expect(
-        crowdfund.connect(alice).claim(ethers.ZeroAddress)
+        crowdfund.connect(alice).claim(alice.address)
       ).to.be.revertedWith("ArmadaCrowdfund: already claimed");
 
       // Alice delegates and votes
@@ -760,7 +760,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // Now all seeds claim their ARM — ARM leaves the crowdfund contract
       for (const seed of localSeeds) {
-        await localCrowdfund.connect(seed).claim(ethers.ZeroAddress);
+        await localCrowdfund.connect(seed).claim(seed.address);
       }
 
       const crowdfundArmAfter = await localArmToken.balanceOf(await localCrowdfund.getAddress());
@@ -799,7 +799,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
 
       // All seeds claim
       for (const seed of localSeeds) {
-        await localCrowdfund.connect(seed).claim(ethers.ZeroAddress);
+        await localCrowdfund.connect(seed).claim(seed.address);
       }
 
       const treasuryAddress = await localTreasury.getAddress();
@@ -855,7 +855,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       // 5 seeds claim
       const claimedSeeds = localSeeds.slice(0, 5);
       for (const seed of claimedSeeds) {
-        await localCrowdfund.connect(seed).claim(ethers.ZeroAddress);
+        await localCrowdfund.connect(seed).claim(seed.address);
       }
 
       // Skip past 7-day governance quiet period

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -126,7 +126,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     await treasuryGov.waitForDeployment();
 
     // Whitelist contracts that transfer ARM tokens
-    await armToken.addToWhitelist(await crowdfund.getAddress());
+    const cfAddr = await crowdfund.getAddress();
+    await armToken.addToWhitelist(cfAddr);
+    await armToken.initAuthorizedDelegators([cfAddr]);
 
     // Send most ARM to treasury address to make quorum reachable.
     // Keep DEPLOYER_KEEP for governance testing.
@@ -470,17 +472,16 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     it("voting power reflects delegation state at proposal snapshot, not current state", async function () {
       await setupCrowdfundAndGovernance();
 
+      // Alice claimed during setup (first 10 seeds) — has voting power
       const alice = seeds[0];
-      const bob = seeds[1];
 
-      // Alice delegates to activate ERC20Votes voting power
-      await armToken.connect(alice).delegate(alice.address);
+      // Bob has NOT claimed yet (seeds[10] was not claimed in setup)
+      const bob = seeds[10];
 
-      // Bob does NOT delegate yet
       await mine(2);
 
       // Create proposal — snapshot is block.number - 1
-      // At snapshot: Alice has voting power, Bob does not
+      // At snapshot: Alice has voting power, Bob does not (hasn't claimed)
       const dummyCalldata = treasuryGov.interface.encodeFunctionData("distribute", [await usdc.getAddress(), deployer.address, 1]);
       await governor.propose(
         ProposalType.Standard,
@@ -491,8 +492,8 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       );
       const proposalId = 1;
 
-      // NOW bob delegates (after proposal creation)
-      await armToken.connect(bob).delegate(bob.address);
+      // NOW bob claims (after proposal creation) — gets ARM + delegation atomically
+      await crowdfund.connect(bob).claim(bob.address);
 
       // Fast-forward to voting
       await time.increase(TWO_DAYS + 1);
@@ -501,7 +502,7 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await governor.connect(alice).castVote(proposalId, Vote.For);
       expect(await governor.hasVoted(proposalId, alice.address)).to.be.true;
 
-      // Bob cannot vote (delegated AFTER snapshot)
+      // Bob cannot vote (claimed and delegated AFTER snapshot)
       await expect(
         governor.connect(bob).castVote(proposalId, Vote.For)
       ).to.be.revertedWith("ArmadaGovernor: no voting power");
@@ -666,7 +667,9 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await localCrowdfund.waitForDeployment();
 
       // Whitelist contracts that transfer ARM tokens
-      await localArmToken.addToWhitelist(await localCrowdfund.getAddress());
+      const localCfAddr = await localCrowdfund.getAddress();
+      await localArmToken.addToWhitelist(localCfAddr);
+      await localArmToken.initAuthorizedDelegators([localCfAddr]);
 
       // Step 5: Fund crowdfund from deployer remainder
       await localArmToken.transfer(await localCrowdfund.getAddress(), CROWDFUND_ALLOCATION);

--- a/test/crowdfund_adversarial.ts
+++ b/test/crowdfund_adversarial.ts
@@ -248,10 +248,10 @@ describe("Crowdfund Adversarial", function () {
 
       // All participants claim ARM + USDC refund via claim() (seeds + hop-1)
       for (const s of seeds) {
-        await crowdfund.connect(s).claim(ethers.ZeroAddress);
+        await crowdfund.connect(s).claim(s.address);
       }
       for (let i = 0; i < 51; i++) {
-        await crowdfund.connect(hop1Pool[i]).claim(ethers.ZeroAddress);
+        await crowdfund.connect(hop1Pool[i]).claim(hop1Pool[i].address);
       }
 
       // Proceeds already pushed to treasury at finalization.
@@ -668,7 +668,7 @@ describe("Crowdfund Adversarial", function () {
 
       // Instead, claim() handles both ARM + refund
       const usdcBefore = await usdc.balanceOf(seeds[0].address);
-      await crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seeds[0]).claim(seeds[0].address);
       const usdcAfter = await usdc.balanceOf(seeds[0].address);
 
       // Seeds at oversubscribed hop-0 should get a USDC refund (allocation < committed)
@@ -752,7 +752,7 @@ describe("Crowdfund Adversarial", function () {
       for (let i = 0; i < 5; i++) {
         const [, refundUsdc] = await crowdfund.computeAllocation(seeds[i].address);
         const usdcBefore = await usdc.balanceOf(seeds[i].address);
-        await crowdfund.connect(seeds[i]).claim(ethers.ZeroAddress);
+        await crowdfund.connect(seeds[i]).claim(seeds[i].address);
         const usdcAfter = await usdc.balanceOf(seeds[i].address);
         expect(usdcAfter - usdcBefore).to.equal(refundUsdc);
       }
@@ -1223,12 +1223,12 @@ describe("Crowdfund Adversarial", function () {
       await crowdfund.finalize();
 
       // Verify claim works normally (proving nonReentrant doesn't block legitimate calls)
-      await crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seeds[0]).claim(seeds[0].address);
       expect(await crowdfund.claimed(seeds[0].address)).to.be.true;
 
       // Double claim should fail
       await expect(
-        crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress)
+        crowdfund.connect(seeds[0]).claim(seeds[0].address)
       ).to.be.revertedWith("ArmadaCrowdfund: already claimed");
     });
 

--- a/test/crowdfund_atomic_delegate.ts
+++ b/test/crowdfund_atomic_delegate.ts
@@ -126,16 +126,13 @@ describe("Crowdfund: Atomic Delegation on Claim", function () {
     expect(await armToken.getVotes(claimant.address)).to.be.gt(0n);
   });
 
-  it("claim(address(0)) skips delegation", async function () {
+  it("claim(address(0)) reverts — delegation is mandatory", async function () {
     const crowdfund = await deployCrowdfund();
     const { seeds } = await setupAndFinalize(crowdfund);
 
     const claimant = seeds[2];
-    await crowdfund.connect(claimant).claim(ethers.ZeroAddress);
-
-    // ARM transferred but no delegation set
-    const balance = await armToken.balanceOf(claimant.address);
-    expect(balance).to.be.gt(0n);
-    expect(await armToken.delegates(claimant.address)).to.equal(ethers.ZeroAddress);
+    await expect(
+      crowdfund.connect(claimant).claim(ethers.ZeroAddress)
+    ).to.be.revertedWith("ArmadaCrowdfund: delegate required");
   });
 });

--- a/test/crowdfund_integration.ts
+++ b/test/crowdfund_integration.ts
@@ -877,7 +877,7 @@ describe("Crowdfund Integration", function () {
       const armBefore = await armToken.balanceOf(seeds[0].address);
       const usdcBefore = await usdc.balanceOf(seeds[0].address);
 
-      await crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seeds[0]).claim(seeds[0].address);
 
       const armAfter = await armToken.balanceOf(seeds[0].address);
       const usdcAfter = await usdc.balanceOf(seeds[0].address);
@@ -900,9 +900,9 @@ describe("Crowdfund Integration", function () {
       await time.increase(THREE_WEEKS + 1);
       await crowdfund.finalize();
 
-      await crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seeds[0]).claim(seeds[0].address);
       await expect(
-        crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress)
+        crowdfund.connect(seeds[0]).claim(seeds[0].address)
       ).to.be.revertedWith("ArmadaCrowdfund: already claimed");
     });
 
@@ -1016,7 +1016,7 @@ describe("Crowdfund Integration", function () {
       const armBefore = await armToken.balanceOf(seeds[0].address);
       const usdcBefore = await usdc.balanceOf(seeds[0].address);
 
-      await crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seeds[0]).claim(seeds[0].address);
 
       // Hop-0 is oversubscribed → both ARM allocated and USDC refunded
       expect(await armToken.balanceOf(seeds[0].address)).to.be.gt(armBefore);
@@ -1084,19 +1084,19 @@ describe("Crowdfund Integration", function () {
 
     it("double claim() reverts", async function () {
       const seeds = await setupOversubscribed();
-      await crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seeds[0]).claim(seeds[0].address);
 
       await expect(
-        crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress)
+        crowdfund.connect(seeds[0]).claim(seeds[0].address)
       ).to.be.revertedWith("ArmadaCrowdfund: already claimed");
     });
 
     it("claim() after claim() reverts (shared claimed flag)", async function () {
       const seeds = await setupOversubscribed();
-      await crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seeds[0]).claim(seeds[0].address);
 
       await expect(
-        crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress)
+        crowdfund.connect(seeds[0]).claim(seeds[0].address)
       ).to.be.revertedWith("ArmadaCrowdfund: already claimed");
     });
 
@@ -1116,7 +1116,7 @@ describe("Crowdfund Integration", function () {
 
       // Post-deadline: ARM forfeited, but refund still transfers
       const usdcBefore = await usdc.balanceOf(seeds[0].address);
-      await crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seeds[0]).claim(seeds[0].address);
       const usdcAfter = await usdc.balanceOf(seeds[0].address);
       expect(usdcAfter - usdcBefore).to.be.gt(0n);
 
@@ -1220,7 +1220,7 @@ describe("Crowdfund Integration", function () {
 
       // Claim first seed
       const armBefore = await armToken.balanceOf(seeds[0].address);
-      await crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seeds[0]).claim(seeds[0].address);
       const armAfter = await armToken.balanceOf(seeds[0].address);
 
       const [alloc, refund] = await crowdfund.computeAllocation(seeds[0].address);
@@ -1280,7 +1280,7 @@ describe("Crowdfund Integration", function () {
       await crowdfund.finalize();
 
       // Claim ARM
-      await crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seeds[0]).claim(seeds[0].address);
       const armBalance = await armToken.balanceOf(seeds[0].address);
       expect(armBalance).to.be.gt(0);
 

--- a/test/crowdfund_integration.ts
+++ b/test/crowdfund_integration.ts
@@ -1104,8 +1104,42 @@ describe("Crowdfund Integration", function () {
       const seeds = await setupOversubscribed();
       const delegate = allSigners[199].address;
 
+      const [expectedArm, expectedRefund] = await crowdfund.computeAllocation(seeds[0].address);
       await expect(crowdfund.connect(seeds[0]).claim(delegate))
-        .to.emit(crowdfund, "Allocated");
+        .to.emit(crowdfund, "Allocated")
+        .withArgs(seeds[0].address, expectedArm, expectedRefund, delegate);
+    });
+
+    it("AllocatedHop only emitted for hops with non-zero allocation", async function () {
+      const seeds = await setupOversubscribed();
+
+      // seeds[0] committed only on hop 0 — should emit exactly one AllocatedHop
+      const tx = await crowdfund.connect(seeds[0]).claim(seeds[0].address);
+      const receipt = await tx.wait();
+
+      // Parse AllocatedHop events from the claim receipt
+      const hopEvents = receipt.logs
+        .map((l: any) => { try { return crowdfund.interface.parseLog(l); } catch { return null; } })
+        .filter((e: any) => e?.name === "AllocatedHop");
+
+      // Participant committed on hop-0 only, so exactly one AllocatedHop expected
+      expect(hopEvents.length).to.equal(1);
+      expect(hopEvents[0].args.participant).to.equal(seeds[0].address);
+      expect(hopEvents[0].args.hop).to.equal(0);
+      expect(hopEvents[0].args.acceptedUsdc).to.be.gt(0n);
+    });
+
+    it("Allocated event emits delegate=address(0) on post-deadline claim", async function () {
+      const seeds = await setupOversubscribed();
+
+      const deadline = await crowdfund.claimDeadline();
+      await time.increaseTo(deadline + 1n);
+
+      // Post-deadline: ARM forfeited, delegate should be address(0) in event
+      const [, expectedRefund] = await crowdfund.computeAllocation(seeds[0].address);
+      await expect(crowdfund.connect(seeds[0]).claim(seeds[0].address))
+        .to.emit(crowdfund, "Allocated")
+        .withArgs(seeds[0].address, 0n, expectedRefund, ethers.ZeroAddress);
     });
 
     it("claim() after deadline still transfers refund (refunds never expire)", async function () {

--- a/test/crowdfund_multinode.ts
+++ b/test/crowdfund_multinode.ts
@@ -271,7 +271,7 @@ describe("Crowdfund Multi-Node", function () {
 
       // Alice claims ARM — stacking → commit → settlement → claim end-to-end
       const armBefore = await armToken.balanceOf(alice.address);
-      await crowdfund.connect(alice).claim(ethers.ZeroAddress);
+      await crowdfund.connect(alice).claim(alice.address);
       const armAfter = await armToken.balanceOf(alice.address);
       expect(armAfter - armBefore).to.be.gt(0);
     });
@@ -555,7 +555,7 @@ describe("Crowdfund Multi-Node", function () {
       expect(allocBefore).to.be.gt(0);
 
       const armBefore = await armToken.balanceOf(seed1.address);
-      await crowdfund.connect(seed1).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seed1).claim(seed1.address);
       const armAfter = await armToken.balanceOf(seed1.address);
 
       expect(armAfter - armBefore).to.equal(allocBefore);
@@ -564,10 +564,10 @@ describe("Crowdfund Multi-Node", function () {
     it("should revert double-claim", async function () {
       await setupAndFinalize();
 
-      await crowdfund.connect(seed1).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seed1).claim(seed1.address);
 
       await expect(
-        crowdfund.connect(seed1).claim(ethers.ZeroAddress)
+        crowdfund.connect(seed1).claim(seed1.address)
       ).to.be.revertedWith("ArmadaCrowdfund: already claimed");
     });
   });

--- a/test/crowdfund_settlement.ts
+++ b/test/crowdfund_settlement.ts
@@ -259,7 +259,7 @@ describe("Crowdfund Settlement Rework", function () {
 
       // All seeds claim ARM + refund in one call
       for (const s of seeds) {
-        await crowdfund.connect(s).claim(ethers.ZeroAddress);
+        await crowdfund.connect(s).claim(s.address);
       }
 
       // Contract should have minimal USDC left (dust from rounding)
@@ -356,14 +356,14 @@ describe("Crowdfund Settlement Rework", function () {
       // So increaseTo(deadline - 1n) → claim tx executes at block.timestamp == deadline
       await time.increaseTo(deadline - 1n);
       const armBefore = await armToken.balanceOf(seeds[0].address);
-      await crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seeds[0]).claim(seeds[0].address);
       const armAfter = await armToken.balanceOf(seeds[0].address);
       expect(armAfter - armBefore).to.be.gt(0n); // ARM transferred
 
       // Now block.timestamp == deadline. Next tx at deadline+1 → no ARM, refund only.
       const armBefore1 = await armToken.balanceOf(seeds[1].address);
       const usdcBefore1 = await usdc.balanceOf(seeds[1].address);
-      await crowdfund.connect(seeds[1]).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seeds[1]).claim(seeds[1].address);
       const armAfter1 = await armToken.balanceOf(seeds[1].address);
       const usdcAfter1 = await usdc.balanceOf(seeds[1].address);
       expect(armAfter1 - armBefore1).to.equal(0n); // no ARM after deadline
@@ -443,7 +443,7 @@ describe("Crowdfund Settlement Rework", function () {
       const allParticipants = [...seeds, ...hop1Invitees];
       for (const p of allParticipants) {
         const before = await usdc.balanceOf(p.address);
-        await crowdfund.connect(p).claim(ethers.ZeroAddress);
+        await crowdfund.connect(p).claim(p.address);
         const after = await usdc.balanceOf(p.address);
         sumRefundsPaid += (after - before);
       }
@@ -552,7 +552,7 @@ describe("Crowdfund Settlement Rework", function () {
 
       // Half the seeds claim — reduces armStillOwed
       for (let i = 0; i < 34; i++) {
-        await crowdfund.connect(seeds[i]).claim(ethers.ZeroAddress);
+        await crowdfund.connect(seeds[i]).claim(seeds[i].address);
       }
 
       // armStillOwed decreased, but no new unsold ARM. Balance = totalAlloc - claimed.
@@ -570,7 +570,7 @@ describe("Crowdfund Settlement Rework", function () {
       await crowdfund.withdrawUnallocatedArm();
 
       // Only 1 of 68 seeds claims
-      await crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress);
+      await crowdfund.connect(seeds[0]).claim(seeds[0].address);
 
       // Before deadline: can't sweep unclaimed
       await expect(

--- a/test/gas_benchmark.ts
+++ b/test/gas_benchmark.ts
@@ -234,8 +234,10 @@ describe("Gas Benchmarks", function () {
         openTimestamp3    // openTimestamp
       );
 
-      await armToken.addToWhitelist(await crowdfund.getAddress());
-      await armToken.transfer(await crowdfund.getAddress(), ARM(1_800_000));
+      const cfAddr = await crowdfund.getAddress();
+      await armToken.addToWhitelist(cfAddr);
+      await armToken.initAuthorizedDelegators([cfAddr]);
+      await armToken.transfer(cfAddr, ARM(1_800_000));
       await crowdfund.loadArm();
 
       const count = 100;

--- a/test/gas_benchmark.ts
+++ b/test/gas_benchmark.ts
@@ -255,15 +255,15 @@ describe("Gas Benchmarks", function () {
       // Measure gas for first, middle, and last claims
       const claimGas: { position: string; gas: bigint }[] = [];
 
-      const firstTx = await crowdfund.connect(seeds[0]).claim(ethers.ZeroAddress);
+      const firstTx = await crowdfund.connect(seeds[0]).claim(seeds[0].address);
       const firstReceipt = await firstTx.wait();
       claimGas.push({ position: "first", gas: firstReceipt!.gasUsed });
 
-      const midTx = await crowdfund.connect(seeds[49]).claim(ethers.ZeroAddress);
+      const midTx = await crowdfund.connect(seeds[49]).claim(seeds[49].address);
       const midReceipt = await midTx.wait();
       claimGas.push({ position: "middle (50th)", gas: midReceipt!.gasUsed });
 
-      const lastTx = await crowdfund.connect(seeds[99]).claim(ethers.ZeroAddress);
+      const lastTx = await crowdfund.connect(seeds[99]).claim(seeds[99].address);
       const lastReceipt = await lastTx.wait();
       claimGas.push({ position: "last (100th)", gas: lastReceipt!.gasUsed });
 


### PR DESCRIPTION
## Summary
- Guard `AllocatedHop` emission so zero-acceptance hops produce no event (spec §Events line 654)
- Emit `delegate: address(0)` in `Allocated` event when no ARM is transferred (spec §Claim mechanics line 403)
- Enforce mandatory delegation (`delegate != address(0)`) when ARM is being transferred (spec §Governance line 508)

## Test plan
- [ ] Verify `AllocatedHop` is not emitted for hops where `allocUsdc == 0`
- [ ] Verify `Allocated` event emits `delegate = address(0)` on post-3yr-expiry claims
- [ ] Verify `claim()` reverts with "delegate required" when `delegate = address(0)` and ARM would be transferred
- [ ] Verify `claim()` succeeds with `delegate = address(0)` on post-expiry refund-only claims

🤖 Generated with [Claude Code](https://claude.com/claude-code)