### PR TITLE
feat(governance): restore proposal on denied veto

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -30,7 +30,7 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     error Gov_AlreadyResolved();
     error Gov_AutoCreatedOnly();
     error Gov_BelowProposalThreshold();
-    error Gov_CommunityOverrodeNoDoubleVeto();
+    error Gov_SingleVetoRule();
     error Gov_EmptyProposal();
     error Gov_ExecutionDelayOutOfBounds();
     error Gov_GovernanceEnded();
@@ -106,6 +106,7 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         bool executed;
         bool canceled;
         bool queued;
+        bool vetoRatificationDenied; // prevents re-veto of a proposal restored after community denied a veto
 
         // Execution data
         address[] targets;
@@ -190,10 +191,6 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
 
     // ============ Veto & Ratification ============
 
-    /// @notice Calldata hashes of proposals where community denied the SC's veto.
-    /// Prevents the SC from vetoing identical proposal content twice.
-    mapping(bytes32 => bool) public vetoDeniedHashes;
-
     /// @notice Maps ratification proposalId → original vetoed proposalId
     mapping(uint256 => uint256) public ratificationOf;
 
@@ -226,6 +223,7 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     event StandardSelectorRemoved(bytes4 indexed selector);
     event StewardContractSet(address indexed steward);
     event ProposalVetoed(uint256 indexed proposalId, bytes32 rationaleHash, uint256 ratificationId);
+    event ProposalRestored(uint256 indexed proposalId);
     event RatificationResolved(uint256 indexed ratificationId, bool vetoUpheld);
     event SecurityCouncilEjected(uint256 indexed ratificationId);
     event ExcludedAddressesSet(address[] addresses);
@@ -527,11 +525,10 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         if (securityCouncil == address(0)) revert Gov_SCEjected();
         if (state(proposalId) != ProposalState.Queued) revert Gov_NotQueued();
 
-        // Double-veto prevention: community denied a veto on identical calldata
-        bytes32 calldataHash = _proposalCalldataHash(proposalId);
-        if (vetoDeniedHashes[calldataHash]) revert Gov_CommunityOverrodeNoDoubleVeto();
-
         Proposal storage p = _proposals[proposalId];
+
+        // Per-proposal re-veto prevention: community already denied a veto on this proposal
+        if (p.vetoRatificationDenied) revert Gov_SingleVetoRule();
 
         // Cancel the original proposal
         p.canceled = true;
@@ -566,12 +563,25 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         bool majorityAgainst = quorumMet && (p.againstVotes > p.forVotes);
 
         if (majorityAgainst) {
-            // Community denies the veto → eject SC, store calldata hash
+            // Community denies the veto → eject SC, restore proposal
             address oldSC = securityCouncil;
             securityCouncil = address(0);
 
-            vetoDeniedHashes[_proposalCalldataHash(vetoedId)] = true;
+            // Restore the original proposal to Queued state
+            Proposal storage orig = _proposals[vetoedId];
+            orig.canceled = false;
+            orig.vetoRatificationDenied = true; // prevent re-veto of this specific proposal
 
+            // Re-queue in timelock with fresh minimum delay.
+            // cancel() cleared _timestamps[id] so scheduleBatch() accepts the same operation ID.
+            timelock.scheduleBatch(
+                orig.targets, orig.values, orig.calldatas,
+                0, // no predecessor
+                _proposalSalt(vetoedId),
+                timelock.getMinDelay()
+            );
+
+            emit ProposalRestored(vetoedId);
             emit SecurityCouncilEjected(ratificationId);
             emit SecurityCouncilUpdated(oldSC, address(0));
             emit RatificationResolved(ratificationId, false);
@@ -609,13 +619,6 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
 
         return ratId;
     }
-
-    /// @dev Compute a deterministic hash of a proposal's calldata for double-veto prevention.
-    function _proposalCalldataHash(uint256 proposalId) internal view returns (bytes32) {
-        Proposal storage p = _proposals[proposalId];
-        return keccak256(abi.encode(p.targets, p.values, p.calldatas));
-    }
-
 
     // ============ Steward Proposals ============
 

