### PR TITLE
fix(crowdfund): correct pre-open delay rationale, shorten Sepolia default

### DIFF
--- a/config/sepolia.env
+++ b/config/sepolia.env
@@ -102,8 +102,12 @@ export TREASURY_ADDRESS=0x4cb6660a5877f28198c400C51fc1766e4647d008
 # Crowdfund Config
 # ============================================================================
 # Delay in seconds from deployment time before the crowdfund window opens.
-# Production should use a longer delay (e.g. 604800 = 7 days) to allow seed setup.
-export CROWDFUND_OPEN_DELAY=3600
+# Operational buffer for deployment verification, announcement lead time, and
+# infra readiness. Not spec-required — seeds are added DURING week 1, not
+# before (see ArmadaCrowdfund.addSeeds / _requireArmLoadedAndPreInviteEnd).
+# Production launches should set this explicitly (or use a wall-clock
+# openTimestamp) rather than relying on the default.
+export CROWDFUND_OPEN_DELAY=600
 
 # ============================================================================
 # Security Council (required — must differ from deployer)

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -104,6 +104,10 @@ async function main() {
   console.log("3. Deploying ArmadaCrowdfund...");
   const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
   const latestBlock = await ethers.provider.getBlock('latest');
+  // crowdfundOpenDelay is an operational buffer (deployment verification,
+  // announcement lead time, infra readiness) — NOT a seed-setup window.
+  // Seeds are added during week 1 of the active window; see
+  // ArmadaCrowdfund._requireArmLoadedAndPreInviteEnd.
   const openTimestamp = latestBlock!.timestamp + config.crowdfundOpenDelay;
   // Security council: config-driven for non-local, Anvil signer[10] fallback for local
   let securityCouncilAddress: string;


### PR DESCRIPTION
## Summary

- Corrects the `CROWDFUND_OPEN_DELAY` comments, which falsely claimed the buffer existed "to allow seed setup before the window opens." `ArmadaCrowdfund.addSeeds()` is gated to the active week-1 window via `_requireArmLoadedAndPreInviteEnd` (requires `block.timestamp >= windowStart`), so seeds cannot be added before open. The delay is purely an operational buffer — deployment verification, announcement lead time, and infra readiness.
- Shortens the Sepolia default from 3600s → 600s to reduce dead time where a freshly deployed crowdfund shows "Closed" in the UI. 600s still clears Sepolia's ~6.4 min finality window. Local default (60s) is unchanged.

Fixes #219

## Test plan

- [ ] Deploy to Sepolia and confirm the window opens ~10 min after `deploy_crowdfund.ts` completes.
- [ ] Confirm the observer/committer UIs transition from pre-open to active state correctly with the shorter delay.
- [ ] No code-path changes — existing tests should continue to pass (`npm run test:crowdfund`, `npm run test:forge`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)