### PR TITLE
Crowdfund UI fixes, deploy corrections, and ARM token spec compliance

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -688,6 +688,26 @@ contract ArmadaCrowdfund is ReentrancyGuard, EIP712 {
         return (totalCommitted, phase, windowStart, windowEnd);
     }
 
+    /// @notice Compute capped demand on the fly without modifying state.
+    ///         Pre-finalization this gives a live estimate; post-finalization it
+    ///         matches the stored cappedDemand value.
+    function getEstimatedCappedDemand() external view returns (
+        uint256 globalCapped,
+        uint256[3] memory perHopCapped
+    ) {
+        uint256 len = participantNodes.length;
+        for (uint256 i = 0; i < len; i++) {
+            ParticipantNode storage node = participantNodes[i];
+            Participant storage p = participants[node.addr][node.hop];
+            if (p.committed == 0) continue;
+
+            uint256 effectiveCap = uint256(p.invitesReceived) * hopConfigs[node.hop].capUsdc;
+            uint256 capped = p.committed < effectiveCap ? p.committed : effectiveCap;
+            perHopCapped[node.hop] += capped;
+            globalCapped += capped;
+        }
+    }
+
     /// @notice Check if an address is whitelisted at a specific hop
     function isWhitelisted(address addr, uint8 hop) external view returns (bool) {
         return participants[addr][hop].isWhitelisted;

--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -115,6 +115,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, EIP712 {
 
     event SeedAdded(address indexed seed);
     event Invited(address indexed inviter, address indexed invitee, uint8 hop, uint256 nonce);
+    event LaunchTeamInvited(address indexed invitee, uint8 hop);
     event Committed(address indexed participant, uint8 hop, uint256 amount);
     event Finalized(uint256 saleSize, uint256 allocatedArm, uint256 netProceeds, bool refundMode);
     event Cancelled();
@@ -295,7 +296,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, EIP712 {
             inviteeNode.invitesReceived++;
         }
 
-        emit Invited(msg.sender, invitee, inviteeHop, 0);
+        emit LaunchTeamInvited(invitee, inviteeHop);
     }
 
     // ============ Commitment Phase ============

--- a/contracts/governance/ArmadaToken.sol
+++ b/contracts/governance/ArmadaToken.sol
@@ -125,10 +125,14 @@ contract ArmadaToken is ERC20Votes {
         emit WhitelistAdded(account);
     }
 
-    /// @notice Enable unrestricted transfers. Only callable by the wind-down contract.
+    /// @notice Enable unrestricted transfers. Callable by the wind-down contract
+    ///         or the governor executor (timelock) via governance proposal.
     ///         One-way: transfers cannot be re-restricted once enabled.
     function setTransferable(bool _transferable) external {
-        require(msg.sender == windDownContract, "ArmadaToken: not wind-down contract");
+        require(
+            msg.sender == windDownContract || msg.sender == timelock,
+            "ArmadaToken: not authorized"
+        );
         require(_transferable, "ArmadaToken: can only enable transfers");
         require(!transferable, "ArmadaToken: transfers already enabled");
         transferable = true;

--- a/crowdfund-ui/packages/admin/src/components/EventLog.tsx
+++ b/crowdfund-ui/packages/admin/src/components/EventLog.tsx
@@ -20,6 +20,7 @@ const EVENT_COLORS: Record<CrowdfundEventType, string> = {
   ArmLoaded: 'bg-success/20 text-success',
   SeedAdded: 'bg-info/20 text-info',
   Invited: 'bg-info/20 text-info',
+  LaunchTeamInvited: 'bg-info/20 text-info',
   Committed: 'bg-primary/20 text-primary',
   Finalized: 'bg-success/20 text-success',
   Cancelled: 'bg-destructive/20 text-destructive',
@@ -31,7 +32,7 @@ const EVENT_COLORS: Record<CrowdfundEventType, string> = {
 }
 
 const ALL_EVENT_TYPES: CrowdfundEventType[] = [
-  'ArmLoaded', 'SeedAdded', 'Invited', 'Committed', 'Finalized',
+  'ArmLoaded', 'SeedAdded', 'Invited', 'LaunchTeamInvited', 'Committed', 'Finalized',
   'Cancelled', 'Allocated', 'AllocatedHop', 'RefundClaimed',
   'InviteNonceRevoked', 'UnallocatedArmWithdrawn',
 ]
@@ -43,6 +44,8 @@ function formatEventData(event: CrowdfundEvent): string {
       return truncateAddress(args.seed as string)
     case 'Invited':
       return `${truncateAddress(args.inviter as string)} -> ${truncateAddress(args.invitee as string)} hop-${args.hop}`
+    case 'LaunchTeamInvited':
+      return `LT -> ${truncateAddress(args.invitee as string)} hop-${args.hop}`
     case 'Committed':
       return `${truncateAddress(args.participant as string)} ${formatUsdc(args.amount as bigint)} hop-${args.hop}`
     case 'Finalized':

--- a/crowdfund-ui/packages/admin/src/components/FinalizePanel.tsx
+++ b/crowdfund-ui/packages/admin/src/components/FinalizePanel.tsx
@@ -74,21 +74,26 @@ export function FinalizePanel({ signer, crowdfundAddress, totalCommitted, saleSi
         </div>
       )}
 
-      {/* Below-min warning */}
+      {/* Below-min: no finalization needed, participants claim refunds directly */}
       {belowMin && (
-        <div className="rounded bg-destructive/10 border border-destructive/30 p-2 text-xs text-destructive">
-          Below minimum sale ({formatUsdc(MIN_SALE)}). Finalization will trigger <strong>refund mode</strong> — all commitments become fully refundable, no ARM is distributed.
+        <div className="rounded bg-destructive/10 border border-destructive/30 p-2 text-xs text-destructive space-y-1">
+          <div>Capped demand is below the minimum raise ({formatUsdc(MIN_SALE)}). The crowdfund cannot be finalized.</div>
+          <div>No admin action is required. Participants can claim full USDC refunds directly via <strong>claimRefund()</strong> in the committer app.</div>
         </div>
       )}
 
-      <button
-        className="w-full rounded bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-        disabled={tx.state.status === 'pending' || tx.state.status === 'submitted'}
-        onClick={handleFinalize}
-      >
-        Finalize
-      </button>
-      <TransactionFlow state={tx.state} onReset={tx.reset} successMessage="Crowdfund finalized!" />
+      {!belowMin && (
+        <>
+          <button
+            className="w-full rounded bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            disabled={tx.state.status === 'pending' || tx.state.status === 'submitted'}
+            onClick={handleFinalize}
+          >
+            Finalize
+          </button>
+          <TransactionFlow state={tx.state} onReset={tx.reset} successMessage="Crowdfund finalized!" />
+        </>
+      )}
     </div>
   )
 }

--- a/crowdfund-ui/packages/admin/src/components/ParticipantTable.tsx
+++ b/crowdfund-ui/packages/admin/src/components/ParticipantTable.tsx
@@ -55,6 +55,14 @@ export function ParticipantTable({ participants, phase, launchTeamAddress }: Par
   const [search, setSearch] = useState('')
   const [viewMode, setViewMode] = useState<'per-hop' | 'per-address'>('per-hop')
 
+  // Reset sorting to the correct column ID when switching view modes,
+  // since per-hop uses 'committed' and per-address uses 'totalCommitted'.
+  const setViewModeWithSort = (mode: 'per-hop' | 'per-address') => {
+    setViewMode(mode)
+    const commitCol = mode === 'per-hop' ? 'committed' : 'totalCommitted'
+    setSorting([{ id: commitCol, desc: true }])
+  }
+
   // Per-hop columns (default view)
   const perHopColumns: ColumnDef<ParticipantRow, any>[] = useMemo(() => {
     const cols: ColumnDef<ParticipantRow, any>[] = [
@@ -71,10 +79,9 @@ export function ParticipantTable({ participants, phase, launchTeamAddress }: Par
       perHopColumnHelper.accessor('invitedBy', {
         header: 'Invited By',
         cell: (info) => {
-          const row = info.row.original
           const val = info.getValue()
           if (val.length === 0) return '-'
-          if (row.hop === 0) return <span className="text-info">Armada</span>
+          if (val[0] === 'armada') return <span className="text-info">Armada</span>
           if (launchTeamAddress && val[0].toLowerCase() === launchTeamAddress.toLowerCase()) {
             return <span className="text-success">Launch Team</span>
           }
@@ -293,13 +300,13 @@ export function ParticipantTable({ participants, phase, launchTeamAddress }: Par
         <div className="flex rounded border border-input overflow-hidden">
           <button
             className={`px-2 py-1 text-[10px] ${viewMode === 'per-hop' ? 'bg-primary text-primary-foreground' : 'bg-background text-muted-foreground'}`}
-            onClick={() => setViewMode('per-hop')}
+            onClick={() => setViewModeWithSort('per-hop')}
           >
             Per-Hop
           </button>
           <button
             className={`px-2 py-1 text-[10px] ${viewMode === 'per-address' ? 'bg-primary text-primary-foreground' : 'bg-background text-muted-foreground'}`}
-            onClick={() => setViewMode('per-address')}
+            onClick={() => setViewModeWithSort('per-address')}
           >
             Per-Address
           </button>

--- a/crowdfund-ui/packages/admin/src/components/StatusDashboard.tsx
+++ b/crowdfund-ui/packages/admin/src/components/StatusDashboard.tsx
@@ -27,16 +27,23 @@ function TimelineRow(props: { label: string; isOpen: boolean; endTimestamp: numb
     <div className="rounded border border-border p-2 space-y-1">
       <div className="flex items-center justify-between">
         <span className="text-muted-foreground">{label}</span>
-        <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
-          isOpen ? 'bg-success/20 text-success' : 'bg-muted text-muted-foreground'
-        }`}>
-          {isOpen ? 'OPEN' : 'CLOSED'}
-        </span>
+        {endTimestamp > 0 && (
+          <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
+            isOpen ? 'bg-success/20 text-success' : 'bg-muted text-muted-foreground'
+          }`}>
+            {isOpen ? 'OPEN' : 'CLOSED'}
+          </span>
+        )}
       </div>
       <div className="text-[10px] text-muted-foreground">
-        {remaining > 0 ? formatCountdown(remaining) : 'ended'}
-        {' — '}
-        {new Date(endTimestamp * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+        {endTimestamp === 0
+          ? 'Not yet set'
+          : <>
+              {remaining > 0 ? formatCountdown(remaining) : 'ended'}
+              {' — '}
+              {new Date(endTimestamp * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+            </>
+        }
       </div>
     </div>
   )
@@ -82,16 +89,10 @@ export function StatusDashboard({ state, role }: StatusDashboardProps) {
       </div>
 
       {/* Timeline */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 text-xs">
+      <div className="grid grid-cols-2 lg:grid-cols-3 gap-3 text-xs">
         <TimelineRow
-          label="Seed Loading"
-          isOpen={state.phase === 0 && localTimestamp < state.windowStart}
-          endTimestamp={state.windowStart}
-          now={localTimestamp}
-        />
-        <TimelineRow
-          label="LT Invite Window"
-          isOpen={state.phase === 0 && localTimestamp >= state.windowStart && localTimestamp <= state.launchTeamInviteEnd}
+          label="Week 1 (Seeds + LT Invites)"
+          isOpen={state.phase === 0 && localTimestamp >= state.windowStart && localTimestamp < state.launchTeamInviteEnd}
           endTimestamp={state.launchTeamInviteEnd}
           now={localTimestamp}
         />

--- a/crowdfund-ui/packages/admin/src/components/StatusDashboard.tsx
+++ b/crowdfund-ui/packages/admin/src/components/StatusDashboard.tsx
@@ -10,6 +10,7 @@ import {
   hopLabel,
   CROWDFUND_CONSTANTS,
   HOP_CONFIGS,
+  estimateAllocation,
 } from '@armada/crowdfund-shared'
 import type { AdminState } from '@/hooks/useAdminState'
 import type { AdminRole } from '@/hooks/useRole'
@@ -65,6 +66,7 @@ export function StatusDashboard({ state, role }: StatusDashboardProps) {
   }, [])
 
   const { MAX_SALE, MIN_SALE, ELASTIC_TRIGGER } = CROWDFUND_CONSTANTS
+  const estimate = estimateAllocation(state.hopStats, state.cappedDemand, state.saleSize)
   const progressPct = MAX_SALE > 0n ? Number((state.totalCommitted * 100n) / MAX_SALE) : 0
   const minPct = MAX_SALE > 0n ? Number((MIN_SALE * 100n) / MAX_SALE) : 0
   const elasticPct = MAX_SALE > 0n ? Number((ELASTIC_TRIGGER * 100n) / MAX_SALE) : 0
@@ -144,6 +146,45 @@ export function StatusDashboard({ state, role }: StatusDashboardProps) {
         </div>
       </div>
 
+      {/* Demand & allocation summary */}
+      {(() => {
+        const committedDiffers = state.totalCommitted !== state.cappedDemand
+        const allocationDiffers = estimate.totalAllocUsdc < state.cappedDemand
+        const belowMin = estimate.totalAllocUsdc < CROWDFUND_CONSTANTS.MIN_SALE && state.cappedDemand > 0n
+
+        return (
+          <div className="rounded border border-border p-3 space-y-1 text-xs">
+            <div className="grid grid-cols-3 gap-3">
+              <div>
+                <span className="text-muted-foreground">Total committed</span>
+                <div className="font-medium">{formatUsdc(state.totalCommitted)}</div>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Effective demand</span>
+                <div className="font-medium">{formatUsdc(state.cappedDemand)}</div>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Est. allocation</span>
+                <div className={`font-medium ${belowMin ? 'text-destructive' : ''}`}>{formatUsdc(estimate.totalAllocUsdc)}</div>
+              </div>
+            </div>
+            {(committedDiffers || allocationDiffers) && (
+              <div className="text-[10px] text-muted-foreground space-y-0.5 pt-1">
+                {committedDiffers && (
+                  <div>Effective demand differs from total committed — some participants committed above their per-slot cap.</div>
+                )}
+                {allocationDiffers && (
+                  <div>Est. allocation is lower than effective demand — hop ceilings limit how much each hop can absorb.</div>
+                )}
+                {belowMin && (
+                  <div className="text-destructive">Estimated allocation is below the minimum raise ({formatUsdc(CROWDFUND_CONSTANTS.MIN_SALE)}). The sale would enter refund mode if finalized now.</div>
+                )}
+              </div>
+            )}
+          </div>
+        )
+      })()}
+
       {/* Per-hop stats table */}
       <div className="overflow-x-auto">
         <table className="w-full text-xs">
@@ -156,6 +197,7 @@ export function StatusDashboard({ state, role }: StatusDashboardProps) {
               <th className="py-1 pr-4">Committers</th>
               <th className="py-1 pr-4">Committed</th>
               <th className="py-1 pr-4">Capped</th>
+              <th className="py-1 pr-4">Est. Alloc</th>
               <th className="py-1 pr-4">Over/Under</th>
             </tr>
           </thead>
@@ -185,6 +227,7 @@ export function StatusDashboard({ state, role }: StatusDashboardProps) {
                   <td className="py-1 pr-4">{stats.uniqueCommitters}</td>
                   <td className="py-1 pr-4">{formatUsdc(stats.totalCommitted)}</td>
                   <td className="py-1 pr-4">{formatUsdc(stats.cappedCommitted)}</td>
+                  <td className="py-1 pr-4">{formatUsdc(estimate.perHopAlloc[hop])}</td>
                   <td className={`py-1 pr-4 font-medium ${overUnderColor}`}>
                     {overUnderPct.toFixed(1)}%
                   </td>

--- a/crowdfund-ui/packages/admin/src/components/TimeControls.tsx
+++ b/crowdfund-ui/packages/admin/src/components/TimeControls.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Local-only time manipulation and USDC minting controls.
 // ABOUTME: Provides quick-skip buttons, custom time advance, and Anvil account switcher.
 
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import type { UseTimeControlsResult } from '@/hooks/useTimeControls'
 import type { AdminState } from '@/hooks/useAdminState'
 
@@ -19,22 +19,69 @@ const ANVIL_ACCOUNTS = [
   { label: 'User 2', address: '0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65' },
 ]
 
+type ButtonStatus = 'idle' | 'busy' | 'done' | 'error'
+
+/** Wraps an async action with busy/done/error status transitions. */
+function useActionStatus() {
+  const [status, setStatus] = useState<ButtonStatus>('idle')
+
+  const run = useCallback(async (action: () => Promise<void>) => {
+    setStatus('busy')
+    try {
+      await action()
+      setStatus('done')
+      setTimeout(() => setStatus('idle'), 1200)
+    } catch {
+      setStatus('error')
+      setTimeout(() => setStatus('idle'), 2000)
+    }
+  }, [])
+
+  return { status, run }
+}
+
+function statusLabel(status: ButtonStatus, idleLabel: string): string {
+  switch (status) {
+    case 'busy': return 'Working...'
+    case 'done': return 'Done'
+    case 'error': return 'Failed'
+    default: return idleLabel
+  }
+}
+
+function statusClass(status: ButtonStatus): string {
+  switch (status) {
+    case 'busy': return 'opacity-70 cursor-wait'
+    case 'done': return 'bg-green-600/30 text-green-400'
+    case 'error': return 'bg-red-600/30 text-red-400'
+    default: return ''
+  }
+}
+
 export function TimeControls({ timeControls, state, onMintUsdc }: TimeControlsProps) {
   const [customSeconds, setCustomSeconds] = useState('')
   const [mintRecipient, setMintRecipient] = useState(ANVIL_ACCOUNTS[3].address)
   const [mintAmount, setMintAmount] = useState('100000')
 
+  const week1 = useActionStatus()
+  const windowEnd = useActionStatus()
+  const claimDeadline = useActionStatus()
+  const customAdvance = useActionStatus()
+  const mint = useActionStatus()
+
   const handleCustomAdvance = async () => {
     const seconds = parseInt(customSeconds, 10)
     if (!isNaN(seconds) && seconds > 0) {
-      await timeControls.advanceTime(seconds)
-      setCustomSeconds('')
+      await customAdvance.run(async () => {
+        await timeControls.advanceTime(seconds)
+        setCustomSeconds('')
+      })
     }
   }
 
   const handleMint = async () => {
     if (onMintUsdc && mintRecipient && mintAmount) {
-      await onMintUsdc(mintRecipient, mintAmount)
+      await mint.run(() => onMintUsdc(mintRecipient, mintAmount))
     }
   }
 
@@ -60,25 +107,25 @@ export function TimeControls({ timeControls, state, onMintUsdc }: TimeControlsPr
         <div className="text-xs text-muted-foreground">Time Warp</div>
         <div className="flex flex-wrap gap-1">
           <button
-            className="px-2 py-1 rounded bg-muted text-xs hover:bg-muted/80"
-            onClick={() => timeControls.skipToWeek1End(state.launchTeamInviteEnd, state.blockTimestamp)}
-            disabled={state.blockTimestamp >= state.launchTeamInviteEnd}
+            className={`px-2 py-1 rounded bg-muted text-xs hover:bg-muted/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors ${statusClass(week1.status)}`}
+            onClick={() => week1.run(() => timeControls.skipToWeek1End(state.launchTeamInviteEnd, state.blockTimestamp))}
+            disabled={state.blockTimestamp >= state.launchTeamInviteEnd || week1.status === 'busy'}
           >
-            Skip to Week-1 End
+            {statusLabel(week1.status, 'Skip to Week-1 End')}
           </button>
           <button
-            className="px-2 py-1 rounded bg-muted text-xs hover:bg-muted/80"
-            onClick={() => timeControls.skipToWindowEnd(state.windowEnd, state.blockTimestamp)}
-            disabled={state.blockTimestamp >= state.windowEnd}
+            className={`px-2 py-1 rounded bg-muted text-xs hover:bg-muted/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors ${statusClass(windowEnd.status)}`}
+            onClick={() => windowEnd.run(() => timeControls.skipToWindowEnd(state.windowEnd, state.blockTimestamp))}
+            disabled={state.blockTimestamp >= state.windowEnd || windowEnd.status === 'busy'}
           >
-            Skip to Window End
+            {statusLabel(windowEnd.status, 'Skip to Window End')}
           </button>
           <button
-            className="px-2 py-1 rounded bg-muted text-xs hover:bg-muted/80"
-            onClick={() => timeControls.skipToClaimDeadline(state.claimDeadline, state.blockTimestamp)}
-            disabled={state.claimDeadline === 0 || state.blockTimestamp >= state.claimDeadline}
+            className={`px-2 py-1 rounded bg-muted text-xs hover:bg-muted/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors ${statusClass(claimDeadline.status)}`}
+            onClick={() => claimDeadline.run(() => timeControls.skipToClaimDeadline(state.claimDeadline, state.blockTimestamp))}
+            disabled={state.claimDeadline === 0 || state.blockTimestamp >= state.claimDeadline || claimDeadline.status === 'busy'}
           >
-            Skip to Claim Deadline
+            {statusLabel(claimDeadline.status, 'Skip to Claim Deadline')}
           </button>
         </div>
       </div>
@@ -93,10 +140,11 @@ export function TimeControls({ timeControls, state, onMintUsdc }: TimeControlsPr
           className="flex-1 rounded border border-input bg-background px-2 py-1 text-xs font-mono placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
         />
         <button
-          className="px-3 py-1 rounded bg-muted text-xs hover:bg-muted/80"
+          className={`px-3 py-1 rounded bg-muted text-xs hover:bg-muted/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors ${statusClass(customAdvance.status)}`}
           onClick={handleCustomAdvance}
+          disabled={customAdvance.status === 'busy'}
         >
-          Advance
+          {statusLabel(customAdvance.status, 'Advance')}
         </button>
       </div>
 
@@ -105,17 +153,27 @@ export function TimeControls({ timeControls, state, onMintUsdc }: TimeControlsPr
         <div className="space-y-1">
           <div className="text-xs text-muted-foreground">Mint USDC</div>
           <div className="flex gap-2">
-            <select
-              className="flex-1 rounded border border-input bg-background px-2 py-1 text-xs"
-              value={mintRecipient}
-              onChange={(e) => setMintRecipient(e.target.value)}
-            >
-              {ANVIL_ACCOUNTS.map((acc) => (
-                <option key={acc.address} value={acc.address}>
-                  {acc.label}
-                </option>
-              ))}
-            </select>
+            <div className="flex-1 flex gap-1">
+              <select
+                className="rounded border border-input bg-background px-2 py-1 text-xs"
+                value={ANVIL_ACCOUNTS.find((a) => a.address.toLowerCase() === mintRecipient.toLowerCase())?.address ?? ''}
+                onChange={(e) => setMintRecipient(e.target.value)}
+              >
+                <option value="" disabled>Presets...</option>
+                {ANVIL_ACCOUNTS.map((acc) => (
+                  <option key={acc.address} value={acc.address}>
+                    {acc.label}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="text"
+                placeholder="0x... recipient address"
+                value={mintRecipient}
+                onChange={(e) => setMintRecipient(e.target.value)}
+                className="flex-1 rounded border border-input bg-background px-2 py-1 text-xs font-mono placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+            </div>
             <input
               type="text"
               placeholder="Amount"
@@ -124,10 +182,11 @@ export function TimeControls({ timeControls, state, onMintUsdc }: TimeControlsPr
               className="w-24 rounded border border-input bg-background px-2 py-1 text-xs font-mono"
             />
             <button
-              className="px-3 py-1 rounded bg-muted text-xs hover:bg-muted/80"
+              className={`px-3 py-1 rounded bg-muted text-xs hover:bg-muted/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors ${statusClass(mint.status)}`}
               onClick={handleMint}
+              disabled={mint.status === 'busy' || !mintRecipient}
             >
-              Mint
+              {statusLabel(mint.status, 'Mint')}
             </button>
           </div>
         </div>

--- a/crowdfund-ui/packages/admin/src/components/TimeControls.tsx
+++ b/crowdfund-ui/packages/admin/src/components/TimeControls.tsx
@@ -13,7 +13,7 @@ export interface TimeControlsProps {
 
 const ANVIL_ACCOUNTS = [
   { label: 'Deployer / LT', address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' },
-  { label: 'Security Council', address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8' },
+  { label: 'Security Council', address: '0xBcd4042DE499D14e55001CcbB24a551F3b954096' },
   { label: 'Treasury', address: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC' },
   { label: 'User 1', address: '0x90F79bf6EB2c4f870365E785982E1f101E93b906' },
   { label: 'User 2', address: '0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65' },
@@ -62,12 +62,15 @@ export function TimeControls({ timeControls, state, onMintUsdc }: TimeControlsPr
   const [customSeconds, setCustomSeconds] = useState('')
   const [mintRecipient, setMintRecipient] = useState(ANVIL_ACCOUNTS[3].address)
   const [mintAmount, setMintAmount] = useState('100000')
+  const [ethRecipient, setEthRecipient] = useState(ANVIL_ACCOUNTS[1].address)
+  const [ethAmount, setEthAmount] = useState('100')
 
   const week1 = useActionStatus()
   const windowEnd = useActionStatus()
   const claimDeadline = useActionStatus()
   const customAdvance = useActionStatus()
   const mint = useActionStatus()
+  const mintEth = useActionStatus()
 
   const handleCustomAdvance = async () => {
     const seconds = parseInt(customSeconds, 10)
@@ -82,6 +85,12 @@ export function TimeControls({ timeControls, state, onMintUsdc }: TimeControlsPr
   const handleMint = async () => {
     if (onMintUsdc && mintRecipient && mintAmount) {
       await mint.run(() => onMintUsdc(mintRecipient, mintAmount))
+    }
+  }
+
+  const handleMintEth = async () => {
+    if (ethRecipient && ethAmount) {
+      await mintEth.run(() => timeControls.setBalance(ethRecipient, ethAmount))
     }
   }
 
@@ -191,6 +200,48 @@ export function TimeControls({ timeControls, state, onMintUsdc }: TimeControlsPr
           </div>
         </div>
       )}
+
+      {/* ETH Balance */}
+      <div className="space-y-1">
+        <div className="text-xs text-muted-foreground">Set ETH Balance</div>
+        <div className="flex gap-2">
+          <div className="flex-1 flex gap-1">
+            <select
+              className="rounded border border-input bg-background px-2 py-1 text-xs"
+              value={ANVIL_ACCOUNTS.find((a) => a.address.toLowerCase() === ethRecipient.toLowerCase())?.address ?? ''}
+              onChange={(e) => setEthRecipient(e.target.value)}
+            >
+              <option value="" disabled>Presets...</option>
+              {ANVIL_ACCOUNTS.map((acc) => (
+                <option key={acc.address} value={acc.address}>
+                  {acc.label}
+                </option>
+              ))}
+            </select>
+            <input
+              type="text"
+              placeholder="0x... recipient address"
+              value={ethRecipient}
+              onChange={(e) => setEthRecipient(e.target.value)}
+              className="flex-1 rounded border border-input bg-background px-2 py-1 text-xs font-mono placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+          </div>
+          <input
+            type="text"
+            placeholder="ETH"
+            value={ethAmount}
+            onChange={(e) => setEthAmount(e.target.value)}
+            className="w-24 rounded border border-input bg-background px-2 py-1 text-xs font-mono"
+          />
+          <button
+            className={`px-3 py-1 rounded bg-muted text-xs hover:bg-muted/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors ${statusClass(mintEth.status)}`}
+            onClick={handleMintEth}
+            disabled={mintEth.status === 'busy' || !ethRecipient}
+          >
+            {statusLabel(mintEth.status, 'Set')}
+          </button>
+        </div>
+      </div>
 
       {/* Account switcher */}
       <div className="space-y-1">

--- a/crowdfund-ui/packages/admin/src/hooks/useAdminState.test.ts
+++ b/crowdfund-ui/packages/admin/src/hooks/useAdminState.test.ts
@@ -8,7 +8,7 @@ import { useAdminState } from './useAdminState'
 const mockPhase = vi.fn()
 const mockArmLoaded = vi.fn()
 const mockTotalCommitted = vi.fn()
-const mockCappedDemand = vi.fn()
+const mockGetEstimatedCappedDemand = vi.fn()
 const mockSaleSize = vi.fn()
 const mockWindowStart = vi.fn()
 const mockWindowEnd = vi.fn()
@@ -33,7 +33,7 @@ vi.mock('ethers', async (importOriginal) => {
           phase: mockPhase,
           armLoaded: mockArmLoaded,
           totalCommitted: mockTotalCommitted,
-          cappedDemand: mockCappedDemand,
+          getEstimatedCappedDemand: mockGetEstimatedCappedDemand,
           saleSize: mockSaleSize,
           windowStart: mockWindowStart,
           windowEnd: mockWindowEnd,
@@ -56,7 +56,7 @@ function setupMocks() {
   mockPhase.mockResolvedValue(0n)
   mockArmLoaded.mockResolvedValue(true)
   mockTotalCommitted.mockResolvedValue(500_000n * 10n ** 6n)
-  mockCappedDemand.mockResolvedValue(500_000n * 10n ** 6n)
+  mockGetEstimatedCappedDemand.mockResolvedValue([500_000n * 10n ** 6n, [180_000n * 10n ** 6n, 190_000n * 10n ** 6n, 95_000n * 10n ** 6n]])
   mockSaleSize.mockResolvedValue(1_200_000n * 10n ** 6n)
   mockWindowStart.mockResolvedValue(1000n)
   mockWindowEnd.mockResolvedValue(100_000n)

--- a/crowdfund-ui/packages/admin/src/hooks/useAdminState.ts
+++ b/crowdfund-ui/packages/admin/src/hooks/useAdminState.ts
@@ -86,7 +86,7 @@ export function useAdminState(
         phase,
         armLoaded,
         totalCommitted,
-        cappedDemand,
+        estimatedCapped,
         saleSize,
         windowStart,
         windowEnd,
@@ -106,7 +106,7 @@ export function useAdminState(
         contract.phase() as Promise<bigint>,
         contract.armLoaded() as Promise<boolean>,
         contract.totalCommitted() as Promise<bigint>,
-        contract.cappedDemand() as Promise<bigint>,
+        contract.getEstimatedCappedDemand() as Promise<[bigint, bigint[]]>,
         contract.saleSize() as Promise<bigint>,
         contract.windowStart() as Promise<bigint>,
         contract.windowEnd() as Promise<bigint>,
@@ -124,9 +124,12 @@ export function useAdminState(
         provider.getBlock('latest'),
       ])
 
-      const parseHopStats = (raw: [bigint, bigint, bigint, bigint]): HopStatsData => ({
+      const estimated = estimatedCapped as [bigint, bigint[]]
+      const perHopCapped = estimated[1]
+
+      const parseHopStats = (raw: [bigint, bigint, bigint, bigint], hop: number): HopStatsData => ({
         totalCommitted: raw[0],
-        cappedCommitted: raw[1],
+        cappedCommitted: perHopCapped[hop] ?? raw[1],
         uniqueCommitters: Number(raw[2]),
         whitelistCount: Number(raw[3]),
       })
@@ -137,7 +140,7 @@ export function useAdminState(
         phase: Number(phase),
         armLoaded,
         totalCommitted,
-        cappedDemand,
+        cappedDemand: estimated[0],
         saleSize,
         windowStart: Number(windowStart),
         windowEnd: Number(windowEnd),
@@ -146,7 +149,7 @@ export function useAdminState(
         claimDeadline: Number(claimDeadline),
         refundMode,
         blockTimestamp: block?.timestamp ?? 0,
-        hopStats: [parseHopStats(hopStats0), parseHopStats(hopStats1), parseHopStats(hopStats2)],
+        hopStats: [parseHopStats(hopStats0, 0), parseHopStats(hopStats1, 1), parseHopStats(hopStats2, 2)],
         participantCount: Number(participantCount),
         seedCount,
         ltBudgetHop1Remaining: Number(ltBudget[0]),

--- a/crowdfund-ui/packages/admin/src/hooks/useTimeControls.ts
+++ b/crowdfund-ui/packages/admin/src/hooks/useTimeControls.ts
@@ -9,6 +9,7 @@ export interface UseTimeControlsResult {
   skipToWeek1End: (launchTeamInviteEnd: number, blockTimestamp: number) => Promise<void>
   skipToWindowEnd: (windowEnd: number, blockTimestamp: number) => Promise<void>
   skipToClaimDeadline: (claimDeadline: number, blockTimestamp: number) => Promise<void>
+  setBalance: (address: string, ethAmount: string) => Promise<void>
 }
 
 export function useTimeControls(provider: JsonRpcProvider | null): UseTimeControlsResult {
@@ -36,5 +37,11 @@ export function useTimeControls(provider: JsonRpcProvider | null): UseTimeContro
     await advanceTime(delta)
   }, [provider, advanceTime])
 
-  return { advanceTime, skipToWeek1End, skipToWindowEnd, skipToClaimDeadline }
+  const setBalance = useCallback(async (address: string, ethAmount: string) => {
+    if (!provider) return
+    const wei = BigInt(Math.floor(parseFloat(ethAmount) * 1e18))
+    await provider.send('anvil_setBalance', [address, '0x' + wei.toString(16)])
+  }, [provider])
+
+  return { advanceTime, skipToWeek1End, skipToWindowEnd, skipToClaimDeadline, setBalance }
 }

--- a/crowdfund-ui/packages/admin/src/hooks/useWallet.ts
+++ b/crowdfund-ui/packages/admin/src/hooks/useWallet.ts
@@ -3,7 +3,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { BrowserProvider, JsonRpcSigner } from 'ethers'
-import { getHubChainId } from '@/config/network'
+import { getHubChainId, isLocalMode, getHubRpcUrl } from '@/config/network'
 
 export interface UseWalletResult {
   address: string | null
@@ -14,6 +14,33 @@ export interface UseWalletResult {
   error: string | null
   connect: () => Promise<void>
   disconnect: () => void
+}
+
+/** Ask the wallet to switch to the expected chain, adding it if unknown. */
+async function ensureCorrectChain(ethereum: any, expectedChainId: number): Promise<void> {
+  const hexChainId = '0x' + expectedChainId.toString(16)
+  try {
+    await ethereum.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: hexChainId }],
+    })
+  } catch (err: any) {
+    // Error 4902: chain not yet added to wallet — add it then retry
+    if (err?.code === 4902) {
+      await ethereum.request({
+        method: 'wallet_addEthereumChain',
+        params: [{
+          chainId: hexChainId,
+          chainName: isLocalMode() ? 'Anvil (Local)' : 'Sepolia',
+          nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+          rpcUrls: [getHubRpcUrl()],
+          ...(isLocalMode() ? {} : { blockExplorerUrls: ['https://sepolia.etherscan.io'] }),
+        }],
+      })
+    } else {
+      throw err
+    }
+  }
 }
 
 export function useWallet(): UseWalletResult {
@@ -36,13 +63,23 @@ export function useWallet(): UseWalletResult {
     try {
       const provider = new BrowserProvider(ethereum)
       await provider.send('eth_requestAccounts', [])
-      const s = await provider.getSigner()
-      const addr = await s.getAddress()
+
+      // Switch to the expected chain if the wallet is on a different one
       const network = await provider.getNetwork()
+      const expectedChainId = getHubChainId()
+      if (Number(network.chainId) !== expectedChainId) {
+        await ensureCorrectChain(ethereum, expectedChainId)
+      }
+
+      // Re-create provider after potential chain switch
+      const finalProvider = new BrowserProvider(ethereum)
+      const s = await finalProvider.getSigner()
+      const addr = await s.getAddress()
+      const finalNetwork = await finalProvider.getNetwork()
 
       setAddress(addr.toLowerCase())
       setSigner(s)
-      setChainId(Number(network.chainId))
+      setChainId(Number(finalNetwork.chainId))
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to connect wallet')
     } finally {
@@ -72,7 +109,11 @@ export function useWallet(): UseWalletResult {
     }
 
     const handleChainChanged = (chainIdHex: string) => {
-      setChainId(parseInt(chainIdHex, 16))
+      const newChainId = parseInt(chainIdHex, 16)
+      setChainId(newChainId)
+      // Re-acquire signer after chain switch so it targets the new chain
+      const provider = new BrowserProvider(ethereum)
+      provider.getSigner().then(setSigner).catch(() => disconnect())
     }
 
     ethereum.on('accountsChanged', handleAccountsChanged)

--- a/crowdfund-ui/packages/admin/src/index.css
+++ b/crowdfund-ui/packages/admin/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@source "../../shared/src";
 
 @plugin "tailwindcss-animate";
 @import "tw-animate";

--- a/crowdfund-ui/packages/admin/vite.config.ts
+++ b/crowdfund-ui/packages/admin/vite.config.ts
@@ -26,7 +26,7 @@ function serveDeployments() {
         '/api/deployments',
         (req: any, res: any, _next: any) => {
           const filename = req.url?.replace(/^\//, '') || ''
-          const deploymentsDir = path.resolve(__dirname, '../../../../deployments')
+          const deploymentsDir = path.resolve(__dirname, '../../../deployments')
           const filepath = path.resolve(deploymentsDir, filename)
 
           // Prevent path traversal — resolved path must stay within deployments/
@@ -122,7 +122,7 @@ export default defineConfig({
   server: {
     port: 5175,
     fs: {
-      allow: ['../../../..'],
+      allow: ['../../..'],
     },
   },
 })

--- a/crowdfund-ui/packages/committer/src/App.tsx
+++ b/crowdfund-ui/packages/committer/src/App.tsx
@@ -16,6 +16,7 @@ import {
   TreeView,
   CROWDFUND_CONSTANTS,
   formatUsdc,
+  formatArm,
   type ConnectedSummary,
 } from '@armada/crowdfund-shared'
 import { getHubRpcUrls, getPollIntervalMs, getNetworkMode } from '@/config/network'
@@ -107,6 +108,7 @@ export function App() {
 
   const crowdfundAddress = deployment?.contracts.crowdfund ?? null
   const usdcAddress = deployment?.contracts.usdc ?? null
+  const armTokenAddress = deployment?.contracts.armToken ?? null
 
   // Shared data layer
   const { events, loading: eventsLoading } = useContractEvents({
@@ -128,7 +130,7 @@ export function App() {
 
   // Wallet-specific hooks
   const eligibility = useEligibility(wallet.address, nodes)
-  const allowance = useAllowance(wallet.address, usdcAddress, crowdfundAddress, provider)
+  const allowance = useAllowance(wallet.address, usdcAddress, crowdfundAddress, armTokenAddress, provider)
   const inviteLinks = useInviteLinks(wallet.address, wallet.signer, crowdfundAddress, contractState.blockTimestamp)
 
   // Compute the user's personal committed amount (not the global total)
@@ -209,6 +211,9 @@ export function App() {
             {wallet.connected && (
               <span className="text-xs text-muted-foreground">
                 {formatUsdc(allowance.balance)}
+                {allowance.armBalance > 0n && (
+                  <> · {formatArm(allowance.armBalance)} ARM</>
+                )}
               </span>
             )}
             <ConnectButton

--- a/crowdfund-ui/packages/committer/src/components/ClaimTab.test.tsx
+++ b/crowdfund-ui/packages/committer/src/components/ClaimTab.test.tsx
@@ -72,7 +72,7 @@ describe('ClaimTab', () => {
   describe('refund mode (phase 1, refundMode true)', () => {
     it('shows refund-only message', () => {
       renderClaimTab({ phase: 1, refundMode: true })
-      expect(screen.getByText(/Sale did not meet minimum/)).toBeInTheDocument()
+      expect(screen.getByText(/did not meet the minimum raise/)).toBeInTheDocument()
       expect(screen.getByText('Claim Refund')).toBeInTheDocument()
     })
   })

--- a/crowdfund-ui/packages/committer/src/components/ClaimTab.tsx
+++ b/crowdfund-ui/packages/committer/src/components/ClaimTab.tsx
@@ -237,7 +237,7 @@ export function ClaimTab(props: ClaimTabProps) {
     return (
       <div className="space-y-4">
         <div className="rounded border border-amber-500/50 bg-amber-500/10 p-3 text-sm text-amber-500">
-          Sale did not meet minimum. Claim your full refund below.
+          Total allocation after hop ceilings did not meet the minimum raise. Claim your full refund below.
         </div>
         <div className="text-sm">
           Refund: <span className="font-medium">{formatUsdc(totalCommitted)}</span>

--- a/crowdfund-ui/packages/committer/src/components/ClaimTab.tsx
+++ b/crowdfund-ui/packages/committer/src/components/ClaimTab.tsx
@@ -351,22 +351,15 @@ export function ClaimTab(props: ClaimTabProps) {
         <div className="text-xs text-success">ARM: {formatArm(armAmount)} claimed</div>
       )}
 
-      {/* USDC refund */}
-      {refundAmount > 0n && !hasRefundClaimed && (
-        <div className="space-y-3 border-t border-border pt-3">
-          <button
-            className="w-full rounded border border-border px-4 py-2 text-sm hover:bg-muted disabled:opacity-50"
-            disabled={claimRefundTx.state.status === 'pending' || claimRefundTx.state.status === 'submitted'}
-            onClick={handleClaimRefund}
-          >
-            Claim USDC Refund ({formatUsdc(refundAmount)})
-          </button>
-          <TransactionFlow state={claimRefundTx.state} onReset={claimRefundTx.reset} successMessage="Refund claimed!" explorerUrl={getExplorerUrl()} />
+      {/* USDC refund info — in a successful sale, the refund is included in claim(delegate) */}
+      {refundAmount > 0n && !hasClaimed && (
+        <div className="text-xs text-muted-foreground border-t border-border pt-2">
+          Your USDC refund ({formatUsdc(refundAmount)}) will be included when you claim ARM above.
         </div>
       )}
 
       {/* Show refund claimed status */}
-      {hasRefundClaimed && refundAmount > 0n && (
+      {hasClaimed && refundAmount > 0n && (
         <div className="text-xs text-success">USDC: {formatUsdc(refundAmount)} refund claimed</div>
       )}
 

--- a/crowdfund-ui/packages/committer/src/components/CommitTab.tsx
+++ b/crowdfund-ui/packages/committer/src/components/CommitTab.tsx
@@ -8,6 +8,7 @@ import {
   formatUsdc,
   parseUsdcInput,
   hopLabel,
+  estimateAllocation,
   CROWDFUND_ABI_FRAGMENTS,
   ERC20_ABI_FRAGMENTS,
   CROWDFUND_CONSTANTS,
@@ -65,21 +66,25 @@ function hopDemandDisplay(
   const stats = hopStats[hop]
   const demand = formatUsdc(stats.cappedCommitted)
 
+  // Use estimateAllocation to get accurate per-hop allocation ceilings,
+  // including the hop-2 floor reservation and hop-0→hop-1 rollover.
+  // Handles saleSize === 0 (Active phase) internally.
+  const cappedDemand = hopStats.reduce((sum, s) => sum + s.cappedCommitted, 0n)
+  const { perHopAlloc } = estimateAllocation(hopStats, cappedDemand, saleSize)
+  const hopAlloc = perHopAlloc[hop] ?? 0n
+
+  if (hopAlloc === 0n && stats.cappedCommitted === 0n) return null
+
   if (hop <= 1) {
-    const ceilingBps = HOP_CONFIGS[hop].ceilingBps
-    const ceiling = (saleSize * BigInt(ceilingBps)) / 10_000n
-    if (ceiling === 0n) return null
-    const pct = Number((stats.cappedCommitted * 100n) / ceiling)
+    const pct = hopAlloc > 0n ? Number((stats.cappedCommitted * 100n) / hopAlloc) : 0
     const warning = pct > 100
       ? `This hop is oversubscribed — pro-rata scaling applies`
       : null
     return { demand, pct, warning }
   }
 
-  // Hop-2: floor-based
-  const floor = (saleSize * BigInt(CROWDFUND_CONSTANTS.HOP2_FLOOR_BPS)) / 10_000n
-  if (floor === 0n) return null
-  const pct = Number((stats.cappedCommitted * 100n) / floor)
+  // Hop-2: show against floor allocation
+  const pct = hopAlloc > 0n ? Number((stats.cappedCommitted * 100n) / hopAlloc) : 0
   const warning = pct < 100
     ? 'Floor not yet filled — full allocation likely'
     : null

--- a/crowdfund-ui/packages/committer/src/hooks/useAllowance.ts
+++ b/crowdfund-ui/packages/committer/src/hooks/useAllowance.ts
@@ -9,6 +9,7 @@ import { ERC20_ABI_FRAGMENTS } from '@armada/crowdfund-shared'
 export interface UseAllowanceResult {
   allowance: bigint
   balance: bigint
+  armBalance: bigint
   loading: boolean
   needsApproval: (amount: bigint) => boolean
   refresh: () => Promise<void>
@@ -18,10 +19,12 @@ export function useAllowance(
   address: string | null,
   usdcAddress: string | null,
   crowdfundAddress: string | null,
+  armTokenAddress: string | null,
   provider: JsonRpcProvider | null,
 ): UseAllowanceResult {
   const [allowance, setAllowance] = useState<bigint>(0n)
   const [balance, setBalance] = useState<bigint>(0n)
+  const [armBalance, setArmBalance] = useState<bigint>(0n)
   const [loading, setLoading] = useState(true)
 
   const refresh = useCallback(async () => {
@@ -32,18 +35,24 @@ export function useAllowance(
 
     try {
       const usdc = new Contract(usdcAddress, ERC20_ABI_FRAGMENTS, provider)
-      const [allowanceResult, balanceResult] = await Promise.all([
+      const queries: Promise<bigint>[] = [
         usdc.allowance(address, crowdfundAddress) as Promise<bigint>,
         usdc.balanceOf(address) as Promise<bigint>,
-      ])
-      setAllowance(allowanceResult)
-      setBalance(balanceResult)
+      ]
+      if (armTokenAddress) {
+        const arm = new Contract(armTokenAddress, ERC20_ABI_FRAGMENTS, provider)
+        queries.push(arm.balanceOf(address) as Promise<bigint>)
+      }
+      const results = await Promise.all(queries)
+      setAllowance(results[0])
+      setBalance(results[1])
+      if (results[2] !== undefined) setArmBalance(results[2])
     } catch {
       // Non-fatal — will retry on next poll
     } finally {
       setLoading(false)
     }
-  }, [address, usdcAddress, crowdfundAddress, provider])
+  }, [address, usdcAddress, crowdfundAddress, armTokenAddress, provider])
 
   useEffect(() => {
     refresh()
@@ -56,5 +65,5 @@ export function useAllowance(
     [allowance],
   )
 
-  return { allowance, balance, loading, needsApproval, refresh }
+  return { allowance, balance, armBalance, loading, needsApproval, refresh }
 }

--- a/crowdfund-ui/packages/committer/src/hooks/useContractState.ts
+++ b/crowdfund-ui/packages/committer/src/hooks/useContractState.ts
@@ -79,7 +79,7 @@ export function useContractState(
         phase,
         armLoaded,
         totalCommitted,
-        cappedDemand,
+        estimatedCapped,
         saleSize,
         windowStart,
         windowEnd,
@@ -96,7 +96,7 @@ export function useContractState(
         contract.phase() as Promise<bigint>,
         contract.armLoaded() as Promise<boolean>,
         contract.totalCommitted() as Promise<bigint>,
-        contract.cappedDemand() as Promise<bigint>,
+        contract.getEstimatedCappedDemand() as Promise<[bigint, bigint[]]>,
         contract.saleSize() as Promise<bigint>,
         contract.windowStart() as Promise<bigint>,
         contract.windowEnd() as Promise<bigint>,
@@ -111,9 +111,12 @@ export function useContractState(
         provider.getBlock('latest'),
       ])
 
-      const parseHopStats = (raw: [bigint, bigint, bigint, bigint]): HopStatsData => ({
+      const estimated = estimatedCapped as [bigint, bigint[]]
+      const perHopCapped = estimated[1]
+
+      const parseHopStats = (raw: [bigint, bigint, bigint, bigint], hop: number): HopStatsData => ({
         totalCommitted: raw[0],
-        cappedCommitted: raw[1],
+        cappedCommitted: perHopCapped[hop] ?? raw[1],
         uniqueCommitters: Number(raw[2]),
         whitelistCount: Number(raw[3]),
       })
@@ -125,7 +128,7 @@ export function useContractState(
         phase: Number(phase),
         armLoaded,
         totalCommitted,
-        cappedDemand,
+        cappedDemand: estimated[0],
         saleSize,
         windowStart: Number(windowStart),
         windowEnd: Number(windowEnd),
@@ -134,7 +137,7 @@ export function useContractState(
         claimDeadline: Number(claimDeadline),
         refundMode,
         blockTimestamp: block?.timestamp ?? 0,
-        hopStats: [parseHopStats(hopStats0), parseHopStats(hopStats1), parseHopStats(hopStats2)],
+        hopStats: [parseHopStats(hopStats0, 0), parseHopStats(hopStats1, 1), parseHopStats(hopStats2, 2)],
         participantCount: Number(participantCount),
         seedCount,
         loading: false,

--- a/crowdfund-ui/packages/committer/src/hooks/useProRataEstimate.ts
+++ b/crowdfund-ui/packages/committer/src/hooks/useProRataEstimate.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Calculates estimated ARM allocation based on current demand if finalized now.
 
 import { useMemo } from 'react'
-import { HOP_CONFIGS, type HopStatsData } from '@armada/crowdfund-shared'
+import { estimateAllocation, type HopStatsData } from '@armada/crowdfund-shared'
 
 export interface HopEstimate {
   hop: number
@@ -21,7 +21,8 @@ export interface UseProRataEstimateResult {
 
 /**
  * Estimate pro-rata allocation for given commit amounts per hop.
- * Pure client-side calculation matching the contract's finalize logic.
+ * Uses the shared estimateAllocation() which mirrors the contract's
+ * _computeHopAllocations logic including hop-2 floor reservation.
  */
 export function useProRataEstimate(
   commitAmounts: Map<number, bigint>,
@@ -33,26 +34,16 @@ export function useProRataEstimate(
     let totalEstimatedArm = 0n
     let totalEstimatedRefund = 0n
 
+    // estimateAllocation handles saleSize === 0 (Active phase) by using
+    // BASE_SALE or MAX_SALE based on current capped demand.
+    const cappedDemand = hopStats.reduce((sum, s) => sum + s.cappedCommitted, 0n)
+    const { perHopCeiling } = estimateAllocation(hopStats, cappedDemand, saleSize)
+
     for (const [hop, commitAmount] of commitAmounts) {
       if (commitAmount <= 0n || hop >= hopStats.length) continue
 
       const stats = hopStats[hop]
-      const ceilingBps = HOP_CONFIGS[hop]?.ceilingBps ?? 0
-
-      // For hop-2 (ceilingBps=0), allocation is the residual after hop-0 and hop-1
-      // This is a simplified estimate — the actual contract logic is more complex
-      let hopAllocation: bigint
-      if (ceilingBps === 0) {
-        // Hop-2 gets the remainder
-        const hop0Ceiling = (saleSize * BigInt(HOP_CONFIGS[0].ceilingBps)) / 10_000n
-        const hop1Ceiling = (saleSize * BigInt(HOP_CONFIGS[1].ceilingBps)) / 10_000n
-        const hop0Used = hopStats[0]?.cappedCommitted > hop0Ceiling ? hop0Ceiling : hopStats[0]?.cappedCommitted ?? 0n
-        const hop1Used = hopStats[1]?.cappedCommitted > hop1Ceiling ? hop1Ceiling : hopStats[1]?.cappedCommitted ?? 0n
-        hopAllocation = saleSize - hop0Used - hop1Used
-        if (hopAllocation < 0n) hopAllocation = 0n
-      } else {
-        hopAllocation = (saleSize * BigInt(ceilingBps)) / 10_000n
-      }
+      const hopAllocation = perHopCeiling[hop] ?? 0n
 
       // Pro-rata within this hop — use totalCommitted (live running total during Active phase)
       const totalDemand = stats.totalCommitted + commitAmount

--- a/crowdfund-ui/packages/committer/src/index.css
+++ b/crowdfund-ui/packages/committer/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@source "../../shared/src";
 
 @plugin "tailwindcss-animate";
 @import "tw-animate";

--- a/crowdfund-ui/packages/committer/vite.config.ts
+++ b/crowdfund-ui/packages/committer/vite.config.ts
@@ -19,7 +19,7 @@ function serveDeployments() {
         '/api/deployments',
         (req: any, res: any, _next: any) => {
           const filename = req.url?.replace(/^\//, '') || ''
-          const deploymentsDir = path.resolve(__dirname, '../../../../deployments')
+          const deploymentsDir = path.resolve(__dirname, '../../../deployments')
           const filepath = path.resolve(deploymentsDir, filename)
 
           // Prevent path traversal — resolved path must stay within deployments/
@@ -57,7 +57,7 @@ export default defineConfig({
   server: {
     port: 5174,
     fs: {
-      allow: ['../../../..'],
+      allow: ['../../..'],
     },
   },
 })

--- a/crowdfund-ui/packages/observer/CLAUDE.md
+++ b/crowdfund-ui/packages/observer/CLAUDE.md
@@ -26,7 +26,7 @@ npm run crowdfund:observer    # Starts on port 5173
 npm run dev
 ```
 
-Requires deployed contracts. Run `npm run setup` from the project root first (starts Anvil chains + deploys contracts). The Vite dev server serves deployment manifests from `../../../../deployments/` via the `serveDeployments()` plugin.
+Requires deployed contracts. Run `npm run setup` from the project root first (starts Anvil chains + deploys contracts). The Vite dev server serves deployment manifests from `../../../deployments/` via the `serveDeployments()` plugin.
 
 ## Dependencies
 

--- a/crowdfund-ui/packages/observer/src/App.tsx
+++ b/crowdfund-ui/packages/observer/src/App.tsx
@@ -234,7 +234,7 @@ export function App() {
           <div className="rounded-lg border border-amber-500/50 bg-amber-500/10 p-4 text-center">
             <h2 className="text-lg font-medium text-amber-500 mb-1">Refund Mode</h2>
             <p className="text-sm text-muted-foreground">
-              Capped demand did not meet the minimum sale size. All participants can claim a full USDC refund.
+              Total allocation after hop ceilings did not meet the minimum raise. All participants can claim a full USDC refund.
             </p>
           </div>
         )}

--- a/crowdfund-ui/packages/observer/src/hooks/useContractState.test.ts
+++ b/crowdfund-ui/packages/observer/src/hooks/useContractState.test.ts
@@ -13,7 +13,7 @@ const mockContract = {
   phase: vi.fn().mockResolvedValue(0n),
   armLoaded: vi.fn().mockResolvedValue(false),
   totalCommitted: vi.fn().mockResolvedValue(0n),
-  cappedDemand: vi.fn().mockResolvedValue(0n),
+  getEstimatedCappedDemand: vi.fn().mockResolvedValue([0n, [0n, 0n, 0n]]),
   saleSize: vi.fn().mockResolvedValue(1_200_000n * 10n ** 6n),
   windowStart: vi.fn().mockResolvedValue(0n),
   windowEnd: vi.fn().mockResolvedValue(0n),
@@ -48,7 +48,7 @@ describe('useContractState', () => {
     mockContract.phase.mockReset().mockResolvedValue(0n)
     mockContract.armLoaded.mockReset().mockResolvedValue(false)
     mockContract.totalCommitted.mockReset().mockResolvedValue(0n)
-    mockContract.cappedDemand.mockReset().mockResolvedValue(0n)
+    mockContract.getEstimatedCappedDemand.mockReset().mockResolvedValue([0n, [0n, 0n, 0n]])
     mockContract.saleSize.mockReset().mockResolvedValue(1_200_000n * 10n ** 6n)
     mockContract.windowStart.mockReset().mockResolvedValue(0n)
     mockContract.windowEnd.mockReset().mockResolvedValue(0n)
@@ -74,7 +74,7 @@ describe('useContractState', () => {
     mockContract.phase.mockResolvedValue(0n)
     mockContract.armLoaded.mockResolvedValue(true)
     mockContract.totalCommitted.mockResolvedValue(500_000n * 10n ** 6n)
-    mockContract.cappedDemand.mockResolvedValue(450_000n * 10n ** 6n)
+    mockContract.getEstimatedCappedDemand.mockResolvedValue([450_000n * 10n ** 6n, [280_000n * 10n ** 6n, 140_000n * 10n ** 6n, 30_000n * 10n ** 6n]])
     mockContract.getHopStats.mockImplementation((hop: number) => {
       if (hop === 0) return Promise.resolve([300_000n * 10n ** 6n, 280_000n * 10n ** 6n, 100n, 42n])
       if (hop === 1) return Promise.resolve([150_000n * 10n ** 6n, 140_000n * 10n ** 6n, 80n, 200n])

--- a/crowdfund-ui/packages/observer/src/hooks/useContractState.ts
+++ b/crowdfund-ui/packages/observer/src/hooks/useContractState.ts
@@ -79,7 +79,7 @@ export function useContractState(
         phase,
         armLoaded,
         totalCommitted,
-        cappedDemand,
+        estimatedCapped,
         saleSize,
         windowStart,
         windowEnd,
@@ -96,7 +96,7 @@ export function useContractState(
         contract.phase() as Promise<bigint>,
         contract.armLoaded() as Promise<boolean>,
         contract.totalCommitted() as Promise<bigint>,
-        contract.cappedDemand() as Promise<bigint>,
+        contract.getEstimatedCappedDemand() as Promise<[bigint, bigint[]]>,
         contract.saleSize() as Promise<bigint>,
         contract.windowStart() as Promise<bigint>,
         contract.windowEnd() as Promise<bigint>,
@@ -111,9 +111,12 @@ export function useContractState(
         provider.getBlock('latest'),
       ])
 
-      const parseHopStats = (raw: [bigint, bigint, bigint, bigint]): HopStatsData => ({
+      const estimated = estimatedCapped as [bigint, bigint[]]
+      const perHopCapped = estimated[1]
+
+      const parseHopStats = (raw: [bigint, bigint, bigint, bigint], hop: number): HopStatsData => ({
         totalCommitted: raw[0],
-        cappedCommitted: raw[1],
+        cappedCommitted: perHopCapped[hop] ?? raw[1],
         uniqueCommitters: Number(raw[2]),
         whitelistCount: Number(raw[3]),
       })
@@ -125,7 +128,7 @@ export function useContractState(
         phase: Number(phase),
         armLoaded,
         totalCommitted,
-        cappedDemand,
+        cappedDemand: estimated[0],
         saleSize,
         windowStart: Number(windowStart),
         windowEnd: Number(windowEnd),
@@ -134,7 +137,7 @@ export function useContractState(
         claimDeadline: Number(claimDeadline),
         refundMode,
         blockTimestamp: block?.timestamp ?? 0,
-        hopStats: [parseHopStats(hopStats0), parseHopStats(hopStats1), parseHopStats(hopStats2)],
+        hopStats: [parseHopStats(hopStats0, 0), parseHopStats(hopStats1, 1), parseHopStats(hopStats2, 2)],
         participantCount: Number(participantCount),
         seedCount,
         loading: false,

--- a/crowdfund-ui/packages/observer/src/index.css
+++ b/crowdfund-ui/packages/observer/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@source "../../shared/src";
 
 @plugin "tailwindcss-animate";
 @import "tw-animate";

--- a/crowdfund-ui/packages/observer/vite.config.ts
+++ b/crowdfund-ui/packages/observer/vite.config.ts
@@ -19,7 +19,7 @@ function serveDeployments() {
         '/api/deployments',
         (req: any, res: any, _next: any) => {
           const filename = req.url?.replace(/^\//, '') || ''
-          const deploymentsDir = path.resolve(__dirname, '../../../../deployments')
+          const deploymentsDir = path.resolve(__dirname, '../../../deployments')
           const filepath = path.resolve(deploymentsDir, filename)
 
           // Prevent path traversal — resolved path must stay within deployments/
@@ -57,7 +57,7 @@ export default defineConfig({
   server: {
     port: 5173,
     fs: {
-      allow: ['../../../..'],
+      allow: ['../../..'],
     },
   },
 })

--- a/crowdfund-ui/packages/shared/src/components/StatsBar.tsx
+++ b/crowdfund-ui/packages/shared/src/components/StatsBar.tsx
@@ -10,6 +10,7 @@ import {
   formatCountdown,
 } from '../lib/format.js'
 import { CROWDFUND_CONSTANTS, HOP_CONFIGS } from '../lib/constants.js'
+import { estimateAllocation } from '../lib/allocation.js'
 
 export interface HopStatsData {
   totalCommitted: bigint
@@ -37,11 +38,13 @@ export interface StatsBarProps {
   connectedSummary?: ConnectedSummary
 }
 
-/** Compute oversubscription percentage for a hop */
+/** Compute oversubscription percentage for a hop.
+ *  Pre-finalization saleSize is 0; fall back to BASE_SALE for ceiling estimates. */
 function oversubPct(cappedCommitted: bigint, hop: number, saleSize: bigint): string {
   const ceilingBps = HOP_CONFIGS[hop]?.ceilingBps ?? 0
   if (ceilingBps === 0) return '—'
-  const ceiling = (saleSize * BigInt(ceilingBps)) / 10_000n
+  const effectiveSaleSize = saleSize > 0n ? saleSize : CROWDFUND_CONSTANTS.BASE_SALE
+  const ceiling = (effectiveSaleSize * BigInt(ceilingBps)) / 10_000n
   if (ceiling === 0n) return '—'
   const pct = Number((cappedCommitted * 100n) / ceiling)
   return `${pct}%`
@@ -138,22 +141,50 @@ export function StatsBar(props: StatsBarProps) {
       </div>
 
       {/* Aggregate totals */}
-      <div className="mt-3 flex items-center justify-between text-sm">
-        <span className="text-muted-foreground">
-          Total committed: <span className="text-foreground font-medium">{formatUsdc(totalCommitted)}</span>
-        </span>
-        {props.connectedSummary && props.connectedSummary.totalCommitted > 0n && (
-          <span className="text-muted-foreground">
-            You: <span className="text-foreground font-medium">{formatUsdc(props.connectedSummary.totalCommitted)}</span>
-            {props.connectedSummary.hopCount > 0 && (
-              <span> across {props.connectedSummary.hopCount} hop{props.connectedSummary.hopCount !== 1 ? 's' : ''}</span>
+      {(() => {
+        const estimate = estimateAllocation(hopStats, cappedDemand, saleSize)
+        const committedDiffers = totalCommitted !== cappedDemand
+        const allocationDiffers = estimate.totalAllocUsdc < cappedDemand
+        const belowMin = estimate.totalAllocUsdc < CROWDFUND_CONSTANTS.MIN_SALE && cappedDemand > 0n
+
+        return (
+          <div className="mt-3 space-y-1">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">
+                Total committed: <span className="text-foreground font-medium">{formatUsdc(totalCommitted)}</span>
+              </span>
+              {props.connectedSummary && props.connectedSummary.totalCommitted > 0n && (
+                <span className="text-muted-foreground">
+                  You: <span className="text-foreground font-medium">{formatUsdc(props.connectedSummary.totalCommitted)}</span>
+                  {props.connectedSummary.hopCount > 0 && (
+                    <span> across {props.connectedSummary.hopCount} hop{props.connectedSummary.hopCount !== 1 ? 's' : ''}</span>
+                  )}
+                </span>
+              )}
+              <span className="text-muted-foreground">
+                Effective demand: <span className="text-foreground font-medium">{formatUsdc(cappedDemand)}</span>
+              </span>
+              <span className="text-muted-foreground">
+                Est. allocation: <span className={`font-medium ${belowMin ? 'text-destructive' : 'text-foreground'}`}>{formatUsdc(estimate.totalAllocUsdc)}</span>
+              </span>
+            </div>
+            {/* Explanatory notes when values diverge */}
+            {(committedDiffers || allocationDiffers) && (
+              <div className="text-[10px] text-muted-foreground space-y-0.5">
+                {committedDiffers && (
+                  <div>Effective demand differs from total committed because some participants committed above their per-slot cap.</div>
+                )}
+                {allocationDiffers && (
+                  <div>Est. allocation is lower than effective demand because hop ceilings limit how much each hop can absorb.</div>
+                )}
+                {belowMin && (
+                  <div className="text-destructive">Estimated allocation is below the minimum raise ({formatUsdc(CROWDFUND_CONSTANTS.MIN_SALE)}). The sale would enter refund mode if finalized now.</div>
+                )}
+              </div>
             )}
-          </span>
-        )}
-        <span className="text-muted-foreground">
-          Capped demand: <span className="text-foreground font-medium">{formatUsdc(cappedDemand)}</span>
-        </span>
-      </div>
+          </div>
+        )
+      })()}
     </div>
   )
 }

--- a/crowdfund-ui/packages/shared/src/components/TableView.tsx
+++ b/crowdfund-ui/packages/shared/src/components/TableView.tsx
@@ -72,7 +72,7 @@ export function TableView(props: TableViewProps) {
     connectedAddress,
   } = props
 
-  const [sorting, setSorting] = useState<SortingState>([{ id: 'committed', desc: true }])
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'totalCommitted', desc: true }])
   const [expanded, setExpanded] = useState<ExpandedState>({})
   const [hopFilter, setHopFilter] = useState<number | null>(null)
   const [multiHopOnly, setMultiHopOnly] = useState(false)

--- a/crowdfund-ui/packages/shared/src/index.ts
+++ b/crowdfund-ui/packages/shared/src/index.ts
@@ -24,6 +24,9 @@ export {
   phaseColor,
 } from './lib/format.js'
 
+export { estimateAllocation } from './lib/allocation.js'
+export type { AllocationEstimate } from './lib/allocation.js'
+
 export { createProvider, fetchLogs, getBlockTimestamp } from './lib/rpc.js'
 
 export type {

--- a/crowdfund-ui/packages/shared/src/lib/allocation.ts
+++ b/crowdfund-ui/packages/shared/src/lib/allocation.ts
@@ -1,0 +1,71 @@
+// ABOUTME: Client-side estimation of hop-level allocations mirroring the contract's _computeHopAllocations.
+// ABOUTME: Used pre-finalization to show estimated total allocation (post-ceiling) in the UI.
+
+import { CROWDFUND_CONSTANTS, HOP_CONFIGS } from './constants.js'
+import type { HopStatsData } from '../components/StatsBar.js'
+
+export interface AllocationEstimate {
+  /** Total USDC that would be allocated (after hop ceilings) */
+  totalAllocUsdc: bigint
+  /** Per-hop allocated amounts [hop0, hop1, hop2] */
+  perHopAlloc: [bigint, bigint, bigint]
+  /** Per-hop effective ceilings (max each hop can absorb) [hop0, hop1, hop2] */
+  perHopCeiling: [bigint, bigint, bigint]
+  /** Effective sale size used for the estimate */
+  effectiveSaleSize: bigint
+}
+
+/**
+ * Estimate hop-level allocations from current capped demand.
+ * Mirrors the contract's _computeHopAllocations logic:
+ *   1. Reserve hop-2 floor off the top
+ *   2. Apply hop-0 ceiling (BPS of available pool)
+ *   3. Roll over leftover to hop-1
+ *   4. Roll over leftover to hop-2 (floor + leftover)
+ *
+ * Pre-finalization, saleSize is 0 — use BASE_SALE or MAX_SALE based on
+ * whether capped demand meets the elastic trigger.
+ */
+export function estimateAllocation(hopStats: HopStatsData[], cappedDemand: bigint, saleSize: bigint): AllocationEstimate {
+  // Determine effective sale size
+  let effectiveSaleSize: bigint
+  if (saleSize > 0n) {
+    effectiveSaleSize = saleSize
+  } else if (cappedDemand >= CROWDFUND_CONSTANTS.ELASTIC_TRIGGER) {
+    effectiveSaleSize = CROWDFUND_CONSTANTS.MAX_SALE
+  } else {
+    effectiveSaleSize = CROWDFUND_CONSTANTS.BASE_SALE
+  }
+
+  const hop2Floor = (effectiveSaleSize * BigInt(CROWDFUND_CONSTANTS.HOP2_FLOOR_BPS)) / 10_000n
+  const available = effectiveSaleSize - hop2Floor
+
+  // Hop-0
+  const hop0Ceiling = (available * BigInt(HOP_CONFIGS[0].ceilingBps)) / 10_000n
+  const hop0Demand = hopStats[0]?.cappedCommitted ?? 0n
+  const hop0Alloc = hop0Demand <= hop0Ceiling ? hop0Demand : hop0Ceiling
+  const hop0Leftover = hop0Ceiling - hop0Alloc
+  const remainingAvailable = available - hop0Alloc
+
+  // Hop-1
+  const hop1BaseCeiling = (available * BigInt(HOP_CONFIGS[1].ceilingBps)) / 10_000n
+  let hop1EffCeiling = hop1BaseCeiling + hop0Leftover
+  if (hop1EffCeiling > remainingAvailable) {
+    hop1EffCeiling = remainingAvailable
+  }
+  const hop1Demand = hopStats[1]?.cappedCommitted ?? 0n
+  const hop1Alloc = hop1Demand <= hop1EffCeiling ? hop1Demand : hop1EffCeiling
+  const hop1Leftover = hop1EffCeiling - hop1Alloc
+
+  // Hop-2
+  const hop2EffCeiling = hop2Floor + hop1Leftover
+  const hop2Demand = hopStats[2]?.cappedCommitted ?? 0n
+  const hop2Alloc = hop2Demand <= hop2EffCeiling ? hop2Demand : hop2EffCeiling
+
+  return {
+    totalAllocUsdc: hop0Alloc + hop1Alloc + hop2Alloc,
+    perHopAlloc: [hop0Alloc, hop1Alloc, hop2Alloc],
+    perHopCeiling: [hop0Ceiling, hop1EffCeiling, hop2EffCeiling],
+    effectiveSaleSize,
+  }
+}

--- a/crowdfund-ui/packages/shared/src/lib/constants.ts
+++ b/crowdfund-ui/packages/shared/src/lib/constants.ts
@@ -38,6 +38,7 @@ export const CROWDFUND_ABI_FRAGMENTS = [
   'event ArmLoaded()',
   'event SeedAdded(address indexed seed)',
   'event Invited(address indexed inviter, address indexed invitee, uint8 hop, uint256 nonce)',
+  'event LaunchTeamInvited(address indexed invitee, uint8 hop)',
   'event Committed(address indexed participant, uint8 hop, uint256 amount)',
   'event Finalized(uint256 saleSize, uint256 allocatedArm, uint256 netProceeds, bool refundMode)',
   'event Cancelled()',

--- a/crowdfund-ui/packages/shared/src/lib/constants.ts
+++ b/crowdfund-ui/packages/shared/src/lib/constants.ts
@@ -51,6 +51,7 @@ export const CROWDFUND_ABI_FRAGMENTS = [
   'function armLoaded() view returns (bool)',
   'function totalCommitted() view returns (uint256)',
   'function cappedDemand() view returns (uint256)',
+  'function getEstimatedCappedDemand() view returns (uint256 globalCapped, uint256[3] perHopCapped)',
   'function saleSize() view returns (uint256)',
   'function windowStart() view returns (uint256)',
   'function windowEnd() view returns (uint256)',

--- a/crowdfund-ui/packages/shared/src/lib/events.test.ts
+++ b/crowdfund-ui/packages/shared/src/lib/events.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Unit tests for crowdfund event parsing.
-// ABOUTME: Verifies parseCrowdfundEvent handles all 11 event types and edge cases.
+// ABOUTME: Verifies parseCrowdfundEvent handles all 12 event types and edge cases.
 
 import { describe, it, expect } from 'vitest'
 import { Interface } from 'ethers'
@@ -56,6 +56,16 @@ describe('parseCrowdfundEvent', () => {
     expect(result!.args.invitee).toBe(invitee.toLowerCase())
     expect(result!.args.hop).toBe(1n)
     expect(result!.args.nonce).toBe(42n)
+  })
+
+  it('parses LaunchTeamInvited event', () => {
+    const invitee = '0x' + '33'.repeat(20)
+    const log = encodeLog('LaunchTeamInvited', [invitee, 1])
+    const result = parseCrowdfundEvent(log)
+    expect(result).not.toBeNull()
+    expect(result!.type).toBe('LaunchTeamInvited')
+    expect(result!.args.invitee).toBe(invitee.toLowerCase())
+    expect(result!.args.hop).toBe(1n)
   })
 
   it('parses Committed event', () => {

--- a/crowdfund-ui/packages/shared/src/lib/events.ts
+++ b/crowdfund-ui/packages/shared/src/lib/events.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Crowdfund event type definitions and parsing utilities.
-// ABOUTME: Converts raw ethers log entries into typed CrowdfundEvent objects.
+// ABOUTME: Converts raw ethers log entries into typed CrowdfundEvent objects (12 event types).
 
 import { Interface } from 'ethers'
 import { CROWDFUND_ABI_FRAGMENTS } from './constants.js'
@@ -9,6 +9,7 @@ export type CrowdfundEventType =
   | 'ArmLoaded'
   | 'SeedAdded'
   | 'Invited'
+  | 'LaunchTeamInvited'
   | 'Committed'
   | 'Finalized'
   | 'Cancelled'
@@ -40,6 +41,7 @@ const VALID_EVENT_TYPES = new Set<string>([
   'ArmLoaded',
   'SeedAdded',
   'Invited',
+  'LaunchTeamInvited',
   'Committed',
   'Finalized',
   'Cancelled',

--- a/crowdfund-ui/packages/shared/src/lib/graph.test.ts
+++ b/crowdfund-ui/packages/shared/src/lib/graph.test.ts
@@ -73,6 +73,44 @@ describe('buildGraph', () => {
     expect(inviteEdge.toHop).toBe(1)
   })
 
+  it('creates LaunchTeamInvited invitee under ROOT without inviter node', () => {
+    const events = [
+      mkEvent('LaunchTeamInvited', { invitee: ADDR.hop1a, hop: 1n }, 1),
+    ]
+    const graph = buildGraph(events)
+
+    // Invitee node exists at hop 1
+    const inviteeNode = graph.nodes.get(`${ADDR.hop1a}-1`)!
+    expect(inviteeNode.invitesReceived).toBe(1)
+    expect(inviteeNode.invitedBy).toEqual(['armada'])
+
+    // No inviter node created — only the invitee
+    expect(graph.nodes.size).toBe(1)
+
+    // Edge from ROOT to invitee
+    expect(graph.edges).toHaveLength(1)
+    expect(graph.edges[0].fromAddress).toBe('armada')
+    expect(graph.edges[0].fromHop).toBe(-1)
+    expect(graph.edges[0].toAddress).toBe(ADDR.hop1a)
+    expect(graph.edges[0].toHop).toBe(1)
+  })
+
+  it('launch team address does not appear in summaries for LaunchTeamInvited', () => {
+    const events = [
+      mkEvent('LaunchTeamInvited', { invitee: ADDR.hop1a, hop: 1n }, 1),
+      mkEvent('Committed', { participant: ADDR.hop1a, hop: 1n, amount: 2_000n * 10n ** 6n }, 2),
+    ]
+    const graph = buildGraph(events)
+
+    // Only the invitee should appear in summaries
+    expect(graph.summaries.size).toBe(1)
+    expect(graph.summaries.has(ADDR.hop1a)).toBe(true)
+
+    // Display inviter should be ROOT
+    const summary = graph.summaries.get(ADDR.hop1a)!
+    expect(summary.displayInviter).toBe('armada')
+  })
+
   it('tracks committed amounts with cap enforcement', () => {
     const events = [
       mkEvent('SeedAdded', { seed: ADDR.seed1 }, 1),

--- a/crowdfund-ui/packages/shared/src/lib/graph.ts
+++ b/crowdfund-ui/packages/shared/src/lib/graph.ts
@@ -230,6 +230,23 @@ function applyEvent(
       break
     }
 
+    case 'LaunchTeamInvited': {
+      const invitee = (event.args.invitee as string).toLowerCase()
+      const hop = Number(event.args.hop)
+      const inviteeNode = getOrCreateNode(nodes, invitee, hop)
+      inviteeNode.invitesReceived += 1
+      inviteeNode.invitedBy.push(ROOT_ADDRESS)
+      recomputeCommitted(inviteeNode)
+
+      edges.push({
+        fromAddress: ROOT_ADDRESS,
+        fromHop: -1,
+        toAddress: invitee,
+        toHop: hop,
+      })
+      break
+    }
+
     case 'Committed': {
       const participant = (event.args.participant as string).toLowerCase()
       const hop = Number(event.args.hop)

--- a/crowdfund-ui/packages/shared/src/lib/treeLayout.test.ts
+++ b/crowdfund-ui/packages/shared/src/lib/treeLayout.test.ts
@@ -47,6 +47,16 @@ function allocatedHopEvent(participant: string, hop: number, acceptedUsdc: bigin
   }
 }
 
+function launchTeamInviteEvent(invitee: string, hop: number, blockNumber = 2): CrowdfundEvent {
+  return {
+    type: 'LaunchTeamInvited',
+    args: { invitee, hop: BigInt(hop) },
+    blockNumber,
+    logIndex: 0,
+    transactionHash: '0xbbb',
+  }
+}
+
 const noResolve = () => null
 
 describe('graphToTree', () => {
@@ -173,6 +183,40 @@ describe('graphToTree', () => {
     // Charlie should appear once, under whichever parent was at the lowest hop (both are hop-0)
     const charlieNodes = findAll(tree, (n) => n.address === '0xcharlie')
     expect(charlieNodes).toHaveLength(1)
+  })
+
+  it('places launch team invitees under root', () => {
+    // Launch team invites 0xDave at hop-1 via LaunchTeamInvited event
+    const events = [
+      seedEvent('0xAlice'),
+      launchTeamInviteEvent('0xDave', 1),
+    ]
+    const graph = buildGraph(events)
+    const tree = graphToTree(graph, noResolve)
+
+    // Dave should appear in the tree as a direct child of root
+    const daveNodes = findAll(tree, (n) => n.address === '0xdave')
+    expect(daveNodes).toHaveLength(1)
+    expect(daveNodes[0].hop).toBe(1)
+
+    const rootChildAddrs = tree.children.map((c) => c.address)
+    expect(rootChildAddrs).toContain('0xdave')
+  })
+
+  it('launch team invitee subtree is placed correctly', () => {
+    // Launch team invites hop-1, who then invites hop-2 via peer invite
+    const events = [
+      launchTeamInviteEvent('0xHop1', 1),
+      inviteEvent('0xHop1', '0xHop2', 2),
+    ]
+    const graph = buildGraph(events)
+    const tree = graphToTree(graph, noResolve)
+
+    // Hop1 should be under root, Hop2 should be under Hop1
+    const hop1Nodes = findAll(tree, (n) => n.address === '0xhop1')
+    expect(hop1Nodes).toHaveLength(1)
+    expect(hop1Nodes[0].children).toHaveLength(1)
+    expect(hop1Nodes[0].children[0].address).toBe('0xhop2')
   })
 
   it('includes allocation data when available', () => {

--- a/crowdfund-ui/packages/shared/src/lib/treeLayout.ts
+++ b/crowdfund-ui/packages/shared/src/lib/treeLayout.ts
@@ -140,6 +140,25 @@ export function graphToTree(
     }
   }
 
+  // Re-parent orphaned subtrees: if a node was never attached to the tree
+  // (e.g., launch team address is not a seed but created invite edges),
+  // move its children directly under root so they aren't lost.
+  const reachable = new Set<string>()
+  function markReachable(n: TreeNode) {
+    reachable.add(n.address)
+    for (const child of n.children) markReachable(child)
+  }
+  markReachable(root)
+
+  for (const [addr, node] of addressToNode) {
+    if (!reachable.has(addr) && node.children.length > 0) {
+      // This node is unreachable but has children — re-parent them under root
+      for (const child of node.children) {
+        root.children.push(child)
+      }
+    }
+  }
+
   // Sort children by committed amount (descending) for visual stability
   sortChildren(root)
 

--- a/scripts/_check_arm.ts
+++ b/scripts/_check_arm.ts
@@ -1,3 +1,5 @@
+// ABOUTME: Debug script to verify ARM token transfer restrictions against the whitelist.
+// ABOUTME: Tests staticCall transfers to whitelisted and non-whitelisted addresses on local Anvil.
 import { ethers } from 'hardhat';
 
 async function main() {

--- a/scripts/_check_arm.ts
+++ b/scripts/_check_arm.ts
@@ -1,0 +1,47 @@
+import { ethers } from 'hardhat';
+
+async function main() {
+  const d = require('../deployments/crowdfund-hub.json');
+  const arm = await ethers.getContractAt('ArmadaToken', d.contracts.armToken);
+  
+  const addr = '0xEfE3DbeACBcde4780F1D5f3e356Ed6B6611ADC52';
+  const nonWL = '0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65'; // random non-whitelisted
+  const deployer = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+  const treasury = d.contracts.treasury;
+  const crowdfund = d.contracts.crowdfund;
+  
+  const signer = await ethers.getImpersonatedSigner(addr);
+  
+  // Test 1: to non-whitelisted address
+  try {
+    await arm.connect(signer).transfer.staticCall(nonWL, ethers.parseUnits('100', 18));
+    console.log('-> non-whitelisted: SUCCEEDS (unexpected)');
+  } catch (err: any) {
+    console.log(`-> non-whitelisted: REVERTS "${err.reason}"`);
+  }
+  
+  // Test 2: to deployer (whitelisted)
+  try {
+    await arm.connect(signer).transfer.staticCall(deployer, ethers.parseUnits('100', 18));
+    console.log('-> deployer (WL):   SUCCEEDS');
+  } catch (err: any) {
+    console.log(`-> deployer (WL):   REVERTS "${err.reason}"`);
+  }
+  
+  // Test 3: to treasury (whitelisted)
+  try {
+    await arm.connect(signer).transfer.staticCall(treasury, ethers.parseUnits('100', 18));
+    console.log('-> treasury (WL):   SUCCEEDS');
+  } catch (err: any) {
+    console.log(`-> treasury (WL):   REVERTS "${err.reason}"`);
+  }
+  
+  // Test 4: to crowdfund (whitelisted)
+  try {
+    await arm.connect(signer).transfer.staticCall(crowdfund, ethers.parseUnits('100', 18));
+    console.log('-> crowdfund (WL):  SUCCEEDS');
+  } catch (err: any) {
+    console.log(`-> crowdfund (WL):  REVERTS "${err.reason}"`);
+  }
+}
+main();

--- a/scripts/_check_state.ts
+++ b/scripts/_check_state.ts
@@ -1,3 +1,5 @@
+// ABOUTME: Debug script to inspect crowdfund contract state on local Anvil.
+// ABOUTME: Prints capped demand estimates, per-hop stats, and final ceilings/demands.
 import { ethers } from 'hardhat';
 import d from '../deployments/crowdfund-hub.json';
 

--- a/scripts/_check_state.ts
+++ b/scripts/_check_state.ts
@@ -1,0 +1,26 @@
+import { ethers } from 'hardhat';
+import d from '../deployments/crowdfund-hub.json';
+
+async function main() {
+  const cf = await ethers.getContractAt('ArmadaCrowdfund', d.contracts.crowdfund);
+  const [est, h0, h1, h2] = await Promise.all([
+    cf.getEstimatedCappedDemand(),
+    cf.getHopStats(0),
+    cf.getHopStats(1),
+    cf.getHopStats(2),
+  ]);
+  console.log('globalCapped:', ethers.formatUnits(est[0], 6));
+  console.log('perHop:', est[1].map((v: bigint) => ethers.formatUnits(v, 6)));
+  console.log('hop0 totalCommitted:', ethers.formatUnits(h0[0], 6), 'cappedCommitted:', ethers.formatUnits(h0[1], 6), 'committers:', h0[2].toString(), 'whitelist:', h0[3].toString());
+  console.log('hop1 totalCommitted:', ethers.formatUnits(h1[0], 6), 'cappedCommitted:', ethers.formatUnits(h1[1], 6), 'committers:', h1[2].toString(), 'whitelist:', h1[3].toString());
+  console.log('hop2 totalCommitted:', ethers.formatUnits(h2[0], 6), 'cappedCommitted:', ethers.formatUnits(h2[1], 6), 'committers:', h2[2].toString(), 'whitelist:', h2[3].toString());
+  
+  // Check finalCeilings/finalDemands
+  const [fc0, fc1, fc2, fd0, fd1, fd2] = await Promise.all([
+    cf.finalCeilings(0), cf.finalCeilings(1), cf.finalCeilings(2),
+    cf.finalDemands(0), cf.finalDemands(1), cf.finalDemands(2),
+  ]);
+  console.log('finalCeilings:', [fc0, fc1, fc2].map((v: bigint) => ethers.formatUnits(v, 6)));
+  console.log('finalDemands:', [fd0, fd1, fd2].map((v: bigint) => ethers.formatUnits(v, 6)));
+}
+main();

--- a/scripts/crowdfund_populate.ts
+++ b/scripts/crowdfund_populate.ts
@@ -126,12 +126,14 @@ async function main() {
   let hop2Count = 0;
 
   if (includeHops) {
-    // With hops: allocate some capacity to each level
-    // Each seed can invite 3 hop-1, each hop-1 can invite 2 hop-2
-    // Use 3 seeds for invitations, rest as seeds for volume
-    const inviteSeeds = 3;
-    hop1Count = inviteSeeds * 3; // 9 hop-1
-    hop2Count = hop1Count * 2;   // 18 hop-2
+    // With hops: allocate enough hop-1/hop-2 so that total allocation
+    // (after hop ceilings) exceeds MIN_SALE. The hop-0 ceiling at BASE_SALE
+    // is $798K, so hop-1/hop-2 must contribute at least $202K to clear $1M.
+    // Each seed can invite 3 hop-1, each hop-1 can invite 2 hop-2.
+    // Kept modest to stay within Hardhat's 200 signer limit.
+    const inviteSeeds = 18; // 18 seeds × 3 invites = 54 hop-1
+    hop1Count = inviteSeeds * 3; // 54 hop-1 × $4K = $216K
+    hop2Count = inviteSeeds * 3; // 54 hop-2 × $1K = $54K (subset of available slots)
 
     const hop1Total = hop1Count * HOP1_CAP;
     const hop2Total = hop2Count * HOP2_CAP;
@@ -241,17 +243,18 @@ async function main() {
     console.log("-".repeat(70));
     log("INVITE", "Sending invitations...");
 
-    // UI seeds (signers[1-3]) each invite 3 hop-1 addresses.
-    // This ensures the UI hop-1 dropdown accounts are real participants.
+    // UI seeds (signers[1-3]) invite first, then generated seeds.
+    // Each seed can invite up to 3 hop-1 addresses.
+    const inviterSeeds = [...uiSeeds, ...seedSigners];
     let h1idx = 0;
-    for (let i = 0; i < uiSeeds.length; i++) {
+    for (let i = 0; i < inviterSeeds.length && h1idx < hop1Signers.length; i++) {
       for (let j = 0; j < 3 && h1idx < hop1Signers.length; j++) {
-        const tx = await crowdfund.connect(uiSeeds[i]).invite(hop1Signers[h1idx].address, 0);
+        const tx = await crowdfund.connect(inviterSeeds[i]).invite(hop1Signers[h1idx].address, 0);
         await tx.wait();
         h1idx++;
       }
     }
-    log("INVITE", `${h1idx} hop-1 addresses invited (by UI seeds)`);
+    log("INVITE", `${h1idx} hop-1 addresses invited (by ${Math.min(Math.ceil(h1idx / 3), inviterSeeds.length)} seeds)`);
 
     // Each hop-1 invites 2 hop-2 addresses
     let h2idx = 0;

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -109,35 +109,45 @@ async function main() {
   const crowdfundAddress = await crowdfund.getAddress();
   console.log(`   ArmadaCrowdfund: ${crowdfundAddress}`);
 
-  // 4. Fund ARM to crowdfund from deployer's remaining balance
-  const armFundAmount = ethers.parseUnits(config.armDistribution.crowdfund, 18);
+  // 4. Set transfer whitelist (one-shot — must happen before any ARM transfers)
+  // Per ARM token spec §5: crowdfund, treasury, revenueLock.
+  // Deployer is included because it needs to distribute ARM in step 5.
+  console.log("4. Setting ARM transfer whitelist...");
+  await (await armToken.initWhitelist([crowdfundAddress, treasuryAddress, revenueLockAddress, deployer.address], nm.override())).wait();
+  console.log(`   initWhitelist: [crowdfund, treasury, revenueLock, deployer]`);
+
+  // 5. Distribute ARM tokens (all distribution deferred from deploy_governance)
+  console.log("5. Distributing ARM tokens...");
   const deployerArmBalance = await armToken.balanceOf(deployer.address);
-  console.log(`4. Funding ARM to crowdfund...`);
   console.log(`   Deployer ARM balance: ${ethers.formatUnits(deployerArmBalance, 18)}`);
-  if (deployerArmBalance < armFundAmount) {
+
+  const treasuryAllocation = ethers.parseUnits(config.armDistribution.treasury, 18);
+  const revenueLockAllocation = ethers.parseUnits(config.armDistribution.revenueLock, 18);
+  const crowdfundAllocation = ethers.parseUnits(config.armDistribution.crowdfund, 18);
+  const totalNeeded = treasuryAllocation + revenueLockAllocation + crowdfundAllocation;
+  if (deployerArmBalance < totalNeeded) {
     throw new Error(
-      `Insufficient ARM balance. Need ${config.armDistribution.crowdfund}, ` +
+      `Insufficient ARM balance. Need ${ethers.formatUnits(totalNeeded, 18)}, ` +
       `have ${ethers.formatUnits(deployerArmBalance, 18)}`
     );
   }
-  await (await armToken.transfer(crowdfundAddress, armFundAmount, nm.override())).wait();
+  await (await armToken.transfer(treasuryAddress, treasuryAllocation, nm.override())).wait();
+  console.log(`   Sent ${config.armDistribution.treasury} ARM to treasury`);
+  await (await armToken.transfer(revenueLockAddress, revenueLockAllocation, nm.override())).wait();
+  console.log(`   Sent ${config.armDistribution.revenueLock} ARM to RevenueLock`);
+  await (await armToken.transfer(crowdfundAddress, crowdfundAllocation, nm.override())).wait();
   console.log(`   Sent ${config.armDistribution.crowdfund} ARM to crowdfund contract`);
 
-  // 4b. Verify ARM pre-load
+  // 5b. Verify ARM pre-load
   console.log("   Verifying ARM pre-load...");
   await (await crowdfund.loadArm(nm.override())).wait();
   console.log("   ARM pre-load verified (loadArm() succeeded)");
 
-  // 5. Register crowdfund as excluded from quorum denominator
-  console.log("5. Registering crowdfund in governor quorum exclusion...");
+  // 6. Register crowdfund as excluded from quorum denominator
+  console.log("6. Registering crowdfund in governor quorum exclusion...");
   const governor = await ethers.getContractAt("ArmadaGovernor", governorAddress);
   await (await governor.setExcludedAddresses([crowdfundAddress], nm.override())).wait();
   console.log(`   Crowdfund excluded from quorum denominator`);
-
-  // 6. Set transfer whitelist (one-shot — per ARM token spec §5: crowdfund, treasury, revenueLock)
-  console.log("6. Setting ARM transfer whitelist...");
-  await (await armToken.initWhitelist([crowdfundAddress, treasuryAddress, revenueLockAddress], nm.override())).wait();
-  console.log(`   initWhitelist: [crowdfund, treasury, revenueLock]`);
 
   // 7. Authorize delegateOnBehalf callers (one-shot — must include all delegators)
   console.log("7. Authorizing delegateOnBehalf delegators...");
@@ -177,8 +187,9 @@ async function main() {
   // Summary
   const deployerRemaining = await armToken.balanceOf(deployer.address);
   console.log("\n=== ARM Distribution Summary ===");
-  console.log(`  Treasury:  ${config.armDistribution.treasury} ARM`);
-  console.log(`  Crowdfund: ${config.armDistribution.crowdfund} ARM`);
+  console.log(`  Treasury:    ${config.armDistribution.treasury} ARM`);
+  console.log(`  RevenueLock: ${config.armDistribution.revenueLock} ARM`);
+  console.log(`  Crowdfund:   ${config.armDistribution.crowdfund} ARM`);
   console.log(`  Deployer:  ${ethers.formatUnits(deployerRemaining, 18)} ARM (remainder — production allocation TBD)`);
   console.log("\n=== Crowdfund deployment complete ===");
 }

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -102,8 +102,13 @@ async function main() {
   const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
   const latestBlock = await ethers.provider.getBlock('latest');
   const openTimestamp = latestBlock!.timestamp + 60; // 1 minute after latest block
+  // Security council uses a separate account from launch team (Anvil signer[10])
+  const signers = await ethers.getSigners();
+  const securityCouncil = signers[10];
+  console.log(`   Launch team: ${deployer.address}`);
+  console.log(`   Security council: ${securityCouncil.address}`);
   const crowdfund = await ArmadaCrowdfund.deploy(
-    usdcAddress, armTokenAddress, treasuryAddress, deployer.address, deployer.address, openTimestamp, nm.override()
+    usdcAddress, armTokenAddress, treasuryAddress, deployer.address, securityCouncil.address, openTimestamp, nm.override()
   );
   await crowdfund.deploymentTransaction()!.wait();
   const crowdfundAddress = await crowdfund.getAddress();

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -134,13 +134,18 @@ async function main() {
   await (await governor.setExcludedAddresses([crowdfundAddress], nm.override())).wait();
   console.log(`   Crowdfund excluded from quorum denominator`);
 
-  // 6. Authorize delegateOnBehalf callers (one-shot — must include all delegators)
-  console.log("6. Authorizing delegateOnBehalf delegators...");
+  // 6. Set transfer whitelist (one-shot — per ARM token spec §5: crowdfund, treasury, revenueLock)
+  console.log("6. Setting ARM transfer whitelist...");
+  await (await armToken.initWhitelist([crowdfundAddress, treasuryAddress, revenueLockAddress], nm.override())).wait();
+  console.log(`   initWhitelist: [crowdfund, treasury, revenueLock]`);
+
+  // 7. Authorize delegateOnBehalf callers (one-shot — must include all delegators)
+  console.log("7. Authorizing delegateOnBehalf delegators...");
   await (await armToken.initAuthorizedDelegators([revenueLockAddress, crowdfundAddress], nm.override())).wait();
   console.log(`   initAuthorizedDelegators: [${revenueLockAddress}, ${crowdfundAddress}] (RevenueLock + Crowdfund)`);
 
-  // 7. Register crowdfund address for governance quiet period
-  console.log("7. Registering crowdfund in governor for quiet period...");
+  // 8. Register crowdfund address for governance quiet period
+  console.log("8. Registering crowdfund in governor for quiet period...");
   await (await governor.setCrowdfundAddress(crowdfundAddress, nm.override())).wait();
   console.log(`   Crowdfund registered for 7-day governance quiet period`);
 

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -296,13 +296,10 @@ async function main() {
     console.log("   setWindDownContract: DEFERRED (wind-down not deployed)");
   }
 
-  // 13. Distribute ARM tokens
-  const treasuryAllocation = ethers.parseUnits(config.armDistribution.treasury, 18);
-  console.log("13. Distributing ARM tokens...");
-  await (await armToken.transfer(treasuryAddress, treasuryAllocation, nm.override())).wait();
-  console.log(`   Sent ${config.armDistribution.treasury} ARM to treasury`);
-  await (await armToken.transfer(revenueLockAddress, revenueLockAllocation, nm.override())).wait();
-  console.log(`   Sent ${config.armDistribution.revenueLock} ARM to RevenueLock`);
+  // 13. ARM distribution
+  // All ARM transfers are deferred to deploy_crowdfund.ts which calls initWhitelist first.
+  // The whitelist must be set before any transfer (including to treasury/revenueLock).
+  console.log("13. ARM distribution: DEFERRED (called by deploy_crowdfund after initWhitelist)");
 
   // 14. Initialize treasury outflow limits
   // TODO: These defaults should be moved to config/networks.ts when finalized

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -280,10 +280,9 @@ async function main() {
   await (await armToken.setNoDelegation(treasuryAddress, nm.override())).wait();
   console.log(`   setNoDelegation: ${treasuryAddress} (treasury)`);
 
-  // Whitelist: deployer, treasury, revenueLock (for release transfers)
-  const whitelistAddresses = [deployer.address, treasuryAddress, revenueLockAddress];
-  await (await armToken.initWhitelist(whitelistAddresses, nm.override())).wait();
-  console.log(`   initWhitelist: ${whitelistAddresses.length} addresses`);
+  // initWhitelist is one-shot and must include the crowdfund address (per ARM token spec §5).
+  // Deferred to deploy_crowdfund.ts which runs after governance and has the crowdfund address.
+  console.log("   initWhitelist: DEFERRED (called by deploy_crowdfund with crowdfund address)");
 
   // initAuthorizedDelegators is one-shot and must include all delegators (RevenueLock + Crowdfund).
   // Deferred to deploy_crowdfund.ts which runs after governance and has both addresses available.

--- a/test/arm_token_votes.ts
+++ b/test/arm_token_votes.ts
@@ -247,14 +247,33 @@ describe("ArmadaToken — ERC20Votes", function () {
       ).to.not.be.reverted;
     });
 
-    it("should only allow wind-down contract to call setTransferable", async function () {
+    it("should only allow wind-down contract or timelock to call setTransferable", async function () {
       await expect(
         armToken.connect(alice).setTransferable(true)
-      ).to.be.revertedWith("ArmadaToken: not wind-down contract");
+      ).to.be.revertedWith("ArmadaToken: not authorized");
 
       await expect(
         armToken.connect(deployer).setTransferable(true)
-      ).to.be.revertedWith("ArmadaToken: not wind-down contract");
+      ).to.be.revertedWith("ArmadaToken: not authorized");
+    });
+
+    it("should allow timelock to call setTransferable", async function () {
+      // The timelock address can enable transfers (governance proposal path)
+      const timelockAddr = await timelockController.getAddress();
+      const timelockSigner = await ethers.getImpersonatedSigner(timelockAddr);
+
+      // Fund the timelock with ETH for gas
+      await deployer.sendTransaction({ to: timelockAddr, value: ethers.parseEther("1") });
+
+      await armToken.connect(timelockSigner).setTransferable(true);
+      expect(await armToken.transferable()).to.equal(true);
+
+      // Verify non-whitelisted can now transfer
+      await armToken.connect(alice).transfer(carol.address, ethers.parseUnits("1000", 18));
+      const [, , , , , , , someone] = await ethers.getSigners();
+      await expect(
+        armToken.connect(carol).transfer(someone.address, ethers.parseUnits("500", 18))
+      ).to.not.be.reverted;
     });
 
     it("should reject setTransferable(false) — one-way only", async function () {

--- a/test/crowdfund_launch_team.ts
+++ b/test/crowdfund_launch_team.ts
@@ -420,11 +420,11 @@ describe("Launch Team & Seed Cap", function () {
       ).to.be.revertedWith("ArmadaCrowdfund: max invites received");
     });
 
-    it("emits Invited on re-invite", async function () {
+    it("emits LaunchTeamInvited on re-invite", async function () {
       await crowdfund.launchTeamInvite(invitee.address, 0);
       await expect(crowdfund.launchTeamInvite(invitee.address, 0))
-        .to.emit(crowdfund, "Invited")
-        .withArgs(deployer.address, invitee.address, 1, 0);
+        .to.emit(crowdfund, "LaunchTeamInvited")
+        .withArgs(invitee.address, 1);
     });
   });
 

--- a/test/crowdfund_lifecycle.ts
+++ b/test/crowdfund_lifecycle.ts
@@ -160,8 +160,8 @@ describe("Crowdfund Full Lifecycle", function () {
       for (const invitee of ltHop1) {
         const tx = await crowdfund.launchTeamInvite(invitee.address, 0);
         await expect(tx)
-          .to.emit(crowdfund, "Invited")
-          .withArgs(deployer.address, invitee.address, 1, 0);
+          .to.emit(crowdfund, "LaunchTeamInvited")
+          .withArgs(invitee.address, 1);
       }
 
       // 2 hop-2 invites from launch team
@@ -170,8 +170,8 @@ describe("Crowdfund Full Lifecycle", function () {
       {
         const tx = await crowdfund.launchTeamInvite(ltHop2[0].address, 1);
         await expect(tx)
-          .to.emit(crowdfund, "Invited")
-          .withArgs(deployer.address, ltHop2[0].address, 2, 0);
+          .to.emit(crowdfund, "LaunchTeamInvited")
+          .withArgs(ltHop2[0].address, 2);
       }
 
       // Verify budget tracking

--- a/test/governance_integration.ts
+++ b/test/governance_integration.ts
@@ -238,6 +238,44 @@ describe("Governance Integration", function () {
       expect(await armToken.getVotes(alice.address)).to.equal(ALICE_AMOUNT);
       expect(await armToken.getVotes(bob.address)).to.equal(BOB_AMOUNT);
     });
+
+    it("should enable transfers via governance proposal", async function () {
+      // Transfers are restricted before the proposal
+      expect(await armToken.transferable()).to.equal(false);
+
+      // Carol is not whitelisted. Give carol some ARM via alice (whitelisted sender).
+      // Then verify carol (non-whitelisted sender) cannot transfer to dave (non-whitelisted receiver).
+      await armToken.connect(alice).transfer(carol.address, ethers.parseUnits("1000", ARM_DECIMALS));
+      await expect(
+        armToken.connect(carol).transfer(dave.address, ethers.parseUnits("100", ARM_DECIMALS))
+      ).to.be.revertedWith("ArmadaToken: transfers restricted");
+
+      // Create a governance proposal to call setTransferable(true) on the ARM token
+      const armTokenAddr = await armToken.getAddress();
+      const calldata = armToken.interface.encodeFunctionData("setTransferable", [true]);
+
+      // Wind-down contract must be set for setTransferable to work
+      const [, , , , , windDown] = await ethers.getSigners();
+      await armToken.setWindDownContract(windDown.address);
+
+      await passProposal(
+        alice,
+        [{ signer: alice, support: Vote.For }, { signer: bob, support: Vote.For }],
+        ProposalType.Standard,
+        [armTokenAddr],
+        [0n],
+        [calldata],
+        "Enable ARM token transfers"
+      );
+
+      // Transfers are now enabled
+      expect(await armToken.transferable()).to.equal(true);
+
+      // Non-whitelisted sender to non-whitelisted receiver now succeeds
+      await expect(
+        armToken.connect(carol).transfer(dave.address, ethers.parseUnits("100", ARM_DECIMALS))
+      ).to.not.be.reverted;
+    });
   });
 
   // ============================================================


### PR DESCRIPTION
## Summary

- **LaunchTeamInvited event**: Separate contract event for launch team invites so frontends don't create phantom participant nodes for the launch team address
- **Allocation estimates**: Add `getEstimatedCappedDemand()` view and shared `estimateAllocation()` logic so all three apps show accurate per-hop allocation estimates accounting for hop ceilings
- **Deploy ordering**: Move `initWhitelist` and all ARM distribution to `deploy_crowdfund.ts` (runs after crowdfund address is known), fixing "transfers restricted" errors during `npm run setup`
- **ARM whitelist**: Whitelist the crowdfund contract per ARM token spec §5, enabling `claim()` to transfer ARM to participants
- **setTransferable authorization**: Allow both timelock and wind-down contract to call `setTransferable(true)` per ARM token spec §5 (was wind-down only)
- **Admin UX**: Visual feedback on dev control buttons, free-text USDC/ETH mint, merged timeline rows, hide finalize when below minimum, separate security council account
- **Populate script**: Increase hop-1/hop-2 participation so `HOPS=true` produces allocations that exceed MIN_SALE after hop ceilings

## Test plan

- [x] `npx hardhat test test/arm_token_votes.ts` — 31 passing (timelock setTransferable, updated error messages)
- [x] `npx hardhat test test/governance_integration.ts` — 42 passing (governance proposal enables transfers end-to-end)
- [x] `npx hardhat test test/governance_adversarial.ts` — 51 passing (no regressions)
- [ ] `npm run chains && npm run setup` — full local deployment with corrected whitelist/distribution order
- [ ] `HOPS=true npm run crowdfund:populate` then finalize — verify allocation > MIN_SALE
- [ ] Manual: observer/admin/committer apps display correct data across lifecycle phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)