### PR TITLE
fix(governance): cap timelock.updateDelay at MAX_EXECUTION_DELAY (#231)

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -60,6 +60,7 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     error Gov_StewardNotActive();
     error Gov_StewardProposerNoLongerActive();
     error Gov_UnknownProposal();
+    error Gov_UpdateDelayExceedsCap(uint256 requested, uint256 cap);
     error Gov_UseResolveRatification();
     error Gov_VotingEnded();
     error Gov_VotingNotEnded();
@@ -183,6 +184,14 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     // The distribute selector is checked specially: if amount > 5% of treasury balance, Extended.
     bytes4 public constant DISTRIBUTE_SELECTOR = bytes4(keccak256("distribute(address,address,uint256)"));
     uint256 public constant TREASURY_EXTENDED_THRESHOLD_BPS = 500; // 5%
+
+    // Timelock.updateDelay(uint256) — guarded at propose() time. Setting the timelock's
+    // _minDelay above MAX_EXECUTION_DELAY would permanently brick queue() because every
+    // proposal's executionDelay (≤ MAX_EXECUTION_DELAY) would fall below getMinDelay().
+    // NOTE: This guard is governor-scoped. It assumes PROPOSER_ROLE on the timelock is
+    // held ONLY by this governor. If another proposer is ever granted the role, that
+    // path bypasses this check and this guard must be re-evaluated.
+    bytes4 public constant UPDATE_DELAY_SELECTOR = bytes4(keccak256("updateDelay(uint256)"));
 
     // Fail-closed classification: selectors not in extendedSelectors AND not in
     // standardSelectors default to Extended. This prevents bypass via unclassified
@@ -741,6 +750,12 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
             if (targets.length != values.length || targets.length != calldatas.length) revert Gov_LengthMismatch();
         }
 
+        // Bound timelock.updateDelay(uint256) at propose-time so a governance action
+        // cannot push _minDelay above MAX_EXECUTION_DELAY and permanently brick queue().
+        if (proposalType != ProposalType.Signaling) {
+            _validateTimelockCalldata(targets, calldatas);
+        }
+
         // Mechanical classification: if any calldata triggers extended, override to Extended.
         // Proposers can opt into Extended voluntarily, but cannot downgrade to Standard
         // when calldata contains extended-classified function calls.
@@ -1104,6 +1119,29 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         }
 
         return declaredType;
+    }
+
+    /// @dev Revert if any action would call timelock.updateDelay(X) with X > MAX_EXECUTION_DELAY.
+    ///      Setting _minDelay above the governor's max per-proposal executionDelay permanently
+    ///      bricks queue() (OZ TimelockController._schedule requires delay >= getMinDelay).
+    ///      Malformed calldata (< 4B selector, or < 36B = selector + uint256) is skipped;
+    ///      it would revert later at the timelock anyway and is not a minDelay escalation.
+    function _validateTimelockCalldata(address[] memory targets, bytes[] memory calldatas) internal view {
+        for (uint256 i = 0; i < targets.length; i++) {
+            if (targets[i] != address(timelock)) continue;
+            if (calldatas[i].length < 36) continue;
+            if (bytes4(calldatas[i]) != UPDATE_DELAY_SELECTOR) continue;
+
+            // Decode the uint256 argument. Skip the 4-byte selector by slicing from index 4.
+            bytes memory params = new bytes(calldatas[i].length - 4);
+            for (uint256 j = 0; j < params.length; j++) {
+                params[j] = calldatas[i][j + 4];
+            }
+            uint256 newDelay = abi.decode(params, (uint256));
+            if (newDelay > MAX_EXECUTION_DELAY) {
+                revert Gov_UpdateDelayExceedsCap(newDelay, MAX_EXECUTION_DELAY);
+            }
+        }
     }
 
     /// @dev Block proposals during the quiet period after crowdfund finalization.

