### PR TITLE
feat: add Signaling proposal type

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -70,6 +70,8 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     error Gov_WindDownContractAlreadySet();
     error Gov_WindDownContractNotSet();
     error Gov_SCEjected();
+    error Gov_SignalingMustBeEmpty();
+    error Gov_SignalingNoExecution();
     error Gov_TreasuryAlreadyExcluded();
 
     // ============ Types ============
@@ -298,6 +300,15 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
             quorumBps: 2000
         });
 
+        // Signaling: non-executable text-only proposals. Standard timing, no execution phase.
+        // Immutable — cannot be changed via setProposalTypeParams().
+        proposalTypeParams[ProposalType.Signaling] = ProposalParams({
+            votingDelay: 2 days,
+            votingPeriod: 7 days,
+            executionDelay: 0,
+            quorumBps: 2000
+        });
+
         // Hardcoded extended selectors per governance spec §Scope table.
         // These cannot be misconfigured at deployment. Governance can expand or
         // shrink this set at any time via addExtendedSelector/removeExtendedSelector.
@@ -441,7 +452,7 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         ProposalParams calldata params
     ) external {
         if (msg.sender != address(timelock)) revert Gov_NotTimelock();
-        if (proposalType == ProposalType.VetoRatification || proposalType == ProposalType.Steward) revert Gov_ImmutableProposalType();
+        if (proposalType == ProposalType.VetoRatification || proposalType == ProposalType.Steward || proposalType == ProposalType.Signaling) revert Gov_ImmutableProposalType();
         if (params.votingDelay < MIN_VOTING_DELAY || params.votingDelay > MAX_VOTING_DELAY) revert Gov_VotingDelayOutOfBounds();
         if (params.votingPeriod < MIN_VOTING_PERIOD || params.votingPeriod > MAX_VOTING_PERIOD) revert Gov_VotingPeriodOutOfBounds();
         if (params.executionDelay < MIN_EXECUTION_DELAY || params.executionDelay > MAX_EXECUTION_DELAY) revert Gov_ExecutionDelayOutOfBounds();
@@ -714,16 +725,26 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         string memory description
     ) external returns (uint256) {
         if (windDownActive) revert Gov_GovernanceEnded();
-        if (targets.length == 0) revert Gov_EmptyProposal();
-        if (targets.length != values.length || targets.length != calldatas.length) revert Gov_LengthMismatch();
         if (proposalType == ProposalType.VetoRatification || proposalType == ProposalType.Steward) revert Gov_AutoCreatedOnly();
         _checkQuietPeriod();
         _checkProposalThreshold(msg.sender);
 
+        // Signaling proposals are text-only: no targets, values, or calldatas allowed.
+        // Executable proposals must have at least one target with matching arrays.
+        if (proposalType == ProposalType.Signaling) {
+            if (targets.length != 0) revert Gov_SignalingMustBeEmpty();
+        } else {
+            if (targets.length == 0) revert Gov_EmptyProposal();
+            if (targets.length != values.length || targets.length != calldatas.length) revert Gov_LengthMismatch();
+        }
+
         // Mechanical classification: if any calldata triggers extended, override to Extended.
         // Proposers can opt into Extended voluntarily, but cannot downgrade to Standard
         // when calldata contains extended-classified function calls.
-        ProposalType effectiveType = _classifyProposal(proposalType, targets, calldatas);
+        // Signaling proposals skip classification (no calldata to classify).
+        ProposalType effectiveType = proposalType == ProposalType.Signaling
+            ? ProposalType.Signaling
+            : _classifyProposal(proposalType, targets, calldatas);
 
         uint256 proposalId = ++proposalCount;
         _initProposal(proposalId, effectiveType, description);
@@ -829,6 +850,7 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
 
         Proposal storage p = _proposals[proposalId];
         if (p.proposalType == ProposalType.VetoRatification) revert Gov_UseResolveRatification();
+        if (p.proposalType == ProposalType.Signaling) revert Gov_SignalingNoExecution();
 
         // Steward proposals must not be queueable after steward removal or term expiry.
         // Creation-time checks in proposeStewardSpend() verify steward status at proposal
@@ -863,6 +885,7 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
 
         Proposal storage p = _proposals[proposalId];
         if (p.proposalType == ProposalType.VetoRatification) revert Gov_UseResolveRatification();
+        if (p.proposalType == ProposalType.Signaling) revert Gov_SignalingNoExecution();
 
         // Mirror the queue()-time steward check: a steward removed or expired during the
         // execution delay must not have their proposal execute. Without this, the SC veto
@@ -929,6 +952,10 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
                 return ProposalState.Defeated;
             }
         }
