### PR TITLE
docs(governance): document steward proposal 2-day execution delay

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -265,7 +265,11 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         });
 
         // Steward: immediate voting, 7d review window, 2d timelock, 20% quorum.
+        // Total lifecycle: 9 days (0d delay + 7d vote + 2d timelock).
         // Pass-by-default: passes unless quorum met AND majority votes AGAINST.
+        // The 2d execution delay is intentional: it provides a veto buffer after the
+        // pass-by-default voting window, giving tokenholders time to queue a
+        // VetoRatification proposal before the steward spend executes.
         // These params bypass setProposalTypeParams() bounds, making Steward timing
         // effectively immutable via governance. Only proposeStewardSpend() creates these.
         proposalTypeParams[ProposalType.Steward] = ProposalParams({

--- a/docs/governance-test-scenarios.md
+++ b/docs/governance-test-scenarios.md
@@ -7,6 +7,19 @@ Scenarios marked with issue numbers (e.g., #19) reference known bugs filed on Co
 
 ---
 
+## Proposal Type Timing Reference
+
+| Type | Voting Delay | Voting Period | Execution Delay | Total Lifecycle | Quorum | Notes |
+|------|-------------|---------------|-----------------|-----------------|--------|-------|
+| Standard | 2d | 7d | 2d | **11d** | 20% | Default for most proposals |
+| Extended | 2d | 14d | 7d | **23d** | 30% | Auto-classified for high-impact selectors |
+| VetoRatification | 0 | 7d | 0 | **7d** | 20% | Auto-created by veto mechanism only |
+| Steward | 0 | 7d | 2d | **9d** | 20% | Pass-by-default; auto-created by `proposeStewardSpend()` only. The 2d execution delay provides a veto buffer — without it, a pass-by-default proposal that attracted no votes would be executable immediately after the voting window closes. |
+
+All timing is set in the `ArmadaGovernor` constructor and is immutable for VetoRatification and Steward types (their params bypass `setProposalTypeParams()` bounds). Standard and Extended timing can be adjusted via governance within the configured bounds.
+
+---
+
 ## A. ArmadaToken — ERC20Votes Delegation/Checkpoints
 
 | # | Scenario | Expected Behavior |


### PR DESCRIPTION
## Summary

- Documents the previously unspecified 2-day execution delay on Steward proposals (total lifecycle: 9 days = 0d delay + 7d vote + 2d timelock)
- Adds a proposal type timing reference table to `docs/governance-test-scenarios.md` covering all 4 proposal types
- Expands the `ArmadaGovernor` constructor comment to explain *why* the delay exists: it provides a veto buffer for pass-by-default proposals

Closes #177

## Test plan

- [x] `npx hardhat compile` passes (comment-only change to Solidity file, no logic changes)
- No test changes needed — this is documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)