### PR TITLE
feat: add governance path to authorize new delegator contracts

### DIFF
--- a/contracts/governance/ArmadaToken.sol
+++ b/contracts/governance/ArmadaToken.sol
@@ -52,6 +52,7 @@ contract ArmadaToken is ERC20Votes {
     event WindDownContractSet(address indexed windDownContract);
     event NoDelegationInitialized(address[] accounts);
     event AuthorizedDelegatorsInitialized(address[] delegators);
+    event AuthorizedDelegatorAdded(address indexed delegator);
 
     // ============ Constructor ============
 
@@ -127,6 +128,17 @@ contract ArmadaToken is ERC20Votes {
         require(account != address(0), "ArmadaToken: zero address");
         transferWhitelist[account] = true;
         emit WhitelistAdded(account);
+    }
+
+    /// @notice Authorize a contract to call delegateOnBehalf. Timelock-only, add-only (no removal).
+    ///         Mirrors the addToWhitelist pattern to allow governance to authorize new delegators
+    ///         (e.g. follow-on RevenueLock cohorts or replacement Crowdfund instances) after
+    ///         deployment without requiring token redeployment.
+    function addAuthorizedDelegator(address delegator) external {
+        require(msg.sender == timelock, "ArmadaToken: not timelock");
+        require(delegator != address(0), "ArmadaToken: zero address");
+        authorizedDelegator[delegator] = true;
+        emit AuthorizedDelegatorAdded(delegator);
     }
 
     /// @notice Remove the deployer from the transfer whitelist. Deployer-only, callable once.

--- a/test-foundry/ArmadaTokenDelegateOnBehalf.t.sol
+++ b/test-foundry/ArmadaTokenDelegateOnBehalf.t.sol
@@ -268,9 +268,9 @@ contract ArmadaTokenDelegateOnBehalfTest is Test {
     }
 
     function test_addAuthorizedDelegator_enablesDelegateOnBehalf() public {
-        // WHY: This is the end-to-end closure of the bug fix — a delegator added via
-        // governance must be able to actually call delegateOnBehalf. If this breaks, the
-        // post-deployment authorization path is useless even if the flag flips correctly.
+        // WHY: A delegator authorized via the timelock path must actually be able to call
+        // delegateOnBehalf. If this breaks, the post-deployment authorization path is useless
+        // even if the authorization flag flips correctly.
         address newDelegator = address(0xDEAD);
 
         // Authorize via timelock (the new governance path)

--- a/test-foundry/ArmadaTokenDelegateOnBehalf.t.sol
+++ b/test-foundry/ArmadaTokenDelegateOnBehalf.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// ABOUTME: Foundry tests for ArmadaToken.delegateOnBehalf and initAuthorizedDelegators.
+// ABOUTME: Foundry tests for ArmadaToken.delegateOnBehalf, initAuthorizedDelegators, and addAuthorizedDelegator.
 // ABOUTME: Covers authorization setup, on-behalf delegation, voting power transfer, and guard interactions.
 pragma solidity ^0.8.17;
 
@@ -10,6 +10,7 @@ import "@openzeppelin/contracts/governance/TimelockController.sol";
 contract ArmadaTokenDelegateOnBehalfTest is Test {
     // Mirror events
     event AuthorizedDelegatorsInitialized(address[] delegators);
+    event AuthorizedDelegatorAdded(address indexed delegator);
     event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate);
 
     ArmadaToken public armToken;
@@ -199,5 +200,107 @@ contract ArmadaTokenDelegateOnBehalfTest is Test {
         armToken.delegateOnBehalf(alice, alice);
         assertEq(armToken.delegates(alice), alice);
         assertEq(armToken.getVotes(alice), 2_000_000 * 1e18);
+    }
+
+    // ============ addAuthorizedDelegator ============
+
+    function test_addAuthorizedDelegator_byTimelock_succeeds() public {
+        // WHY: Governance must be able to authorize new delegator contracts post-deployment
+        // (e.g. follow-on RevenueLock cohorts, replacement Crowdfund). Without this path the
+        // one-time init was the only authorization route and later contracts would be stranded.
+        address newDelegator = address(0xDEAD);
+
+        vm.expectEmit(true, false, false, false);
+        emit AuthorizedDelegatorAdded(newDelegator);
+
+        vm.prank(address(timelock));
+        armToken.addAuthorizedDelegator(newDelegator);
+
+        assertTrue(armToken.authorizedDelegator(newDelegator));
+    }
+
+    function test_addAuthorizedDelegator_notTimelock_reverts() public {
+        // WHY: Only the timelock (governance executor) may authorize new delegators.
+        // Deployer, EOAs, and already-authorized contracts must all be rejected — otherwise
+        // the deployer or a compromised delegator could escalate the authorized set.
+        address newDelegator = address(0xDEAD);
+
+        vm.prank(deployer);
+        vm.expectRevert("ArmadaToken: not timelock");
+        armToken.addAuthorizedDelegator(newDelegator);
+
+        vm.prank(alice);
+        vm.expectRevert("ArmadaToken: not timelock");
+        armToken.addAuthorizedDelegator(newDelegator);
+
+        // Even a previously authorized delegator cannot add others
+        address[] memory delegators = new address[](1);
+        delegators[0] = authorizedContract;
+        armToken.initAuthorizedDelegators(delegators);
+
+        vm.prank(authorizedContract);
+        vm.expectRevert("ArmadaToken: not timelock");
+        armToken.addAuthorizedDelegator(newDelegator);
+    }
+
+    function test_addAuthorizedDelegator_zeroAddress_reverts() public {
+        // WHY: Zero-address authorization would be meaningless and likely indicates a
+        // misconfigured proposal. Matches the zero-address guard in addToWhitelist.
+        vm.prank(address(timelock));
+        vm.expectRevert("ArmadaToken: zero address");
+        armToken.addAuthorizedDelegator(address(0));
+    }
+
+    function test_addAuthorizedDelegator_idempotent() public {
+        // WHY: Re-adding an already-authorized delegator should be a no-op (does not revert),
+        // matching addToWhitelist semantics. This keeps governance proposals forgiving and
+        // avoids race conditions where two proposals authorize the same contract.
+        address newDelegator = address(0xDEAD);
+
+        vm.prank(address(timelock));
+        armToken.addAuthorizedDelegator(newDelegator);
+        assertTrue(armToken.authorizedDelegator(newDelegator));
+
+        // Second call should succeed without reverting
+        vm.prank(address(timelock));
+        armToken.addAuthorizedDelegator(newDelegator);
+        assertTrue(armToken.authorizedDelegator(newDelegator));
+    }
+
+    function test_addAuthorizedDelegator_enablesDelegateOnBehalf() public {
+        // WHY: This is the end-to-end closure of the bug fix — a delegator added via
+        // governance must be able to actually call delegateOnBehalf. If this breaks, the
+        // post-deployment authorization path is useless even if the flag flips correctly.
+        address newDelegator = address(0xDEAD);
+
+        // Authorize via timelock (the new governance path)
+        vm.prank(address(timelock));
+        armToken.addAuthorizedDelegator(newDelegator);
+
+        // The newly-authorized contract can now delegate on behalf of a holder
+        assertEq(armToken.getVotes(bob), 0);
+        vm.prank(newDelegator);
+        armToken.delegateOnBehalf(alice, bob);
+
+        assertEq(armToken.delegates(alice), bob);
+        assertEq(armToken.getVotes(bob), 2_000_000 * 1e18);
+    }
+
+    function test_addAuthorizedDelegator_worksBeforeInit() public {
+        // WHY: The timelock path must not depend on initAuthorizedDelegators having been
+        // called. If the deployer skipped the one-time init (or the codebase moves away
+        // from it), governance should still be able to authorize delegators directly.
+        assertFalse(armToken.authorizedDelegatorsInitialized());
+
+        address newDelegator = address(0xDEAD);
+        vm.prank(address(timelock));
+        armToken.addAuthorizedDelegator(newDelegator);
+
+        assertTrue(armToken.authorizedDelegator(newDelegator));
+
+        // And it actually works — delegateOnBehalf succeeds
+        vm.prank(newDelegator);
+        armToken.delegateOnBehalf(alice, bob);
+        assertEq(armToken.delegates(alice), bob);
     }
 }


### PR DESCRIPTION
## Summary

Closes #224.

- Adds `addAuthorizedDelegator(address)` to `ArmadaToken`, gated to the timelock. Mirrors the existing `addToWhitelist` pattern (timelock-only, add-only, zero-address guarded).
- Adds `AuthorizedDelegatorAdded(address)` event for observability.
- Closes the post-deployment authorization gap: without this, follow-on `RevenueLock` cohorts or a replacement `ArmadaCrowdfund` could be deployed and whitelisted for transfers, but `delegateOnBehalf()` would still revert because the one-time `initAuthorizedDelegators()` had already been consumed.

## Design notes

- **Add-only, no removal** — matches `addToWhitelist` semantics. Removing a delegator mid-operation could strand atomic transfer+delegate flows.
- **Idempotent** — re-adding an already-authorized delegator is a no-op (no revert). Matches `addToWhitelist` and keeps governance proposals forgiving against races.
- **No dependency on `initAuthorizedDelegators`** — the new timelock path works even if the one-time init was never called, giving governance a clean escape hatch.

## Test plan

- [x] New Foundry tests in `test-foundry/ArmadaTokenDelegateOnBehalf.t.sol`:
  - `test_addAuthorizedDelegator_byTimelock_succeeds`
  - `test_addAuthorizedDelegator_notTimelock_reverts` (deployer, EOA, and existing authorized delegator all rejected)
  - `test_addAuthorizedDelegator_zeroAddress_reverts`
  - `test_addAuthorizedDelegator_idempotent`
  - `test_addAuthorizedDelegator_enablesDelegateOnBehalf` (end-to-end: new delegator can actually call `delegateOnBehalf`)
  - `test_addAuthorizedDelegator_worksBeforeInit`
- [x] Full Foundry suite: `forge test --offline` — 533/533 passing, no regressions
- [ ] Hardhat integration tests — not run locally (require Anvil chains). This change is pure access-control surface that is well-covered by Foundry; existing Hardhat tests still exercise the `initAuthorizedDelegators` path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)