--- a/test-foundry/GovernorVeto.t.sol
+++ b/test-foundry/GovernorVeto.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // ABOUTME: Foundry tests for Security Council veto mechanism and ratification votes.
-// ABOUTME: Covers veto lifecycle, SC ejection, double-veto prevention, and bond deferral.
+// ABOUTME: Covers veto lifecycle, SC ejection, proposal restoration on denied veto, and re-veto prevention.
 pragma solidity ^0.8.17;
 
 import "forge-std/Test.sol";
@@ -11,7 +11,7 @@ import "../contracts/governance/IArmadaGovernance.sol";
 import "@openzeppelin/contracts/governance/TimelockController.sol";
 import "./helpers/GovernorDeployHelper.sol";
 
-/// @title GovernorVetoTest — Tests for SC veto, ratification, ejection, and double-veto prevention
+/// @title GovernorVetoTest — Tests for SC veto, ratification, ejection, proposal restoration, and re-veto prevention
 contract GovernorVetoTest is Test, GovernorDeployHelper {
     // Mirror events from governor for expectEmit
     event ProposalVetoed(uint256 indexed proposalId, bytes32 rationaleHash, uint256 ratificationId);
@@ -27,6 +27,7 @@ contract GovernorVetoTest is Test, GovernorDeployHelper {
         string description
     );
     event ProposalCanceled(uint256 indexed proposalId);
+    event ProposalRestored(uint256 indexed proposalId);
     ArmadaGovernor public governor;
     ArmadaToken public armToken;
     TimelockController public timelock;
@@ -421,6 +422,8 @@ contract GovernorVetoTest is Test, GovernorDeployHelper {
         vm.warp(block.timestamp + SEVEN_DAYS + 1);
 
         vm.expectEmit(true, false, false, false);
+        emit ProposalRestored(proposalId);
+        vm.expectEmit(true, false, false, false);
         emit SecurityCouncilEjected(ratId);
         vm.expectEmit(true, true, false, false);
         emit SecurityCouncilUpdated(sc, address(0));
@@ -431,21 +434,56 @@ contract GovernorVetoTest is Test, GovernorDeployHelper {
 
         // SC ejected
         assertEq(governor.securityCouncil(), address(0));
+        // Proposal restored to Queued
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Queued));
     }
 
-    function test_resolve_againstStoresCalldataHash() public {
+    /// @dev WHY: When the community denies a veto (votes AGAINST), the original proposal
+    ///      must be restored to Queued state so it can proceed to execution without
+    ///      re-submission through the full governance lifecycle.
+    function test_resolve_againstRestoresProposal() public {
         uint256 proposalId = _createAndQueueProposal(alice);
-
-        // Compute expected calldata hash
-        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
-            governor.getProposalActions(proposalId);
-        bytes32 expectedHash = keccak256(abi.encode(targets, values, calldatas));
 
         vm.prank(sc);
         governor.veto(proposalId, keccak256("rationale"));
         uint256 ratId = governor.proposalCount();
 
-        // Vote AGAINST
+        // Vote AGAINST (deny veto)
+        vm.prank(alice);
+        governor.castVote(ratId, 0);
+        vm.prank(bob);
+        governor.castVote(ratId, 0);
+
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+
+        vm.expectEmit(true, false, false, false);
+        emit ProposalRestored(proposalId);
+
+        governor.resolveRatification(ratId);
+
+        // Original proposal should be Queued again (not Canceled)
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Queued));
+    }
+
+    /// @dev WHY: After the community denies a veto and the proposal is restored,
+    ///      the timelock must have a fresh pending operation so execute() works
+    ///      after the minimum delay.
+    function test_resolve_againstRequeuesInTimelock() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
+            governor.getProposalActions(proposalId);
+        bytes32 timelockId = timelock.hashOperationBatch(
+            targets, values, calldatas, 0, bytes32(proposalId)
+        );
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+
+        // Timelock op is cleared by veto
+        assertFalse(timelock.isOperationPending(timelockId));
+
+        uint256 ratId = governor.proposalCount();
         vm.prank(alice);
         governor.castVote(ratId, 0);
         vm.prank(bob);
