### PR TITLE
fix: clean up stale invite/commit phase references

### DIFF
--- a/.claude/TESTING_NEXT_STEPS.md
+++ b/.claude/TESTING_NEXT_STEPS.md
@@ -94,12 +94,12 @@ After finalization with 100+ participants across all hops:
 ### 2d. Access Control & State Machine
 
 **Phase transition violations (crowdfund):**
-- `commit()` during Invitation phase (before commitment window)
-- `invite()` during Commitment phase
-- `finalize()` before commitment ends
-- `addSeeds()` after Setup phase
+- `commit()` outside active window (before windowStart or after windowEnd)
+- `invite()` outside active window
+- `finalize()` before windowEnd
+- `addSeeds()` after week-1 window closes
 - `claim()` when phase is Canceled (should use `refund()`)
-- Non-admin calls `finalize()`, `addSeeds()`, `startInvitations()`, `withdrawProceeds()`
+- Non-admin calls `finalize()`, `addSeeds()`, `withdrawProceeds()`
 
 **Governor state machine:**
 - `queue()` a Defeated proposal — should revert

--- a/audit-reports/01-entry-points.md
+++ b/audit-reports/01-entry-points.md
@@ -151,9 +151,9 @@ State-changing functions callable by anyone --- prioritize for attack surface an
 ### Crowdfund Admin
 | Function | File | Notes |
 |----------|------|-------|
-| `addSeeds(address[])` | `ArmadaCrowdfund.sol:113` | Add seed participants (Setup phase only) |
-| `addSeed(address)` | `ArmadaCrowdfund.sol:120` | Add single seed (Setup phase only) |
-| `startInvitations()` | `ArmadaCrowdfund.sol:138` | Transition to Invitation phase |
+| `addSeeds(address[])` | `ArmadaCrowdfund.sol:113` | Add seed participants (week-1 window only) |
+| `addSeed(address)` | `ArmadaCrowdfund.sol:120` | Add single seed (week-1 window only) |
+| ~~`startInvitations()`~~ | ~~`ArmadaCrowdfund.sol:138`~~ | ~~Removed — invites and commits happen concurrently during Active phase~~ |
 | `finalize()` | `ArmadaCrowdfund.sol:222` | Compute allocations or cancel. nonReentrant. |
 | `withdrawProceeds(address)` | `ArmadaCrowdfund.sol:356` | Withdraw USDC proceeds to treasury |
 | `withdrawUnallocatedArm(address)` | `ArmadaCrowdfund.sol:372` | Withdraw excess ARM tokens |
@@ -221,9 +221,10 @@ Functions with access control patterns that need manual verification.
 - **Risk**: `initialize()` has no deployer check --- can be front-run on deployment
 - **Impact**: Attacker could initialize with malicious parameters
 
-### LOW: Crowdfund phase transition has no `inPhase(Phase.Commitment)` gate
-- **Risk**: `finalize()` checks `phase == Invitation || phase == Phase.Commitment`
-- **Impact**: Could finalize directly from Invitation phase (mitigated by `block.timestamp > commitmentEnd` check)
+### ~~LOW: Crowdfund phase transition has no `inPhase(Phase.Commitment)` gate~~ [RESOLVED]
+- ~~**Risk**: `finalize()` checks `phase == Invitation || phase == Phase.Commitment`~~
+- ~~**Impact**: Could finalize directly from Invitation phase~~
+- **Resolution**: Phase model simplified to Active → Finalized/Canceled. Separate Invitation/Commitment phases removed; `finalize()` now checks `phase == Phase.Active`.
 
 ---
 

--- a/audit-reports/02-audit-context.md
+++ b/audit-reports/02-audit-context.md
@@ -216,9 +216,11 @@ Removing a steward doesn't cancel their pending actions. A newly elected steward
 
 Owner set once during `initialize()`, cannot be changed. Key loss = permanent lockout.
 
-### LOW: `Phase.Commitment` Dead State in Crowdfund
+### ~~LOW: `Phase.Commitment` Dead State in Crowdfund~~ [RESOLVED]
 
-The `Phase` enum includes `Commitment` (value 2) but no code ever sets `phase = Phase.Commitment`. The finalize check includes it in an OR condition, but the branch is unreachable.
+~~The `Phase` enum includes `Commitment` (value 2) but no code ever sets `phase = Phase.Commitment`.~~
+
+**Resolution**: Phase model simplified to `{Active, Finalized, Canceled}`. The dead `Setup`, `Invitation`, and `Commitment` enum values were removed. Invites and commits happen concurrently during the Active phase.
 
 ### LOW: `withdrawProceeds()` Lacks Reentrancy Guard
 

