### PR TITLE
fix(token,governor): whitelist sender-only restriction + remove assembly

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -1143,13 +1143,7 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         for (uint256 i = 0; i < calldatas.length; i++) {
             if (calldatas[i].length < 4) continue;
 
-            bytes4 selector;
-            // solhint-disable-next-line no-inline-assembly
-            assembly {
-                // calldatas[i] is a bytes memory; its data starts at offset 0x20
-                let dataPtr := mload(add(add(calldatas, 0x20), mul(i, 0x20)))
-                selector := mload(add(dataPtr, 0x20))
-            }
+            bytes4 selector = bytes4(calldatas[i]);
 
             // Check registered extended selectors
             if (extendedSelectors[selector]) return ProposalType.Extended;
@@ -1157,15 +1151,12 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
             // Special case: distribute() calls exceeding 5% of treasury balance
             if (selector == DISTRIBUTE_SELECTOR && calldatas[i].length >= 100) {
                 // Decode: distribute(address token, address recipient, uint256 amount)
-                // token is at bytes 4..35, amount is at bytes 68..99
-                address token;
-                uint256 amount;
-                // solhint-disable-next-line no-inline-assembly
-                assembly {
-                    let dataPtr := mload(add(add(calldatas, 0x20), mul(i, 0x20)))
-                    token := mload(add(dataPtr, 0x24))  // skip 4-byte selector + 32 bytes but token is at offset 4
-                    amount := mload(add(dataPtr, 0x64)) // offset 4 + 32 + 32 = 68
+                // Skip the 4-byte selector by slicing from index 4 onward
+                bytes memory params = new bytes(calldatas[i].length - 4);
+                for (uint256 j = 0; j < params.length; j++) {
+                    params[j] = calldatas[i][j + 4];
                 }
+                (address token, , uint256 amount) = abi.decode(params, (address, address, uint256));
                 uint256 treasuryBalance = IERC20(token).balanceOf(treasuryAddress);
                 if (treasuryBalance > 0 && amount > (treasuryBalance * TREASURY_EXTENDED_THRESHOLD_BPS) / 10000) {
                     return ProposalType.Extended;

--- a/contracts/governance/ArmadaToken.sol
+++ b/contracts/governance/ArmadaToken.sol
@@ -19,7 +19,7 @@ contract ArmadaToken is ERC20Votes {
 
     // ============ Transfer Restriction State ============
 
-    /// @notice When false, only whitelisted senders/receivers can transfer. Starts false.
+    /// @notice When false, only whitelisted senders can transfer. Starts false.
     bool public transferable;
 
     /// @notice Addresses exempt from transfer restrictions (add-only, no removal).
@@ -150,7 +150,7 @@ contract ArmadaToken is ERC20Votes {
 
     // ============ Transfer Restriction ============
 
-    /// @dev Restrict transfers when transferable is false: only whitelisted senders/receivers
+    /// @dev Restrict transfers when transferable is false: only whitelisted senders
     ///      or mints (from == address(0)) are allowed.
     function _beforeTokenTransfer(
         address from,
@@ -161,8 +161,7 @@ contract ArmadaToken is ERC20Votes {
         if (!transferable) {
             require(
                 from == address(0) ||
-                transferWhitelist[from] ||
-                transferWhitelist[to],
+                transferWhitelist[from],
                 "ArmadaToken: transfers restricted"
             );
         }

--- a/test/arm_token_votes.ts
+++ b/test/arm_token_votes.ts
@@ -199,7 +199,7 @@ describe("ArmadaToken — ERC20Votes", function () {
 
     it("should block non-whitelisted sender even when receiver is whitelisted", async function () {
       // WHY: The whitelist check is sender-only. A whitelisted receiver does NOT
-      // make the transfer valid — this was the spec-code mismatch fixed in this change.
+      // make the transfer valid — only the sender's whitelist status is checked.
       // Get tokens to carol (non-whitelisted) via whitelisted alice
       await armToken.connect(alice).transfer(carol.address, ethers.parseUnits("1000", 18));
 

--- a/test/arm_token_votes.ts
+++ b/test/arm_token_votes.ts
@@ -172,17 +172,18 @@ describe("ArmadaToken — ERC20Votes", function () {
       expect(await armToken.transferable()).to.equal(false);
     });
 
-    it("should block transfer between non-whitelisted addresses", async function () {
-      // Carol is not whitelisted. Try carol → dave (neither whitelisted)
+    it("should block transfer from non-whitelisted sender", async function () {
+      // WHY: Only whitelisted senders may transfer during the restricted phase.
+      // A non-whitelisted sender must be blocked regardless of receiver status.
       // First get some tokens to carol via whitelisted alice
       await armToken.connect(alice).transfer(carol.address, ethers.parseUnits("1000", 18));
 
-      // carol → dave should fail (neither is whitelisted)
+      // carol (non-whitelisted sender) → deployer (whitelisted) should fail
       await expect(
         armToken.connect(carol).transfer(deployer.address, ethers.parseUnits("500", 18))
-      ).to.not.be.reverted; // deployer IS whitelisted as receiver — bad test
+      ).to.be.revertedWith("ArmadaToken: transfers restricted");
 
-      // carol → someone not whitelisted
+      // carol (non-whitelisted sender) → someone else not whitelisted should also fail
       const [, , , , , , notWhitelisted] = await ethers.getSigners();
       await expect(
         armToken.connect(carol).transfer(notWhitelisted.address, ethers.parseUnits("500", 18))
@@ -196,14 +197,16 @@ describe("ArmadaToken — ERC20Votes", function () {
       ).to.not.be.reverted;
     });
 
-    it("should allow anyone to transfer to whitelisted receiver", async function () {
+    it("should block non-whitelisted sender even when receiver is whitelisted", async function () {
+      // WHY: The whitelist check is sender-only. A whitelisted receiver does NOT
+      // make the transfer valid — this was the spec-code mismatch fixed in this change.
       // Get tokens to carol (non-whitelisted) via whitelisted alice
       await armToken.connect(alice).transfer(carol.address, ethers.parseUnits("1000", 18));
 
-      // Carol (non-whitelisted) can send to alice (whitelisted)
+      // Carol (non-whitelisted) sending to alice (whitelisted) should still fail
       await expect(
         armToken.connect(carol).transfer(alice.address, ethers.parseUnits("500", 18))
-      ).to.not.be.reverted;
+      ).to.be.revertedWith("ArmadaToken: transfers restricted");
     });
 
     it("should allow minting regardless of transferable flag", async function () {


### PR DESCRIPTION
## Summary

- **ArmadaToken transfer whitelist fix**: Removed `transferWhitelist[to]` check from `_beforeTokenTransfer` — during the restricted transfer phase, only whitelisted **senders** may transfer. The previous code allowed any non-whitelisted holder to send ARM to whitelisted contracts (treasury, crowdfund, revenue-lock), breaking the transfer restriction invariant.
- **ArmadaGovernor assembly removal**: Replaced two inline assembly blocks in `_classifyProposal` with safe Solidity equivalents (`bytes4()` cast and `abi.decode`). This was the most expensive audit pattern per-line in the codebase — removing it eliminates manual pointer verification during security review.

## Details

### Token whitelist (ArmadaToken.sol)
The spec requires transfers to succeed in RESTRICTED state only if the **sender** is whitelisted. The code was checking `transferWhitelist[from] || transferWhitelist[to]`. Fix: remove `|| transferWhitelist[to]`. Verified safe — all contracts that transfer ARM during the restricted phase (Crowdfund, RevenueLock, Deployer) are already whitelisted as senders.

### Assembly removal (ArmadaGovernor.sol)
1. Selector extraction (4 lines of assembly) → `bytes4 selector = bytes4(calldatas[i]);`
2. distribute() decoding (5 lines of assembly) → byte copy + `abi.decode(params, (address, address, uint256))`

Note: Solidity 0.8.17 doesn't support memory slice syntax, so the decode uses a manual byte copy to strip the 4-byte selector.

## Test plan

- [x] ARM token unit tests pass (31/31)
- [x] Governance integration tests pass (42/42)
- [x] Foundry fuzz/invariant tests pass (532/532)

🤖 Generated with [Claude Code](https://claude.com/claude-code)