### PR TITLE
fix(governance): immediate bond unlock for expired-succeeded proposals

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -1050,12 +1050,17 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
                 unlockTime = 0;
             }
         } else if (currentState == ProposalState.Defeated) {
-            // Determine defeat reason: quorum not met vs majority against
+            // Determine defeat reason to set appropriate bond lock period
             bool quorumMet = _quorumReached(proposalId);
-            if (!quorumMet) {
+            bool votePassed = _voteSucceeded(proposalId);
+            if (quorumMet && votePassed) {
+                // Vote passed but proposal expired (grace period elapsed without queuing).
+                // Proposer did nothing wrong — treat like a passed proposal.
+                unlockTime = 0;
+            } else if (!quorumMet) {
                 unlockTime = p.voteEnd + BOND_LOCK_QUORUM_FAIL;
             } else {
-                // Quorum met but majority against (or expired grace period)
+                // Quorum met but majority voted against
                 unlockTime = p.voteEnd + BOND_LOCK_VOTE_FAIL;
             }
         } else {

--- a/test-foundry/GovernorClassificationBondWindDown.t.sol
+++ b/test-foundry/GovernorClassificationBondWindDown.t.sol
@@ -647,4 +647,36 @@ contract GovernorClassificationBondWindDownTest is Test, GovernorDeployHelper {
         vm.expectRevert("ArmadaGovernor: no bond");
         governor.claimBond(proposalId);
     }
+
+    function test_bond_immediateClaimOnGracePeriodExpiry() public {
+        _enableTransfersAndApproveBond(alice);
+
+        uint256 proposalId = _proposeStandard(alice);
+
+        // Fast-forward past voting delay
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+
+        // Vote FOR with enough to reach quorum
+        vm.prank(alice);
+        governor.castVote(proposalId, 1); // FOR
+        vm.prank(bob);
+        governor.castVote(proposalId, 1); // FOR
+
+        // Fast-forward past voting period
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        // Proposal succeeded — do NOT queue it
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Succeeded));
+
+        // Fast-forward past 14-day queue grace period
+        vm.warp(block.timestamp + FOURTEEN_DAYS + 1);
+
+        // Now Defeated due to grace period expiry
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Defeated));
+
+        // Bond should be immediately claimable — proposer did nothing wrong
+        uint256 aliceBalBefore = armToken.balanceOf(alice);
+        governor.claimBond(proposalId);
+        assertEq(armToken.balanceOf(alice) - aliceBalBefore, BOND_AMOUNT);
+    }
 }

--- a/test/governance_adversarial.ts
+++ b/test/governance_adversarial.ts
@@ -738,6 +738,37 @@ describe("Governance Adversarial", function () {
       ).to.be.revertedWith("ArmadaGovernor: not succeeded");
     });
 
+    it("expired-succeeded proposal bond is immediately claimable", async function () {
+      // Enable transfers and approve bond
+      await armToken.setWindDownContract(dave.address);
+      await armToken.connect(dave).setTransferable(true);
+      const bondAmount = ethers.parseUnits("1000", ARM_DECIMALS);
+      await armToken.connect(alice).approve(await governor.getAddress(), bondAmount);
+
+      const balanceBefore = await armToken.balanceOf(alice.address);
+      const proposalId = await createProposal(alice);
+
+      // Bond was taken
+      expect(await armToken.balanceOf(alice.address)).to.equal(balanceBefore - bondAmount);
+
+      // Vote it through
+      await time.increase(TWO_DAYS + 1);
+      await governor.connect(alice).castVote(proposalId, Vote.For);
+      await governor.connect(bob).castVote(proposalId, Vote.For);
+
+      // Wait for voting to end — Succeeded
+      await time.increase(STANDARD_VOTING_PERIOD + 1);
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Succeeded);
+
+      // Wait past the 14-day grace period without queuing — now Defeated
+      await time.increase(FOURTEEN_DAYS + 1);
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Defeated);
+
+      // Bond should be immediately claimable — proposer did nothing wrong
+      await governor.claimBond(proposalId);
+      expect(await armToken.balanceOf(alice.address)).to.equal(balanceBefore);
+    });
+
     it("queued proposal is unaffected by grace period expiry", async function () {
       const proposalId = await createProposal(alice);
 


### PR DESCRIPTION
## Summary

- Fixes #174: proposers were penalized with a 45-day bond lock when their proposal passed voting but nobody called `queue()` within the 14-day grace period
- In `claimBond()`, detects the expired-succeeded case (quorum met AND vote passed while state is Defeated) and returns the bond immediately — matching spec intent that passed proposals get immediate unlock
- No ABI or enum changes; minimal code diff in the `Defeated` branch of `claimBond()`

## Test plan

- [x] Foundry: `test_bond_immediateClaimOnGracePeriodExpiry` — passes vote, skips queue for 14 days, confirms immediate bond claim
- [x] Hardhat: `expired-succeeded proposal bond is immediately claimable` — same scenario with full balance assertions
- [x] All 534 Foundry tests pass (`npm run test:forge`)
- [x] All 118 Hardhat governance tests pass (`npm run test:governance`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)