### PR TITLE
fix(governance): auto-resolve steward circuit breaker

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -176,6 +176,12 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     uint256 public constant CIRCUIT_BREAKER_THRESHOLD = 5;
     uint256 public constant CIRCUIT_BREAKER_PARTICIPATION_BPS = 3000; // 30%
 
+    /// @notice Ordered list of steward proposal IDs for auto-resolution tracking.
+    uint256[] private _stewardProposalIds;
+
+    /// @notice Cursor into _stewardProposalIds; all entries before this index are resolved.
+    uint256 private _stewardResolveIndex;
+
     // ============ Events ============
 
     event ProposalCreated(
@@ -624,6 +630,11 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
             ITreasurySteward(stewardContract).isStewardActive(),
             "ArmadaGovernor: steward not active"
         );
+
+        // Auto-resolve all prior steward proposals whose voting has ended.
+        // Must run before the pause check: resolution may trigger the circuit breaker.
+        _autoResolveStewardProposals();
+
         require(!stewardChannelPaused, "ArmadaGovernor: steward channel paused");
         require(tokens.length > 0, "ArmadaGovernor: empty proposal");
         require(
@@ -669,6 +680,9 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         // No bond required for steward proposals — the steward is an elected role
         // operating within budget limits. Bonds are for standard/extended proposals only.
 
+        // Track for auto-resolution on next proposeStewardSpend() call
+        _stewardProposalIds.push(proposalId);
+
         emit ProposalCreated(
             proposalId, msg.sender, ProposalType.Steward,
             p.voteStart, p.voteEnd, description
@@ -687,6 +701,15 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         require(p.proposalType == ProposalType.Steward, "ArmadaGovernor: not steward proposal");
         require(block.timestamp > p.voteEnd, "ArmadaGovernor: voting not ended");
         require(!stewardProposalResolved[proposalId], "ArmadaGovernor: already resolved");
+        _resolveStewardProposal(proposalId);
+    }
+
+    /// @dev Core resolution logic for a steward proposal. Idempotent — skips already-resolved
+    /// proposals. Returns false if voting hasn't ended yet (caller should stop iterating).
+    function _resolveStewardProposal(uint256 proposalId) internal returns (bool) {
+        Proposal storage p = _proposals[proposalId];
+        if (stewardProposalResolved[proposalId]) return true;
+        if (block.timestamp <= p.voteEnd) return false;
 
         stewardProposalResolved[proposalId] = true;
 
@@ -705,6 +728,21 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         } else {
             consecutiveLowParticipationCount = 0;
         }
+        return true;
+    }
+
+    /// @dev Auto-resolve all prior steward proposals whose voting period has ended.
+    /// Walks from the cursor forward. Because steward proposals are created sequentially
+    /// with the same voting period, voteEnd times are monotonically increasing — we can
+    /// stop as soon as one hasn't ended yet.
+    function _autoResolveStewardProposals() internal {
+        uint256 len = _stewardProposalIds.length;
+        uint256 i = _stewardResolveIndex;
+        while (i < len) {
+            if (!_resolveStewardProposal(_stewardProposalIds[i])) break;
+            i++;
+        }
+        _stewardResolveIndex = i;
     }
 
     /// @notice Resume the steward channel after a circuit breaker pause.
@@ -1241,6 +1279,6 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
 
     // ============ Storage Gap ============
 
-    /// @dev Reserved storage for future upgrades. 23 state slots + 27 gap = 50 total.
-    uint256[27] private __gap;
+    /// @dev Reserved storage for future upgrades. 25 state slots + 25 gap = 50 total.
+    uint256[25] private __gap;
 }