+
+        // Signaling proposals are terminal at outcome — no queue/execute phase.
+        // Succeeded is permanent (no grace period expiry).
+        if (p.proposalType == ProposalType.Signaling) return ProposalState.Succeeded;
 
         if (p.queued) return ProposalState.Queued;
 

--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -732,7 +732,7 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         // Signaling proposals are text-only: no targets, values, or calldatas allowed.
         // Executable proposals must have at least one target with matching arrays.
         if (proposalType == ProposalType.Signaling) {
-            if (targets.length != 0) revert Gov_SignalingMustBeEmpty();
+            if (targets.length != 0 || values.length != 0 || calldatas.length != 0) revert Gov_SignalingMustBeEmpty();
         } else {
             if (targets.length == 0) revert Gov_EmptyProposal();
             if (targets.length != values.length || targets.length != calldatas.length) revert Gov_LengthMismatch();

--- a/contracts/governance/IArmadaGovernance.sol
+++ b/contracts/governance/IArmadaGovernance.sol
@@ -12,7 +12,8 @@ enum ProposalType {
     Standard,          // 0 — 7d voting, 48h execution, 20% quorum
     Extended,          // 1 — 14d voting, 7d execution, 30% quorum
     VetoRatification,  // 2 — 7d voting, no delay, 20% quorum (auto-created only)
-    Steward            // 3 — 7d voting, 2d execution, 20% quorum (pass-by-default, auto-created only)
+    Steward,           // 3 — 7d voting, 2d execution, 20% quorum (pass-by-default, auto-created only)
+    Signaling          // 4 — 7d voting, no execution, 20% quorum (text-only, non-executable)
 }
 
 enum ProposalState {

--- a/test-foundry/GovernorInvariant.t.sol
+++ b/test-foundry/GovernorInvariant.t.sol
@@ -184,6 +184,39 @@ contract GovernorHandler is Test {
         }
     }
 
+    /// @dev Create a signaling (non-executable) proposal.
+    /// Signaling proposals have empty targets/values/calldatas and use Signaling type.
+    function createSignalingProposal(uint256 actorIdx) external {
+        actorIdx = bound(actorIdx, 0, actors.length - 1);
+        address actor = actors[actorIdx];
+
+        if (block.number < 2) {
+            vm.roll(2);
+        }
+
+        address[] memory targets = new address[](0);
+        uint256[] memory values = new uint256[](0);
+        bytes[] memory calldatas = new bytes[](0);
+
+        vm.prank(actor);
+        try governor.propose(
+            ProposalType.Signaling,
+            targets,
+            values,
+            calldatas,
+            "Signaling proposal"
+        ) returns (uint256 proposalId) {
+            ghost_proposalCount = proposalId;
+            ghost_highestState[proposalId] = 0; // Pending
+            ghost_quorumAtCreation[proposalId] = governor.quorum(proposalId);
+        } catch {}
+
+        // Update all proposal states
+        for (uint256 i = 1; i <= ghost_proposalCount; i++) {
+            _checkAndUpdateState(i);
+        }
+    }
+
     /// @dev Cast or change a vote on a proposal.
     /// Voters can switch between FOR, AGAINST, and ABSTAIN. Only records a new VoteRecord
     /// for first-time voters; re-votes update the existing record.
@@ -333,7 +366,7 @@ contract GovernorInvariantTest is Test, GovernorDeployHelper {
 
         targetContract(address(handler));
 
-        bytes4[] memory selectors = new bytes4[](7);
+        bytes4[] memory selectors = new bytes4[](8);
         selectors[0] = GovernorHandler.delegateVotes.selector;
         selectors[1] = GovernorHandler.transferTokens.selector;
         selectors[2] = GovernorHandler.createProposal.selector;
@@ -341,6 +374,7 @@ contract GovernorInvariantTest is Test, GovernorDeployHelper {
         selectors[4] = GovernorHandler.advanceTime.selector;
         selectors[5] = GovernorHandler.queueProposal.selector;
         selectors[6] = GovernorHandler.transferToTreasury.selector;
+        selectors[7] = GovernorHandler.createSignalingProposal.selector;
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
     }
 

--- a/test-foundry/GovernorSignaling.t.sol
+++ b/test-foundry/GovernorSignaling.t.sol
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Foundry tests for the Signaling proposal type — non-executable, text-only proposals.
+// ABOUTME: Covers lifecycle, state transitions, execution guards, immutability, and timing.
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/ArmadaGovernor.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/governance/ArmadaTreasuryGov.sol";
+import "../contracts/governance/IArmadaGovernance.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+import "./helpers/GovernorDeployHelper.sol";
+
+/// @title GovernorSignalingTest — Tests for non-executable signaling proposals
+contract GovernorSignalingTest is Test, GovernorDeployHelper {
+    ArmadaGovernor public governor;
+    ArmadaToken public armToken;
+    TimelockController public timelock;
+    ArmadaTreasuryGov public treasury;
+
+    address public deployer = address(this);
+    address public alice = address(0xA11CE);
+    address public bob = address(0xB0B);
+    address public carol = address(0xCA201);
+
+    uint256 constant TOTAL_SUPPLY = 12_000_000 * 1e18;
+    uint256 constant TWO_DAYS = 2 days;
+    uint256 constant SEVEN_DAYS = 7 days;
+    uint256 constant FOURTEEN_DAYS = 14 days;
+    uint256 constant QUEUE_GRACE_PERIOD = 14 days;
+
+    function setUp() public {
+        // Deploy timelock
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        timelock = new TimelockController(TWO_DAYS, proposers, executors, deployer);
+
+        // Deploy ARM token
+        armToken = new ArmadaToken(deployer, address(timelock));
+
+        // Deploy treasury
+        treasury = new ArmadaTreasuryGov(address(timelock));
+
+        // Deploy governor
+        governor = _deployGovernorProxy(
+            address(armToken),
+            payable(address(timelock)),
+            address(treasury)
+        );
+
+        // Whitelist participants
+        address[] memory whitelist = new address[](3);
+        whitelist[0] = deployer;
+        whitelist[1] = alice;
+        whitelist[2] = bob;
+        armToken.initWhitelist(whitelist);
+
+        // Distribute tokens: alice 20%, bob 15%, deployer keeps rest
+        armToken.transfer(alice, TOTAL_SUPPLY * 20 / 100);
+        armToken.transfer(bob, TOTAL_SUPPLY * 15 / 100);
+
+        // Delegate to activate voting power
+        vm.prank(alice);
+        armToken.delegate(alice);
+        vm.prank(bob);
+        armToken.delegate(bob);
+
+        // Advance block so checkpoints are available
+        vm.roll(block.number + 1);
+
+        // Grant timelock roles to governor
+        timelock.grantRole(timelock.PROPOSER_ROLE(), address(governor));
+        timelock.grantRole(timelock.EXECUTOR_ROLE(), address(governor));
+        timelock.grantRole(timelock.CANCELLER_ROLE(), address(governor));
+    }
+
+    // ======== Helpers ========
+
+    /// @dev Create a signaling proposal from the given proposer.
+    function _createSignalingProposal(address proposer, string memory description) internal returns (uint256) {
+        address[] memory targets = new address[](0);
+        uint256[] memory values = new uint256[](0);
+        bytes[] memory calldatas = new bytes[](0);
+
+        vm.prank(proposer);
+        governor.propose(ProposalType.Signaling, targets, values, calldatas, description);
+        return governor.proposalCount();
+    }
+
+    /// @dev Create a signaling proposal and advance it to Succeeded state.
+    function _createAndPassSignalingProposal(address proposer) internal returns (uint256) {
+        uint256 proposalId = _createSignalingProposal(proposer, "test signaling");
+
+        // Advance past voting delay (2 days)
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+
+        // Vote FOR with alice (20% of eligible supply — meets 20% quorum)
+        vm.prank(alice);
+        governor.castVote(proposalId, 1); // FOR
+
+        // Advance past voting period (7 days)
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Succeeded));
+        return proposalId;
+    }
+
+    // ======== Lifecycle Tests ========
+
+    // WHY: Core lifecycle — signaling proposals must be creatable with empty arrays
+    // and start in Pending state. This validates the propose() guard relaxation.
+    function test_signaling_succeedsWithQuorumAndMajority() public {
+        uint256 proposalId = _createAndPassSignalingProposal(alice);
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Succeeded));
+    }
+
+    // WHY: Signaling proposals must be Defeated when quorum is not reached,
+    // using the same quorum logic as executable proposals.
+    function test_signaling_defeatedWithoutQuorum() public {
+        uint256 proposalId = _createSignalingProposal(alice, "no quorum");
+
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+        // No one votes
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Defeated));
+    }
+
+    // WHY: Signaling proposals must be Defeated when quorum is met but
+    // the majority votes against (againstVotes >= forVotes).
+    function test_signaling_defeatedWithMajorityAgainst() public {
+        uint256 proposalId = _createSignalingProposal(alice, "majority against");
+
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+
+        // Alice AGAINST (20%), Bob FOR (15%) — quorum met, majority against
+        vm.prank(alice);
+        governor.castVote(proposalId, 0); // AGAINST
+        vm.prank(bob);
+        governor.castVote(proposalId, 1); // FOR
+
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Defeated));
+    }
+
+    // ======== Execution Guard Tests ========
+
+    // WHY: Signaling proposals must never be queueable. The explicit revert in
+    // queue() is defense-in-depth — state() also prevents this, but the
+    // explicit guard provides a clear error message.
+    function test_signaling_cannotQueue() public {
+        uint256 proposalId = _createAndPassSignalingProposal(alice);
+
+        vm.expectRevert(abi.encodeWithSelector(ArmadaGovernor.Gov_SignalingNoExecution.selector));
+        governor.queue(proposalId);
+    }
+
+    // WHY: Signaling proposals must never be executable. Since they can never
+    // be queued, state() will never return Queued, so execute() would revert
+    // with Gov_NotQueued. This test confirms that path.
+    function test_signaling_cannotExecute() public {
+        uint256 proposalId = _createAndPassSignalingProposal(alice);
+
+        // execute() checks state() == Queued first, which will be Succeeded for signaling
+        vm.expectRevert(abi.encodeWithSelector(ArmadaGovernor.Gov_NotQueued.selector));
+        governor.execute(proposalId);
+    }
+
+    // ======== Input Validation Tests ========
+
+    // WHY: Signaling proposals must reject non-empty targets — they must not carry
+    // execution data. This prevents disguising executable proposals as signaling.
+    function test_signaling_cannotHaveTargets() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(governor);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature("proposalCount()");
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(ArmadaGovernor.Gov_SignalingMustBeEmpty.selector));
+        governor.propose(ProposalType.Signaling, targets, values, calldatas, "sneaky");
+    }
+
+    // ======== Immutability Tests ========
+
+    // WHY: Signaling params (timing, quorum) are spec-fixed and must not be changeable
+    // via governance. Like VetoRatification and Steward, Signaling is immutable.
+    function test_signaling_paramsImmutable() public {
+        ProposalParams memory newParams = ProposalParams({
+            votingDelay: 1 days,
+            votingPeriod: 14 days,
+            executionDelay: 2 days,
+            quorumBps: 3000
+        });
+
+        vm.prank(address(timelock));
+        vm.expectRevert(abi.encodeWithSelector(ArmadaGovernor.Gov_ImmutableProposalType.selector));
+        governor.setProposalTypeParams(ProposalType.Signaling, newParams);
+    }
+
+    // ======== Grace Period Tests ========
+
+    // WHY: Signaling Succeeded state must be permanent. Without the Signaling-specific
+    // check in state(), the QUEUE_GRACE_PERIOD (14 days) would cause Succeeded
+    // signaling proposals to expire to Defeated — which is incorrect because
+    // there is nothing to queue.
+    function test_signaling_succeededDoesNotExpire() public {
+        uint256 proposalId = _createAndPassSignalingProposal(alice);
+
+        // Advance well past the QUEUE_GRACE_PERIOD
+        vm.warp(block.timestamp + QUEUE_GRACE_PERIOD + 30 days);
+
+        // Still Succeeded — not expired
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Succeeded));
+    }
+
+    // ======== Classification Tests ========
+
+    // WHY: Signaling proposals must always use Standard timing (7d vote, 48h delay).
+    // They skip _classifyProposal() entirely so there is no risk of Extended
+    // auto-promotion. Verify the actual timing matches Standard params.
+    function test_signaling_notAutoPromotedToExtended() public {
+        uint256 proposalId = _createSignalingProposal(alice, "stays standard");
+
+        (,, uint256 voteStart, uint256 voteEnd,,,,,) = governor.getProposal(proposalId);
+        uint256 votingPeriod = voteEnd - voteStart;
+
+        // Standard voting period = 7 days (not 14 days Extended)
+        assertEq(votingPeriod, SEVEN_DAYS);
+    }
+
+    // ======== Cancellation Tests ========
+
+    // WHY: Signaling proposals follow Standard cancellation rules — proposer can
+    // cancel during Pending but not during Active. This verifies both directions.
+    function test_signaling_cancelDuringPending() public {
+        uint256 proposalId = _createSignalingProposal(alice, "cancel me");
+
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Pending));
+
+        vm.prank(alice);
+        governor.cancel(proposalId);
+
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Canceled));
+    }
+
+    function test_signaling_cannotCancelDuringActive() public {
+        uint256 proposalId = _createSignalingProposal(alice, "too late");
+
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Active));
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(ArmadaGovernor.Gov_NotPending.selector));
+        governor.cancel(proposalId);
+    }
+}