--- a/audit-reports/05-spec-compliance.md
+++ b/audit-reports/05-spec-compliance.md
@@ -858,7 +858,12 @@ if (block.timestamp > commitmentEnd + FINALIZATION_DEADLINE && phase != Phase.Fi
 
 ---
 
-### FINDING-16: MEDIUM -- `Phase.Commitment` Dead State in Crowdfund
+### ~~FINDING-16: MEDIUM -- `Phase.Commitment` Dead State in Crowdfund~~ [RESOLVED]
+
+**Resolution**: Phase model simplified to `{Active, Finalized, Canceled}`. The dead `Setup`, `Invitation`, and `Commitment` enum values were removed. Invites and commits happen concurrently during the Active phase. `finalize()` now checks `phase == Phase.Active`.
+
+<details>
+<summary>Original finding (archived)</summary>
 
 **Spec claim** (DOC-7 Section 5):
 > "Phase.Commitment (value 2) exists in the enum but no code ever sets phase = Phase.Commitment"
@@ -884,11 +889,8 @@ require(
 
 The `Phase.Commitment` variant in the finalize check is dead code since no path ever sets `phase = Phase.Commitment`.
 
-**Evidence links**:
-- Code: `/Volumes/T7/railgun/poc/contracts/crowdfund/IArmadaCrowdfund.sol` L10
-- Code: `/Volumes/T7/railgun/poc/contracts/crowdfund/ArmadaCrowdfund.sol` L225-227
-
 **Severity justification**: MEDIUM. The state machine is incomplete. The `commit()` function at L187 does not transition phase from Invitation to Commitment. If the spec intended a distinct Commitment phase, it is unimplemented. If it was not intended, the enum value should be removed.
+</details>
 
 ---
 
@@ -1083,7 +1085,7 @@ This means user A pays LESS yield fee than they should (fee based on 1.05 cost b
 | ID | Spec Flow | Code Flow | Divergence |
 |----|-----------|-----------|------------|
 | FM-1 | Cross-chain shield with relayer fee: user sends amount, relayer gets fee from commitment | No relayer fee field; CCTP maxFee is protocol-level only | Relayer fee architecture missing (FINDING-02) |
-| FM-2 | Crowdfund: Setup -> Invitation -> Commitment -> Finalized | Setup -> Invitation -> Finalized (Commitment phase never entered) | Dead state (FINDING-16) |
+| ~~FM-2~~ | ~~Crowdfund: Setup -> Invitation -> Commitment -> Finalized~~ | ~~Setup -> Invitation -> Finalized (Commitment phase never entered)~~ | ~~Dead state (FINDING-16)~~ [RESOLVED — Phase model simplified to Active → Finalized/Canceled] |
 
 ---
 
@@ -1140,7 +1142,7 @@ This means user A pays LESS yield fee than they should (fee based on 1.05 cost b
 8. **FINDING-11**: Document the cost basis limitation of the adapter pattern.
 9. **FINDING-14**: Snapshot treasury balance at proposal creation for quorum calculation.
 10. **FINDING-15**: Add finalization deadline to crowdfund.
-11. **FINDING-16**: Either implement the Commitment phase transition or remove it from the enum.
+11. ~~**FINDING-16**: Either implement the Commitment phase transition or remove it from the enum.~~ [RESOLVED — dead phases removed]
 
 ### Low Priority
 
@@ -1157,7 +1159,7 @@ This means user A pays LESS yield fee than they should (fee based on 1.05 cost b
 2. **Relayer fee architecture**: Mark DOC-1 Section "Cross-Chain Shields (Option A)" and DOC-2 Phase 4 as NOT YET IMPLEMENTED.
 3. **Quorum counting**: Add explicit rule: "Quorum = forVotes + abstainVotes >= threshold. Against votes do not count."
 4. **Proposal threshold**: Clarify whether "eligible supply" means total supply or circulating supply.
-5. **Phase.Commitment**: Document that the Commitment phase is implicit (time-based, not state-transition based).
+5. ~~**Phase.Commitment**: Document that the Commitment phase is implicit (time-based, not state-transition based).~~ [RESOLVED — dead phases removed from enum]
 6. **Unshield fee**: Document that unshield fee is intentionally set to 0 in the POC deployment.
 7. **Adapter cost basis**: Add a known-limitation section explaining that per-user cost basis tracking is approximated when using the adapter pattern.
 

--- a/audit-reports/06-function-analysis.md
+++ b/audit-reports/06-function-analysis.md
@@ -204,8 +204,8 @@ Finalizes crowdfund after commitment window. Determines sale size (elastic expan
 
 ### 6.2 finalize Block-by-Block
 
-- L223: `require(block.timestamp > commitmentEnd)` — timing gate
-- L224-227: Phase guard — requires Invitation or Commitment (Commitment is unreachable dead code)
+- `require(block.timestamp > windowEnd)` — timing gate
+- Phase guard — requires Active (old Invitation/Commitment dead code was removed)
 - L230-234: If `totalCommitted < MIN_SALE` ($1M), cancels sale
 - L237-241: Elastic expansion — if `totalCommitted >= ELASTIC_TRIGGER` ($1.8M), saleSize = MAX_SALE
 - L244-248: ARM sufficiency check
@@ -226,13 +226,13 @@ Lazy per-participant allocation using stored hop-level data:
 - **INV-FZ-1**: `sum(reserveBps) == 10000`, so `sum(reserves) == saleSize`
 - **INV-FZ-2**: Post-rollover: `reserves + treasuryLeftover == saleSize`
 - **INV-CA-1**: `allocUsdc + refundUsdc == committed` exactly (no rounding leakage to user)
-- **INV-FZ-4**: Phase transitions are one-way (Invitation -> Finalized or Canceled)
+- **INV-FZ-4**: Phase transitions are one-way (Active -> Finalized or Canceled)
 
 ### 6.5 Observations
 
-- **Phase.Commitment dead code**: `commit()` at L187-L217 does NOT transition phase to Commitment. The guard at L225 checking `Phase.Commitment` is unreachable.
+- ~~**Phase.Commitment dead code**~~: [RESOLVED — dead phases removed; `finalize()` now checks `phase == Phase.Active`]
 - **Integer division dust**: In over-subscribed hops, per-participant `allocUsdc` rounds down. Sum of all allocations may be less than `finalReserves[hop]`. Dust remains in contract.
-- **No finalization deadline**: Admin can delay `finalize()` indefinitely after `commitmentEnd`, locking participant USDC.
+- **No finalization deadline**: Admin can delay `finalize()` indefinitely after `windowEnd`, locking participant USDC.
 - **ARM recovery after cancellation**: `withdrawUnallocatedArm()` requires `phase == Finalized`. If sale is canceled, ARM tokens are permanently locked.
 
 ---

--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -168,7 +168,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, EIP712 {
 
     // ============ Seed Management ============
 
-    /// @notice Add seed addresses (hop 0). Allowed before invite period ends (requires ARM loaded).
+    /// @notice Add seed addresses (hop 0). Allowed during week 1 only (requires ARM loaded).
     function addSeeds(address[] calldata seeds) external onlyLaunchTeam {
         _requireArmLoadedAndPreInviteEnd();
         for (uint256 i = 0; i < seeds.length; i++) {
@@ -176,7 +176,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, EIP712 {
         }
     }
 
-    /// @notice Add a single seed address (hop 0). Allowed before invite period ends (requires ARM loaded).
+    /// @notice Add a single seed address (hop 0). Allowed during week 1 only (requires ARM loaded).
     function addSeed(address seed) external onlyLaunchTeam {
         _requireArmLoadedAndPreInviteEnd();
         _addSeed(seed);
@@ -214,7 +214,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, EIP712 {
         emit ArmLoaded();
     }
 
-    // ============ Invitation Phase ============
+    // ============ Invitations ============
 
     /// @notice Invite an address to participate at (inviterHop + 1).
     ///         Re-inviting an already-whitelisted (invitee, hop) node increments its
@@ -274,7 +274,7 @@ contract ArmadaCrowdfund is ReentrancyGuard, EIP712 {
         emit LaunchTeamInvited(invitee, inviteeHop);
     }
 
-    // ============ Commitment Phase ============
+    // ============ Commitments ============
 
     /// @notice Commit USDC to the crowdfund at a specific hop level
     /// @param hop Which of the caller's (address, hop) nodes to commit to

--- a/crowdfund-ui/packages/committer/src/components/InviteTab.tsx
+++ b/crowdfund-ui/packages/committer/src/components/InviteTab.tsx
@@ -161,7 +161,7 @@ export function InviteTab(props: InviteTabProps) {
   if (phase !== 0 || !windowOpen) {
     return (
       <div className="p-4 text-center text-muted-foreground">
-        Invites can only be sent during the active commitment window.
+        Invites can only be sent during the active sale window.
       </div>
     )
   }

--- a/mcp-server/src/tools/contract-state.ts
+++ b/mcp-server/src/tools/contract-state.ts
@@ -246,11 +246,9 @@ async function queryCrowdfund(env: DeployEnv): Promise<ContractQueryResult> {
 
   const cf = deployments.hub.crowdfund.contracts;
 
-  // Phase enum: 0 = Setup, 1 = Invitation, 2 = Commitment, 3 = Finalized, 4 = Canceled
+  // Phase enum: 0 = Active, 1 = Finalized, 2 = Canceled
   const CROWDFUND_PHASES = [
-    "Setup",
-    "Invitation",
-    "Commitment",
+    "Active",
     "Finalized",
     "Canceled",
   ];

--- a/reports/integration-flows.md
+++ b/reports/integration-flows.md
@@ -53,9 +53,9 @@
 
 | Step | Test | File |
 |------|------|------|
-| Add seeds, start invitations | ✓ | `cross_contract_integration.ts` — "full lifecycle" |
+| Add seeds, invite hop-1 | ✓ | `cross_contract_integration.ts` — "full lifecycle" |
 | Seeds invite hop-1 | ✓ | Same |
-| Commitment phase (80 seeds × $15K) | ✓ | Same |
+| Commit (80 seeds × $15K) | ✓ | Same |
 | Finalize | ✓ | Same |
 | Claim ARM | ✓ | Same |
 | Lock in VotingLocker | ✓ | Same |

--- a/reports/manual-review-correctness.md
+++ b/reports/manual-review-correctness.md
@@ -12,7 +12,7 @@
 | Overflow | ✅ | Solidity 0.8+ built-in checks. Bounds in `_computeAllocation` (committed, reserve, demand) prevent overflow; Halmos proven for alloc+refund=committed. |
 | Division-by-zero | ✅ | `finalDemands[hop]` set from `hopStats[h].totalCommitted`; over-subscribed case has `demand > 0`. Under-subscribed uses `ARM_PRICE` (constant 1e6). |
 | Rounding | ✅ | Pro-rata: `(committed * reserve) / demand` — rounds down; refund = committed - allocUsdc. Formally proven. Hop-level `totalAllocArm` uses same formula. |
-| State machine | ✅ | Phase: Setup → Invitation → Commitment → Finalized/Canceled. `inPhase` modifier enforces. `finalize()` sets phase once. |
+| State machine | ✅ | Phase: Active → Finalized/Canceled. Direct `require(phase == Phase.Active)` guards enforce. `finalize()` sets phase once. |
 
 **Known:** `finalize()` O(n) over `participantList` — not used; allocations computed lazily in `claim()`. Documented in TESTING_NEXT_STEPS.
 

--- a/reports/threat-model-governance-crowdfund.md
+++ b/reports/threat-model-governance-crowdfund.md
@@ -48,7 +48,7 @@
 | C-01 | **Allocation rounding** | Pro-rata creates dust or over-allocates | Integer division; allocUsdc + refund == committed | AllocationFuzz, adversarial |
 | C-02 | **Over-allocation** | sum(allocations) > totalAllocated | Hop-level upper bound; per-participant alloc <= reserve share | Invariant tests |
 | C-03 | **Double claim** | Participant claims twice | p.claimed check | Integration tests |
-| C-04 | **Phase violation** | commit during wrong phase | inPhase modifier; timestamp checks | Adversarial tests |
+| C-04 | **Phase violation** | commit during wrong phase | `require(phase == Phase.Active)` guards; timestamp checks | Adversarial tests |
 | C-05 | **Reentrancy** | claim/refund re-entered | ReentrancyGuard | ReentrancyAttacker tests |
 | C-06 | **Hop cap bypass** | Commit exceeds per-hop cap | capUsdc enforced in commit | Integration tests |
 | C-07 | **Invite graph cycles** | invitee invites inviter | Invite graph is tree; hop = inviter.hop + 1 | — |


### PR DESCRIPTION
## Summary

- **Bug fix**: MCP server phase enum mapping was wrong — `Active` (0) displayed as "Setup", `Finalized` (1) as "Invitation", `Canceled` (2) as "Commitment"
- **Contract cleanup**: Updated stale section headers ("Invitation Phase" → "Invitations", "Commitment Phase" → "Commitments") and NatSpec ("before invite period ends" → "during week 1 only")
- **UI text fix**: "active commitment window" → "active sale window" in InviteTab
- **Docs/reports**: Updated 6 report files and 1 planning doc to reflect the current 3-phase model (Active/Finalized/Canceled), marking resolved audit findings as such

## Context

The crowdfund was refactored from a sequential Invite→Commit phase model to a single concurrent Active window (launch team invites restricted to week 1, everyone else can invite+commit throughout all 3 weeks). The contract logic was changed correctly, but leftover references to the old model persisted across comments, docs, UI copy, and the MCP server.

## Test plan

- [ ] Contract compiles cleanly (verified — comments/NatSpec only, no logic changes)
- [ ] InviteTab test still passes (asserts on partial string "Invites can only be sent during" which matches new text)
- [ ] MCP server phase names now match contract enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)