--- a/test-foundry/GovernorUpdateDelayCap.t.sol
+++ b/test-foundry/GovernorUpdateDelayCap.t.sol
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+// ABOUTME: Foundry tests for the propose-time guard on timelock.updateDelay(uint256).
+// ABOUTME: Prevents a governance action from bricking queue() by setting _minDelay > MAX_EXECUTION_DELAY.
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/governance/ArmadaGovernor.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/governance/ArmadaTreasuryGov.sol";
+import "../contracts/governance/IArmadaGovernance.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+import "./helpers/GovernorDeployHelper.sol";
+
+/// @title GovernorUpdateDelayCapTest — Propose-time cap on timelock.updateDelay(uint256).
+/// @notice OZ TimelockController._schedule requires `delay >= getMinDelay()`. If governance
+///         ever sets _minDelay above MAX_EXECUTION_DELAY (14 days), every subsequent queue()
+///         reverts permanently. The governor enforces a cap at propose() so this cannot happen
+///         via the governor's PROPOSER_ROLE path (the only path today).
+contract GovernorUpdateDelayCapTest is Test, GovernorDeployHelper {
+    ArmadaGovernor public governor;
+    ArmadaToken public armToken;
+    TimelockController public timelock;
+    ArmadaTreasuryGov public treasury;
+
+    address public deployer = address(this);
+    address public alice = address(0xA11CE);
+    address public bob = address(0xB0B);
+
+    uint256 constant TOTAL_SUPPLY = 12_000_000 * 1e18;
+    uint256 constant TWO_DAYS = 2 days;
+
+    function setUp() public {
+        address[] memory proposers = new address[](0);
+        address[] memory executors = new address[](0);
+        timelock = new TimelockController(TWO_DAYS, proposers, executors, deployer);
+
+        armToken = new ArmadaToken(deployer, address(timelock));
+        treasury = new ArmadaTreasuryGov(address(timelock));
+
+        governor = _deployGovernorProxy(
+            address(armToken),
+            payable(address(timelock)),
+            address(treasury)
+        );
+
+        // Give alice well above the 0.1% proposal threshold so she can propose.
+        address[] memory whitelist = new address[](3);
+        whitelist[0] = deployer;
+        whitelist[1] = alice;
+        whitelist[2] = bob;
+        armToken.initWhitelist(whitelist);
+
+        armToken.transfer(alice, TOTAL_SUPPLY * 20 / 100);
+        armToken.transfer(bob, TOTAL_SUPPLY * 10 / 100);
+
+        vm.prank(alice);
+        armToken.delegate(alice);
+        vm.prank(bob);
+        armToken.delegate(bob);
+
+        vm.roll(block.number + 1);
+    }
+
+    // ======== Helpers ========
+
+    function _singleAction(address target, bytes memory data) internal pure returns (
+        address[] memory targets, uint256[] memory values, bytes[] memory calldatas
+    ) {
+        targets = new address[](1);
+        values = new uint256[](1);
+        calldatas = new bytes[](1);
+        targets[0] = target;
+        values[0] = 0;
+        calldatas[0] = data;
+    }
+
+    function _updateDelayCalldata(uint256 newDelay) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(TimelockController.updateDelay.selector, newDelay);
+    }
+
+    // ======== Tests ========
+
+    // WHY: Within-cap updateDelay must still be proposable — the guard is a ceiling,
+    // not a blanket ban. Verifies normal governance operation is unaffected.
+    function test_propose_updateDelay_withinCap_succeeds() public {
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
+            _singleAction(address(timelock), _updateDelayCalldata(7 days));
+
+        vm.prank(alice);
+        uint256 id = governor.propose(ProposalType.Extended, targets, values, calldatas, "updateDelay 7d");
+        assertGt(id, 0, "proposal id should be assigned");
+    }
+
+    // WHY: The cap equals MAX_EXECUTION_DELAY. A value exactly at the cap is still safe
+    // because a proposal type with executionDelay == 14d can satisfy delay >= getMinDelay.
+    // Boundary test ensures the guard uses strict inequality (>), not >=.
+    function test_propose_updateDelay_atCap_succeeds() public {
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
+            _singleAction(address(timelock), _updateDelayCalldata(14 days));
+
+        vm.prank(alice);
+        uint256 id = governor.propose(ProposalType.Extended, targets, values, calldatas, "updateDelay 14d");
+        assertGt(id, 0, "at-cap updateDelay should be proposable");
+    }
+
+    // WHY: Core protection. One day over the cap is a permanent queue() brick if executed,
+    // so the governor must refuse to create the proposal. Custom error carries the
+    // requested value and the cap to aid off-chain monitoring / UI messaging.
+    function test_propose_updateDelay_aboveCap_reverts() public {
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
+            _singleAction(address(timelock), _updateDelayCalldata(15 days));
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(ArmadaGovernor.Gov_UpdateDelayExceedsCap.selector, 15 days, 14 days)
+        );
+        governor.propose(ProposalType.Extended, targets, values, calldatas, "updateDelay 15d");
+    }
+
+    // WHY: Unbounded uint256 is the exact scenario in issue #231. A far-out value (e.g.
+    // type(uint256).max or hundreds of years) must be rejected the same as a small-but-over
+    // value, with no decoding edge cases.
+    function test_propose_updateDelay_maxUint_reverts() public {
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
+            _singleAction(address(timelock), _updateDelayCalldata(type(uint256).max));
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(ArmadaGovernor.Gov_UpdateDelayExceedsCap.selector, type(uint256).max, 14 days)
+        );
+        governor.propose(ProposalType.Extended, targets, values, calldatas, "updateDelay max");
+    }
+
+    // WHY: The guard must catch a bad entry regardless of its position in a multi-action
+    // batch. A proposer could otherwise hide a cap-violating call behind innocuous actions.
+    function test_propose_updateDelay_batchWithBadEntry_reverts() public {
+        address[] memory targets = new address[](2);
+        uint256[] memory values = new uint256[](2);
+        bytes[] memory calldatas = new bytes[](2);
+
+        // Action 0: innocuous call on the governor (proposalCount() view — unused but legal calldata).
+        targets[0] = address(governor);
+        values[0] = 0;
+        calldatas[0] = abi.encodeWithSignature("proposalCount()");
+
+        // Action 1: the offending updateDelay above the cap.
+        targets[1] = address(timelock);
+        values[1] = 0;
+        calldatas[1] = _updateDelayCalldata(30 days);
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(ArmadaGovernor.Gov_UpdateDelayExceedsCap.selector, 30 days, 14 days)
+        );
+        governor.propose(ProposalType.Extended, targets, values, calldatas, "batch brick");
+    }
+
+    // WHY: The guard is scoped to `target == address(timelock)`. A proposal calling some
+    // other contract that happens to share the updateDelay(uint256) selector must NOT be
+    // rejected by our cap — it has no bearing on the timelock's _minDelay. Out-of-scope
+    // contracts are not our concern; classification handles their risk tier.
+    function test_propose_updateDelay_nonTimelockTarget_notBlocked() public {
+        // Treasury contract has no updateDelay — but we're proving the guard ignores the
+        // selector when the target isn't the timelock. The proposal will be Extended via
+        // fail-closed classification (selector not registered), which is fine.
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
+            _singleAction(address(treasury), _updateDelayCalldata(100 days));
+
+        vm.prank(alice);
+        uint256 id = governor.propose(ProposalType.Extended, targets, values, calldatas, "not timelock");
+        assertGt(id, 0, "non-timelock target should not trip the updateDelay guard");
+    }
+
+    // WHY: Malformed calldata (selector only, no uint256 argument) cannot actually raise
+    // _minDelay — it would revert at the timelock during execution. The guard must skip
+    // rather than revert, so that accidental/invalid calldata doesn't block propose() with
+    // a misleading error. Defensive parity with _classifyProposal's length checks.
+    function test_propose_updateDelay_malformedCalldata_skipped() public {
+        bytes memory malformed = abi.encodePacked(TimelockController.updateDelay.selector);
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
+            _singleAction(address(timelock), malformed);
+
+        vm.prank(alice);
+        uint256 id = governor.propose(ProposalType.Extended, targets, values, calldatas, "malformed");
+        assertGt(id, 0, "selector-only updateDelay calldata should be skipped, not reverted");
+    }
+
+    // WHY: Signaling proposals carry no calldatas — the guard must not spuriously revert
+    // on the empty path. Verifies the `proposalType != Signaling` short-circuit is correct.
+    function test_propose_signaling_skipsUpdateDelayGuard() public {
+        address[] memory targets = new address[](0);
+        uint256[] memory values = new uint256[](0);
+        bytes[] memory calldatas = new bytes[](0);
+
+        vm.prank(alice);
+        uint256 id = governor.propose(ProposalType.Signaling, targets, values, calldatas, "signaling only");
+        assertGt(id, 0, "signaling proposals must bypass the updateDelay guard");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a propose-time guard on `timelock.updateDelay(uint256)` so a governance action cannot push `_minDelay` above `MAX_EXECUTION_DELAY` (14 days) and permanently brick `queue()`.
- New error `Gov_UpdateDelayExceedsCap(uint256 requested, uint256 cap)` surfaces both values for off-chain monitoring.
- 8 new Foundry tests cover within-cap, at-cap (boundary), above-cap, `type(uint256).max`, multi-action batch with bad entry, non-timelock target (correctly scoped), malformed calldata, and Signaling bypass.

Closes #231.

## Why

Without this guard, a proposal executing `timelock.updateDelay(X)` with `X > 14 days` would set the timelock's `_minDelay` above every proposal's max `executionDelay`. OZ's `TimelockController._schedule` requires `delay >= getMinDelay()`, so every subsequent `queue()` call would revert — including any proposal to fix it. Recovery would require social recovery / hard fork once the timelock admin role is renounced.

## Scope

- `contracts/governance/ArmadaGovernor.sol` (+38 LOC): new error, `UPDATE_DELAY_SELECTOR` constant, `_validateTimelockCalldata()` helper, call site in `propose()`.
- `test-foundry/GovernorUpdateDelayCap.t.sol` (new): 8 tests.

## Caveat

The guard is governor-scoped. It assumes `PROPOSER_ROLE` on the timelock is held only by this governor (true today per `scripts/deploy_governance.ts`). A `NOTE` comment on the constant flags this assumption so any future role-grant triggers a re-review.

## Test plan

- [x] `forge test --offline` — all 551 tests pass (8 new + 543 existing)
- [x] Hardhat governance suites (`governance_param_updates.ts`, `governance_adversarial.ts`) — 71 tests pass
- [ ] Reviewer to confirm assumption about sole PROPOSER_ROLE holder is acceptable going forward, or request upgrade to `ArmadaTimelock` subclass approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)