### PR TITLE
refactor(governance): deduplicate helpers and remove dead code

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -884,38 +884,14 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
             // Vote change: subtract from old bucket, add to new bucket
             uint8 oldSupport = voteChoice[proposalId][msg.sender];
             if (oldSupport == support) revert Gov_SameVote();
-
-            if (oldSupport == 0) {
-                p.againstVotes -= weight;
-            } else if (oldSupport == 1) {
-                p.forVotes -= weight;
-            } else {
-                p.abstainVotes -= weight;
-            }
-
-            if (support == 0) {
-                p.againstVotes += weight;
-            } else if (support == 1) {
-                p.forVotes += weight;
-            } else {
-                p.abstainVotes += weight;
-            }
-
+            _removeVoteBucket(p, oldSupport, weight);
+            _addVoteBucket(p, support, weight);
             voteChoice[proposalId][msg.sender] = support;
             emit VoteChanged(msg.sender, proposalId, oldSupport, support, weight);
         } else {
-            // First vote
             hasVoted[proposalId][msg.sender] = true;
             voteChoice[proposalId][msg.sender] = support;
-
-            if (support == 0) {
-                p.againstVotes += weight;
-            } else if (support == 1) {
-                p.forVotes += weight;
-            } else {
-                p.abstainVotes += weight;
-            }
-
+            _addVoteBucket(p, support, weight);
             emit VoteCast(msg.sender, proposalId, support, weight);
         }
     }
@@ -1118,6 +1094,28 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         Proposal storage p = _proposals[proposalId];
         // Quorum measures total participation — all vote types count
         return (p.forVotes + p.againstVotes + p.abstainVotes) >= quorum(proposalId);
+    }
+
+    /// @dev Add voting weight to the appropriate tally bucket.
+    function _addVoteBucket(Proposal storage p, uint8 support, uint256 weight) internal {
+        if (support == 0) {
+            p.againstVotes += weight;
+        } else if (support == 1) {
+            p.forVotes += weight;
+        } else {
+            p.abstainVotes += weight;
+        }
+    }
+
+    /// @dev Remove voting weight from the appropriate tally bucket.
+    function _removeVoteBucket(Proposal storage p, uint8 support, uint256 weight) internal {
+        if (support == 0) {
+            p.againstVotes -= weight;
+        } else if (support == 1) {
+            p.forVotes -= weight;
+        } else {
+            p.abstainVotes -= weight;
+        }
     }
 
     function _voteSucceeded(uint256 proposalId) internal view returns (bool) {

--- a/contracts/governance/ArmadaToken.sol
+++ b/contracts/governance/ArmadaToken.sol
@@ -176,22 +176,4 @@ contract ArmadaToken is ERC20Votes {
         require(!noDelegation[delegator], "ArmadaToken: delegation blocked");
         super._delegate(delegator, delegatee);
     }
-
-    // ============ Required ERC20Votes Overrides ============
-
-    function _afterTokenTransfer(
-        address from,
-        address to,
-        uint256 amount
-    ) internal override {
-        super._afterTokenTransfer(from, to, amount);
-    }
-
-    function _mint(address to, uint256 amount) internal override {
-        super._mint(to, amount);
-    }
-
-    function _burn(address account, uint256 amount) internal override {
-        super._burn(account, amount);
-    }
 }

--- a/contracts/governance/ArmadaTreasuryGov.sol
+++ b/contracts/governance/ArmadaTreasuryGov.sol
@@ -117,7 +117,7 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
         require(budget.authorized, "ArmadaTreasuryGov: token not authorized for steward");
 
         // Rolling window: sum all steward spends within the trailing window
-        uint256 recentSpend = _sumRecentStewardSpends(token, budget.window);
+        uint256 recentSpend = _sumRecentRecords(_stewardSpendHistory[token], budget.window);
         require(
             recentSpend + amount <= budget.limit,
             "ArmadaTreasuryGov: exceeds steward budget"
@@ -247,16 +247,11 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
         OutflowConfig storage config = _outflowConfigs[token];
         require(config.initialized, "ArmadaTreasuryGov: outflow config required");
 
-        // Calculate effective limit: max(pct of current balance, absolute), then max(result, floor)
         uint256 treasuryBalance = IERC20(token).balanceOf(address(this));
-        uint256 pctLimit = (treasuryBalance * config.limitBps) / 10000;
-        uint256 effectiveLimit = pctLimit > config.limitAbsolute ? pctLimit : config.limitAbsolute;
-        if (effectiveLimit < config.floorAbsolute) {
-            effectiveLimit = config.floorAbsolute;
-        }
+        uint256 effectiveLimit = _effectiveLimit(config, treasuryBalance);
 
         // Sum recent outflows within the rolling window
-        uint256 recentOutflow = _sumRecentOutflows(token, config.windowDuration);
+        uint256 recentOutflow = _sumRecentRecords(_outflowHistory[token], config.windowDuration);
 
         require(
             recentOutflow + amount <= effectiveLimit,
@@ -270,9 +265,8 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
         }));
     }
 
