### PR TITLE
fix(governance): make quiet period immutable

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -1204,9 +1204,9 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
 
     /// @dev Block proposals during the quiet period after crowdfund finalization.
     ///      Reads finalizedAt from the crowdfund contract. Skips gracefully if no
-    ///      crowdfund is registered, quiet period is zero, or crowdfund isn't finalized.
+    ///      crowdfund is registered or crowdfund isn't finalized.
     function _checkQuietPeriod() internal view {
-        if (crowdfundAddress == address(0) || QUIET_PERIOD_DURATION == 0) return;
+        if (crowdfundAddress == address(0)) return;
 
         uint256 _finalizedAt = IArmadaCrowdfundReadable(crowdfundAddress).finalizedAt();
         if (_finalizedAt == 0) return;

--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -101,11 +101,10 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     uint256 public constant QUORUM_FLOOR = 100_000 * 1e18;
 
     // Governance quiet period — no proposals allowed for this duration after crowdfund finalization.
-    // One-time bootstrapping measure; governable (can be shortened or removed).
+    // One-time bootstrapping constant; not governable.
     address public crowdfundAddress;
     bool public crowdfundAddressLocked;
-    uint256 public quietPeriodDuration;
-    uint256 public constant MAX_QUIET_PERIOD = 30 days;
+    uint256 public constant QUIET_PERIOD_DURATION = 7 days;
 
     // Wind-down integration: when triggered, governance permanently stops accepting new proposals.
     // The wind-down contract is registered via one-time setter; only it can flip the flag.
@@ -193,7 +192,7 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     event ProposalCanceled(uint256 indexed proposalId);
     event ProposalTypeParamsUpdated(ProposalType indexed proposalType, ProposalParams params);
     event CrowdfundAddressSet(address indexed crowdfund);
-    event QuietPeriodUpdated(uint256 newDuration);
+
     event WindDownContractSet(address indexed windDownContract);
     event WindDownActivated();
     event ExtendedSelectorAdded(bytes4 indexed selector);
@@ -279,9 +278,6 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
             quorumBps: 2000
         });
 
-        // Governance quiet period: 7 days post-crowdfund-finalization before proposals allowed
-        quietPeriodDuration = 7 days;
-
         // Register function selectors that force Extended classification.
         // Any proposal containing a call to one of these selectors is automatically Extended
         // regardless of what the proposer declared.
@@ -302,8 +298,6 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         extendedSelectors[bytes4(keccak256("setYieldFeeBps(uint256)"))] = true;
 
         // Governance parameter changes (on governor, via timelock)
-        extendedSelectors[bytes4(keccak256("setQuietPeriodDuration(uint256)"))] = true;
-
         // Security Council management
         extendedSelectors[this.setSecurityCouncil.selector] = true;
 
@@ -420,17 +414,6 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
 
         proposalTypeParams[proposalType] = params;
         emit ProposalTypeParamsUpdated(proposalType, params);
-    }
-
-    /// @notice Update the governance quiet period duration.
-    /// @dev Only callable by the timelock (requires a governance vote).
-    ///      Setting to 0 removes the quiet period entirely.
-    function setQuietPeriodDuration(uint256 _duration) external {
-        require(msg.sender == address(timelock), "ArmadaGovernor: not timelock");
-        require(_duration <= MAX_QUIET_PERIOD, "ArmadaGovernor: exceeds max");
-
-        quietPeriodDuration = _duration;
-        emit QuietPeriodUpdated(_duration);
     }
 
     // ============ Extended Selector Management ============
@@ -1223,13 +1206,13 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     ///      Reads finalizedAt from the crowdfund contract. Skips gracefully if no
     ///      crowdfund is registered, quiet period is zero, or crowdfund isn't finalized.
     function _checkQuietPeriod() internal view {
-        if (crowdfundAddress == address(0) || quietPeriodDuration == 0) return;
+        if (crowdfundAddress == address(0) || QUIET_PERIOD_DURATION == 0) return;
 
         uint256 _finalizedAt = IArmadaCrowdfundReadable(crowdfundAddress).finalizedAt();
         if (_finalizedAt == 0) return;
 
         require(
-            block.timestamp >= _finalizedAt + quietPeriodDuration,
+            block.timestamp >= _finalizedAt + QUIET_PERIOD_DURATION,
             "ArmadaGovernor: quiet period active"
         );
     }

--- a/test/governance_quiet_period.ts
+++ b/test/governance_quiet_period.ts
@@ -1,12 +1,11 @@
-// ABOUTME: Tests the 7-day governance quiet period after crowdfund finalization.
-// ABOUTME: Covers proposal blocking, boundary conditions, governable duration, and access control.
+// ABOUTME: Tests the immutable 7-day governance quiet period after crowdfund finalization.
+// ABOUTME: Covers proposal blocking, boundary conditions, edge cases, and access control.
 
 /**
  * Governance Quiet Period Tests (T6.1)
  *
- * After crowdfund finalization, a 7-day quiet period blocks all governance proposals.
+ * After crowdfund finalization, an immutable 7-day quiet period blocks all governance proposals.
  * This gives participants time to claim ARM and delegate before governance begins.
- * The quiet period is governable — governance can shorten, extend, or remove it.
  */
 
 import { expect } from "chai";
