### PR TITLE
fix: include RevenueLock in quorum exclusion

### DIFF
--- a/docs/GOVERNANCE_ACTIVATION.md
+++ b/docs/GOVERNANCE_ACTIVATION.md
@@ -46,7 +46,7 @@ Contracts must deploy in this order. Each step depends on artifacts from previou
    └─ Read governance manifest → get armToken, treasury, governor addresses
    └─ Deploy ArmadaCrowdfund(usdc, armToken, admin, treasury)
    └─ Transfer crowdfund ARM allocation from deployer
-   └─ governor.setExcludedAddresses([crowdfundAddress])
+   └─ governor.setExcludedAddresses([crowdfundAddress, revenueLockAddress])
 ```
 
 The `deploy_crowdfund.ts` script hard-fails if the governance deployment manifest is missing.
@@ -59,7 +59,7 @@ The governor's `quorum()` function calculates eligible supply as:
 eligibleSupply = totalSupply - treasuryBalance - sum(excludedBalances)
 ```
 
-Without excluding the crowdfund contract, its 1.8M ARM balance would count toward the quorum denominator even though no one can vote with those tokens (they're locked in the contract until claimed). This would inflate quorum requirements, making governance harder to activate.
+Without excluding the crowdfund and RevenueLock contracts, their combined 4.2M ARM balance would count toward the quorum denominator even though no one can vote with those tokens (crowdfund ARM is locked until claimed; RevenueLock ARM is locked until revenue milestones are met). This would inflate quorum requirements, making governance harder to activate.
 
 The `setExcludedAddresses` call is a **one-time** operation gated by the deployer address. Once called, the excluded list is locked and cannot be changed. This prevents the deployer from manipulating quorum calculations post-deployment.
 

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -151,8 +151,8 @@ async function main() {
   // 6. Register crowdfund as excluded from quorum denominator
   console.log("6. Registering crowdfund in governor quorum exclusion...");
   const governor = await ethers.getContractAt("ArmadaGovernor", governorAddress);
-  await (await governor.setExcludedAddresses([crowdfundAddress], nm.override())).wait();
-  console.log(`   Crowdfund excluded from quorum denominator`);
+  await (await governor.setExcludedAddresses([crowdfundAddress, revenueLockAddress], nm.override())).wait();
+  console.log(`   Crowdfund + RevenueLock excluded from quorum denominator`);
 
   // 7. Authorize delegateOnBehalf callers (one-shot — must include all delegators)
   console.log("7. Authorizing delegateOnBehalf delegators...");


### PR DESCRIPTION
## Summary
- Add `revenueLockAddress` to `setExcludedAddresses()` call in `deploy_crowdfund.ts`, preventing RevenueLock's 2.4M ARM (20% of supply) from inflating the quorum denominator
- Update `GOVERNANCE_ACTIVATION.md` to reflect both exclusions

Fixes #209

## Test plan
- [ ] `npm run setup` succeeds on local Anvil chains
- [ ] Verify `getExcludedAddresses()` returns both crowdfund and RevenueLock addresses after deploy
- [ ] Existing governance tests pass (`npm run test:governance`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)