### PR TITLE
fix(governance): use rolling window for steward budget

### DIFF
--- a/contracts/governance/ArmadaTreasuryGov.sol
+++ b/contracts/governance/ArmadaTreasuryGov.sol
@@ -47,8 +47,7 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
     }
 
     mapping(address => StewardBudget) public stewardBudgets;
-    mapping(address => uint256) public stewardBudgetSpent;
-    mapping(address => uint256) public stewardBudgetWindowStart;
+    mapping(address => OutflowRecord[]) internal _stewardSpendHistory;
 
     // Aggregate outflow rate limits (per token)
     //
@@ -117,22 +116,23 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
         StewardBudget storage budget = stewardBudgets[token];
         require(budget.authorized, "ArmadaTreasuryGov: token not authorized for steward");
 
-        // Reset window if expired
-        if (block.timestamp >= stewardBudgetWindowStart[token] + budget.window) {
-            stewardBudgetSpent[token] = 0;
-            stewardBudgetWindowStart[token] = block.timestamp;
-        }
-
+        // Rolling window: sum all steward spends within the trailing window
+        uint256 recentSpend = _sumRecentStewardSpends(token, budget.window);
         require(
-            stewardBudgetSpent[token] + amount <= budget.limit,
+            recentSpend + amount <= budget.limit,
             "ArmadaTreasuryGov: exceeds steward budget"
         );
 
-        stewardBudgetSpent[token] += amount;
+        // Record this spend for rolling window tracking
+        _stewardSpendHistory[token].push(OutflowRecord({
+            amount: amount,
+            timestamp: block.timestamp
+        }));
+
         _checkAndRecordOutflow(token, amount);
         IERC20(token).safeTransfer(recipient, amount);
 
-        uint256 remaining = budget.limit - stewardBudgetSpent[token];
+        uint256 remaining = budget.limit - (recentSpend + amount);
         emit StewardSpent(token, recipient, amount, remaining);
     }
 
@@ -177,8 +177,7 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
         require(stewardBudgets[token].authorized, "ArmadaTreasuryGov: token not authorized");
 
         delete stewardBudgets[token];
-        stewardBudgetSpent[token] = 0;
-        stewardBudgetWindowStart[token] = 0;
+        delete _stewardSpendHistory[token];
 
         emit StewardBudgetTokenRemoved(token);
     }
@@ -287,6 +286,22 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
         }
     }
 
+    /// @dev Sum steward spend amounts within the rolling window, iterating backwards from most recent.
+    function _sumRecentStewardSpends(address token, uint256 windowDuration) internal view returns (uint256 total) {
+        OutflowRecord[] storage records = _stewardSpendHistory[token];
+        uint256 len = records.length;
+        if (len == 0) return 0;
+
+        uint256 cutoff = block.timestamp > windowDuration ? block.timestamp - windowDuration : 0;
+
+        // Iterate backwards — most recent records are at the end
+        for (uint256 i = len; i > 0; i--) {
+            OutflowRecord storage r = records[i - 1];
+            if (r.timestamp < cutoff) break; // older entries are further back, stop early
+            total += r.amount;
+        }
+    }
+
     // ============ Wind-Down Sweep Authority ============
 
     /// @notice Set the wind-down contract address. One-time setter, timelock-only.
@@ -332,12 +347,7 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
         if (!b.authorized) return (0, 0, 0);
 
         budget = b.limit;
-        if (block.timestamp >= stewardBudgetWindowStart[token] + b.window) {
-            // Window expired — full budget available
-            spent = 0;
-        } else {
-            spent = stewardBudgetSpent[token];
-        }
+        spent = _sumRecentStewardSpends(token, b.window);
         remaining = budget > spent ? budget - spent : 0;
     }
 