--- a/test-foundry/GovernorCircuitBreaker.t.sol
+++ b/test-foundry/GovernorCircuitBreaker.t.sol
@@ -373,6 +373,120 @@ contract GovernorCircuitBreakerTest is Test, GovernorDeployHelper {
     // Fuzz: participation boundary
     // ══════════════════════════════════════════════════════════════════════
 
+    // ══════════════════════════════════════════════════════════════════════
+    // Auto-resolve: proposeStewardSpend resolves prior proposals automatically
+    // ══════════════════════════════════════════════════════════════════════
+
+    function test_autoResolve_resolvesPriorProposals() public {
+        // Create a proposal, warp past voting, then create another.
+        // The first should be auto-resolved by the second call.
+        uint256 firstId = _createStewardProposal();
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        assertFalse(governor.stewardProposalResolved(firstId), "should not be resolved yet");
+
+        // Creating a new proposal auto-resolves the first
+        _createStewardProposal();
+
+        assertTrue(governor.stewardProposalResolved(firstId), "should be auto-resolved");
+        assertEq(governor.consecutiveLowParticipationCount(), 1, "low participation counted");
+    }
+
+    function test_autoResolve_triggersCircuitBreaker() public {
+        // Create 5 low-participation proposals without warping between them
+        // (so none get auto-resolved during creation). Then warp past all voting,
+        // and the 6th attempt should auto-resolve all 5 and revert.
+        uint256[] memory ids = new uint256[](5);
+        for (uint256 i = 0; i < 5; i++) {
+            ids[i] = _createStewardProposal();
+        }
+
+        // Warp past all voting periods at once
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        // None resolved yet
+        for (uint256 i = 0; i < 5; i++) {
+            assertFalse(governor.stewardProposalResolved(ids[i]));
+        }
+        assertFalse(governor.stewardChannelPaused());
+
+        // 6th proposal attempt should auto-resolve all 5 and then revert
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(usdc);
+        address[] memory recipients = new address[](1);
+        recipients[0] = alice;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 100 * 1e6;
+
+        vm.prank(stewardPerson);
+        vm.expectRevert("ArmadaGovernor: steward channel paused");
+        governor.proposeStewardSpend(tokens, recipients, amounts, "should fail");
+    }
+
+    function test_autoResolve_stopsAtActiveVoting() public {
+        // Create proposal #1, warp past voting. Create #2 (still in voting).
+        // Creating #3 should only auto-resolve #1, not #2.
+        uint256 firstId = _createStewardProposal();
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        uint256 secondId = _createStewardProposal();
+        // Only a small warp — second proposal's voting is still active
+        vm.warp(block.timestamp + 1 days);
+
+        uint256 thirdId = _createStewardProposal();
+
+        assertTrue(governor.stewardProposalResolved(firstId), "first should be resolved");
+        assertFalse(governor.stewardProposalResolved(secondId), "second still in voting");
+        assertFalse(governor.stewardProposalResolved(thirdId), "third just created");
+        // Only first was low-participation
+        assertEq(governor.consecutiveLowParticipationCount(), 1);
+    }
+
+    function test_autoResolve_skipsAlreadyResolved() public {
+        // Create proposal, warp, manually resolve it, then create another.
+        // Auto-resolve should skip the already-resolved one without error.
+        uint256 firstId = _createStewardProposal();
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        // Manually resolve
+        governor.resolveStewardProposal(firstId);
+        assertEq(governor.consecutiveLowParticipationCount(), 1);
+
+        // Creating a new proposal should succeed without double-resolution issues
+        uint256 secondId = _createStewardProposal();
+        assertTrue(secondId > firstId);
+        // Counter should still be 1 (not incremented again)
+        assertEq(governor.consecutiveLowParticipationCount(), 1);
+    }
+
+    function test_autoResolve_highParticipationResetsCounter() public {
+        // Create 3 low-participation proposals and 1 high-participation proposal
+        // without warping between them (so none auto-resolve during creation).
+        // Then warp and create a 5th — auto-resolve should process all 4,
+        // with the high-participation one resetting the counter.
+        for (uint256 i = 0; i < 3; i++) {
+            _createStewardProposal();
+        }
+
+        // 4th proposal: alice votes (40% of eligible > 30% threshold)
+        uint256 highPartId = _createStewardProposal();
+        vm.prank(alice);
+        governor.castVote(highPartId, 1); // FOR
+
+        // Warp past all voting periods at once
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        // None resolved yet
+        assertEq(governor.consecutiveLowParticipationCount(), 0);
+
+        // 5th proposal auto-resolves all 4 prior proposals
+        _createStewardProposal();
+
+        // 3 low → counter=3, then 1 high → counter=0
+        assertEq(governor.consecutiveLowParticipationCount(), 0);
+        assertFalse(governor.stewardChannelPaused());
+    }
+
     function testFuzz_participationThreshold(uint256 aliceVote, uint256 bobVote) public {
         // 0 = no vote, 1 = FOR, 2 = AGAINST, 3 = ABSTAIN
         aliceVote = bound(aliceVote, 0, 3);


### PR DESCRIPTION
## Summary

- Makes the steward circuit breaker self-enforcing by auto-resolving all prior steward proposals inside `proposeStewardSpend()` before checking the pause flag
- Extracts shared `_resolveStewardProposal()` internal helper used by both auto-resolve and the existing external `resolveStewardProposal()`
- Uses a cursor-based iteration (`_stewardResolveIndex`) so already-resolved proposals are never re-visited

Closes #176

## Test plan

- [x] All 538 existing Foundry tests pass (`forge test`)
- [x] Hardhat compilation succeeds
- [ ] Halmos symbolic verification passes (`npm run halmos`)
- [x] 5 new auto-resolve test cases added:
  - Auto-resolves prior proposals on new submission
  - Triggers circuit breaker when 5 unresolved low-participation proposals are batch-resolved
  - Stops at proposals still in voting period
  - Skips already-resolved proposals (no double-resolution)
  - High participation in batch correctly resets counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)