--- a/test/governance_signaling.ts
+++ b/test/governance_signaling.ts
@@ -1,11 +1,5 @@
-/**
- * Governance Signaling Proposal Tests
- *
- * Tests the Signaling proposal type — non-executable, text-only proposals
- * for measuring token-holder preference. Signaling proposals follow the
- * standard lifecycle (submit → pending → active → outcome) but skip the
- * execution phase (no queue, no timelock, no execute).
- */
+// ABOUTME: Integration tests for the Signaling proposal type in ArmadaGovernor.
+// ABOUTME: Covers lifecycle, voting, revert guards, and non-executability constraints.
 
 import { expect } from "chai";
 import { ethers } from "hardhat";

--- a/test/governance_signaling.ts
+++ b/test/governance_signaling.ts
@@ -1,0 +1,416 @@
+/**
+ * Governance Signaling Proposal Tests
+ *
+ * Tests the Signaling proposal type — non-executable, text-only proposals
+ * for measuring token-holder preference. Signaling proposals follow the
+ * standard lifecycle (submit → pending → active → outcome) but skip the
+ * execution phase (no queue, no timelock, no execute).
+ */
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time, mine } from "@nomicfoundation/hardhat-network-helpers";
+import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { deployGovernorProxy } from "./helpers/deploy-governor";
+
+// Proposal types (must match IArmadaGovernance.sol enum order)
+const ProposalType = { Standard: 0, Extended: 1, VetoRatification: 2, Steward: 3, Signaling: 4 };
+// Proposal states
+const ProposalState = {
+  Pending: 0, Active: 1, Defeated: 2, Succeeded: 3,
+  Queued: 4, Executed: 5, Canceled: 6,
+};
+// Vote support values
+const Vote = { Against: 0, For: 1, Abstain: 2 };
+
+// Time constants
+const ONE_DAY = 86400;
+const TWO_DAYS = 2 * ONE_DAY;
+const SEVEN_DAYS = 7 * ONE_DAY;
+const FOURTEEN_DAYS = 14 * ONE_DAY;
+const THIRTY_DAYS = 30 * ONE_DAY;
+
+describe("Governance — Signaling Proposals", function () {
+  // Contracts
+  let armToken: any;
+  let timelockController: any;
+  let governor: any;
+  let treasury: any;
+
+  // Signers
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let carol: SignerWithAddress;
+  let dave: SignerWithAddress;
+
+  // Constants
+  const ARM_DECIMALS = 18;
+  const TOTAL_SUPPLY = ethers.parseUnits("12000000", ARM_DECIMALS);
+  const TREASURY_AMOUNT = TOTAL_SUPPLY * 65n / 100n;
+  const ALICE_AMOUNT = TOTAL_SUPPLY * 20n / 100n;
+  const BOB_AMOUNT = TOTAL_SUPPLY * 15n / 100n;
+
+  async function mineBlock() {
+    await mine(1);
+  }
+
+  // Helper: create a signaling proposal
+  async function createSignalingProposal(
+    proposer: SignerWithAddress,
+    description: string,
+  ): Promise<number> {
+    await governor.connect(proposer).propose(
+      ProposalType.Signaling, [], [], [], description
+    );
+    return Number(await governor.proposalCount());
+  }
+
+  beforeEach(async function () {
+    [deployer, alice, bob, carol, dave] = await ethers.getSigners();
+
+    // 1. Deploy TimelockController
+    const TimelockController = await ethers.getContractFactory("TimelockController");
+    timelockController = await TimelockController.deploy(
+      TWO_DAYS, [], [], deployer.address
+    );
+    await timelockController.waitForDeployment();
+    const timelockAddr = await timelockController.getAddress();
+
+    // 2. Deploy ARM token
+    const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+    armToken = await ArmadaToken.deploy(deployer.address, timelockAddr);
+    await armToken.waitForDeployment();
+
+    // 3. Deploy Treasury
+    const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+    treasury = await ArmadaTreasuryGov.deploy(timelockAddr);
+    await treasury.waitForDeployment();
+
+    // 4. Deploy Governor
+    governor = await deployGovernorProxy(
+      await armToken.getAddress(),
+      timelockAddr,
+      await treasury.getAddress(),
+    );
+
+    // 5. Configure token: whitelist and noDelegation
+    await armToken.initWhitelist([
+      deployer.address,
+      await treasury.getAddress(),
+      alice.address,
+      bob.address,
+    ]);
+    await armToken.initNoDelegation([await treasury.getAddress()]);
+
+    // 6. Configure timelock roles
+    const PROPOSER_ROLE = await timelockController.PROPOSER_ROLE();
+    const EXECUTOR_ROLE = await timelockController.EXECUTOR_ROLE();
+    const ADMIN_ROLE = await timelockController.TIMELOCK_ADMIN_ROLE();
+
+    await timelockController.grantRole(PROPOSER_ROLE, await governor.getAddress());
+    await timelockController.grantRole(EXECUTOR_ROLE, await governor.getAddress());
+
+    // 7. Distribute ARM tokens
+    await armToken.transfer(await treasury.getAddress(), TREASURY_AMOUNT);
+    await armToken.transfer(alice.address, ALICE_AMOUNT);
+    await armToken.transfer(bob.address, BOB_AMOUNT);
+
+    // 8. Renounce deployer admin
+    await timelockController.renounceRole(ADMIN_ROLE, deployer.address);
+
+    // 9. Self-delegate to activate voting power
+    await armToken.connect(alice).delegate(alice.address);
+    await armToken.connect(bob).delegate(bob.address);
+
+    await mineBlock();
+  });
+
+  // ========== Lifecycle Tests ==========
+
+  describe("Lifecycle", function () {
+    // WHY: Signaling proposals must be creatable with empty execution arrays.
+    // This is the fundamental difference from executable proposals — the propose()
+    // function must accept empty targets for Signaling type.
+    it("should create a signaling proposal in Pending state", async function () {
+      const proposalId = await createSignalingProposal(alice, "Should we pursue cross-chain MASP?");
+
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Pending);
+      const proposal = await governor.getProposal(proposalId);
+      expect(proposal.proposalType).to.equal(ProposalType.Signaling);
+    });
+
+    // WHY: Verify that the signaling lifecycle correctly transitions through
+    // Pending → Active after the standard 48h voting delay.
+    it("should become Active after voting delay", async function () {
+      const proposalId = await createSignalingProposal(alice, "Temperature check: Aave integration");
+
+      await time.increase(TWO_DAYS + 1);
+
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Active);
+    });
+
+    // WHY: After voting ends with quorum met and majority FOR, signaling proposals
+    // must resolve to Succeeded. This is terminal — no queue/execute phase follows.
+    it("should resolve to Succeeded when quorum met and majority FOR", async function () {
+      const proposalId = await createSignalingProposal(alice, "Pursue hub-and-spoke architecture");
+
+      // Fast-forward past voting delay
+      await time.increase(TWO_DAYS + 1);
+
+      // Alice votes FOR (20% > quorum of 20% eligible = passes)
+      await governor.connect(alice).castVote(proposalId, Vote.For);
+
+      // Fast-forward past voting period
+      await time.increase(SEVEN_DAYS + 1);
+
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Succeeded);
+    });
+
+    // WHY: Signaling Succeeded state must be permanent — there is no grace period
+    // because there is nothing to queue. Without the Signaling-specific check in
+    // state(), the grace period expiry would incorrectly transition to Defeated.
+    it("should remain Succeeded indefinitely (no grace period expiry)", async function () {
+      const proposalId = await createSignalingProposal(alice, "Permanent signaling result");
+
+      await time.increase(TWO_DAYS + 1);
+      await governor.connect(alice).castVote(proposalId, Vote.For);
+      await time.increase(SEVEN_DAYS + 1);
+
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Succeeded);
+
+      // Fast-forward well past the QUEUE_GRACE_PERIOD (14 days)
+      await time.increase(THIRTY_DAYS);
+
+      // Still Succeeded — not expired to Defeated
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Succeeded);
+    });
+
+    // WHY: Signaling proposals with insufficient quorum must be Defeated,
+    // same as executable proposals. The quorum mechanism is shared.
+    it("should resolve to Defeated when quorum not reached", async function () {
+      const proposalId = await createSignalingProposal(alice, "No quorum scenario");
+
+      await time.increase(TWO_DAYS + 1);
+
+      // No one votes — quorum not met
+      await time.increase(SEVEN_DAYS + 1);
+
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Defeated);
+    });
+
+    // WHY: A majority of AGAINST votes with quorum must defeat the proposal.
+    it("should resolve to Defeated when majority votes AGAINST", async function () {
+      const proposalId = await createSignalingProposal(alice, "Unpopular idea");
+
+      await time.increase(TWO_DAYS + 1);
+
+      // Alice FOR, Bob AGAINST — Bob has 15% but with Alice's 20%, quorum met.
+      // Majority is AGAINST only if againstVotes >= forVotes. Here Alice 20% > Bob 15%
+      // so we need Bob to have more weight. Let's have Alice AGAINST, Bob FOR isn't enough.
+      // Actually: Alice 20% FOR, Bob 15% AGAINST — majority FOR. Let's flip.
+      await governor.connect(alice).castVote(proposalId, Vote.Against);
+      await governor.connect(bob).castVote(proposalId, Vote.For);
+
+      await time.increase(SEVEN_DAYS + 1);
+
+      // Alice has 20% against, Bob has 15% for — majority against, quorum met
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Defeated);
+    });
+  });
+
+  // ========== Guard Tests ==========
+
+  describe("Guards", function () {
+    // WHY: Signaling proposals must not carry execution data. If targets are non-empty,
+    // someone is trying to sneak executable data into a non-executable proposal type.
+    it("should revert when creating signaling with non-empty targets", async function () {
+      const target = await governor.getAddress();
+      await expect(
+        governor.connect(alice).propose(
+          ProposalType.Signaling,
+          [target],
+          [0n],
+          ["0x"],
+          "Sneaky executable"
+        )
+      ).to.be.revertedWithCustomError(governor, "Gov_SignalingMustBeEmpty");
+    });
+
+    // WHY: Defense-in-depth — even though state() prevents Signaling from reaching
+    // Succeeded-with-queue-eligibility, the explicit guard in queue() provides a
+    // clear revert reason and prevents reliance on state machine logic alone.
+    it("should revert when trying to queue a signaling proposal", async function () {
+      const proposalId = await createSignalingProposal(alice, "Cannot queue me");
+
+      await time.increase(TWO_DAYS + 1);
+      await governor.connect(alice).castVote(proposalId, Vote.For);
+      await time.increase(SEVEN_DAYS + 1);
+
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Succeeded);
+
+      await expect(
+        governor.queue(proposalId)
+      ).to.be.revertedWithCustomError(governor, "Gov_SignalingNoExecution");
+    });
+
+    // WHY: Signaling proposal params (timing, quorum) must be immutable — they represent
+    // fixed spec requirements and should not be changeable via governance votes.
+    it("should revert when trying to change signaling params", async function () {
+      // Need to call via timelock — impersonate it
+      const timelockAddr = await timelockController.getAddress();
+      await ethers.provider.send("hardhat_impersonateAccount", [timelockAddr]);
+      await deployer.sendTransaction({ to: timelockAddr, value: ethers.parseEther("1") });
+      const timelockSigner = await ethers.getSigner(timelockAddr);
+
+      await expect(
+        governor.connect(timelockSigner).setProposalTypeParams(
+          ProposalType.Signaling,
+          { votingDelay: ONE_DAY, votingPeriod: FOURTEEN_DAYS, executionDelay: 0, quorumBps: 3000 }
+        )
+      ).to.be.revertedWithCustomError(governor, "Gov_ImmutableProposalType");
+
+      await ethers.provider.send("hardhat_stopImpersonatingAccount", [timelockAddr]);
+    });
+
+    // WHY: Signaling proposals must enforce the same proposal threshold as all other types.
+    // A proposer without sufficient delegated ARM must be rejected.
+    it("should require proposal threshold to create signaling proposal", async function () {
+      // Carol has no ARM tokens — should fail threshold check
+      await expect(
+        governor.connect(carol).propose(
+          ProposalType.Signaling, [], [], [], "No tokens carol"
+        )
+      ).to.be.revertedWithCustomError(governor, "Gov_BelowProposalThreshold");
+    });
+
+    // WHY: Signaling proposals must be blocked after wind-down is activated,
+    // same as all other proposal types.
+    it("should be blocked after wind-down", async function () {
+      // Register a mock wind-down address and activate via impersonation.
+      // We only need windDownActive=true; full ArmadaWindDown deployment is tested elsewhere.
+      const timelockAddr = await timelockController.getAddress();
+      await ethers.provider.send("hardhat_impersonateAccount", [timelockAddr]);
+      await deployer.sendTransaction({ to: timelockAddr, value: ethers.parseEther("1") });
+      const timelockSigner = await ethers.getSigner(timelockAddr);
+
+      const mockWindDown = dave.address;
+      await governor.connect(timelockSigner).setWindDownContract(mockWindDown);
+      await ethers.provider.send("hardhat_stopImpersonatingAccount", [timelockAddr]);
+
+      await ethers.provider.send("hardhat_impersonateAccount", [mockWindDown]);
+      await governor.connect(dave).setWindDownActive();
+      await ethers.provider.send("hardhat_stopImpersonatingAccount", [mockWindDown]);
+
+      await expect(
+        governor.connect(alice).propose(
+          ProposalType.Signaling, [], [], [], "After wind-down"
+        )
+      ).to.be.revertedWithCustomError(governor, "Gov_GovernanceEnded");
+    });
+
+    // WHY: Signaling proposals use standard timing and must never be auto-promoted
+    // to Extended. Since they have no calldata, classification is skipped entirely.
+    it("should use standard timing (7d vote, 48h delay)", async function () {
+      const proposalId = await createSignalingProposal(alice, "Check timing params");
+
+      const proposal = await governor.getProposal(proposalId);
+      const votingPeriod = Number(proposal.voteEnd - proposal.voteStart);
+      const votingDelay = Number(proposal.voteStart) - (await time.latest());
+
+      // Voting period = 7 days (604800 seconds)
+      expect(votingPeriod).to.equal(SEVEN_DAYS);
+      // Voting delay should be approximately 2 days (with small block time variance)
+      expect(votingDelay).to.be.closeTo(TWO_DAYS, 5);
+    });
+  });
+
+  // ========== Voting Tests ==========
+
+  describe("Voting", function () {
+    // WHY: FOR/AGAINST/ABSTAIN voting mechanics must work identically to executable
+    // proposals. The voting system is shared across all proposal types.
+    it("should support FOR/AGAINST/ABSTAIN votes", async function () {
+      const proposalId = await createSignalingProposal(alice, "Vote mechanics test");
+
+      await time.increase(TWO_DAYS + 1);
+
+      await governor.connect(alice).castVote(proposalId, Vote.For);
+      await governor.connect(bob).castVote(proposalId, Vote.Against);
+
+      const proposal = await governor.getProposal(proposalId);
+      expect(proposal.forVotes).to.equal(ALICE_AMOUNT);
+      expect(proposal.againstVotes).to.equal(BOB_AMOUNT);
+    });
+
+    // WHY: Vote changing during the voting period is a core governance feature
+    // that must work for signaling proposals too.
+    it("should allow vote changing during voting period", async function () {
+      const proposalId = await createSignalingProposal(alice, "Change your mind");
+
+      await time.increase(TWO_DAYS + 1);
+
+      await governor.connect(alice).castVote(proposalId, Vote.For);
+      expect((await governor.getProposal(proposalId)).forVotes).to.equal(ALICE_AMOUNT);
+
+      // Change vote from FOR to AGAINST
+      await governor.connect(alice).castVote(proposalId, Vote.Against);
+      const proposal = await governor.getProposal(proposalId);
+      expect(proposal.forVotes).to.equal(0n);
+      expect(proposal.againstVotes).to.equal(ALICE_AMOUNT);
+    });
+  });
+
+  // ========== Cancellation Tests ==========
+
+  describe("Cancellation", function () {
+    // WHY: Signaling proposals follow Standard cancellation rules — proposer can
+    // cancel only during the Pending state (before voting starts).
+    it("should allow proposer to cancel during Pending", async function () {
+      const proposalId = await createSignalingProposal(alice, "Cancel me");
+
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Pending);
+
+      await governor.connect(alice).cancel(proposalId);
+
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Canceled);
+    });
+
+    // WHY: Signaling proposals (like Standard) must not be cancellable once voting
+    // has started. Only Steward proposals have the extended cancel window.
+    it("should revert cancel during Active (Standard rule)", async function () {
+      const proposalId = await createSignalingProposal(alice, "Too late to cancel");
+
+      await time.increase(TWO_DAYS + 1);
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Active);
+
+      await expect(
+        governor.connect(alice).cancel(proposalId)
+      ).to.be.revertedWithCustomError(governor, "Gov_NotPending");
+    });
+  });
+
+  // ========== Event Tests ==========
+
+  describe("Events", function () {
+    // WHY: The ProposalCreated event must correctly reflect the Signaling type
+    // so off-chain indexers and UIs can distinguish proposal kinds.
+    it("should emit ProposalCreated with Signaling type", async function () {
+      const description = "Signaling event test";
+
+      await expect(
+        governor.connect(alice).propose(
+          ProposalType.Signaling, [], [], [], description
+        )
+      ).to.emit(governor, "ProposalCreated")
+        .withArgs(
+          1, // proposalId (first proposal)
+          alice.address,
+          ProposalType.Signaling,
+          (v: any) => true, // voteStart (any timestamp)
+          (v: any) => true, // voteEnd (any timestamp)
+          description
+        );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements the **Signaling** proposal type per GOVERNANCE.md spec — non-executable, text-only proposals for measuring token-holder preference
- Adds `Signaling` (value 4) to `ProposalType` enum with standard timing (48h delay, 7d voting, 20% quorum, 0 execution delay)
- Signaling proposals skip the execution phase entirely: no queue, no timelock, no execute. Succeeded state is permanent (no grace period expiry)
- Params are immutable (like VetoRatification/Steward). SC veto is structurally inapplicable (nothing queued)

## Changes

| File | Change |
|---|---|
| `IArmadaGovernance.sol` | Add `Signaling` to `ProposalType` enum |
| `ArmadaGovernor.sol` | 2 new custom errors, modify `initialize()`, `propose()`, `state()`, `queue()`, `execute()`, `setProposalTypeParams()` |
| `test/governance_signaling.ts` | 17 Hardhat integration tests |
| `test-foundry/GovernorSignaling.t.sol` | 11 Foundry unit tests |
| `test-foundry/GovernorInvariant.t.sol` | Add `createSignalingProposal` to invariant handler |

## Test plan

- [x] 17 Hardhat signaling tests pass (`npm run test:governance`)
- [x] 11 Foundry signaling tests pass (`forge test --match-contract GovernorSignalingTest`)
- [x] Invariant tests pass with signaling handler (6 invariants, 256 runs)
- [x] Full Hardhat suite: 748 passing, 0 failing
- [x] Full Foundry suite: 535 passing, 0 failing
- [ ] Halmos symbolic verification (not run — can be verified separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)