--- a/test-foundry/GovernorSteward.t.sol
+++ b/test-foundry/GovernorSteward.t.sol
@@ -615,7 +615,8 @@ contract GovernorStewardTest is Test, GovernorDeployHelper {
         treasury.stewardSpend(address(usdc), alice, spendAmount);
 
         assertEq(usdc.balanceOf(alice), spendAmount);
-        assertEq(treasury.stewardBudgetSpent(address(usdc)), spendAmount);
+        (, uint256 spent,) = treasury.getStewardBudget(address(usdc));
+        assertEq(spent, spendAmount);
     }
 
     function test_stewardSpend_exceedsBudget() public {
@@ -633,7 +634,7 @@ contract GovernorStewardTest is Test, GovernorDeployHelper {
         treasury.stewardSpend(address(usdc), alice, 100);
     }
 
-    function test_stewardSpend_budgetWindowResets() public {
+    function test_stewardSpend_budgetRollingWindow() public {
         vm.prank(address(timelock));
         treasury.addStewardBudgetToken(address(usdc), BUDGET_LIMIT, BUDGET_WINDOW);
 
@@ -646,14 +647,40 @@ contract GovernorStewardTest is Test, GovernorDeployHelper {
         vm.expectRevert("ArmadaTreasuryGov: exceeds steward budget");
         treasury.stewardSpend(address(usdc), alice, 1);
 
-        // Warp past window
+        // Warp past window — original spend falls out of trailing window
         vm.warp(block.timestamp + BUDGET_WINDOW + 1);
 
-        // Can spend again after window reset
+        // Can spend again after original spend exits the rolling window
         vm.prank(address(timelock));
         treasury.stewardSpend(address(usdc), alice, BUDGET_LIMIT);
 
         assertEq(usdc.balanceOf(alice), BUDGET_LIMIT * 2);
+    }
+
+    function test_stewardSpend_rollingWindowPreventsBoundaryGaming() public {
+        vm.prank(address(timelock));
+        treasury.addStewardBudgetToken(address(usdc), BUDGET_LIMIT, BUDGET_WINDOW);
+
+        // Spend full budget at T=0
+        vm.prank(address(timelock));
+        treasury.stewardSpend(address(usdc), alice, BUDGET_LIMIT);
+
+        // Advance to just before the spend would fall out of the rolling window.
+        // With a fixed window this would reset and allow another full spend.
+        // With a rolling window the original spend is still within the trailing 30 days.
+        vm.warp(block.timestamp + BUDGET_WINDOW - 1);
+
+        // Rolling window: original spend is still within the trailing window, so this must revert
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaTreasuryGov: exceeds steward budget");
+        treasury.stewardSpend(address(usdc), alice, 1);
+
+        // Advance 2 more seconds — now the original spend is outside the trailing window
+        vm.warp(block.timestamp + 2);
+
+        // Now the budget is available again
+        vm.prank(address(timelock));
+        treasury.stewardSpend(address(usdc), alice, BUDGET_LIMIT);
     }
 
     function test_stewardSpend_multipleSpendsSameWindow() public {
@@ -672,7 +699,8 @@ contract GovernorStewardTest is Test, GovernorDeployHelper {
         vm.prank(address(timelock));
         treasury.stewardSpend(address(usdc), alice, spend3);
 
-        assertEq(treasury.stewardBudgetSpent(address(usdc)), spend1 + spend2 + spend3);
+        (, uint256 spent,) = treasury.getStewardBudget(address(usdc));
+        assertEq(spent, spend1 + spend2 + spend3);
     }
 
     // ══════════════════════════════════════════════════════════════════════
@@ -778,12 +806,10 @@ contract GovernorStewardTest is Test, GovernorDeployHelper {
             treasury.stewardSpend(address(usdc), alice, spend2);
 
             // Verify: spent + remaining = limit
-            uint256 spent = treasury.stewardBudgetSpent(address(usdc));
-            assertEq(spent, spend1 + spend2);
-            (uint256 budget, uint256 viewSpent, uint256 remaining) = treasury.getStewardBudget(address(usdc));
+            (uint256 budget, uint256 spent, uint256 remaining) = treasury.getStewardBudget(address(usdc));
             assertEq(budget, limit);
-            assertEq(viewSpent, spent);
-            assertEq(remaining, limit - spent);
+            assertEq(spent, spend1 + spend2);
+            assertEq(remaining, limit - (spend1 + spend2));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace fixed/tumbling window in steward budget with a true rolling window, matching the spec's requirement for trailing-window enforcement (fixes #173)
- Reuses the existing `OutflowRecord[]` pattern already used for aggregate outflow limits in the same contract
- Adds `test_stewardSpend_rollingWindowPreventsBoundaryGaming` to verify the exact attack scenario from the issue is blocked

## Test plan
- [x] `npm run test:forge` — 543 Foundry tests pass (including new rolling window + boundary gaming tests)
- [x] `npm run test:governance` — 118 Hardhat governance tests pass
- [ ] `npm run halmos` — symbolic verification
- [ ] `npm run test:all` — full Hardhat suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)