### PR TITLE
fix(revenue-lock): monotonic ratchet + rate-limit vs counter rewind/jump (#225)

### DIFF
--- a/contracts/governance/RevenueLock.sol
+++ b/contracts/governance/RevenueLock.sol
@@ -18,6 +18,12 @@ interface IArmadaTokenRevenueLock {
 /// @notice Holds ARM for beneficiaries and releases it as cumulative protocol revenue
 ///         milestones are reached. Immutable after deployment: no admin, no upgradeability,
 ///         no sweep. Released ARM is atomically delegated via delegateOnBehalf.
+///
+///         Entitlements derive from `maxObservedRevenue`, a monotonic ratchet maintained
+///         internally — never from a direct read of RevenueCounter. The ratchet advances
+///         at no more than MAX_REVENUE_INCREASE_PER_DAY per elapsed day, which structurally
+///         neutralises governance-controlled RevenueCounter upgrades that could otherwise
+///         rewind (→ freeze) or accelerate (→ instant-unlock) entitlements.
 contract RevenueLock {
 
     // ============ Constants ============
@@ -36,6 +42,14 @@ contract RevenueLock {
     /// @notice Total ARM allocated across all beneficiaries
     uint256 public immutable totalAllocation;
 
+    /// @notice Maximum amount that `maxObservedRevenue` can advance per elapsed day,
+    ///         in 18-decimal USD to match RevenueCounter.recognizedRevenueUsd.
+    ///         Defensive security calibration: if set to $10k/day, a malicious
+    ///         RevenueCounter upgrade cannot accelerate $0 → $1M full-unlock faster
+    ///         than ~100 days, giving the community and Security Council time to respond.
+    ///         See PARAMETER_MANIFEST.md (ship-armada/crowdfund) and issue #225.
+    uint256 public immutable MAX_REVENUE_INCREASE_PER_DAY;
+
     // ============ State ============
 
     /// @notice Per-beneficiary total allocation
@@ -47,6 +61,17 @@ contract RevenueLock {
     /// @notice Ordered list of beneficiaries (for enumeration)
     address[] internal _beneficiaries;
 
+    /// @notice Monotonic ratchet over RevenueCounter reads. Used for all entitlement math.
+    ///         Only ever advances, never decreases, even if RevenueCounter returns a lower
+    ///         value on a later call.
+    uint256 public maxObservedRevenue;
+
+    /// @notice Wall-clock timestamp of the most recent call to `_updateMaxObservedRevenue`.
+    ///         Advances unconditionally on every sync (including no-ops) so the rate-limit
+    ///         allowance budget is consumed by real elapsed time rather than accumulating
+    ///         indefinitely during quiet periods.
+    uint256 public lastSyncTimestamp;
+
     // ============ Events ============
 
     event Released(
@@ -56,25 +81,48 @@ contract RevenueLock {
         uint256 cumulativeReleased
     );
 
+    /// @notice Emitted on every actual ratchet advance of maxObservedRevenue.
+    /// @param oldMax             Previous maxObservedRevenue value.
+    /// @param newMax             New maxObservedRevenue value (post-ratchet, post-cap).
+    /// @param reportedByCounter  Raw value returned by RevenueCounter at the time of update.
+    ///                           If `reportedByCounter > newMax`, the advance was rate-limited.
+    event ObservedRevenueUpdated(
+        uint256 oldMax,
+        uint256 newMax,
+        uint256 reportedByCounter
+    );
+
     // ============ Constructor ============
 
     /// @param _armToken ARM token address (must whitelist this contract for transfers)
     /// @param _revenueCounter RevenueCounter UUPS proxy address
+    /// @param _maxIncreasePerDay Max observed-revenue advance per elapsed day, 18-decimal USD
     /// @param beneficiaries Array of beneficiary addresses
     /// @param amounts Array of allocation amounts (18-decimal ARM), parallel to beneficiaries
     constructor(
         address _armToken,
         address _revenueCounter,
+        uint256 _maxIncreasePerDay,
         address[] memory beneficiaries,
         uint256[] memory amounts
     ) {
         require(_armToken != address(0), "RevenueLock: zero armToken");
         require(_revenueCounter != address(0), "RevenueLock: zero revenueCounter");
+        require(_maxIncreasePerDay > 0, "RevenueLock: zero maxIncrease");
         require(beneficiaries.length > 0, "RevenueLock: empty beneficiaries");
         require(beneficiaries.length == amounts.length, "RevenueLock: length mismatch");
 
         armToken = IArmadaTokenRevenueLock(_armToken);
         revenueCounter = IRevenueCounterRevenueLock(_revenueCounter);
+        MAX_REVENUE_INCREASE_PER_DAY = _maxIncreasePerDay;
+
+        // CRITICAL: lastSyncTimestamp must start at block.timestamp, NOT 0.
+        // A zero timestamp would make the first _updateMaxObservedRevenue() see
+        // `elapsed == block.timestamp`, which would let the ratchet leap to whatever
+        // RevenueCounter reports on the first call — fully bypassing the rate limit.
+        // Do NOT seed maxObservedRevenue from the counter for the same reason: a
+        // malicious initial counter implementation could start the ratchet high.
+        lastSyncTimestamp = block.timestamp;
 
         uint256 total = 0;
         for (uint256 i = 0; i < beneficiaries.length; i++) {
@@ -100,7 +148,10 @@ contract RevenueLock {
         uint256 alloc = allocation[msg.sender];
         require(alloc > 0, "RevenueLock: not a beneficiary");
 
-        uint256 unlockBps = unlockPercentage();
+        // Advance the ratchet first so entitlement math uses the current capped value.
+        _updateMaxObservedRevenue();
+
+        uint256 unlockBps = _unlockBpsForRevenue(maxObservedRevenue);
         uint256 entitled = (alloc * unlockBps) / BPS_100;
         uint256 alreadyReleased = released[msg.sender];
         uint256 amount = entitled - alreadyReleased;
@@ -114,28 +165,62 @@ contract RevenueLock {
         emit Released(msg.sender, amount, delegatee, released[msg.sender]);
     }
 
+    /// @notice Permissionless: advance the observed-revenue ratchet without claiming.
+    /// @dev Intended for monitoring bots and operational tooling. Keeps the rate-limit
+    ///      allowance window tight: without regular syncs, elapsed-time budget
+    ///      accumulates and a single later call could leap `maxObservedRevenue` by
+    ///      N × MAX_REVENUE_INCREASE_PER_DAY. OPERATIONS.md requires at least daily
+    ///      calls; monitoring infrastructure should call more frequently.
+    ///      Every call writes to storage (lastSyncTimestamp), including no-ops — that
+    ///      is expected behavior, not an inefficiency.
+    function syncObservedRevenue() external {
+        _updateMaxObservedRevenue();
+    }
+
     // ============ View Functions ============
 
     /// @notice Amount currently available for a beneficiary to release.
+    /// @dev Uses `getCappedObservedRevenue()` so this view reflects what `release()`
+    ///      would actually deliver after advancing the ratchet. Callers should prefer
+    ///      this over simulating the internal logic themselves.
     function releasable(address beneficiary) external view returns (uint256) {
         uint256 alloc = allocation[beneficiary];
         if (alloc == 0) return 0;
-        uint256 entitled = (alloc * unlockPercentage()) / BPS_100;
+        uint256 effective = getCappedObservedRevenue();
+        uint256 entitled = (alloc * _unlockBpsForRevenue(effective)) / BPS_100;
         uint256 alreadyReleased = released[beneficiary];
         if (entitled <= alreadyReleased) return 0;
         return entitled - alreadyReleased;
     }
 
     /// @notice Current unlock percentage in basis points (0 = 0%, 10000 = 100%).
-    ///         Step function based on cumulative protocol revenue milestones.
+    ///         Step function based on the rate-limited observed-revenue ratchet —
+    ///         NOT a direct read of the RevenueCounter. This matches what `release()`
+    ///         will see after `_updateMaxObservedRevenue()` runs.
     function unlockPercentage() public view returns (uint256) {
-        uint256 revenue = revenueCounter.recognizedRevenueUsd();
-        return _unlockBpsForRevenue(revenue);
+        return _unlockBpsForRevenue(getCappedObservedRevenue());
     }
 
-    /// @notice Current cumulative recognized revenue from the RevenueCounter.
+    /// @notice Raw cumulative recognized revenue as reported by the RevenueCounter.
+    /// @dev Exposed for monitoring/diagnostics only — does NOT flow through the ratchet.
+    ///      Entitlement logic uses `maxObservedRevenue` / `getCappedObservedRevenue()`.
+    ///      A sustained divergence between `currentRevenue()` and `getCappedObservedRevenue()`
+    ///      indicates either an over-reporting RevenueCounter being rate-limited or a
+    ///      malicious upgrade in progress; either warrants off-chain investigation.
     function currentRevenue() external view returns (uint256) {
         return revenueCounter.recognizedRevenueUsd();
+    }
+
+    /// @notice Preview of `maxObservedRevenue` after a hypothetical call to
+    ///         `syncObservedRevenue()` at the current block, without modifying state.
+    /// @dev Mirrors `_updateMaxObservedRevenue()` exactly. Monitoring bots should use
+    ///      this instead of re-implementing the cap math off-chain.
+    function getCappedObservedRevenue() public view returns (uint256) {
+        uint256 reported = revenueCounter.recognizedRevenueUsd();
+        uint256 elapsed = block.timestamp - lastSyncTimestamp;
+        uint256 maxAllowedIncrease = (elapsed * MAX_REVENUE_INCREASE_PER_DAY) / 1 days;
+        uint256 capped = _min(reported, maxObservedRevenue + maxAllowedIncrease);
+        return capped > maxObservedRevenue ? capped : maxObservedRevenue;
     }
 
     /// @notice Number of beneficiaries in the list.
@@ -144,6 +229,29 @@ contract RevenueLock {
     }
 
     // ============ Internal ============
+
+    /// @dev Advance `maxObservedRevenue` to the minimum of (reported, prev + budget),
+    ///      where budget = elapsed * MAX_REVENUE_INCREASE_PER_DAY / 1 days.
+    ///      `lastSyncTimestamp` ALWAYS advances to `block.timestamp`, even when
+    ///      `maxObservedRevenue` does not. This is the mechanism that consumes the
+    ///      elapsed-time allowance on every sync — without it, daily syncs during
+    ///      flat-revenue periods would fail to bound the cumulative budget and the
+    ///      rate cap would become meaningless over time.
+    function _updateMaxObservedRevenue() internal {
+        uint256 reported = revenueCounter.recognizedRevenueUsd();
+
+        uint256 elapsed = block.timestamp - lastSyncTimestamp;
+        uint256 maxAllowedIncrease = (elapsed * MAX_REVENUE_INCREASE_PER_DAY) / 1 days;
+        uint256 capped = _min(reported, maxObservedRevenue + maxAllowedIncrease);
+
+        if (capped > maxObservedRevenue) {
+            uint256 oldMax = maxObservedRevenue;
+            maxObservedRevenue = capped;
+            emit ObservedRevenueUpdated(oldMax, capped, reported);
+        }
+
+        lastSyncTimestamp = block.timestamp;
+    }
 
     /// @dev Step function: returns the unlock bps for a given cumulative revenue.
     ///      No interpolation — jumps at each threshold.
@@ -156,5 +264,9 @@ contract RevenueLock {
         if (revenue >= 50_000e18)    return 2500;  // 25%
         if (revenue >= 10_000e18)    return 1000;  // 10%
         return 0;
+    }
+
+    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
     }
 }

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -186,6 +186,12 @@ async function main() {
   const revenueLockBeneficiaries = beneficiaryConfig.map(b => b.address);
   const revenueLockAmounts = beneficiaryConfig.map(b => ethers.parseUnits(b.amount, 18));
 
+  // Max advance per elapsed day for the observed-revenue ratchet — 18-decimal USD.
+  // $10k/day per PARAMETER_MANIFEST.md (ship-armada/crowdfund) and issue #225:
+  // forces a malicious RevenueCounter upgrade to take ≥100 days to accelerate
+  // $0 → $1M full-unlock, giving community + Security Council time to respond.
+  const MAX_REVENUE_INCREASE_PER_DAY = ethers.parseUnits("10000", 18);
+
   // Guard: reject Anvil default addresses on non-local environments
   rejectAnvilAddresses(revenueLockBeneficiaries, "RevenueLock beneficiaries");
   if (config.treasuryAddress) {
@@ -198,7 +204,7 @@ async function main() {
 
   const RevenueLock = await ethers.getContractFactory("RevenueLock");
   const revenueLockContract = await RevenueLock.deploy(
-    armTokenAddress, revenueCounterAddress,
+    armTokenAddress, revenueCounterAddress, MAX_REVENUE_INCREASE_PER_DAY,
     revenueLockBeneficiaries, revenueLockAmounts, nm.override()
   );
   await revenueLockContract.deploymentTransaction()!.wait();

--- a/scripts/deploy_revenue_lock_cohort.ts
+++ b/scripts/deploy_revenue_lock_cohort.ts
@@ -135,10 +135,15 @@ async function main() {
   const addrArray = beneficiaries.map((b) => b.address);
   const amountArray = beneficiaries.map((b) => ethers.parseUnits(b.amount, 18));
 
+  // $10k/day in 18-decimal USD. See PARAMETER_MANIFEST.md / issue #225 — rate cap on
+  // the observed-revenue ratchet, defends against malicious RevenueCounter upgrades.
+  const MAX_REVENUE_INCREASE_PER_DAY = ethers.parseUnits("10000", 18);
+
   const RevenueLock = await ethers.getContractFactory("RevenueLock");
   const lock = await RevenueLock.deploy(
     armTokenAddress,
     revenueCounterAddress,
+    MAX_REVENUE_INCREASE_PER_DAY,
     addrArray,
     amountArray,
     nm.override(),

--- a/scripts/verify_sepolia.ts
+++ b/scripts/verify_sepolia.ts
@@ -138,8 +138,16 @@ async function main() {
     },
     {
       name: "RevenueLock",
+      // $10k/day rate cap — must match the value used at deployment in deploy_governance.ts.
+      // See PARAMETER_MANIFEST.md (ship-armada/crowdfund) and issue #225.
       address: c.revenueLock,
-      constructorArguments: [c.armToken, c.revenueCounter, beneficiaryAddresses, beneficiaryAmounts],
+      constructorArguments: [
+        c.armToken,
+        c.revenueCounter,
+        ethers.parseUnits("10000", 18),
+        beneficiaryAddresses,
+        beneficiaryAmounts,
+      ],
     },
     {
       name: "ShieldPauseController",

--- a/test-foundry/RevenueLock.t.sol
+++ b/test-foundry/RevenueLock.t.sol
@@ -40,6 +40,10 @@ contract RevenueLockTest is Test {
     uint256 constant ALLOC_C = 400_000 * 1e18;   // ~3.3%
     uint256 constant TOTAL_LOCK = ALLOC_A + ALLOC_B + ALLOC_C; // 2,400,000 ARM
 
+    // $10k/day, 18-decimal USD. Matches PARAMETER_MANIFEST.md / issue #225.
+    // With this cap, full unlock requires the ratchet to walk ≥100 days from $0 → $1M.
+    uint256 constant MAX_INCREASE_PER_DAY = 10_000e18;
+
     function setUp() public {
         // Deploy mock revenue counter
         revenueCounter = new MockRevenueCounterRL();
@@ -66,6 +70,7 @@ contract RevenueLockTest is Test {
         revenueLock = new RevenueLock(
             address(armToken),
             address(revenueCounter),
+            MAX_INCREASE_PER_DAY,
             beneficiaries,
             amounts
         );
@@ -89,6 +94,20 @@ contract RevenueLockTest is Test {
 
         // Mine a block so getPastVotes works
         vm.roll(block.number + 1);
+    }
+
+    /// @dev Set mock-counter revenue AND warp enough wall-clock time that the
+    ///      ratchet budget can absorb the full increment. Isolates milestone /
+    ///      release mechanics from rate-limit behavior (which has its own section
+    ///      below and must NOT use this helper).
+    function _setRevenueAndBudget(uint256 revenue) internal {
+        revenueCounter.setRevenue(revenue);
+        uint256 current = revenueLock.maxObservedRevenue();
+        if (revenue > current) {
+            uint256 needed = revenue - current;
+            uint256 daysNeeded = (needed / MAX_INCREASE_PER_DAY) + 1;
+            vm.warp(block.timestamp + daysNeeded * 1 days);
+        }
     }
 
     // ============ Constructor Tests ============
@@ -119,7 +138,7 @@ contract RevenueLockTest is Test {
         a[0] = 1e18;
 
         vm.expectRevert("RevenueLock: zero armToken");
-        new RevenueLock(address(0), address(revenueCounter), b, a);
+        new RevenueLock(address(0), address(revenueCounter), MAX_INCREASE_PER_DAY, b, a);
     }
 
     function test_constructor_zeroRevenueCounter_reverts() public {
@@ -129,7 +148,20 @@ contract RevenueLockTest is Test {
         a[0] = 1e18;
 
         vm.expectRevert("RevenueLock: zero revenueCounter");
-        new RevenueLock(address(armToken), address(0), b, a);
+        new RevenueLock(address(armToken), address(0), MAX_INCREASE_PER_DAY, b, a);
+    }
+
+    // WHY: a zero MAX_REVENUE_INCREASE_PER_DAY would permanently pin
+    //      maxObservedRevenue to 0 (budget is always 0), permanently freezing all
+    //      entitlements. The constructor must reject this misconfiguration.
+    function test_constructor_zeroMaxIncrease_reverts() public {
+        address[] memory b = new address[](1);
+        b[0] = beneficiaryA;
+        uint256[] memory a = new uint256[](1);
+        a[0] = 1e18;
+
+        vm.expectRevert("RevenueLock: zero maxIncrease");
+        new RevenueLock(address(armToken), address(revenueCounter), 0, b, a);
     }
 
     function test_constructor_emptyBeneficiaries_reverts() public {
@@ -137,7 +169,7 @@ contract RevenueLockTest is Test {
         uint256[] memory a = new uint256[](0);
 
         vm.expectRevert("RevenueLock: empty beneficiaries");
-        new RevenueLock(address(armToken), address(revenueCounter), b, a);
+        new RevenueLock(address(armToken), address(revenueCounter), MAX_INCREASE_PER_DAY, b, a);
     }
 
     function test_constructor_lengthMismatch_reverts() public {
@@ -148,7 +180,7 @@ contract RevenueLockTest is Test {
         a[0] = 1e18;
 
         vm.expectRevert("RevenueLock: length mismatch");
-        new RevenueLock(address(armToken), address(revenueCounter), b, a);
+        new RevenueLock(address(armToken), address(revenueCounter), MAX_INCREASE_PER_DAY, b, a);
     }
 
     function test_constructor_zeroBeneficiaryAddress_reverts() public {
@@ -158,7 +190,7 @@ contract RevenueLockTest is Test {
         a[0] = 1e18;
 
         vm.expectRevert("RevenueLock: zero beneficiary");
-        new RevenueLock(address(armToken), address(revenueCounter), b, a);
+        new RevenueLock(address(armToken), address(revenueCounter), MAX_INCREASE_PER_DAY, b, a);
     }
 
     function test_constructor_zeroAmount_reverts() public {
@@ -168,7 +200,7 @@ contract RevenueLockTest is Test {
         a[0] = 0;
 
         vm.expectRevert("RevenueLock: zero amount");
-        new RevenueLock(address(armToken), address(revenueCounter), b, a);
+        new RevenueLock(address(armToken), address(revenueCounter), MAX_INCREASE_PER_DAY, b, a);
     }
 
     function test_constructor_duplicateBeneficiary_reverts() public {
@@ -180,7 +212,47 @@ contract RevenueLockTest is Test {
         a[1] = 1e18;
 
         vm.expectRevert("RevenueLock: duplicate beneficiary");
-        new RevenueLock(address(armToken), address(revenueCounter), b, a);
+        new RevenueLock(address(armToken), address(revenueCounter), MAX_INCREASE_PER_DAY, b, a);
+    }
+
+    // WHY: the issue #225 auditor checklist explicitly requires that
+    //      lastSyncTimestamp is initialized to block.timestamp (NOT 0). A zero
+    //      initialization would make the first observation see
+    //      `elapsed == block.timestamp`, producing an unbounded budget that
+    //      completely bypasses the rate limit on day 1.
+    function test_constructor_lastSyncTimestampInitializedToNow() public {
+        assertEq(revenueLock.lastSyncTimestamp(), block.timestamp, "lastSyncTimestamp must be now");
+        assertGt(revenueLock.lastSyncTimestamp(), 0, "lastSyncTimestamp must not be 0");
+    }
+
+    // WHY: the issue #225 auditor checklist also requires that maxObservedRevenue
+    //      is NOT seeded from the counter. A malicious initial counter
+    //      implementation could otherwise start the ratchet at an arbitrary high
+    //      value and bypass the rate limit immediately.
+    function test_constructor_maxObservedRevenueStartsAtZero() public {
+        // Even if the counter reports a nonzero value at deployment, the ratchet
+        // must start at 0. Deploy a fresh lock against a pre-populated counter
+        // and confirm.
+        MockRevenueCounterRL prePopulated = new MockRevenueCounterRL();
+        prePopulated.setRevenue(1_000_000e18);
+
+        address[] memory b = new address[](1);
+        b[0] = beneficiaryA;
+        uint256[] memory a = new uint256[](1);
+        a[0] = 1e18;
+
+        RevenueLock freshLock = new RevenueLock(
+            address(armToken),
+            address(prePopulated),
+            MAX_INCREASE_PER_DAY,
+            b,
+            a
+        );
+        assertEq(freshLock.maxObservedRevenue(), 0, "maxObservedRevenue must start at 0");
+    }
+
+    function test_constructor_maxIncreasePerDaySet() public {
+        assertEq(revenueLock.MAX_REVENUE_INCREASE_PER_DAY(), MAX_INCREASE_PER_DAY);
     }
 
     // ============ View Function Tests ============
@@ -194,52 +266,52 @@ contract RevenueLockTest is Test {
     }
 
     function test_unlockPercentage_belowFirstMilestone() public {
-        revenueCounter.setRevenue(9_999e18);
+        _setRevenueAndBudget(9_999e18);
         assertEq(revenueLock.unlockPercentage(), 0);
     }
 
     function test_unlockPercentage_atFirstMilestone() public {
-        revenueCounter.setRevenue(10_000e18);
+        _setRevenueAndBudget(10_000e18);
         assertEq(revenueLock.unlockPercentage(), 1000); // 10%
     }
 
     function test_unlockPercentage_betweenMilestones() public {
-        revenueCounter.setRevenue(49_999e18);
+        _setRevenueAndBudget(49_999e18);
         assertEq(revenueLock.unlockPercentage(), 1000); // still 10%, step function
     }
 
     function test_unlockPercentage_atSecondMilestone() public {
-        revenueCounter.setRevenue(50_000e18);
+        _setRevenueAndBudget(50_000e18);
         assertEq(revenueLock.unlockPercentage(), 2500); // 25%
     }
 
     function test_unlockPercentage_atThirdMilestone() public {
-        revenueCounter.setRevenue(100_000e18);
+        _setRevenueAndBudget(100_000e18);
         assertEq(revenueLock.unlockPercentage(), 4000); // 40%
     }
 
     function test_unlockPercentage_atFourthMilestone() public {
-        revenueCounter.setRevenue(250_000e18);
+        _setRevenueAndBudget(250_000e18);
         assertEq(revenueLock.unlockPercentage(), 6000); // 60%
     }
 
     function test_unlockPercentage_atFifthMilestone() public {
-        revenueCounter.setRevenue(500_000e18);
+        _setRevenueAndBudget(500_000e18);
         assertEq(revenueLock.unlockPercentage(), 8000); // 80%
     }
 
     function test_unlockPercentage_atSixthMilestone() public {
-        revenueCounter.setRevenue(1_000_000e18);
+        _setRevenueAndBudget(1_000_000e18);
         assertEq(revenueLock.unlockPercentage(), 10000); // 100%
     }
 
     function test_unlockPercentage_aboveMaxMilestone() public {
-        revenueCounter.setRevenue(5_000_000e18);
+        _setRevenueAndBudget(5_000_000e18);
         assertEq(revenueLock.unlockPercentage(), 10000); // still 100%
     }
 
     function test_currentRevenue_readsCounter() public {
-        revenueCounter.setRevenue(42e18);
+        _setRevenueAndBudget(42e18);
         assertEq(revenueLock.currentRevenue(), 42e18);
     }
 
@@ -248,12 +320,12 @@ contract RevenueLockTest is Test {
     }
 
     function test_releasable_nonBeneficiary() public {
-        revenueCounter.setRevenue(1_000_000e18);
+        _setRevenueAndBudget(1_000_000e18);
         assertEq(revenueLock.releasable(nonBeneficiary), 0);
     }
 
     function test_releasable_atFirstMilestone() public {
-        revenueCounter.setRevenue(10_000e18);
+        _setRevenueAndBudget(10_000e18);
         // 10% of ALLOC_A = 120,000 ARM
         assertEq(revenueLock.releasable(beneficiaryA), ALLOC_A * 1000 / 10000);
     }
@@ -261,14 +333,14 @@ contract RevenueLockTest is Test {
     // ============ Release Tests ============
 
     function test_release_nonBeneficiary_reverts() public {
-        revenueCounter.setRevenue(10_000e18);
+        _setRevenueAndBudget(10_000e18);
         vm.prank(nonBeneficiary);
         vm.expectRevert("RevenueLock: not a beneficiary");
         revenueLock.release(delegateeX);
     }
 
     function test_release_zeroDelegatee_reverts() public {
-        revenueCounter.setRevenue(10_000e18);
+        _setRevenueAndBudget(10_000e18);
         vm.prank(beneficiaryA);
         vm.expectRevert("RevenueLock: zero delegatee");
         revenueLock.release(address(0));
@@ -281,7 +353,7 @@ contract RevenueLockTest is Test {
     }
 
     function test_release_atFirstMilestone_transfers10Percent() public {
-        revenueCounter.setRevenue(10_000e18);
+        _setRevenueAndBudget(10_000e18);
 
         uint256 expected = ALLOC_A * 1000 / 10000; // 10%
         uint256 balBefore = armToken.balanceOf(beneficiaryA);
@@ -294,7 +366,7 @@ contract RevenueLockTest is Test {
     }
 
     function test_release_delegatesToSpecifiedAddress() public {
-        revenueCounter.setRevenue(10_000e18);
+        _setRevenueAndBudget(10_000e18);
 
         vm.prank(beneficiaryA);
         revenueLock.release(delegateeX);
@@ -303,7 +375,7 @@ contract RevenueLockTest is Test {
     }
 
     function test_release_secondCallAtSameMilestone_reverts() public {
-        revenueCounter.setRevenue(10_000e18);
+        _setRevenueAndBudget(10_000e18);
 
         vm.prank(beneficiaryA);
         revenueLock.release(delegateeX);
@@ -315,13 +387,13 @@ contract RevenueLockTest is Test {
 
     function test_release_atSecondMilestone_transfersDelta() public {
         // First release at 10%
-        revenueCounter.setRevenue(10_000e18);
+        _setRevenueAndBudget(10_000e18);
         vm.prank(beneficiaryA);
         revenueLock.release(delegateeX);
         uint256 firstRelease = ALLOC_A * 1000 / 10000;
 
         // Revenue increases to $50k (25%)
-        revenueCounter.setRevenue(50_000e18);
+        _setRevenueAndBudget(50_000e18);
         uint256 balBefore = armToken.balanceOf(beneficiaryA);
 
         vm.prank(beneficiaryA);
@@ -333,7 +405,7 @@ contract RevenueLockTest is Test {
     }
 
     function test_release_atFullUnlock_transfersEverything() public {
-        revenueCounter.setRevenue(1_000_000e18);
+        _setRevenueAndBudget(1_000_000e18);
 
         vm.prank(beneficiaryA);
         revenueLock.release(delegateeX);
@@ -344,7 +416,7 @@ contract RevenueLockTest is Test {
     }
 
     function test_release_emitsEvent() public {
-        revenueCounter.setRevenue(10_000e18);
+        _setRevenueAndBudget(10_000e18);
         uint256 expectedAmount = ALLOC_A * 1000 / 10000;
 
         vm.expectEmit(true, false, false, true);
@@ -355,7 +427,7 @@ contract RevenueLockTest is Test {
     }
 
     function test_release_multipleBeneficiariesIndependent() public {
-        revenueCounter.setRevenue(100_000e18); // 40% unlock
+        _setRevenueAndBudget(100_000e18); // 40% unlock
 
         // Beneficiary A releases
         vm.prank(beneficiaryA);
@@ -373,7 +445,7 @@ contract RevenueLockTest is Test {
     }
 
     function test_release_changesDelegatee() public {
-        revenueCounter.setRevenue(10_000e18);
+        _setRevenueAndBudget(10_000e18);
 
         // First release: delegate to X
         vm.prank(beneficiaryA);
@@ -381,14 +453,14 @@ contract RevenueLockTest is Test {
         assertEq(armToken.delegates(beneficiaryA), delegateeX);
 
         // Increase revenue, release again with different delegatee
-        revenueCounter.setRevenue(50_000e18);
+        _setRevenueAndBudget(50_000e18);
         vm.prank(beneficiaryA);
         revenueLock.release(delegateeY);
         assertEq(armToken.delegates(beneficiaryA), delegateeY);
     }
 
     function test_release_selfDelegation() public {
-        revenueCounter.setRevenue(10_000e18);
+        _setRevenueAndBudget(10_000e18);
 
         vm.prank(beneficiaryA);
         revenueLock.release(beneficiaryA);
@@ -405,7 +477,7 @@ contract RevenueLockTest is Test {
         uint256 prevReleased = 0;
 
         for (uint256 i = 0; i < 6; i++) {
-            revenueCounter.setRevenue(thresholds[i]);
+            _setRevenueAndBudget(thresholds[i]);
             uint256 entitled = ALLOC_A * bps[i] / 10000;
             uint256 expectedDelta = entitled - prevReleased;
 
@@ -422,7 +494,7 @@ contract RevenueLockTest is Test {
     }
 
     function test_supplyConservation_afterReleases() public {
-        revenueCounter.setRevenue(250_000e18); // 60%
+        _setRevenueAndBudget(250_000e18); // 60%
 
         vm.prank(beneficiaryA);
         revenueLock.release(delegateeX);
@@ -477,5 +549,206 @@ contract RevenueLockTest is Test {
             pct == 6000 || pct == 8000 || pct == 10000,
             "unlock percentage not a valid step value"
         );
+    }
+
+    // ============ Ratchet (issue #225) Tests ============
+    //
+    // These tests target the monotonic ratchet + rate-limit introduced to neutralise
+    // governance-controlled RevenueCounter upgrades. They MUST use raw setRevenue
+    // (not _setRevenueAndBudget) so that the rate-limit boundary is actually
+    // exercised instead of being hidden by the helper's auto-warp.
+
+    event ObservedRevenueUpdated(uint256 oldMax, uint256 newMax, uint256 reportedByCounter);
+
+    /// @dev WHY: the spec's defining property — if RevenueCounter is upgraded to
+    ///      return a value LOWER than the previously observed high-water mark,
+    ///      the ratchet must hold. Otherwise an attacker can freeze beneficiaries
+    ///      mid-release by forcing `entitled < alreadyReleased`.
+    function test_ratchet_rewindIsIgnored() public {
+        // Warp a day, counter reports $10k, ratchet advances to $10k.
+        vm.warp(block.timestamp + 1 days);
+        revenueCounter.setRevenue(10_000e18);
+        revenueLock.syncObservedRevenue();
+        assertEq(revenueLock.maxObservedRevenue(), 10_000e18, "ratchet should be at 10k");
+
+        // Simulate a malicious upgrade that reports 0.
+        revenueCounter.setRevenue(0);
+
+        // Another day passes — the ratchet must not move backward.
+        vm.warp(block.timestamp + 1 days);
+        revenueLock.syncObservedRevenue();
+        assertEq(revenueLock.maxObservedRevenue(), 10_000e18, "ratchet must not rewind");
+
+        // And views (which flow through the ratchet) remain stable.
+        assertEq(revenueLock.unlockPercentage(), 1000, "unlockPercentage must not rewind");
+    }
+
+    /// @dev WHY: the acceleration attack from issue #225 — a malicious upgrade
+    ///      reports type(uint256).max trying to flip every milestone at once.
+    ///      The ratchet must cap the advance to `elapsed * maxIncrease / 1 day`,
+    ///      not to whatever the counter reports.
+    function test_ratchet_capsInstantAcceleration() public {
+        // Attacker reports astronomical revenue.
+        revenueCounter.setRevenue(type(uint256).max);
+
+        // Only 1 day has passed since deployment.
+        vm.warp(block.timestamp + 1 days);
+        revenueLock.syncObservedRevenue();
+
+        // Ratchet may only advance by MAX_INCREASE_PER_DAY.
+        assertEq(revenueLock.maxObservedRevenue(), MAX_INCREASE_PER_DAY, "advance must be rate-capped");
+
+        // Even with the counter still at max, unlockPercentage only reflects what the
+        // capped ratchet allows. $10k → 10% (first milestone), NOT 100%.
+        assertEq(revenueLock.unlockPercentage(), 1000, "step must reflect capped value");
+    }
+
+    /// @dev WHY: the issue #225 auditor checklist calls this out explicitly —
+    ///      lastSyncTimestamp must advance on EVERY call, even when the ratchet
+    ///      itself does not move. Otherwise a daily no-op sync during a flat-
+    ///      revenue period fails to consume the elapsed-time allowance and the
+    ///      rate cap becomes meaningless over long idle windows.
+    function test_ratchet_lastSyncTimestampAdvancesOnNoOp() public {
+        // No revenue, no elapsed time, nothing to advance.
+        uint256 tsBefore = revenueLock.lastSyncTimestamp();
+
+        // Warp forward and sync with the counter still at 0.
+        vm.warp(block.timestamp + 1 days);
+        revenueLock.syncObservedRevenue();
+
+        // Ratchet did NOT advance (nothing to advance to).
+        assertEq(revenueLock.maxObservedRevenue(), 0, "no-op sync must not advance ratchet");
+        // But lastSyncTimestamp DID advance. This is the critical property.
+        assertGt(revenueLock.lastSyncTimestamp(), tsBefore, "no-op sync must still advance timestamp");
+        assertEq(revenueLock.lastSyncTimestamp(), block.timestamp, "timestamp must be now");
+    }
+
+    /// @dev WHY: without unconditional timestamp advancement, an attacker could
+    ///      accumulate budget over a long idle period (no sync, no release) and
+    ///      then burn it all in a single transaction after a malicious upgrade,
+    ///      defeating the purpose of the rate cap. This test proves budget DOES
+    ///      accumulate proportionally to elapsed time — forming the basis of the
+    ///      "call syncObservedRevenue() regularly" operational requirement.
+    function test_ratchet_budgetAccumulatesOverIdlePeriod() public {
+        // 10 days pass with no sync.
+        vm.warp(block.timestamp + 10 days);
+
+        // Counter jumps to a huge value.
+        revenueCounter.setRevenue(type(uint256).max);
+
+        // A single sync: budget = 10 * MAX_INCREASE_PER_DAY, ratchet advances by that much.
+        revenueLock.syncObservedRevenue();
+        assertEq(revenueLock.maxObservedRevenue(), 10 * MAX_INCREASE_PER_DAY,
+            "budget accumulates over idle days - exactly why regular syncs are required");
+    }
+
+    /// @dev WHY: ratchet must cap to `reported` when the counter is the smaller
+    ///      value, and to `prev + budget` when the counter is larger. Both sides
+    ///      of min() must be exercised.
+    function test_ratchet_capsToReportedWhenReportedIsSmaller() public {
+        revenueCounter.setRevenue(1_500e18);
+        vm.warp(block.timestamp + 1 days);
+        revenueLock.syncObservedRevenue();
+        // Reported ($1.5k) < budget ($10k) → ratchet caps to reported.
+        assertEq(revenueLock.maxObservedRevenue(), 1_500e18, "must cap to reported when smaller");
+    }
+
+    /// @dev WHY: getCappedObservedRevenue is the off-chain monitoring primitive.
+    ///      It must return the EXACT value that a simultaneous syncObservedRevenue
+    ///      would produce, otherwise bots cannot trust it. Mirrors the auditor
+    ///      checklist item "view and state-modifying return consistent values".
+    function test_view_getCappedObservedRevenue_matchesSync() public {
+        vm.warp(block.timestamp + 3 days);
+        revenueCounter.setRevenue(50_000e18);
+
+        uint256 predicted = revenueLock.getCappedObservedRevenue();
+        revenueLock.syncObservedRevenue();
+        assertEq(revenueLock.maxObservedRevenue(), predicted, "view must match actual sync");
+    }
+
+    /// @dev WHY: permissionless access is a hard requirement from the spec —
+    ///      monitoring bots need to advance the ratchet without holding special
+    ///      privileges. Any address must be able to call it.
+    function test_syncObservedRevenue_isPermissionless() public {
+        vm.warp(block.timestamp + 1 days);
+        revenueCounter.setRevenue(5_000e18);
+
+        // nonBeneficiary has no role, but can still sync.
+        vm.prank(nonBeneficiary);
+        revenueLock.syncObservedRevenue();
+
+        assertEq(revenueLock.maxObservedRevenue(), 5_000e18, "anyone must be able to sync");
+    }
+
+    /// @dev WHY: the ObservedRevenueUpdated event is the monitoring infrastructure's
+    ///      only on-chain signal for "ratchet advance happened". Its payload must
+    ///      include the oldMax, newMax, and (critically) the raw reported value so
+    ///      off-chain tools can distinguish a clean advance from a rate-limited one.
+    function test_ratchet_emitsObservedRevenueUpdated() public {
+        vm.warp(block.timestamp + 1 days);
+        revenueCounter.setRevenue(type(uint256).max);
+
+        vm.expectEmit(false, false, false, true);
+        emit ObservedRevenueUpdated(0, MAX_INCREASE_PER_DAY, type(uint256).max);
+        revenueLock.syncObservedRevenue();
+    }
+
+    /// @dev WHY: converse to the event test — the event must NOT fire on a no-op
+    ///      sync. Otherwise monitoring would be flooded with non-events and real
+    ///      advances would be harder to spot. `ObservedRevenueUpdated` is reserved
+    ///      for *actual* state changes of maxObservedRevenue.
+    function test_ratchet_noEventOnNoOpSync() public {
+        vm.recordLogs();
+        revenueLock.syncObservedRevenue();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "no-op sync must not emit ObservedRevenueUpdated");
+    }
+
+    /// @dev WHY: the primary bug from issue #225 — `release()` previously computed
+    ///      `entitled - alreadyReleased`. A malicious downgrade of RevenueCounter
+    ///      could push `entitled` below `alreadyReleased`, causing 0.8.x safe-math
+    ///      underflow and freezing the beneficiary. With the ratchet, `entitled`
+    ///      is computed from maxObservedRevenue which only grows, so this class
+    ///      of freeze is structurally impossible.
+    function test_ratchet_releaseDoesNotUnderflowOnCounterRewind() public {
+        // First release at the $10k milestone.
+        _setRevenueAndBudget(10_000e18);
+        vm.prank(beneficiaryA);
+        revenueLock.release(delegateeX);
+        uint256 releasedBefore = revenueLock.released(beneficiaryA);
+        assertGt(releasedBefore, 0, "setup: first release should have succeeded");
+
+        // Attacker downgrades the counter to 0.
+        revenueCounter.setRevenue(0);
+
+        // A subsequent release should simply revert with "nothing to release" — NOT
+        // underflow — because the ratchet still sees $10k. Beneficiaries remain
+        // whole; they just have nothing new to claim until real revenue grows.
+        vm.prank(beneficiaryA);
+        vm.expectRevert("RevenueLock: nothing to release");
+        revenueLock.release(delegateeX);
+
+        // And `released` is unchanged.
+        assertEq(revenueLock.released(beneficiaryA), releasedBefore, "released must not change");
+    }
+
+    /// @dev WHY: releasable() and unlockPercentage() are views driving UIs and
+    ///      integrations. They must preview the effect of a hypothetical release
+    ///      (which would call _updateMaxObservedRevenue first), not read stale
+    ///      storage. Concretely: after the counter reports a new milestone but
+    ///      before anyone syncs, the views should already reflect what release
+    ///      would deliver.
+    function test_views_previewPostSyncState() public {
+        // Stage: counter reports $10k, one day has passed, but no sync yet.
+        vm.warp(block.timestamp + 1 days);
+        revenueCounter.setRevenue(10_000e18);
+
+        // Storage is still 0.
+        assertEq(revenueLock.maxObservedRevenue(), 0, "storage not yet advanced");
+
+        // But views reflect what a release would see: 10% unlock, allocation * 10%.
+        assertEq(revenueLock.unlockPercentage(), 1000, "unlockPercentage must preview");
+        assertEq(revenueLock.releasable(beneficiaryA), ALLOC_A * 1000 / 10000,
+            "releasable must preview");
     }
 }

--- a/test-foundry/RevenueLock.t.sol
+++ b/test-foundry/RevenueLock.t.sol
@@ -551,9 +551,9 @@ contract RevenueLockTest is Test {
         );
     }
 
-    // ============ Ratchet (issue #225) Tests ============
+    // ============ Ratchet Tests ============
     //
-    // These tests target the monotonic ratchet + rate-limit introduced to neutralise
+    // These tests target the monotonic ratchet and rate-limit that neutralise
     // governance-controlled RevenueCounter upgrades. They MUST use raw setRevenue
     // (not _setRevenueAndBudget) so that the rate-limit boundary is actually
     // exercised instead of being hidden by the helper's auto-warp.

--- a/test-foundry/RevenueLockInvariant.t.sol
+++ b/test-foundry/RevenueLockInvariant.t.sol
@@ -30,6 +30,8 @@ contract RevenueLockHandler is Test {
     uint256 public ghost_revertCount;
     // Ghost: high-water mark of released amount per beneficiary (for monotonicity check)
     mapping(address => uint256) public ghost_releasedHighWater;
+    // Ghost: high-water mark of maxObservedRevenue (for ratchet monotonicity invariant)
+    uint256 public ghost_maxObservedRevenueHighWater;
 
     constructor(
         RevenueLock _revenueLock,
@@ -65,8 +67,28 @@ contract RevenueLockHandler is Test {
             // Track high-water mark for monotonicity invariant
             uint256 currentReleased = revenueLock.released(beneficiary);
             ghost_releasedHighWater[beneficiary] = currentReleased;
+            // release() may advance the ratchet too — refresh the high-water mark.
+            _refreshRatchetHighWater();
         } catch {
             ghost_revertCount++;
+        }
+    }
+
+    /// @dev Fuzzed: advance time by up to 30 days and sync the ratchet. Without
+    ///      this handler method, the ratchet would never have budget to advance
+    ///      during invariant runs (block.timestamp does not move between handler
+    ///      calls by default), and the release handler would almost always revert.
+    function warpAndSync(uint256 daysDelta) external {
+        daysDelta = bound(daysDelta, 1, 30);
+        vm.warp(block.timestamp + daysDelta * 1 days);
+        revenueLock.syncObservedRevenue();
+        _refreshRatchetHighWater();
+    }
+
+    function _refreshRatchetHighWater() internal {
+        uint256 current = revenueLock.maxObservedRevenue();
+        if (current > ghost_maxObservedRevenueHighWater) {
+            ghost_maxObservedRevenueHighWater = current;
         }
     }
 }
@@ -84,6 +106,7 @@ contract RevenueLockInvariantTest is Test {
     uint256[] public amounts;
 
     uint256 constant TOTAL_LOCK = 2_400_000 * 1e18;
+    uint256 constant MAX_INCREASE_PER_DAY = 10_000e18;
 
     function setUp() public {
         // Deploy mock revenue counter
@@ -118,6 +141,7 @@ contract RevenueLockInvariantTest is Test {
         revenueLock = new RevenueLock(
             address(armToken),
             address(revenueCounter),
+            MAX_INCREASE_PER_DAY,
             beneficiaries,
             amounts
         );
@@ -228,5 +252,30 @@ contract RevenueLockInvariantTest is Test {
                 );
             }
         }
+    }
+
+    /// @notice INV-RL7: maxObservedRevenue is monotonically non-decreasing.
+    ///         WHY: this is the core ratchet property from issue #225 —
+    ///         RevenueCounter downgrades must not be visible to entitlement math.
+    ///         A violation would mean the rewind-attack class is live again.
+    function invariant_ratchetMonotonic() public {
+        assertGe(
+            revenueLock.maxObservedRevenue(),
+            handler.ghost_maxObservedRevenueHighWater(),
+            "INV-RL7: maxObservedRevenue must be monotonic"
+        );
+    }
+
+    /// @notice INV-RL8: lastSyncTimestamp never exceeds block.timestamp.
+    ///         WHY: lastSyncTimestamp is only ever set to block.timestamp during
+    ///         `_updateMaxObservedRevenue`. If it could exceed the current time,
+    ///         a later `elapsed = now - lastSyncTimestamp` would underflow
+    ///         (Solidity 0.8.x panic) and render the contract bricked.
+    function invariant_lastSyncTimestampBounded() public {
+        assertLe(
+            revenueLock.lastSyncTimestamp(),
+            block.timestamp,
+            "INV-RL8: lastSyncTimestamp must not exceed block.timestamp"
+        );
     }
 }

--- a/test/revenue_lock.ts
+++ b/test/revenue_lock.ts
@@ -453,13 +453,13 @@ describe("RevenueLock", function () {
   });
 
   // ============================================================
-  // 8. Ratchet + Rate-Limit (issue #225)
+  // 8. Ratchet + Rate-Limit
   // ============================================================
   //
   // End-to-end integration tests for the monotonic ratchet and daily rate cap
-  // introduced to neutralise RevenueCounter governance-upgrade attacks. These
-  // tests use the REAL RevenueCounter (UUPS proxy, not a mock) so they exercise
-  // the full governance + ratchet interaction.
+  // that guard against RevenueCounter governance-upgrade attacks. These tests
+  // use the REAL RevenueCounter (UUPS proxy, not a mock) so they exercise the
+  // full governance + ratchet interaction.
 
   describe("Ratchet + Rate Limit", function () {
     it("initializes lastSyncTimestamp to deployment time (not zero)", async function () {

--- a/test/revenue_lock.ts
+++ b/test/revenue_lock.ts
@@ -15,7 +15,7 @@
 
 import { expect } from "chai";
 import { ethers } from "hardhat";
-import { mine } from "@nomicfoundation/hardhat-network-helpers";
+import { mine, time } from "@nomicfoundation/hardhat-network-helpers";
 import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 
 describe("RevenueLock", function () {
@@ -46,6 +46,28 @@ describe("RevenueLock", function () {
   const REV_250K = ethers.parseUnits("250000", 18);
   const REV_500K = ethers.parseUnits("500000", 18);
   const REV_1M = ethers.parseUnits("1000000", 18);
+
+  // Rate cap for the observed-revenue ratchet: $10k/day (18-decimal USD).
+  // Matches PARAMETER_MANIFEST.md / issue #225.
+  const MAX_INCREASE_PER_DAY = ethers.parseUnits("10000", 18);
+  const ONE_DAY = 24 * 60 * 60;
+
+  /**
+   * Attest cumulative revenue AND advance the chain clock enough that the ratchet
+   * can absorb the full increment on the next sync/release. Keeps milestone/release
+   * tests isolated from rate-limit semantics (which are covered by the dedicated
+   * ratchet test suite below).
+   */
+  async function attestRevenueWithBudget(revenue: bigint) {
+    const current: bigint = await revenueLock.maxObservedRevenue();
+    if (revenue > current) {
+      const needed = revenue - current;
+      // Ceil-divide, plus one extra day as a safety cushion.
+      const daysNeeded = Number(needed / MAX_INCREASE_PER_DAY) + 1;
+      await time.increase(daysNeeded * ONE_DAY);
+    }
+    await revenueCounter.attestRevenue(revenue);
+  }
 
   async function deployAll() {
     [deployer, beneficiaryA, beneficiaryB, beneficiaryC, delegateeX, delegateeY, nonBeneficiary] =
@@ -89,6 +111,7 @@ describe("RevenueLock", function () {
     revenueLock = await RevenueLock.deploy(
       await armToken.getAddress(),
       await revenueCounter.getAddress(),
+      MAX_INCREASE_PER_DAY,
       [beneficiaryA.address, beneficiaryB.address, beneficiaryC.address],
       [ALLOC_A, ALLOC_B, ALLOC_C]
     );
@@ -168,25 +191,24 @@ describe("RevenueLock", function () {
       ];
 
       for (const { revenue, expectedBps } of milestones) {
-        // Use attestRevenue (deployer is owner)
-        await revenueCounter.attestRevenue(revenue);
+        await attestRevenueWithBudget(revenue);
         expect(await revenueLock.unlockPercentage()).to.equal(expectedBps);
       }
     });
 
     it("releasable returns correct amount at 10% unlock", async function () {
-      await revenueCounter.attestRevenue(REV_10K);
+      await attestRevenueWithBudget(REV_10K);
       const expected = (ALLOC_A * 1000n) / 10000n;
       expect(await revenueLock.releasable(beneficiaryA.address)).to.equal(expected);
     });
 
     it("releasable returns 0 for non-beneficiary", async function () {
-      await revenueCounter.attestRevenue(REV_1M);
+      await attestRevenueWithBudget(REV_1M);
       expect(await revenueLock.releasable(nonBeneficiary.address)).to.equal(0);
     });
 
     it("currentRevenue reads from RevenueCounter", async function () {
-      await revenueCounter.attestRevenue(REV_50K);
+      await attestRevenueWithBudget(REV_50K);
       expect(await revenueLock.currentRevenue()).to.equal(REV_50K);
     });
   });
@@ -203,21 +225,21 @@ describe("RevenueLock", function () {
     });
 
     it("reverts for non-beneficiary", async function () {
-      await revenueCounter.attestRevenue(REV_10K);
+      await attestRevenueWithBudget(REV_10K);
       await expect(
         revenueLock.connect(nonBeneficiary).release(delegateeX.address)
       ).to.be.revertedWith("RevenueLock: not a beneficiary");
     });
 
     it("reverts for zero delegatee", async function () {
-      await revenueCounter.attestRevenue(REV_10K);
+      await attestRevenueWithBudget(REV_10K);
       await expect(
         revenueLock.connect(beneficiaryA).release(ethers.ZeroAddress)
       ).to.be.revertedWith("RevenueLock: zero delegatee");
     });
 
     it("releases 10% at $10k milestone", async function () {
-      await revenueCounter.attestRevenue(REV_10K);
+      await attestRevenueWithBudget(REV_10K);
       const expected = (ALLOC_A * 1000n) / 10000n;
 
       await revenueLock.connect(beneficiaryA).release(delegateeX.address);
@@ -227,7 +249,7 @@ describe("RevenueLock", function () {
     });
 
     it("sets delegation atomically on release", async function () {
-      await revenueCounter.attestRevenue(REV_10K);
+      await attestRevenueWithBudget(REV_10K);
 
       await revenueLock.connect(beneficiaryA).release(delegateeX.address);
 
@@ -235,7 +257,7 @@ describe("RevenueLock", function () {
     });
 
     it("delegatee receives voting power after release", async function () {
-      await revenueCounter.attestRevenue(REV_10K);
+      await attestRevenueWithBudget(REV_10K);
       await revenueLock.connect(beneficiaryA).release(delegateeX.address);
 
       // Mine a block so getPastVotes captures the checkpoint
@@ -246,7 +268,7 @@ describe("RevenueLock", function () {
     });
 
     it("reverts on second call at same milestone (nothing new)", async function () {
-      await revenueCounter.attestRevenue(REV_10K);
+      await attestRevenueWithBudget(REV_10K);
       await revenueLock.connect(beneficiaryA).release(delegateeX.address);
 
       await expect(
@@ -256,12 +278,12 @@ describe("RevenueLock", function () {
 
     it("releases delta at next milestone", async function () {
       // First release at 10%
-      await revenueCounter.attestRevenue(REV_10K);
+      await attestRevenueWithBudget(REV_10K);
       await revenueLock.connect(beneficiaryA).release(delegateeX.address);
       const firstRelease = (ALLOC_A * 1000n) / 10000n;
 
       // Second release at 25%
-      await revenueCounter.attestRevenue(REV_50K);
+      await attestRevenueWithBudget(REV_50K);
       await revenueLock.connect(beneficiaryA).release(delegateeX.address);
       const totalEntitled = (ALLOC_A * 2500n) / 10000n;
       const secondRelease = totalEntitled - firstRelease;
@@ -271,7 +293,7 @@ describe("RevenueLock", function () {
     });
 
     it("releases full allocation at $1M", async function () {
-      await revenueCounter.attestRevenue(REV_1M);
+      await attestRevenueWithBudget(REV_1M);
       await revenueLock.connect(beneficiaryA).release(delegateeX.address);
 
       expect(await revenueLock.released(beneficiaryA.address)).to.equal(ALLOC_A);
@@ -280,7 +302,7 @@ describe("RevenueLock", function () {
     });
 
     it("emits Released event", async function () {
-      await revenueCounter.attestRevenue(REV_10K);
+      await attestRevenueWithBudget(REV_10K);
       const expected = (ALLOC_A * 1000n) / 10000n;
 
       await expect(revenueLock.connect(beneficiaryA).release(delegateeX.address))
@@ -289,11 +311,11 @@ describe("RevenueLock", function () {
     });
 
     it("changes delegatee on subsequent release", async function () {
-      await revenueCounter.attestRevenue(REV_10K);
+      await attestRevenueWithBudget(REV_10K);
       await revenueLock.connect(beneficiaryA).release(delegateeX.address);
       expect(await armToken.delegates(beneficiaryA.address)).to.equal(delegateeX.address);
 
-      await revenueCounter.attestRevenue(REV_50K);
+      await attestRevenueWithBudget(REV_50K);
       await revenueLock.connect(beneficiaryA).release(delegateeY.address);
       expect(await armToken.delegates(beneficiaryA.address)).to.equal(delegateeY.address);
     });
@@ -305,7 +327,7 @@ describe("RevenueLock", function () {
 
   describe("Multi-Beneficiary", function () {
     it("beneficiaries release independently", async function () {
-      await revenueCounter.attestRevenue(REV_100K); // 40% unlock
+      await attestRevenueWithBudget(REV_100K); // 40% unlock
 
       // Only A releases
       await revenueLock.connect(beneficiaryA).release(delegateeX.address);
@@ -324,7 +346,7 @@ describe("RevenueLock", function () {
 
     it("late beneficiary gets full entitled amount on first release", async function () {
       // Revenue reaches $250k (60%) — beneficiary C hasn't released at any prior milestone
-      await revenueCounter.attestRevenue(REV_250K);
+      await attestRevenueWithBudget(REV_250K);
 
       await revenueLock.connect(beneficiaryC).release(delegateeX.address);
       const expected = (ALLOC_C * 6000n) / 10000n;
@@ -338,7 +360,7 @@ describe("RevenueLock", function () {
 
   describe("Supply Conservation", function () {
     it("ARM balance + released == totalAllocation after partial releases", async function () {
-      await revenueCounter.attestRevenue(REV_250K); // 60%
+      await attestRevenueWithBudget(REV_250K); // 60%
 
       await revenueLock.connect(beneficiaryA).release(delegateeX.address);
       await revenueLock.connect(beneficiaryB).release(delegateeX.address);
@@ -353,7 +375,7 @@ describe("RevenueLock", function () {
     });
 
     it("ARM balance is zero after all beneficiaries fully release", async function () {
-      await revenueCounter.attestRevenue(REV_1M);
+      await attestRevenueWithBudget(REV_1M);
 
       await revenueLock.connect(beneficiaryA).release(delegateeX.address);
       await revenueLock.connect(beneficiaryB).release(delegateeX.address);
@@ -376,6 +398,12 @@ describe("RevenueLock", function () {
 
       // Revenue counter should now show $10k in 18 decimals
       expect(await revenueCounter.recognizedRevenueUsd()).to.equal(REV_10K);
+
+      // Advance the chain clock enough for the ratchet budget to absorb $10k,
+      // then sync the ratchet. Without this, the rate cap leaves
+      // maxObservedRevenue at 0 and downstream entitlement would be 0.
+      await time.increase(2 * ONE_DAY);
+      await revenueLock.syncObservedRevenue();
 
       // RevenueLock should see 10% unlock
       expect(await revenueLock.unlockPercentage()).to.equal(1000n);
@@ -405,7 +433,7 @@ describe("RevenueLock", function () {
       let prevReleased = 0n;
 
       for (const { revenue, bps } of milestones) {
-        await revenueCounter.attestRevenue(revenue);
+        await attestRevenueWithBudget(revenue);
 
         const entitled = (ALLOC_A * bps) / 10000n;
         const expectedDelta = entitled - prevReleased;
@@ -421,6 +449,122 @@ describe("RevenueLock", function () {
       // Fully released
       expect(await revenueLock.released(beneficiaryA.address)).to.equal(ALLOC_A);
       expect(await revenueLock.releasable(beneficiaryA.address)).to.equal(0);
+    });
+  });
+
+  // ============================================================
+  // 8. Ratchet + Rate-Limit (issue #225)
+  // ============================================================
+  //
+  // End-to-end integration tests for the monotonic ratchet and daily rate cap
+  // introduced to neutralise RevenueCounter governance-upgrade attacks. These
+  // tests use the REAL RevenueCounter (UUPS proxy, not a mock) so they exercise
+  // the full governance + ratchet interaction.
+
+  describe("Ratchet + Rate Limit", function () {
+    it("initializes lastSyncTimestamp to deployment time (not zero)", async function () {
+      // WHY: issue #225 auditor checklist — a zero lastSyncTimestamp would make
+      // the first observation see enormous elapsed time and bypass the rate cap.
+      const ts = await revenueLock.lastSyncTimestamp();
+      expect(ts).to.be.gt(0);
+      // Must be recent (within the last minute — block.timestamp at deploy).
+      const now = await time.latest();
+      expect(Number(ts)).to.be.closeTo(now, 60);
+    });
+
+    it("initializes MAX_REVENUE_INCREASE_PER_DAY to the spec-calibrated value", async function () {
+      expect(await revenueLock.MAX_REVENUE_INCREASE_PER_DAY()).to.equal(MAX_INCREASE_PER_DAY);
+    });
+
+    it("starts maxObservedRevenue at zero, even if counter has history", async function () {
+      // WHY: also from the auditor checklist — the ratchet must NOT be seeded
+      // from the counter, otherwise a malicious initial counter implementation
+      // could pre-populate the ratchet.
+      expect(await revenueLock.maxObservedRevenue()).to.equal(0);
+    });
+
+    it("rate-caps instant acceleration from a malicious counter jump", async function () {
+      // WHY: the acceleration attack from #225. Even if governance upgrades
+      // RevenueCounter to report a huge value, only MAX_INCREASE_PER_DAY can
+      // flow into maxObservedRevenue per elapsed day.
+      await revenueCounter.attestRevenue(ethers.parseUnits("10000000", 18)); // $10M
+      await time.increase(ONE_DAY);
+      await revenueLock.syncObservedRevenue();
+
+      // Tolerance: hardhat mines one block per tx between `lastSyncTimestamp`
+      // (set in the RevenueLock constructor) and this sync, so a handful of
+      // extra seconds of budget accumulate beyond the literal one-day value.
+      // The cap is still ~$10k — orders of magnitude below $10M — which is
+      // all the anti-acceleration property requires.
+      const tolerance = (MAX_INCREASE_PER_DAY * 60n) / 86400n; // up to 60s of budget
+      const actual = await revenueLock.maxObservedRevenue();
+      expect(actual).to.be.gte(MAX_INCREASE_PER_DAY);
+      expect(actual).to.be.lte(MAX_INCREASE_PER_DAY + tolerance);
+      expect(await revenueLock.unlockPercentage()).to.equal(1000n); // only 10% unlocked
+    });
+
+    it("holds firm against a would-be rewind (but counter is monotonic anyway)", async function () {
+      // WHY: while the real RevenueCounter refuses non-monotonic attestations,
+      // a malicious UUPS upgrade could bypass that check entirely by replacing
+      // the implementation. The ratchet must not rely on the counter being
+      // well-behaved — that's the whole point.
+      await attestRevenueWithBudget(REV_10K);
+      await revenueLock.syncObservedRevenue();
+      expect(await revenueLock.maxObservedRevenue()).to.equal(REV_10K);
+
+      // Note: we cannot actually downgrade the real counter without deploying
+      // a replacement impl. The Foundry tests cover the rewind-immunity property
+      // with a mock counter. Here we verify the ratchet at least doesn't reset
+      // itself on its own — a sync with no new revenue must keep it stable.
+      await time.increase(ONE_DAY);
+      await revenueLock.syncObservedRevenue();
+      expect(await revenueLock.maxObservedRevenue()).to.equal(REV_10K);
+    });
+
+    it("advances lastSyncTimestamp on every sync — including no-ops", async function () {
+      // WHY: the central mechanism that makes regular syncs meaningful. Without
+      // this, budget accumulates indefinitely during quiet periods.
+      const before = await revenueLock.lastSyncTimestamp();
+      await time.increase(ONE_DAY);
+      await revenueLock.syncObservedRevenue(); // counter is at 0 — this is a no-op
+      const after = await revenueLock.lastSyncTimestamp();
+      expect(after).to.be.gt(before);
+    });
+
+    it("exposes a permissionless sync for monitoring bots", async function () {
+      // WHY: operational security model requires that any monitoring address
+      // can call syncObservedRevenue without holding special privileges.
+      await attestRevenueWithBudget(REV_10K);
+      await revenueLock.connect(nonBeneficiary).syncObservedRevenue();
+      expect(await revenueLock.maxObservedRevenue()).to.equal(REV_10K);
+    });
+
+    it("getCappedObservedRevenue previews what a sync would produce", async function () {
+      // WHY: off-chain monitoring needs a view that exactly mirrors the
+      // state-modifying sync. Divergence would make monitoring unreliable.
+      await revenueCounter.attestRevenue(REV_50K);
+      await time.increase(10 * ONE_DAY);
+
+      const predicted = await revenueLock.getCappedObservedRevenue();
+      await revenueLock.syncObservedRevenue();
+      expect(await revenueLock.maxObservedRevenue()).to.equal(predicted);
+    });
+
+    it("emits ObservedRevenueUpdated on actual ratchet advance", async function () {
+      await revenueCounter.attestRevenue(REV_10K);
+      await time.increase(2 * ONE_DAY);
+
+      // Advance actually happens — event must fire with raw reported value.
+      await expect(revenueLock.syncObservedRevenue())
+        .to.emit(revenueLock, "ObservedRevenueUpdated")
+        .withArgs(0n, REV_10K, REV_10K);
+    });
+
+    it("does NOT emit ObservedRevenueUpdated on a no-op sync", async function () {
+      await time.increase(ONE_DAY);
+      // Counter is at 0, ratchet is at 0 — no advance possible.
+      await expect(revenueLock.syncObservedRevenue())
+        .to.not.emit(revenueLock, "ObservedRevenueUpdated");
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #225.

- Add a monotonic ratchet (\`maxObservedRevenue\`) to RevenueLock so that a malicious UUPS upgrade of RevenueCounter can neither **rewind** (underflow → frozen releases) nor **instantly accelerate** the unlock schedule.
- Rate-cap increases at \`MAX_REVENUE_INCREASE_PER_DAY\` = **\$10k / day** (spec value from \`REVENUE_LOCK.md\` / \`PARAMETER_MANIFEST.md\`, in 18-dec USD). Passed as an immutable constructor arg so it's visible on-chain and in Etherscan verification.
- Entitlement math (\`release()\`, \`releasable()\`, \`unlockPercentage()\`) now reads the ratchet; \`currentRevenue()\` remains a raw passthrough for monitoring.
- Expose a permissionless \`syncObservedRevenue()\` so a monitoring bot can keep the ratchet fresh; \`release()\` also advances it.
- Initialize \`lastSyncTimestamp = block.timestamp\` in the constructor (a zero value would let the first observation bypass the cap).

## Threat model recap

| Attack | Pre-fix | Post-fix |
|---|---|---|
| Malicious counter impl reports value **below** current max | \`entitled - released\` underflows → \`release()\` panics forever | Ratchet ignores it; releases continue at prior max |
| Malicious counter impl reports enormous value (e.g. \$10M) | Whole schedule unlocks atomically | Only ~\$10k can flow into the ratchet per day regardless of counter |

## Test plan

- [x] Foundry: 65/65 passing — \`npm run test:forge\` (RevenueLock.t.sol + RevenueLockInvariant.t.sol)
  - New invariants: **INV-RL7** (ratchet monotonicity) and **INV-RL8** (\`lastSyncTimestamp ≤ block.timestamp\`)
  - 11 new ratchet-specific tests: rewind immunity, instant-acceleration cap, unconditional timestamp advance, budget accumulation, view/sync parity, permissionless sync, event emission
- [x] Hardhat: 37/37 passing — \`npx hardhat test test/revenue_lock.ts\`
  - 10 new "Ratchet + Rate Limit" tests exercising the same behaviours against the real RevenueCounter UUPS proxy
- [ ] Sepolia redeploy (follow-up) — constructor signature changed; \`deploy_governance.ts\`, \`deploy_revenue_lock_cohort.ts\`, and \`verify_sepolia.ts\` already updated

## Files

- \`contracts/governance/RevenueLock.sol\` — ratchet state + rate-limit logic + event
- \`scripts/deploy_governance.ts\` / \`deploy_revenue_lock_cohort.ts\` / \`verify_sepolia.ts\` — new constructor arg
- \`test/revenue_lock.ts\`, \`test-foundry/RevenueLock.t.sol\`, \`test-foundry/RevenueLockInvariant.t.sol\` — new test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)