@@ -454,8 +492,33 @@ contract GovernorVetoTest is Test, GovernorDeployHelper {
         vm.warp(block.timestamp + SEVEN_DAYS + 1);
         governor.resolveRatification(ratId);
 
-        // Calldata hash should be stored
-        assertTrue(governor.vetoDeniedHashes(expectedHash));
+        // Timelock op should be re-scheduled and pending
+        assertTrue(timelock.isOperationPending(timelockId));
+    }
+
+    /// @dev WHY: A restored proposal must be executable after the fresh timelock delay.
+    ///      This verifies the full lifecycle: veto → denied → restored → executed.
+    function test_resolve_restoredProposalCanBeExecuted() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
+
+        vm.prank(sc);
+        governor.veto(proposalId, keccak256("rationale"));
+        uint256 ratId = governor.proposalCount();
+
+        vm.prank(alice);
+        governor.castVote(ratId, 0);
+        vm.prank(bob);
+        governor.castVote(ratId, 0);
+
+        vm.warp(block.timestamp + SEVEN_DAYS + 1);
+        governor.resolveRatification(ratId);
+
+        // Advance past fresh timelock delay (getMinDelay = 2 days)
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+
+        // Execute should succeed
+        governor.execute(proposalId);
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Executed));
     }
 
     function test_resolve_revertsBeforeVotingEnds() public {
@@ -496,25 +559,26 @@ contract GovernorVetoTest is Test, GovernorDeployHelper {
         governor.resolveRatification(ratId);
     }
 
-    // ======== Double-Veto Prevention ========
+    // ======== Re-Veto Prevention ========
 
-    function test_doubleVeto_identicalCalldataReverts() public {
-        // First proposal: create, queue, veto, community AGAINST → deny veto
-        uint256 proposalId1 = _createAndQueueProposalWithCalldata(
-            alice, address(governor), abi.encodeWithSignature("proposalCount()"), "first attempt"
-        );
+    /// @dev WHY: A restored proposal has vetoRatificationDenied=true, preventing a newly
+    ///      appointed SC from vetoing the same proposal again. The community already
+    ///      overrode the veto — re-vetoing would undermine community sovereignty.
+    function test_reVeto_restoredProposalCannotBeVetoed() public {
+        uint256 proposalId = _createAndQueueProposal(alice);
 
         vm.prank(sc);
-        governor.veto(proposalId1, keccak256("rationale"));
-        uint256 ratId1 = governor.proposalCount();
+        governor.veto(proposalId, keccak256("rationale"));
+        uint256 ratId = governor.proposalCount();
 
+        // Community denies veto
         vm.prank(alice);
-        governor.castVote(ratId1, 0); // AGAINST
+        governor.castVote(ratId, 0);
         vm.prank(bob);
-        governor.castVote(ratId1, 0); // AGAINST
+        governor.castVote(ratId, 0);
 
         vm.warp(block.timestamp + SEVEN_DAYS + 1);
-        governor.resolveRatification(ratId1);
+        governor.resolveRatification(ratId);
 
         // SC ejected, set new SC
         assertEq(governor.securityCouncil(), address(0));
@@ -522,21 +586,19 @@ contract GovernorVetoTest is Test, GovernorDeployHelper {
         vm.prank(address(timelock));
         governor.setSecurityCouncil(newSC);
 
-        // Second proposal with identical calldata: create, queue
-        uint256 proposalId2 = _createAndQueueProposalWithCalldata(
-            alice, address(governor), abi.encodeWithSignature("proposalCount()"), "second attempt"
-        );
-
-        // New SC tries to veto — should revert
+        // New SC tries to veto restored proposal — should revert
         vm.prank(newSC);
-        vm.expectRevert(abi.encodeWithSelector(ArmadaGovernor.Gov_CommunityOverrodeNoDoubleVeto.selector));
-        governor.veto(proposalId2, keccak256("rationale2"));
+        vm.expectRevert(abi.encodeWithSelector(ArmadaGovernor.Gov_SingleVetoRule.selector));
+        governor.veto(proposalId, keccak256("rationale2"));
     }
 
-    function test_doubleVeto_modifiedCalldataAllowed() public {
-        // First: veto denied
+    /// @dev WHY: The re-veto prevention is per-proposal, not per-calldata. A future
+    ///      proposal with identical calldata is a separate governance decision and
+    ///      must be vetoable by the SC.
+    function test_reVeto_identicalCalldataOnNewProposalAllowed() public {
+        // First proposal: veto denied → restored
         uint256 proposalId1 = _createAndQueueProposalWithCalldata(
-            alice, address(governor), abi.encodeWithSignature("proposalCount()"), "first"
+            alice, address(governor), abi.encodeWithSignature("proposalCount()"), "first attempt"
         );
 
         vm.prank(sc);
@@ -556,16 +618,15 @@ contract GovernorVetoTest is Test, GovernorDeployHelper {
         vm.prank(address(timelock));
         governor.setSecurityCouncil(newSC);
 
-        // Second proposal with DIFFERENT calldata
+        // Second proposal with IDENTICAL calldata — different proposal, should be vetoable
         uint256 proposalId2 = _createAndQueueProposalWithCalldata(
-            alice, address(governor), abi.encodeWithSignature("proposalThreshold()"), "different calldata"
+            alice, address(governor), abi.encodeWithSignature("proposalCount()"), "second attempt"
         );
 
-        // New SC can veto — different calldata hash
+        // New SC can veto — different proposal instance, no vetoRatificationDenied flag
         vm.prank(newSC);
         governor.veto(proposalId2, keccak256("rationale2"));
 
-        // Veto succeeds
         assertEq(uint256(governor.state(proposalId2)), uint256(ProposalState.Canceled));
     }
 
@@ -671,7 +732,11 @@ contract GovernorVetoTest is Test, GovernorDeployHelper {
         assertEq(uint256(governor.state(ratId)), uint256(ProposalState.Executed));
     }
 
-    function test_fullLifecycle_vetoDeniedSCEjected() public {
+    /// @dev WHY: End-to-end lifecycle test for veto-denied path. The community denies
+    ///      the veto, the SC is ejected, the proposal is restored to Queued, and
+    ///      can be executed after the fresh timelock delay. Verifies no state corruption
+    ///      across the full sequence.
+    function test_fullLifecycle_vetoDeniedRestoredAndExecuted() public {
         // 1. Create and queue
         uint256 proposalId = _createAndQueueProposal(alice);
 
@@ -686,18 +751,20 @@ contract GovernorVetoTest is Test, GovernorDeployHelper {
         vm.prank(bob);
         governor.castVote(ratId, 0);
 
-        // 4. Resolve
+        // 4. Resolve → proposal restored
         vm.warp(block.timestamp + SEVEN_DAYS + 1);
         governor.resolveRatification(ratId);
 
         // 5. SC ejected
         assertEq(governor.securityCouncil(), address(0));
 
-        // 6. Calldata hash stored — identical proposal cannot be vetoed again
-        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
-            governor.getProposalActions(proposalId);
-        bytes32 calldataHash = keccak256(abi.encode(targets, values, calldatas));
-        assertTrue(governor.vetoDeniedHashes(calldataHash));
+        // 6. Proposal is Queued again (not Canceled)
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Queued));
+
+        // 7. Execute after fresh timelock delay
+        vm.warp(block.timestamp + TWO_DAYS + 1);
+        governor.execute(proposalId);
+        assertEq(uint256(governor.state(proposalId)), uint256(ProposalState.Executed));
     }
 
     // ======== Voting on Canceled Proposals ========

--- a/test/governance_veto.ts
+++ b/test/governance_veto.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Hardhat integration tests for SC veto mechanism, ratification votes, and bond deferral.
-// ABOUTME: Covers veto lifecycle, SC ejection, double-veto prevention, queue/execute guards, and post-ejection behavior.
+// ABOUTME: Covers veto lifecycle, SC ejection, proposal restoration on denied veto, re-veto prevention, and post-ejection behavior.
 
 import { expect } from "chai";
 import { ethers } from "hardhat";

--- a/test/governance_veto.ts
+++ b/test/governance_veto.ts
@@ -375,26 +375,19 @@ describe("Governance Veto", function () {
       await time.increase(SEVEN_DAYS + 1);
 
       const tx = governor.resolveRatification(ratId);
+      await expect(tx).to.emit(governor, "ProposalRestored").withArgs(proposalId);
       await expect(tx).to.emit(governor, "SecurityCouncilEjected").withArgs(ratId);
       await expect(tx).to.emit(governor, "SecurityCouncilUpdated").withArgs(carol.address, ethers.ZeroAddress);
       await expect(tx).to.emit(governor, "RatificationResolved").withArgs(ratId, false);
 
       // SC ejected
       expect(await governor.securityCouncil()).to.equal(ethers.ZeroAddress);
+      // Proposal restored to Queued
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Queued);
     });
 
-    it("should store calldata hash when veto is denied", async function () {
+    it("should restore original proposal to Queued state when veto is denied", async function () {
       const proposalId = await createAndQueueProposal(alice);
-
-      // Compute expected calldata hash
-      const [targets, values, calldatas] = await governor.getProposalActions(proposalId);
-      const expectedHash = ethers.keccak256(
-        ethers.AbiCoder.defaultAbiCoder().encode(
-          ["address[]", "uint256[]", "bytes[]"],
-          [targets, values, calldatas]
-        )
-      );
-
       const ratId = await vetoProposal(proposalId);
 
       // Vote AGAINST
@@ -404,7 +397,13 @@ describe("Governance Veto", function () {
       await time.increase(SEVEN_DAYS + 1);
       await governor.resolveRatification(ratId);
 
-      expect(await governor.vetoDeniedHashes(expectedHash)).to.be.true;
+      // Proposal must be Queued, not Canceled
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Queued);
+
+      // Execute after fresh timelock delay (2 days)
+      await time.increase(TWO_DAYS + 1);
+      await governor.execute(proposalId);
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Executed);
     });
 
     it("should revert if voting hasn't ended", async function () {
@@ -438,18 +437,18 @@ describe("Governance Veto", function () {
     });
   });
 
-  // ======== Double-Veto Prevention ========
+  // ======== Re-Veto Prevention ========
 
-  describe("Double-Veto Prevention", function () {
-    it("should block veto on identical calldata after community denial", async function () {
-      // First proposal: create, queue, veto, community AGAINST → deny veto
-      const proposalId1 = await createAndQueueProposal(alice);
-      const ratId1 = await vetoProposal(proposalId1);
+  describe("Re-Veto Prevention", function () {
+    it("should block re-veto of a restored proposal", async function () {
+      // Veto → community AGAINST → proposal restored
+      const proposalId = await createAndQueueProposal(alice);
+      const ratId = await vetoProposal(proposalId);
 
-      await governor.connect(alice).castVote(ratId1, Vote.Against);
-      await governor.connect(bob).castVote(ratId1, Vote.Against);
+      await governor.connect(alice).castVote(ratId, Vote.Against);
+      await governor.connect(bob).castVote(ratId, Vote.Against);
       await time.increase(SEVEN_DAYS + 1);
-      await governor.resolveRatification(ratId1);
+      await governor.resolveRatification(ratId);
 
       // SC ejected, set new SC (dave)
       expect(await governor.securityCouncil()).to.equal(ethers.ZeroAddress);
@@ -457,24 +456,16 @@ describe("Governance Veto", function () {
       await governor.connect(timelockSigner).setSecurityCouncil(dave.address);
       await stopImpersonatingTimelock();
 
-      // Second proposal with identical calldata
-      const proposalId2 = await createAndQueueProposal(
-        alice,
-        undefined, // same targets (governor)
-        undefined, // same calldatas (proposalCount)
-        "second attempt"
-      );
-
-      // New SC tries to veto — should revert
+      // New SC tries to veto restored proposal — should revert
       await expect(
         governor.connect(dave).veto(
-          proposalId2, ethers.keccak256(ethers.toUtf8Bytes("rationale2"))
+          proposalId, ethers.keccak256(ethers.toUtf8Bytes("rationale2"))
         )
-      ).to.be.revertedWithCustomError(governor, "Gov_CommunityOverrodeNoDoubleVeto");
+      ).to.be.revertedWithCustomError(governor, "Gov_SingleVetoRule");
     });
 
-    it("should allow veto on modified calldata", async function () {
-      // First: veto denied
+    it("should allow veto on a new proposal with identical calldata", async function () {
+      // First: veto denied → proposal restored
       const proposalId1 = await createAndQueueProposal(alice);
       const ratId1 = await vetoProposal(proposalId1);
 
@@ -488,16 +479,15 @@ describe("Governance Veto", function () {
       await governor.connect(timelockSigner).setSecurityCouncil(dave.address);
       await stopImpersonatingTimelock();
 
-      // Second proposal with DIFFERENT calldata
-      const govAddr = await governor.getAddress();
+      // Second proposal with IDENTICAL calldata — different proposal, should be vetoable
       const proposalId2 = await createAndQueueProposal(
         alice,
-        [govAddr],
-        [governor.interface.encodeFunctionData("proposalThreshold")],
-        "different calldata"
+        undefined, // same targets
+        undefined, // same calldatas
+        "second attempt"
       );
 
-      // New SC can veto — different calldata hash
+      // New SC can veto — per-proposal flag, not calldata-based
       await governor.connect(dave).veto(
         proposalId2, ethers.keccak256(ethers.toUtf8Bytes("rationale2"))
       );
@@ -614,7 +604,7 @@ describe("Governance Veto", function () {
       expect(await governor.state(ratId)).to.equal(ProposalState.Executed);
     });
 
-    it("should complete veto-denied lifecycle: propose → vote → queue → veto → AGAINST → SC ejected → new SC set", async function () {
+    it("should complete veto-denied lifecycle: propose → queue → veto → AGAINST → restored → executed", async function () {
       // 1. Create and queue
       const proposalId = await createAndQueueProposal(alice);
 
@@ -628,24 +618,22 @@ describe("Governance Veto", function () {
       await governor.connect(alice).castVote(ratId, Vote.Against);
       await governor.connect(bob).castVote(ratId, Vote.Against);
 
-      // 4. Resolve
+      // 4. Resolve → proposal restored
       await time.increase(SEVEN_DAYS + 1);
       await governor.resolveRatification(ratId);
 
       // 5. SC ejected
       expect(await governor.securityCouncil()).to.equal(ethers.ZeroAddress);
 
-      // 6. Calldata hash stored
-      const [targets, values, calldatas] = await governor.getProposalActions(proposalId);
-      const calldataHash = ethers.keccak256(
-        ethers.AbiCoder.defaultAbiCoder().encode(
-          ["address[]", "uint256[]", "bytes[]"],
-          [targets, values, calldatas]
-        )
-      );
-      expect(await governor.vetoDeniedHashes(calldataHash)).to.be.true;
+      // 6. Proposal is Queued (restored)
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Queued);
 
-      // 7. Governance can set new SC
+      // 7. Execute after fresh timelock delay
+      await time.increase(TWO_DAYS + 1);
+      await governor.execute(proposalId);
+      expect(await governor.state(proposalId)).to.equal(ProposalState.Executed);
+
+      // 8. Governance can set new SC
       const timelockSigner = await asTimelock();
       await governor.connect(timelockSigner).setSecurityCouncil(dave.address);
       await stopImpersonatingTimelock();


### PR DESCRIPTION
## Summary
- When a veto ratification vote resolves AGAINST (community overrides SC), the original proposal is now **restored to Queued state** with a fresh 2-day timelock delay, instead of staying canceled and requiring full re-submission (~23 day savings)
- Re-veto prevention changed from **calldata-hash based** to **per-proposal flag** (`vetoRatificationDenied`), so future proposals with identical calldata remain vetoable
- Removes `vetoDeniedHashes` mapping, `_proposalCalldataHash()` helper, and `Gov_CommunityOverrodeNoDoubleVeto` error; adds `Gov_SingleVetoRule` error and `ProposalRestored` event

Closes #229

## Test plan
- [x] Foundry: 28 veto tests pass (28/28), 543 total tests pass (0 regressions)
- [x] Hardhat: 24 veto tests pass (24/24)
- [x] New tests cover: proposal restoration to Queued state, timelock re-scheduling, execute after restore, re-veto prevention on restored proposal, identical-calldata on new proposal is still vetoable, full lifecycle end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)