@@ -123,16 +122,6 @@ describe("Governance Quiet Period (T6.1)", function () {
     );
   }
 
-  // Helper: call setQuietPeriodDuration through the timelock (the only authorized caller)
-  async function setQuietPeriodViaTImelock(duration: number) {
-    const calldata = governor.interface.encodeFunctionData("setQuietPeriodDuration", [duration]);
-    const governorAddr = await governor.getAddress();
-    const salt = ethers.id(`set-quiet-period-${duration}`);
-    await timelockController.schedule(governorAddr, 0, calldata, ethers.ZeroHash, salt, ONE_DAY);
-    await time.increase(ONE_DAY + 1);
-    await timelockController.execute(governorAddr, 0, calldata, ethers.ZeroHash, salt);
-  }
-
   // Helper: run crowdfund to finalization (normal path — above MIN_SALE)
   async function finalizeCrowdfund() {
     { const ws = Number(await crowdfund.windowStart()); if ((await time.latest()) < ws) await time.increaseTo(ws); }
@@ -219,67 +208,9 @@ describe("Governance Quiet Period (T6.1)", function () {
     });
   });
 
-  // ============ Governable quiet period duration ============
-
-  describe("Governable quiet period duration", function () {
-    it("governance can set quietPeriodDuration to 0 to remove it", async function () {
-      await governor.setCrowdfundAddress(await crowdfund.getAddress());
-      await finalizeCrowdfund();
-      await lockArmForProposal();
-
-      // Quiet period active — proposal should revert
-      await expect(propose("before removal")).to.be.revertedWith("ArmadaGovernor: quiet period active");
-
-      // Governance (timelock) sets quiet period to 0
-      await setQuietPeriodViaTImelock(0);
-
-      // Now proposal succeeds during what would have been the quiet period
-      await expect(propose("after removal")).to.not.be.reverted;
-    });
-
-    it("governance can extend quiet period — propose at day 8 reverts if extended to 14 days", async function () {
-      await governor.setCrowdfundAddress(await crowdfund.getAddress());
-
-      // Extend quiet period to 14 days via timelock BEFORE finalization
-      // (so we don't have to time-travel through the quiet period to execute the timelock op)
-      await setQuietPeriodViaTImelock(14 * ONE_DAY);
-
-      await finalizeCrowdfund();
-      await lockArmForProposal();
-
-      // Day 8 — would succeed with 7-day period, but now reverts with 14-day
-      await time.increase(8 * ONE_DAY);
-      await expect(propose()).to.be.revertedWith("ArmadaGovernor: quiet period active");
-
-      // Day 15 (from finalization) — succeeds after extended period
-      await time.increase(7 * ONE_DAY);
-      await expect(propose()).to.not.be.reverted;
-    });
-  });
-
   // ============ Access control ============
 
   describe("Access control", function () {
-    it("setQuietPeriodDuration by non-timelock reverts", async function () {
-      await expect(
-        governor.connect(nonDeployer).setQuietPeriodDuration(0)
-      ).to.be.revertedWith("ArmadaGovernor: not timelock");
-    });
-
-    it("setQuietPeriodDuration above MAX_QUIET_PERIOD reverts", async function () {
-      const MAX_QUIET_PERIOD = 30 * ONE_DAY;
-      const calldata = governor.interface.encodeFunctionData(
-        "setQuietPeriodDuration", [MAX_QUIET_PERIOD + 1]
-      );
-      const governorAddr = await governor.getAddress();
-      const salt = ethers.id("exceeds-max-quiet");
-      await timelockController.schedule(governorAddr, 0, calldata, ethers.ZeroHash, salt, ONE_DAY);
-      await time.increase(ONE_DAY + 1);
-      await expect(
-        timelockController.execute(governorAddr, 0, calldata, ethers.ZeroHash, salt)
-      ).to.be.revertedWith("TimelockController: underlying transaction reverted");
-    });
-
     it("setCrowdfundAddress is one-time only (second call reverts)", async function () {
       await governor.setCrowdfundAddress(await crowdfund.getAddress());
 


### PR DESCRIPTION
## Summary

- Remove `setQuietPeriodDuration()` — the 7-day quiet period is now a compile-time `constant` (`QUIET_PERIOD_DURATION`), not a governable parameter
- Remove associated `MAX_QUIET_PERIOD`, `QuietPeriodUpdated` event, and extended selector registration
- Remove tests for governability and setter access control; keep all behavioral tests (blocking, boundary, edge cases, refund mode)

Closes #175

## Test plan

- [x] `npx hardhat compile` — compiles cleanly
- [x] `npx hardhat test test/governance_quiet_period.ts` — 9 tests pass
- [x] `npm run test:governance` — 117 tests pass
- [x] `npm run test:forge` — 533 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)