-    /// @dev Sum outflow amounts within the rolling window, iterating backwards from most recent.
-    function _sumRecentOutflows(address token, uint256 windowDuration) internal view returns (uint256 total) {
-        OutflowRecord[] storage records = _outflowHistory[token];
+    /// @dev Sum amounts within a rolling window, iterating backwards from most recent.
+    function _sumRecentRecords(OutflowRecord[] storage records, uint256 windowDuration) internal view returns (uint256 total) {
         uint256 len = records.length;
         if (len == 0) return 0;
 
@@ -286,20 +280,11 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
         }
     }
 
-    /// @dev Sum steward spend amounts within the rolling window, iterating backwards from most recent.
-    function _sumRecentStewardSpends(address token, uint256 windowDuration) internal view returns (uint256 total) {
-        OutflowRecord[] storage records = _stewardSpendHistory[token];
-        uint256 len = records.length;
-        if (len == 0) return 0;
-
-        uint256 cutoff = block.timestamp > windowDuration ? block.timestamp - windowDuration : 0;
-
-        // Iterate backwards — most recent records are at the end
-        for (uint256 i = len; i > 0; i--) {
-            OutflowRecord storage r = records[i - 1];
-            if (r.timestamp < cutoff) break; // older entries are further back, stop early
-            total += r.amount;
-        }
+    /// @dev Calculate effective outflow limit: max(pct of balance, absolute), then max(result, floor).
+    function _effectiveLimit(OutflowConfig storage config, uint256 treasuryBalance) internal view returns (uint256) {
+        uint256 pctLimit = (treasuryBalance * config.limitBps) / 10000;
+        uint256 limit = pctLimit > config.limitAbsolute ? pctLimit : config.limitAbsolute;
+        return limit > config.floorAbsolute ? limit : config.floorAbsolute;
     }
 
     // ============ Wind-Down Sweep Authority ============
@@ -347,7 +332,7 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
         if (!b.authorized) return (0, 0, 0);
 
         budget = b.limit;
-        spent = _sumRecentStewardSpends(token, b.window);
+        spent = _sumRecentRecords(_stewardSpendHistory[token], b.window);
         remaining = budget > spent ? budget - spent : 0;
     }
 
@@ -372,13 +357,8 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
         if (!config.initialized) return (0, 0, 0);
 
         uint256 treasuryBalance = IERC20(token).balanceOf(address(this));
-        uint256 pctLimit = (treasuryBalance * config.limitBps) / 10000;
-        effectiveLimit = pctLimit > config.limitAbsolute ? pctLimit : config.limitAbsolute;
-        if (effectiveLimit < config.floorAbsolute) {
-            effectiveLimit = config.floorAbsolute;
-        }
-
-        recentOutflow = _sumRecentOutflows(token, config.windowDuration);
+        effectiveLimit = _effectiveLimit(config, treasuryBalance);
+        recentOutflow = _sumRecentRecords(_outflowHistory[token], config.windowDuration);
         available = effectiveLimit > recentOutflow ? effectiveLimit - recentOutflow : 0;
     }
 }

--- a/contracts/governance/ShieldPauseController.sol
+++ b/contracts/governance/ShieldPauseController.sol
@@ -146,7 +146,6 @@ contract ShieldPauseController is IShieldPauseController {
     ///         Shields are permanently disabled; unshields remain available indefinitely.
     function setWindDownActive() external {
         require(msg.sender == windDownContract, "ShieldPauseController: not wind-down contract");
-        require(windDownContract != address(0), "ShieldPauseController: wind-down not set");
         require(!windDownActive, "ShieldPauseController: wind-down already active");
         windDownActive = true;
         emit WindDownActivated();


### PR DESCRIPTION
## Summary
- Unify `_sumRecentOutflows`/`_sumRecentStewardSpends` into a single `_sumRecentRecords` helper in ArmadaTreasuryGov
- Extract `_effectiveLimit` helper to eliminate duplicated outflow cap calculation
- Extract `_addVoteBucket`/`_removeVoteBucket` from castVote's repeated if-chains in ArmadaGovernor
- Remove redundant zero-address check in `ShieldPauseController.setWindDownActive` (unreachable after `msg.sender == windDownContract`)
- Remove no-op `_afterTokenTransfer`/`_mint`/`_burn` overrides in ArmadaToken (compiler confirms unnecessary with single-chain ERC20Votes inheritance)

Net: 38 additions, 79 deletions across 4 contracts. All 119 Hardhat governance tests and 540 Foundry tests pass.

## Test plan
- [x] `npm run test:governance` — 119 passing
- [x] `npm run test:forge` — 540 passing
- [x] `npx hardhat compile` — 118 files compiled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)