### PR TITLE
fix(treasury): require outflow config for token distributions

### DIFF
--- a/contracts/governance/ArmadaTreasuryGov.sol
+++ b/contracts/governance/ArmadaTreasuryGov.sol
@@ -243,10 +243,10 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
     // ============ Internal: Outflow Enforcement ============
 
     /// @dev Check that a proposed outflow does not exceed the rolling-window limit,
-    ///      and record the outflow if it passes. Skips if no config is initialized.
+    ///      and record the outflow if it passes. Reverts if no outflow config is initialized for the token.
     function _checkAndRecordOutflow(address token, uint256 amount) internal {
         OutflowConfig storage config = _outflowConfigs[token];
-        if (!config.initialized) return; // no limit configured — allow
+        require(config.initialized, "ArmadaTreasuryGov: outflow config required");
 
         // Calculate effective limit: max(pct of current balance, absolute), then max(result, floor)
         uint256 treasuryBalance = IERC20(token).balanceOf(address(this));

--- a/test-foundry/GovernorSteward.t.sol
+++ b/test-foundry/GovernorSteward.t.sol
@@ -103,9 +103,12 @@ contract GovernorStewardTest is Test, GovernorDeployHelper {
         // Advance block for checkpoint availability
         vm.roll(block.number + 1);
 
-        // Deploy mock USDC and fund treasury
+        // Deploy mock USDC, fund treasury, and initialize outflow config
         usdc = new MockToken();
         usdc.mint(address(treasury), 1_000_000 * 1e6);
+
+        vm.prank(address(timelock));
+        treasury.initOutflowConfig(address(usdc), 30 days, 5000, 1_000_000 * 1e6, 1000 * 1e6);
 
         // Grant timelock roles to governor
         timelock.grantRole(timelock.PROPOSER_ROLE(), address(governor));

--- a/test-foundry/TreasurySweepAuthority.t.sol
+++ b/test-foundry/TreasurySweepAuthority.t.sol
@@ -122,6 +122,24 @@ contract TreasurySweepAuthorityTest is Test {
         assertEq(usdc.balanceOf(recipient), fullBalance);
     }
 
+    // ======== Unconfigured token outflow (Issue #178) ========
+
+    function test_distribute_revertsWithoutOutflowConfig() public {
+        // Treasury has USDC but no outflow config initialized
+        vm.prank(timelockAddr);
+        vm.expectRevert("ArmadaTreasuryGov: outflow config required");
+        treasury.distribute(address(usdc), recipient, 100e6);
+    }
+
+    function test_transferTo_worksWithoutOutflowConfig() public {
+        _setupWindDown();
+        // No initOutflowConfig — transferTo should still work (bypasses outflow entirely)
+        uint256 fullBalance = usdc.balanceOf(address(treasury));
+        vm.prank(windDown);
+        treasury.transferTo(address(usdc), recipient, fullBalance);
+        assertEq(usdc.balanceOf(recipient), fullBalance);
+    }
+
     // ======== transferETHTo ========
 
     function test_transferETHTo_windDownOnly() public {

--- a/test-foundry/TreasurySweepAuthority.t.sol
+++ b/test-foundry/TreasurySweepAuthority.t.sol
@@ -131,6 +131,16 @@ contract TreasurySweepAuthorityTest is Test {
         treasury.distribute(address(usdc), recipient, 100e6);
     }
 
+    function test_stewardSpend_revertsWithoutOutflowConfig() public {
+        // Authorize USDC for steward spending but do NOT initialize outflow config
+        vm.prank(timelockAddr);
+        treasury.addStewardBudgetToken(address(usdc), 500_000e6, 30 days);
+
+        vm.prank(timelockAddr);
+        vm.expectRevert("ArmadaTreasuryGov: outflow config required");
+        treasury.stewardSpend(address(usdc), recipient, 100e6);
+    }
+
     function test_transferTo_worksWithoutOutflowConfig() public {
         _setupWindDown();
         // No initOutflowConfig — transferTo should still work (bypasses outflow entirely)

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -125,6 +125,24 @@ describe("Cross-Contract Integration (Phase 6)", function () {
     treasuryGov = await ArmadaTreasuryGov.deploy(timelockAddr);
     await treasuryGov.waitForDeployment();
 
+    // Initialize USDC outflow config on treasury (via timelock, deployer has proposer+executor)
+    const outflowTargets = [await treasuryGov.getAddress()];
+    const outflowValues = [0n];
+    const outflowCalldatas = [
+      treasuryGov.interface.encodeFunctionData("initOutflowConfig", [
+        await usdc.getAddress(), 30 * ONE_DAY, 5000,
+        ethers.parseUnits("100000", 6), ethers.parseUnits("1", 6),
+      ]),
+    ];
+    const outflowSalt = ethers.id("outflow-config-usdc");
+    await timelockController.scheduleBatch(
+      outflowTargets, outflowValues, outflowCalldatas, ethers.ZeroHash, outflowSalt, ONE_DAY
+    );
+    await time.increase(ONE_DAY + 1);
+    await timelockController.executeBatch(
+      outflowTargets, outflowValues, outflowCalldatas, ethers.ZeroHash, outflowSalt
+    );
+
     // Whitelist contracts that transfer ARM tokens
     const cfAddr = await crowdfund.getAddress();
     await armToken.addToWhitelist(cfAddr);
@@ -649,11 +667,30 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       // Step 3: Send treasury allocation
       await localArmToken.transfer(await localTreasury.getAddress(), TREASURY_ALLOCATION);
 
-      // Step 4: Deploy crowdfund with shared ARM + treasury
+      // Step 4: Deploy USDC and initialize outflow config via timelock
       const MockUSDCV2 = await ethers.getContractFactory("MockUSDCV2");
       localUsdc = await MockUSDCV2.deploy("Mock USDC", "USDC");
       await localUsdc.waitForDeployment();
 
+      // Initialize USDC outflow config on treasury (via timelock, deployer has proposer+executor)
+      const outflowTargets = [await localTreasury.getAddress()];
+      const outflowValues = [0n];
+      const outflowCalldatas = [
+        localTreasury.interface.encodeFunctionData("initOutflowConfig", [
+          await localUsdc.getAddress(), 30 * ONE_DAY, 5000,
+          ethers.parseUnits("100000", 6), ethers.parseUnits("1", 6),
+        ]),
+      ];
+      const outflowSalt = ethers.id("outflow-config-usdc");
+      await localTimelockController.scheduleBatch(
+        outflowTargets, outflowValues, outflowCalldatas, ethers.ZeroHash, outflowSalt, ONE_DAY
+      );
+      await time.increase(ONE_DAY + 1);
+      await localTimelockController.executeBatch(
+        outflowTargets, outflowValues, outflowCalldatas, ethers.ZeroHash, outflowSalt
+      );
+
+      // Step 5: Deploy crowdfund with shared ARM + treasury
       const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
       const localOpenTimestamp = (await time.latest()) + 300;
       localCrowdfund = await ArmadaCrowdfund.deploy(
@@ -671,11 +708,11 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       await localArmToken.addToWhitelist(localCfAddr);
       await localArmToken.initAuthorizedDelegators([localCfAddr]);
 
-      // Step 5: Fund crowdfund from deployer remainder
+      // Step 6: Fund crowdfund from deployer remainder
       await localArmToken.transfer(await localCrowdfund.getAddress(), CROWDFUND_ALLOCATION);
       await localCrowdfund.loadArm();
 
-      // Step 6: Register crowdfund in quorum exclusion and quiet period
+      // Step 7: Register crowdfund in quorum exclusion and quiet period
       await localGovernor.setExcludedAddresses([await localCrowdfund.getAddress()]);
       await localGovernor.setCrowdfundAddress(await localCrowdfund.getAddress());
     });

--- a/test/governance_adversarial.ts
+++ b/test/governance_adversarial.ts
@@ -777,8 +777,11 @@ describe("Governance Adversarial", function () {
       budgetTreasury = await ArmadaTreasuryGov.deploy(deployer.address);
       await budgetTreasury.waitForDeployment();
 
-      // Fund with USDC and authorize token for steward spending
+      // Fund with USDC, initialize outflow config, and authorize token for steward spending
       await usdc.mint(await budgetTreasury.getAddress(), TREASURY_USDC);
+      await budgetTreasury.initOutflowConfig(
+        await usdc.getAddress(), STEWARD_WINDOW, 1000, TREASURY_USDC, STEWARD_LIMIT
+      ); // 10% or $1M absolute, floor=$10K — permissive enough for steward tests
       await budgetTreasury.addStewardBudgetToken(await usdc.getAddress(), STEWARD_LIMIT, STEWARD_WINDOW);
     }
 

--- a/test/governance_integration.ts
+++ b/test/governance_integration.ts
@@ -164,21 +164,50 @@ describe("Governance Integration", function () {
     await timelockController.grantRole(PROPOSER_ROLE, await governor.getAddress());
     await timelockController.grantRole(EXECUTOR_ROLE, await governor.getAddress());
 
-    // 8. Renounce deployer admin
-    await timelockController.renounceRole(ADMIN_ROLE, deployer.address);
-
-    // 9. Deploy mock USDC for treasury tests
+    // 8. Deploy mock USDC (needed before outflow config)
     const MockUSDCV2 = await ethers.getContractFactory("MockUSDCV2");
     usdc = await MockUSDCV2.deploy("Mock USDC", "USDC");
     await usdc.waitForDeployment();
 
-    // 10. Distribute ARM tokens
+    // 9. Distribute ARM tokens and mint USDC to treasury
     await armToken.transfer(await treasury.getAddress(), TREASURY_AMOUNT);
     await armToken.transfer(alice.address, ALICE_AMOUNT);
     await armToken.transfer(bob.address, BOB_AMOUNT);
-
-    // 11. Mint USDC to treasury for payout tests
     await usdc.mint(await treasury.getAddress(), ethers.parseUnits("100000", USDC_DECIMALS));
+
+    // 10. Initialize outflow configs via timelock (deployer still has admin role)
+    //     Grant deployer temporary proposer+executor to schedule outflow config calls.
+    await timelockController.grantRole(PROPOSER_ROLE, deployer.address);
+    await timelockController.grantRole(EXECUTOR_ROLE, deployer.address);
+
+    const treasuryAddr = await treasury.getAddress();
+    const usdcAddr = await usdc.getAddress();
+    const armAddr = await armToken.getAddress();
+    const iface = treasury.interface;
+
+    // Schedule outflow configs for both USDC and ARM tokens
+    const targets = [treasuryAddr, treasuryAddr];
+    const values = [0n, 0n];
+    const calldatas = [
+      iface.encodeFunctionData("initOutflowConfig", [
+        usdcAddr, THIRTY_DAYS, 5000, ethers.parseUnits("100000", USDC_DECIMALS), ethers.parseUnits("1000", USDC_DECIMALS),
+      ]),
+      iface.encodeFunctionData("initOutflowConfig", [
+        armAddr, THIRTY_DAYS, 5000, TREASURY_AMOUNT, ethers.parseUnits("1000", ARM_DECIMALS),
+      ]),
+    ];
+    const salt = ethers.id("outflow-config-setup");
+
+    await timelockController.scheduleBatch(targets, values, calldatas, ethers.ZeroHash, salt, TWO_DAYS);
+    await time.increase(TWO_DAYS + 1);
+    await timelockController.executeBatch(targets, values, calldatas, ethers.ZeroHash, salt);
+
+    // Revoke deployer's temporary roles
+    await timelockController.revokeRole(PROPOSER_ROLE, deployer.address);
+    await timelockController.revokeRole(EXECUTOR_ROLE, deployer.address);
+
+    // 11. Renounce deployer admin
+    await timelockController.renounceRole(ADMIN_ROLE, deployer.address);
 
     // 12. Alice and Bob self-delegate to activate voting power
     await armToken.connect(alice).delegate(alice.address);

--- a/test/treasury_outflow.ts
+++ b/test/treasury_outflow.ts
@@ -308,11 +308,12 @@ describe("Treasury Outflow Rate Limits", function () {
       ).to.be.revertedWith("ArmadaTreasuryGov: outflow limit exceeded");
     });
 
-    it("should skip outflow check if no config initialized for token", async function () {
+    it("should revert if no outflow config initialized for token", async function () {
       await fundTreasury(USDC(1_000_000));
-      // No initOutflowConfig called — distribute should work without limits
-      await treasury.distribute(await usdc.getAddress(), recipient.address, USDC(1_000_000));
-      expect(await usdc.balanceOf(recipient.address)).to.equal(USDC(1_000_000));
+      // No initOutflowConfig called — distribute should revert
+      await expect(
+        treasury.distribute(await usdc.getAddress(), recipient.address, USDC(1_000_000))
+      ).to.be.revertedWith("ArmadaTreasuryGov: outflow config required");
     });
   });
 


### PR DESCRIPTION
## Summary
- Tokens without an initialized outflow config previously bypassed treasury rate limits entirely via a silent early return in `_checkAndRecordOutflow()`. This undermined the outflow system's role as the primary defense against governance capture.
- Changed to `require(config.initialized)` so distributions and steward spends revert unless outflow config is initialized for the token.
- Updated all test suites (Hardhat + Foundry) to initialize outflow configs in setup and added new tests for the revert behavior and wind-down bypass.

Closes #178

## Test plan
- [x] `npm run test:all` — 736 Hardhat tests passing
- [x] `npm run test:forge` — 535 Foundry tests passing
- [x] New Foundry tests: `test_distribute_revertsWithoutOutflowConfig`, `test_transferTo_worksWithoutOutflowConfig`
- [x] Existing test flipped: `should revert if no outflow config initialized for token`
- [x] Wind-down bypass confirmed unaffected (does not call `_checkAndRecordOutflow`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)