### PR TITLE
fix(treasury): 24-day activation delay on outflow-loosening changes

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -66,6 +66,7 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     error Gov_VotingNotStarted();
     error Gov_VotingDelayOutOfBounds();
     error Gov_VotingPeriodOutOfBounds();
+    error Gov_WouldBreakOutflowDelayInvariant();
     error Gov_WindDownAlreadyActive();
     error Gov_WindDownContractAlreadySet();
     error Gov_WindDownContractNotSet();
@@ -152,6 +153,12 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
 
     // Succeeded proposals must be queued within this window or they expire
     uint256 public constant QUEUE_GRACE_PERIOD = 14 days;
+
+    // Mirror of ArmadaTreasuryGov.LIMIT_ACTIVATION_DELAY. Duplicated here (instead of
+    // read cross-contract) to keep the governor under the 24576-byte mainnet deploy limit.
+    // The two constants must stay in sync; a divergence test in test/ asserts parity at
+    // deploy time, so a future edit that changes one without the other will fail CI.
+    uint256 public constant TREASURY_OUTFLOW_ACTIVATION_DELAY = 24 days;
 
     // Absolute quorum floor: prevents governance passing on trivial turnout regardless
     // of how small the circulating delegated supply is. Quorum = max(percentage, floor).
@@ -455,6 +462,16 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         if (params.votingPeriod < MIN_VOTING_PERIOD || params.votingPeriod > MAX_VOTING_PERIOD) revert Gov_VotingPeriodOutOfBounds();
         if (params.executionDelay < MIN_EXECUTION_DELAY || params.executionDelay > MAX_EXECUTION_DELAY) revert Gov_ExecutionDelayOutOfBounds();
         if (params.quorumBps < MIN_QUORUM_BPS || params.quorumBps > MAX_QUORUM_BPS) revert Gov_QuorumBpsOutOfBounds();
+
+        // Extended timing invariant: the full Extended proposal cycle must stay strictly
+        // shorter than the treasury's outflow-loosening activation delay. Without this,
+        // a captured governance could stretch the Extended cycle to meet or exceed the
+        // activation delay, letting a second drain proposal complete its own cycle exactly
+        // as a scheduled loosening activates.
+        if (proposalType == ProposalType.Extended) {
+            uint256 cycle = params.votingDelay + params.votingPeriod + params.executionDelay;
+            if (cycle >= TREASURY_OUTFLOW_ACTIVATION_DELAY) revert Gov_WouldBreakOutflowDelayInvariant();
+        }
 
         proposalTypeParams[proposalType] = params;
         emit ProposalTypeParamsUpdated(proposalType, params);

--- a/contracts/governance/ArmadaTreasuryGov.sol
+++ b/contracts/governance/ArmadaTreasuryGov.sol
@@ -19,12 +19,30 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
     /// @notice Per-token outflow rate limit configuration.
     /// The effective limit is: max(percentageOfBalance, limitAbsolute),
     /// then max(result, floorAbsolute). The floor is immutable once set.
+    ///
+    /// Each of the three governance-tunable knobs (windowDuration, limitBps, limitAbsolute)
+    /// has a paired pending slot. Governance changes that LOOSEN spending capacity are
+    /// written to the pending slot and only take effect after LIMIT_ACTIVATION_DELAY
+    /// elapses. Changes that TIGHTEN take effect immediately and clear the matching
+    /// pending slot. See _lazyActivate and the three setters for the activation rules.
     struct OutflowConfig {
         uint256 windowDuration;   // rolling window in seconds (e.g. 30 days)
         uint256 limitBps;         // percentage of current treasury balance (1000 = 10%)
         uint256 limitAbsolute;    // absolute cap in token units
         uint256 floorAbsolute;    // immutable minimum — governance can never reduce below this
         bool initialized;         // whether config has been set for this token
+
+        // Pending-activation slots for loosening changes.
+        // activation == 0 means no pending change. activation > 0 means the stored
+        // pending* value becomes active at that timestamp. Loosening direction is
+        // parameter-specific: Absolute/Bps loosen on increase; WindowDuration loosens
+        // on decrease (shorter lookback = faster budget refresh).
+        uint256 pendingLimitAbsolute;
+        uint256 pendingLimitAbsoluteActivation;
+        uint256 pendingLimitBps;
+        uint256 pendingLimitBpsActivation;
+        uint256 pendingWindowDuration;
+        uint256 pendingWindowDurationActivation;
     }
 
     /// @notice Record of a single outflow event, used for rolling window accounting.
@@ -36,6 +54,14 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
     // ============ State ============
 
     address public immutable owner; // TimelockController address (set once at deployment, cannot be changed)
+
+    /// @notice Delay applied to outflow-loosening parameter changes before they take effect.
+    /// @dev Must strictly exceed the maximum Extended-proposal governance cycle
+    ///      (proposalDelay + votingPeriod + executionDelay). ArmadaGovernor.setProposalTypeParams
+    ///      enforces this invariant at setter time so a captured governance cannot stretch
+    ///      the Extended cycle to exceed this delay and bypass the defense.
+    ///      24 days > 23 days (current Extended default: 2d + 14d + 7d).
+    uint256 public constant LIMIT_ACTIVATION_DELAY = 24 days;
 
     // Per-token steward budget table (governance-managed via Extended proposals).
     // Each authorized token has an absolute spending limit per rolling window.
@@ -72,9 +98,23 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
     event StewardBudgetTokenUpdated(address indexed token, uint256 limit, uint256 window);
     event StewardBudgetTokenRemoved(address indexed token);
     event OutflowConfigInitialized(address indexed token, uint256 windowDuration, uint256 limitBps, uint256 limitAbsolute, uint256 floorAbsolute);
-    event OutflowWindowUpdated(address indexed token, uint256 newWindow);
-    event OutflowLimitBpsUpdated(address indexed token, uint256 newBps);
-    event OutflowLimitAbsoluteUpdated(address indexed token, uint256 newAbsolute);
+
+    // Absolute limit: loosening = increase. Scheduled → activates at activatesAt.
+    event OutflowLimitAbsoluteIncreaseScheduled(address indexed token, uint256 oldActive, uint256 pendingValue, uint256 activatesAt);
+    event OutflowLimitAbsoluteActivated(address indexed token, uint256 oldActive, uint256 newActive);
+    event OutflowLimitAbsoluteDecreased(address indexed token, uint256 oldActive, uint256 newActive);
+
+    // Bps limit: loosening = increase.
+    event OutflowLimitBpsIncreaseScheduled(address indexed token, uint256 oldActive, uint256 pendingValue, uint256 activatesAt);
+    event OutflowLimitBpsActivated(address indexed token, uint256 oldActive, uint256 newActive);
+    event OutflowLimitBpsDecreased(address indexed token, uint256 oldActive, uint256 newActive);
+
+    // Window duration: loosening = decrease (shorter lookback drops older outflow records
+    // from the rolling sum faster, freeing budget sooner). Semantics are inverted vs. the
+    // limit parameters by design — this is not a bug. See _sumRecentRecords.
+    event OutflowWindowDurationDecreaseScheduled(address indexed token, uint256 oldActive, uint256 pendingValue, uint256 activatesAt);
+    event OutflowWindowDurationActivated(address indexed token, uint256 oldActive, uint256 newActive);
+    event OutflowWindowDurationIncreased(address indexed token, uint256 oldActive, uint256 newActive);
     event WindDownContractSet(address indexed windDownContract);
     event WindDownTransfer(address indexed token, address indexed recipient, uint256 amount);
     event WindDownETHTransfer(address indexed recipient, uint256 amount);
@@ -209,35 +249,149 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
             limitBps: limitBps,
             limitAbsolute: limitAbsolute,
             floorAbsolute: floorAbsolute,
-            initialized: true
+            initialized: true,
+            pendingLimitAbsolute: 0,
+            pendingLimitAbsoluteActivation: 0,
+            pendingLimitBps: 0,
+            pendingLimitBpsActivation: 0,
+            pendingWindowDuration: 0,
+            pendingWindowDurationActivation: 0
         });
 
         emit OutflowConfigInitialized(token, windowDuration, limitBps, limitAbsolute, floorAbsolute);
     }
 
     /// @notice Update the rolling window duration for a token's outflow limit.
+    /// @dev Loosening (newWindow < active) goes to a pending slot with a LIMIT_ACTIVATION_DELAY
+    ///      timer; a later overlapping call overwrites the pending value and resets the timer.
+    ///      Tightening or no-op (newWindow >= active) takes effect immediately and clears any
+    ///      pending decrease. Direction is measured against the active window after lazy
+    ///      activation, not against any currently-pending value — see issue #226 edge case.
     function setOutflowWindow(address token, uint256 newWindow) external onlyOwner {
         require(_outflowConfigs[token].initialized, "ArmadaTreasuryGov: outflow not initialized");
         require(newWindow >= 1 days, "ArmadaTreasuryGov: window too short");
-        _outflowConfigs[token].windowDuration = newWindow;
-        emit OutflowWindowUpdated(token, newWindow);
+
+        _lazyActivate(token);
+        OutflowConfig storage config = _outflowConfigs[token];
+        uint256 activeWindow = config.windowDuration;
+
+        if (newWindow < activeWindow) {
+            // Loosening: shorter lookback would drop records and free budget faster — delay.
+            uint256 activatesAt = block.timestamp + LIMIT_ACTIVATION_DELAY;
+            config.pendingWindowDuration = newWindow;
+            config.pendingWindowDurationActivation = activatesAt;
+            emit OutflowWindowDurationDecreaseScheduled(token, activeWindow, newWindow, activatesAt);
+        } else {
+            // Tightening or no-op: immediate, clears any pending loosening.
+            config.windowDuration = newWindow;
+            config.pendingWindowDuration = 0;
+            config.pendingWindowDurationActivation = 0;
+            emit OutflowWindowDurationIncreased(token, activeWindow, newWindow);
+        }
     }
 
     /// @notice Update the percentage-based outflow limit for a token.
+    /// @dev Loosening (newBps > active) goes to a pending slot with a LIMIT_ACTIVATION_DELAY
+    ///      timer; a later overlapping call overwrites the pending value and resets the timer.
+    ///      Tightening or no-op (newBps <= active) takes effect immediately and clears any
+    ///      pending increase.
     function setOutflowLimitBps(address token, uint256 newBps) external onlyOwner {
         require(_outflowConfigs[token].initialized, "ArmadaTreasuryGov: outflow not initialized");
         require(newBps > 0, "ArmadaTreasuryGov: zero bps");
         require(newBps <= 10000, "ArmadaTreasuryGov: bps out of range");
-        _outflowConfigs[token].limitBps = newBps;
-        emit OutflowLimitBpsUpdated(token, newBps);
+
+        _lazyActivate(token);
+        OutflowConfig storage config = _outflowConfigs[token];
+        uint256 activeBps = config.limitBps;
+
+        if (newBps > activeBps) {
+            uint256 activatesAt = block.timestamp + LIMIT_ACTIVATION_DELAY;
+            config.pendingLimitBps = newBps;
+            config.pendingLimitBpsActivation = activatesAt;
+            emit OutflowLimitBpsIncreaseScheduled(token, activeBps, newBps, activatesAt);
+        } else {
+            config.limitBps = newBps;
+            config.pendingLimitBps = 0;
+            config.pendingLimitBpsActivation = 0;
+            emit OutflowLimitBpsDecreased(token, activeBps, newBps);
+        }
     }
 
     /// @notice Update the absolute outflow limit for a token. Cannot be set below floor.
+    /// @dev Loosening (newAbsolute > active) goes to a pending slot with a LIMIT_ACTIVATION_DELAY
+    ///      timer; a later overlapping call overwrites the pending value and resets the timer.
+    ///      Tightening or no-op (newAbsolute <= active) takes effect immediately and clears any
+    ///      pending increase. The floor check applies to the new value regardless of direction.
     function setOutflowLimitAbsolute(address token, uint256 newAbsolute) external onlyOwner {
         require(_outflowConfigs[token].initialized, "ArmadaTreasuryGov: outflow not initialized");
         require(newAbsolute >= _outflowConfigs[token].floorAbsolute, "ArmadaTreasuryGov: absolute below floor");
-        _outflowConfigs[token].limitAbsolute = newAbsolute;
-        emit OutflowLimitAbsoluteUpdated(token, newAbsolute);
+
+        _lazyActivate(token);
+        OutflowConfig storage config = _outflowConfigs[token];
+        uint256 activeAbsolute = config.limitAbsolute;
+
+        if (newAbsolute > activeAbsolute) {
+            uint256 activatesAt = block.timestamp + LIMIT_ACTIVATION_DELAY;
+            config.pendingLimitAbsolute = newAbsolute;
+            config.pendingLimitAbsoluteActivation = activatesAt;
+            emit OutflowLimitAbsoluteIncreaseScheduled(token, activeAbsolute, newAbsolute, activatesAt);
+        } else {
+            config.limitAbsolute = newAbsolute;
+            config.pendingLimitAbsolute = 0;
+            config.pendingLimitAbsoluteActivation = 0;
+            emit OutflowLimitAbsoluteDecreased(token, activeAbsolute, newAbsolute);
+        }
+    }
+
+    /// @notice Permissionless trigger to activate any pending outflow parameter changes
+    ///         whose activation timestamps have elapsed. No-op if nothing is due.
+    /// @dev Intended for monitoring bots and operational tooling that want to emit the
+    ///      OutflowLimit*Activated event at the activation timestamp rather than waiting
+    ///      for the next distribute/stewardSpend call. Does not revert, does not modify
+    ///      state if nothing is due.
+    function activatePendingOutflowParams(address token) external {
+        _lazyActivate(token);
+    }
+
+    // ============ Internal: Lazy Activation ============
+
+    /// @dev Promote any pending outflow parameter values whose activation timestamps have
+    ///      elapsed. Must be called at the top of every code path that reads an outflow
+    ///      parameter for enforcement (currently: _checkAndRecordOutflow and the three
+    ///      setOutflow* setters). Missing this call in a future code path would silently
+    ///      enforce stale values — the single most important correctness check.
+    function _lazyActivate(address token) internal {
+        OutflowConfig storage config = _outflowConfigs[token];
+
+        if (config.pendingLimitAbsoluteActivation > 0 &&
+            block.timestamp >= config.pendingLimitAbsoluteActivation) {
+            uint256 oldActive = config.limitAbsolute;
+            uint256 newActive = config.pendingLimitAbsolute;
+            config.limitAbsolute = newActive;
+            config.pendingLimitAbsolute = 0;
+            config.pendingLimitAbsoluteActivation = 0;
+            emit OutflowLimitAbsoluteActivated(token, oldActive, newActive);
+        }
+
+        if (config.pendingLimitBpsActivation > 0 &&
+            block.timestamp >= config.pendingLimitBpsActivation) {
+            uint256 oldActive = config.limitBps;
+            uint256 newActive = config.pendingLimitBps;
+            config.limitBps = newActive;
+            config.pendingLimitBps = 0;
+            config.pendingLimitBpsActivation = 0;
+            emit OutflowLimitBpsActivated(token, oldActive, newActive);
+        }
+
+        if (config.pendingWindowDurationActivation > 0 &&
+            block.timestamp >= config.pendingWindowDurationActivation) {
+            uint256 oldActive = config.windowDuration;
+            uint256 newActive = config.pendingWindowDuration;
+            config.windowDuration = newActive;
+            config.pendingWindowDuration = 0;
+            config.pendingWindowDurationActivation = 0;
+            emit OutflowWindowDurationActivated(token, oldActive, newActive);
+        }
     }
 
     // ============ Internal: Outflow Enforcement ============
@@ -253,9 +407,14 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
     ///      (3) Steward spends (~daily) produce ~365 records/year — still manageable.
     ///      If usage patterns change significantly, a pruning mechanism could be added.
     function _checkAndRecordOutflow(address token, uint256 amount) internal {
-        OutflowConfig storage config = _outflowConfigs[token];
-        require(config.initialized, "ArmadaTreasuryGov: outflow config required");
+        require(_outflowConfigs[token].initialized, "ArmadaTreasuryGov: outflow config required");
 
+        // Promote any pending loosenings whose timers have elapsed BEFORE enforcement reads
+        // the parameters. Without this, a drain executed in the same block as a just-activated
+        // loosening would still enforce the stale pre-loosening limit.
+        _lazyActivate(token);
+
+        OutflowConfig storage config = _outflowConfigs[token];
         uint256 treasuryBalance = IERC20(token).balanceOf(address(this));
         uint256 effectiveLimit = _effectiveLimit(config, treasuryBalance);
 
@@ -351,7 +510,11 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
         remaining = budget > spent ? budget - spent : 0;
     }
 
-    /// @notice Get the outflow configuration for a token.
+    /// @notice Get the RAW stored outflow configuration for a token (pre-lazy-activation).
+    /// @dev Returns the literal storage values. For values that reflect enforcement behavior
+    ///      (i.e. what the next distribute/stewardSpend call would enforce), use
+    ///      getEffectiveOutflowConfig instead. Kept for debugging and monitoring that needs
+    ///      to distinguish scheduled-but-not-yet-activated pending values from stale storage.
     function getOutflowConfig(address token) external view returns (
         uint256 windowDuration,
         uint256 limitBps,
@@ -362,7 +525,47 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
         return (config.windowDuration, config.limitBps, config.limitAbsolute, config.floorAbsolute);
     }
 
+    /// @notice Get the effective outflow configuration that would apply right now to a
+    ///         distribute or stewardSpend call (i.e. after lazy activation of any pending
+    ///         values whose timers have elapsed). View counterpart of _lazyActivate.
+    /// @dev Must return identical values to what _lazyActivate would produce if called now.
+    ///      Cyfrin verifies this parity as part of the delay-mechanism audit.
+    function getEffectiveOutflowConfig(address token) external view returns (
+        uint256 windowDuration,
+        uint256 limitBps,
+        uint256 limitAbsolute,
+        uint256 floorAbsolute
+    ) {
+        OutflowConfig storage config = _outflowConfigs[token];
+        (windowDuration, limitBps, limitAbsolute) = _effectiveParams(config);
+        floorAbsolute = config.floorAbsolute;
+    }
+
+    /// @notice Get the pending (not-yet-activated) outflow parameter state for a token.
+    ///         Each activation timestamp is 0 if no change is pending for that parameter.
+    /// @dev Intended for monitoring frontends so users can see upcoming loosenings.
+    function getPendingOutflowConfig(address token) external view returns (
+        uint256 pendingWindowDuration,
+        uint256 pendingWindowDurationActivation,
+        uint256 pendingLimitBps,
+        uint256 pendingLimitBpsActivation,
+        uint256 pendingLimitAbsolute,
+        uint256 pendingLimitAbsoluteActivation
+    ) {
+        OutflowConfig storage config = _outflowConfigs[token];
+        return (
+            config.pendingWindowDuration,
+            config.pendingWindowDurationActivation,
+            config.pendingLimitBps,
+            config.pendingLimitBpsActivation,
+            config.pendingLimitAbsolute,
+            config.pendingLimitAbsoluteActivation
+        );
+    }
+
     /// @notice Get the current outflow status for a token: effective limit, recent outflow, and available.
+    /// @dev Uses post-lazy-activation values so the reported `available` matches what the next
+    ///      distribute/stewardSpend call would actually enforce.
     function getOutflowStatus(address token) external view returns (
         uint256 effectiveLimit,
         uint256 recentOutflow,
@@ -371,9 +574,35 @@ contract ArmadaTreasuryGov is ReentrancyGuard {
         OutflowConfig storage config = _outflowConfigs[token];
         if (!config.initialized) return (0, 0, 0);
 
+        (uint256 effWindow, uint256 effBps, uint256 effAbsolute) = _effectiveParams(config);
+
         uint256 treasuryBalance = IERC20(token).balanceOf(address(this));
-        effectiveLimit = _effectiveLimit(config, treasuryBalance);
-        recentOutflow = _sumRecentRecords(_outflowHistory[token], config.windowDuration);
+        uint256 pctLimit = (treasuryBalance * effBps) / 10000;
+        uint256 limit = pctLimit > effAbsolute ? pctLimit : effAbsolute;
+        effectiveLimit = limit > config.floorAbsolute ? limit : config.floorAbsolute;
+
+        recentOutflow = _sumRecentRecords(_outflowHistory[token], effWindow);
         available = effectiveLimit > recentOutflow ? effectiveLimit - recentOutflow : 0;
+    }
+
+    /// @dev View-only computation of effective outflow parameters: mirrors _lazyActivate
+    ///      without mutating state. Returns (windowDuration, limitBps, limitAbsolute) that
+    ///      would be active right now.
+    function _effectiveParams(OutflowConfig storage config) internal view returns (
+        uint256 effWindowDuration,
+        uint256 effLimitBps,
+        uint256 effLimitAbsolute
+    ) {
+        effLimitAbsolute = (config.pendingLimitAbsoluteActivation > 0 &&
+            block.timestamp >= config.pendingLimitAbsoluteActivation)
+            ? config.pendingLimitAbsolute : config.limitAbsolute;
+
+        effLimitBps = (config.pendingLimitBpsActivation > 0 &&
+            block.timestamp >= config.pendingLimitBpsActivation)
+            ? config.pendingLimitBps : config.limitBps;
+
+        effWindowDuration = (config.pendingWindowDurationActivation > 0 &&
+            block.timestamp >= config.pendingWindowDurationActivation)
+            ? config.pendingWindowDuration : config.windowDuration;
     }
 }

--- a/test-foundry/TreasuryOutflowInvariant.t.sol
+++ b/test-foundry/TreasuryOutflowInvariant.t.sol
@@ -66,7 +66,7 @@ contract TreasuryOutflowHandler is Test {
 
     // ---- Issue #226: asymmetric delay on outflow-loosening setters ----
     //
-    // These handler actions exercise the new delayed-activation path so the existing
+    // These handler actions exercise the delayed-activation path so the existing
     // value-conservation invariants (INV-TO1/2/3) are re-verified under fuzzed setter
     // sequences, not just fuzzed distribute/stewardSpend sequences. Bounds are chosen
     // so both loosening and tightening directions are reachable from the starting config.

--- a/test-foundry/TreasuryOutflowInvariant.t.sol
+++ b/test-foundry/TreasuryOutflowInvariant.t.sol
@@ -63,6 +63,46 @@ contract TreasuryOutflowHandler is Test {
         delta = bound(delta, 0, 60 days);
         vm.warp(block.timestamp + delta);
     }
+
+    // ---- Issue #226: asymmetric delay on outflow-loosening setters ----
+    //
+    // These handler actions exercise the new delayed-activation path so the existing
+    // value-conservation invariants (INV-TO1/2/3) are re-verified under fuzzed setter
+    // sequences, not just fuzzed distribute/stewardSpend sequences. Bounds are chosen
+    // so both loosening and tightening directions are reachable from the starting config.
+
+    function setLimitAbsoluteFuzzed(uint256 newAbsolute) external {
+        newAbsolute = bound(newAbsolute, 100_000e6, 5_000_000e6); // >= floor
+        vm.prank(owner);
+        try treasury.setOutflowLimitAbsolute(token, newAbsolute) {
+        } catch {
+            ghost_revertCount++;
+        }
+    }
+
+    function setLimitBpsFuzzed(uint256 newBps) external {
+        newBps = bound(newBps, 1, 10_000);
+        vm.prank(owner);
+        try treasury.setOutflowLimitBps(token, newBps) {
+        } catch {
+            ghost_revertCount++;
+        }
+    }
+
+    function setWindowFuzzed(uint256 newWindow) external {
+        newWindow = bound(newWindow, 1 days, 365 days);
+        vm.prank(owner);
+        try treasury.setOutflowWindow(token, newWindow) {
+        } catch {
+            ghost_revertCount++;
+        }
+    }
+
+    /// @dev Permissionless trigger for pending outflow param activation. Must be a no-op
+    ///      when nothing is due and must not revert in any state.
+    function activatePending() external {
+        treasury.activatePendingOutflowParams(token);
+    }
 }
 
 contract TreasuryOutflowInvariantTest is Test {
@@ -133,5 +173,38 @@ contract TreasuryOutflowInvariantTest is Test {
             handler.ghost_totalDistributed() + handler.ghost_totalStewardSpent(),
             "INV-TO3: recipient balance"
         );
+    }
+
+    /// @notice INV-TO4: Raw storage never exceeds effective values when no pending
+    ///         activation is overdue. When pendingActivation > 0 and block.timestamp
+    ///         >= pendingActivation, getEffectiveOutflowConfig must return the pending
+    ///         value; getOutflowConfig must still return the (pre-activation) active
+    ///         value. After calling activatePendingOutflowParams, the two must match.
+    ///         WHY: This is the view-vs-state-modifying parity property. A divergence
+    ///         would mean enforcement reads a different value than what monitoring sees.
+    function invariant_effectiveMatchesRawAfterActivation() public {
+        // Snapshot effective view (state-read only)
+        (uint256 effW, uint256 effB, uint256 effA,) = treasury.getEffectiveOutflowConfig(address(usdc));
+
+        // Check: if no pending is overdue, effective must equal raw
+        (uint256 pW, uint256 pWA, uint256 pB, uint256 pBA, uint256 pA, uint256 pAA) =
+            treasury.getPendingOutflowConfig(address(usdc));
+        (uint256 rawW, uint256 rawB, uint256 rawA,) = treasury.getOutflowConfig(address(usdc));
+
+        if (!(pWA > 0 && block.timestamp >= pWA)) {
+            assertEq(effW, rawW, "INV-TO4: effective window drift");
+        } else {
+            assertEq(effW, pW, "INV-TO4: effective window should be pending");
+        }
+        if (!(pBA > 0 && block.timestamp >= pBA)) {
+            assertEq(effB, rawB, "INV-TO4: effective bps drift");
+        } else {
+            assertEq(effB, pB, "INV-TO4: effective bps should be pending");
+        }
+        if (!(pAA > 0 && block.timestamp >= pAA)) {
+            assertEq(effA, rawA, "INV-TO4: effective absolute drift");
+        } else {
+            assertEq(effA, pA, "INV-TO4: effective absolute should be pending");
+        }
     }
 }

--- a/test/governance_param_updates.ts
+++ b/test/governance_param_updates.ts
@@ -333,6 +333,115 @@ describe("Governance Parameter Updates", function () {
   });
 
   // ============================================================
+  // 2b. Outflow Activation Delay Invariant (issue #226)
+  // ============================================================
+  //
+  // The Extended proposal cycle (votingDelay + votingPeriod + executionDelay) must
+  // stay strictly shorter than the treasury's outflow-loosening activation delay.
+  // Without this, a captured governance could stretch Extended timing to match or
+  // exceed the 24-day delay, letting a second-proposal drain complete exactly as
+  // the scheduled loosening activates.
+
+  describe("Outflow Activation Delay Invariant", function () {
+    let standaloneGovernor: any;
+
+    beforeEach(async function () {
+      standaloneGovernor = await deployGovernorProxy(
+        await armToken.getAddress(),
+        deployer.address,
+        await treasury.getAddress(),
+      );
+    });
+
+    const ACTIVATION_DELAY = 24 * ONE_DAY;
+
+    // WHY: The governor mirrors LIMIT_ACTIVATION_DELAY as a local constant to stay
+    // under the 24576-byte mainnet deploy limit. The two constants must agree — a
+    // divergence would silently weaken the defense. This test is the contract-level
+    // CI guard for the mirror.
+    it("governor TREASURY_OUTFLOW_ACTIVATION_DELAY matches treasury LIMIT_ACTIVATION_DELAY", async function () {
+      const govDelay = await standaloneGovernor.TREASURY_OUTFLOW_ACTIVATION_DELAY();
+      const treasuryDelay = await treasury.LIMIT_ACTIVATION_DELAY();
+      expect(govDelay).to.equal(treasuryDelay);
+      expect(govDelay).to.equal(ACTIVATION_DELAY);
+    });
+
+    // WHY: The current Extended default is 2d + 14d + 7d = 23 days, exactly one day
+    // under the 24-day delay. This test locks in that the default config is within
+    // the invariant — regressions to the defaults or the invariant will trip it.
+    it("accepts Extended cycle of exactly 23 days (default config)", async function () {
+      const params = {
+        votingDelay: 2 * ONE_DAY,
+        votingPeriod: 14 * ONE_DAY,
+        executionDelay: 7 * ONE_DAY,
+        quorumBps: 3000,
+      };
+      await standaloneGovernor.setProposalTypeParams(ProposalType.Extended, params);
+      const [, , , quorum] = await standaloneGovernor.proposalTypeParams(ProposalType.Extended);
+      expect(quorum).to.equal(3000);
+    });
+
+    // WHY: The invariant is STRICT inequality (cycle < delay). A cycle exactly equal
+    // to the delay could allow a drain proposal to finish its cycle in the same block
+    // the loosening activates — the single-block overlap the delay exists to prevent.
+    it("rejects Extended cycle of exactly 24 days (equal to delay)", async function () {
+      const params = {
+        votingDelay: 3 * ONE_DAY,
+        votingPeriod: 14 * ONE_DAY,
+        executionDelay: 7 * ONE_DAY, // 3 + 14 + 7 = 24 days
+        quorumBps: 3000,
+      };
+      await expect(
+        standaloneGovernor.setProposalTypeParams(ProposalType.Extended, params)
+      ).to.be.revertedWithCustomError(standaloneGovernor, "Gov_WouldBreakOutflowDelayInvariant");
+    });
+
+    it("rejects Extended cycle above 24 days", async function () {
+      const params = {
+        votingDelay: 7 * ONE_DAY,
+        votingPeriod: 14 * ONE_DAY,
+        executionDelay: 7 * ONE_DAY, // 28 days
+        quorumBps: 3000,
+      };
+      await expect(
+        standaloneGovernor.setProposalTypeParams(ProposalType.Extended, params)
+      ).to.be.revertedWithCustomError(standaloneGovernor, "Gov_WouldBreakOutflowDelayInvariant");
+    });
+
+    // WHY: Only Extended is gated — Standard proposals cannot execute against
+    // treasury-draining calldata without first being reclassified to Extended by
+    // _classifyProposal. Gating Standard would block legitimate tightenings with no
+    // security benefit.
+    it("does not gate Standard type timing", async function () {
+      // Max Standard bounds: 14+30+14 = 58 days cycle, well over 24
+      const params = {
+        votingDelay: 14 * ONE_DAY,
+        votingPeriod: 30 * ONE_DAY,
+        executionDelay: 14 * ONE_DAY,
+        quorumBps: 2000,
+      };
+      await standaloneGovernor.setProposalTypeParams(ProposalType.Standard, params);
+      const [delay] = await standaloneGovernor.proposalTypeParams(ProposalType.Standard);
+      expect(delay).to.equal(14 * ONE_DAY);
+    });
+
+    // WHY: Bounds validation (votingDelay/Period/ExecutionDelay/quorum) must fire
+    // BEFORE the invariant check, so operators get precise error messages about
+    // individual out-of-range fields rather than a generic invariant violation.
+    it("bounds errors take precedence over invariant error", async function () {
+      const params = {
+        votingDelay: 15 * ONE_DAY, // exceeds MAX_VOTING_DELAY = 14
+        votingPeriod: 14 * ONE_DAY,
+        executionDelay: 7 * ONE_DAY,
+        quorumBps: 3000,
+      };
+      await expect(
+        standaloneGovernor.setProposalTypeParams(ProposalType.Extended, params)
+      ).to.be.revertedWithCustomError(standaloneGovernor, "Gov_VotingDelayOutOfBounds");
+    });
+  });
+
+  // ============================================================
   // 3. Quorum Snapshotting
   // ============================================================
 

--- a/test/treasury_outflow.ts
+++ b/test/treasury_outflow.ts
@@ -137,7 +137,11 @@ describe("Treasury Outflow Rate Limits", function () {
       await initUsdcOutflow();
     });
 
-    it("should allow owner to update outflow window", async function () {
+    // WHY: Setting the window to a longer duration is TIGHTENING (longer lookback sums
+    // more past records), so it takes effect immediately under the asymmetric-delay
+    // behavior added in issue #226. The loosening direction (shorter window) is covered
+    // in the "Asymmetric Activation Delay" section below.
+    it("should allow owner to update outflow window (tightening, immediate)", async function () {
       await treasury.setOutflowWindow(await usdc.getAddress(), 60 * ONE_DAY);
       const config = await treasury.getOutflowConfig(await usdc.getAddress());
       expect(config.windowDuration).to.equal(60 * ONE_DAY);
@@ -149,10 +153,12 @@ describe("Treasury Outflow Rate Limits", function () {
       ).to.be.revertedWith("ArmadaTreasuryGov: window too short");
     });
 
-    it("should allow owner to update outflow bps", async function () {
-      await treasury.setOutflowLimitBps(await usdc.getAddress(), 2000);
+    // WHY: Tightening direction (lower bps) takes effect immediately. The loosening
+    // direction (higher bps) is covered in the "Asymmetric Activation Delay" section.
+    it("should allow owner to update outflow bps (tightening, immediate)", async function () {
+      await treasury.setOutflowLimitBps(await usdc.getAddress(), 500);
       const config = await treasury.getOutflowConfig(await usdc.getAddress());
-      expect(config.limitBps).to.equal(2000);
+      expect(config.limitBps).to.equal(500);
     });
 
     it("should reject zero bps", async function () {
@@ -167,10 +173,13 @@ describe("Treasury Outflow Rate Limits", function () {
       ).to.be.revertedWith("ArmadaTreasuryGov: bps out of range");
     });
 
-    it("should allow owner to update absolute limit", async function () {
-      await treasury.setOutflowLimitAbsolute(await usdc.getAddress(), USDC(200_000));
+    // WHY: Tightening direction (lower absolute, still >= floor) takes effect immediately.
+    // The loosening direction (higher absolute) is covered below.
+    it("should allow owner to update absolute limit (tightening, immediate)", async function () {
+      // Initial absolute = $100K, floor = $50K → tighten to $75K
+      await treasury.setOutflowLimitAbsolute(await usdc.getAddress(), USDC(75_000));
       const config = await treasury.getOutflowConfig(await usdc.getAddress());
-      expect(config.limitAbsolute).to.equal(USDC(200_000));
+      expect(config.limitAbsolute).to.equal(USDC(75_000));
     });
 
     it("should reject absolute limit below floor", async function () {
@@ -443,16 +452,24 @@ describe("Treasury Outflow Rate Limits", function () {
       expect(config.limitAbsolute).to.equal(USDC(50_000));
     });
 
-    it("should allow governance to increase limits freely", async function () {
+    // WHY: Governance can still raise the limits, but under issue #226 the raises are
+    // scheduled rather than applied immediately. This test confirms there is no upper
+    // bound on what governance can request — the floor is immutable but the ceiling isn't
+    // — while the activation-delay section below confirms the delay is enforced.
+    it("should allow governance to schedule limit increases without upper cap", async function () {
       await fundTreasury(USDC(5_000_000));
       await initUsdcOutflow();
 
       await treasury.setOutflowLimitBps(await usdc.getAddress(), 5000); // 50%
       await treasury.setOutflowLimitAbsolute(await usdc.getAddress(), USDC(1_000_000));
 
-      const config = await treasury.getOutflowConfig(await usdc.getAddress());
-      expect(config.limitBps).to.equal(5000);
-      expect(config.limitAbsolute).to.equal(USDC(1_000_000));
+      const pending = await treasury.getPendingOutflowConfig(await usdc.getAddress());
+      expect(pending.pendingLimitBps).to.equal(5000);
+      expect(pending.pendingLimitAbsolute).to.equal(USDC(1_000_000));
+      // Active values unchanged until activation
+      const active = await treasury.getOutflowConfig(await usdc.getAddress());
+      expect(active.limitBps).to.equal(1000);
+      expect(active.limitAbsolute).to.equal(USDC(100_000));
     });
   });
 
@@ -473,6 +490,271 @@ describe("Treasury Outflow Rate Limits", function () {
       expect(status.effectiveLimit).to.equal(USDC(100_000));
       expect(status.recentOutflow).to.equal(USDC(30_000));
       expect(status.available).to.equal(USDC(70_000));
+    });
+  });
+
+  // ============================================================
+  // 8. Asymmetric Activation Delay (issue #226)
+  // ============================================================
+  //
+  // Outflow-loosening parameter changes are written to a pending slot and only take
+  // effect after LIMIT_ACTIVATION_DELAY (24 days) elapses. Tightening takes effect
+  // immediately. Direction is parameter-specific:
+  //   - setOutflowLimitAbsolute: loosens when new > active
+  //   - setOutflowLimitBps: loosens when new > active
+  //   - setOutflowWindow: loosens when new < active (shorter lookback = faster refresh)
+  //
+  // This suite covers schedule/tighten/activate semantics for each knob, the atomic
+  // loosen-then-drain attack the delay prevents, overwrite semantics, permissionless
+  // activation, and view/state-modifying parity.
+
+  describe("Asymmetric Activation Delay", function () {
+    const ACTIVATION_DELAY = 24 * ONE_DAY;
+
+    beforeEach(async function () {
+      await fundTreasury(USDC(5_000_000));
+      await initUsdcOutflow();
+    });
+
+    // ---- setOutflowLimitAbsolute ----
+
+    // WHY: The core attack from issue #226 — batching a limit raise with a drain in the
+    // same proposal. Under the delay, the drain must enforce the old (pre-pending) limit.
+    it("schedules limitAbsolute increase and enforces old limit until activation", async function () {
+      const usdcAddr = await usdc.getAddress();
+
+      // Attacker-requested increase: $100K → $1M
+      const tx = await treasury.setOutflowLimitAbsolute(usdcAddr, USDC(1_000_000));
+      const block = await ethers.provider.getBlock(tx.blockNumber!);
+      const activatesAt = BigInt(block!.timestamp) + BigInt(ACTIVATION_DELAY);
+
+      // Scheduled event emitted
+      await expect(tx)
+        .to.emit(treasury, "OutflowLimitAbsoluteIncreaseScheduled")
+        .withArgs(usdcAddr, USDC(100_000), USDC(1_000_000), activatesAt);
+
+      // Active value is unchanged; pending slot populated
+      expect((await treasury.getOutflowConfig(usdcAddr)).limitAbsolute).to.equal(USDC(100_000));
+      const pending = await treasury.getPendingOutflowConfig(usdcAddr);
+      expect(pending.pendingLimitAbsolute).to.equal(USDC(1_000_000));
+      expect(pending.pendingLimitAbsoluteActivation).to.equal(activatesAt);
+
+      // Drain attempt against the new limit fails: $5M treasury, 10% pct = $500K effective.
+      // Try $600K (would pass under $1M pending but not under $500K current).
+      await expect(
+        treasury.distribute(usdcAddr, recipient.address, USDC(600_000))
+      ).to.be.revertedWith("ArmadaTreasuryGov: outflow limit exceeded");
+
+      // Within the current effective limit still works
+      await treasury.distribute(usdcAddr, recipient.address, USDC(400_000));
+    });
+
+    // WHY: After the delay elapses, the first outflow call (or any reader) lazily
+    // promotes the pending value and emits the activation event. A reviewer should
+    // see the event fire exactly once at the transition.
+    it("lazily activates pending limitAbsolute at T+24d and emits Activated", async function () {
+      const usdcAddr = await usdc.getAddress();
+
+      await treasury.setOutflowLimitAbsolute(usdcAddr, USDC(1_000_000));
+      await time.increase(ACTIVATION_DELAY);
+
+      // Trigger via activatePendingOutflowParams
+      await expect(treasury.activatePendingOutflowParams(usdcAddr))
+        .to.emit(treasury, "OutflowLimitAbsoluteActivated")
+        .withArgs(usdcAddr, USDC(100_000), USDC(1_000_000));
+
+      const config = await treasury.getOutflowConfig(usdcAddr);
+      expect(config.limitAbsolute).to.equal(USDC(1_000_000));
+      // Pending cleared
+      const pending = await treasury.getPendingOutflowConfig(usdcAddr);
+      expect(pending.pendingLimitAbsolute).to.equal(0);
+      expect(pending.pendingLimitAbsoluteActivation).to.equal(0);
+    });
+
+    // WHY: Tightening must NOT be delayed — the issue explicitly requires immediate
+    // effect so operators can respond to emerging risk without waiting 24 days. Also
+    // confirms tightening clears any pending loosening (cancellation semantics).
+    it("tightens limitAbsolute immediately and clears pending loosening", async function () {
+      const usdcAddr = await usdc.getAddress();
+
+      // Schedule a loosening first
+      await treasury.setOutflowLimitAbsolute(usdcAddr, USDC(1_000_000));
+      expect(
+        (await treasury.getPendingOutflowConfig(usdcAddr)).pendingLimitAbsolute
+      ).to.equal(USDC(1_000_000));
+
+      // Tighten: from $100K active → $75K immediate, pending cleared
+      await expect(treasury.setOutflowLimitAbsolute(usdcAddr, USDC(75_000)))
+        .to.emit(treasury, "OutflowLimitAbsoluteDecreased")
+        .withArgs(usdcAddr, USDC(100_000), USDC(75_000));
+
+      expect((await treasury.getOutflowConfig(usdcAddr)).limitAbsolute).to.equal(USDC(75_000));
+      const pending = await treasury.getPendingOutflowConfig(usdcAddr);
+      expect(pending.pendingLimitAbsolute).to.equal(0);
+      expect(pending.pendingLimitAbsoluteActivation).to.equal(0);
+    });
+
+    // WHY: Issue #226 edge case — if active=100, pending=500, and a later proposal
+    // sets 300, that's still an increase over active (300 > 100) so it goes to pending
+    // with a fresh 24-day timer, even though it's tighter than the existing pending.
+    // Governance's most recent decision is authoritative.
+    it("overwrites pending loosening with fresh timer on subsequent loosening", async function () {
+      const usdcAddr = await usdc.getAddress();
+
+      await treasury.setOutflowLimitAbsolute(usdcAddr, USDC(500_000));
+      await time.increase(10 * ONE_DAY);
+
+      const tx = await treasury.setOutflowLimitAbsolute(usdcAddr, USDC(300_000));
+      const block = await ethers.provider.getBlock(tx.blockNumber!);
+      const newActivatesAt = BigInt(block!.timestamp) + BigInt(ACTIVATION_DELAY);
+
+      const pending = await treasury.getPendingOutflowConfig(usdcAddr);
+      expect(pending.pendingLimitAbsolute).to.equal(USDC(300_000));
+      expect(pending.pendingLimitAbsoluteActivation).to.equal(newActivatesAt);
+      // Active untouched
+      expect((await treasury.getOutflowConfig(usdcAddr)).limitAbsolute).to.equal(USDC(100_000));
+    });
+
+    // ---- setOutflowLimitBps ----
+
+    it("schedules bps increase and applies old bps until activation", async function () {
+      const usdcAddr = await usdc.getAddress();
+      await expect(treasury.setOutflowLimitBps(usdcAddr, 5000))
+        .to.emit(treasury, "OutflowLimitBpsIncreaseScheduled");
+
+      expect((await treasury.getOutflowConfig(usdcAddr)).limitBps).to.equal(1000);
+      expect((await treasury.getPendingOutflowConfig(usdcAddr)).pendingLimitBps).to.equal(5000);
+    });
+
+    it("tightens bps immediately and clears pending", async function () {
+      const usdcAddr = await usdc.getAddress();
+      await treasury.setOutflowLimitBps(usdcAddr, 5000); // schedule
+
+      await expect(treasury.setOutflowLimitBps(usdcAddr, 500))
+        .to.emit(treasury, "OutflowLimitBpsDecreased")
+        .withArgs(usdcAddr, 1000, 500);
+
+      expect((await treasury.getOutflowConfig(usdcAddr)).limitBps).to.equal(500);
+      expect((await treasury.getPendingOutflowConfig(usdcAddr)).pendingLimitBps).to.equal(0);
+    });
+
+    // ---- setOutflowWindow (INVERTED direction) ----
+
+    // WHY: Window semantics are inverted vs limits. Shorter lookback loosens because
+    // older records drop out of the rolling sum faster. This is a commonly missed edge
+    // in reviews — the test nails the inverted direction.
+    it("schedules window DECREASE (loosening) with delay", async function () {
+      const usdcAddr = await usdc.getAddress();
+      // Initial window = 30 days; try to shorten to 7 days
+      const tx = await treasury.setOutflowWindow(usdcAddr, 7 * ONE_DAY);
+      const block = await ethers.provider.getBlock(tx.blockNumber!);
+      const activatesAt = BigInt(block!.timestamp) + BigInt(ACTIVATION_DELAY);
+
+      await expect(tx)
+        .to.emit(treasury, "OutflowWindowDurationDecreaseScheduled")
+        .withArgs(usdcAddr, THIRTY_DAYS, 7 * ONE_DAY, activatesAt);
+
+      expect((await treasury.getOutflowConfig(usdcAddr)).windowDuration).to.equal(THIRTY_DAYS);
+      expect(
+        (await treasury.getPendingOutflowConfig(usdcAddr)).pendingWindowDuration
+      ).to.equal(7 * ONE_DAY);
+    });
+
+    it("applies window INCREASE (tightening) immediately and clears pending", async function () {
+      const usdcAddr = await usdc.getAddress();
+      await treasury.setOutflowWindow(usdcAddr, 7 * ONE_DAY); // schedule loosening
+
+      await expect(treasury.setOutflowWindow(usdcAddr, 60 * ONE_DAY))
+        .to.emit(treasury, "OutflowWindowDurationIncreased")
+        .withArgs(usdcAddr, THIRTY_DAYS, 60 * ONE_DAY);
+
+      expect((await treasury.getOutflowConfig(usdcAddr)).windowDuration).to.equal(60 * ONE_DAY);
+      expect(
+        (await treasury.getPendingOutflowConfig(usdcAddr)).pendingWindowDuration
+      ).to.equal(0);
+    });
+
+    // ---- Permissionless trigger & view parity ----
+
+    // WHY: activatePendingOutflowParams is a no-op-safe public wrapper for monitoring
+    // bots. It must not revert when there's nothing to activate and must not emit
+    // events in that case — otherwise a bot calling it every block would spam logs.
+    it("activatePendingOutflowParams is a no-op when nothing is due", async function () {
+      const usdcAddr = await usdc.getAddress();
+
+      // Case 1: no pending state at all
+      const tx1 = await treasury.activatePendingOutflowParams(usdcAddr);
+      const receipt1 = await tx1.wait();
+      expect(receipt1!.logs.length).to.equal(0);
+
+      // Case 2: pending exists but timer hasn't elapsed
+      await treasury.setOutflowLimitAbsolute(usdcAddr, USDC(1_000_000));
+      await time.increase(10 * ONE_DAY);
+      const tx2 = await treasury.activatePendingOutflowParams(usdcAddr);
+      const receipt2 = await tx2.wait();
+      // No Activated events emitted (timer not elapsed)
+      expect(
+        receipt2!.logs.filter((l: any) => {
+          try {
+            return treasury.interface.parseLog(l)?.name.includes("Activated");
+          } catch {
+            return false;
+          }
+        }).length
+      ).to.equal(0);
+    });
+
+    // WHY: The view-only getEffectiveOutflowConfig MUST agree with what a
+    // state-modifying _lazyActivate path would produce. Divergence between the two
+    // is the single most important correctness failure mode — Cyfrin verifies this
+    // as part of the delay-mechanism audit.
+    it("view getEffectiveOutflowConfig agrees with state-modifying activation", async function () {
+      const usdcAddr = await usdc.getAddress();
+
+      // Schedule changes for all three knobs
+      await treasury.setOutflowLimitAbsolute(usdcAddr, USDC(800_000));
+      await treasury.setOutflowLimitBps(usdcAddr, 3000);
+      await treasury.setOutflowWindow(usdcAddr, 7 * ONE_DAY);
+
+      // Advance past activation
+      await time.increase(ACTIVATION_DELAY);
+
+      // View should report effective (post-activation) values without mutating
+      const effectiveBefore = await treasury.getEffectiveOutflowConfig(usdcAddr);
+      expect(effectiveBefore.limitAbsolute).to.equal(USDC(800_000));
+      expect(effectiveBefore.limitBps).to.equal(3000);
+      expect(effectiveBefore.windowDuration).to.equal(7 * ONE_DAY);
+
+      // Raw storage still holds pre-activation values (view didn't mutate)
+      const rawBefore = await treasury.getOutflowConfig(usdcAddr);
+      expect(rawBefore.limitAbsolute).to.equal(USDC(100_000));
+
+      // Now trigger state-modifying activation
+      await treasury.activatePendingOutflowParams(usdcAddr);
+
+      // Raw now matches effective
+      const rawAfter = await treasury.getOutflowConfig(usdcAddr);
+      const effectiveAfter = await treasury.getEffectiveOutflowConfig(usdcAddr);
+      expect(rawAfter.limitAbsolute).to.equal(effectiveAfter.limitAbsolute);
+      expect(rawAfter.limitBps).to.equal(effectiveAfter.limitBps);
+      expect(rawAfter.windowDuration).to.equal(effectiveAfter.windowDuration);
+    });
+
+    // WHY: The headline attack in issue #226: a single Extended proposal batching
+    // setOutflowLimitAbsolute + distribute at the new limit. The delay must force
+    // the drain to enforce the old limit. This simulates the batch by calling both
+    // in the same block (same tx ordering the timelock would produce).
+    it("blocks atomic batch: loosen + drain in same block enforces old limit", async function () {
+      const usdcAddr = await usdc.getAddress();
+
+      // Attacker-requested batch: raise limit to $5M, then distribute $2M.
+      // Without the delay, $2M > $500K (current pct effective) would pass against the
+      // new $5M limit. With the delay, it must fail against the old $500K.
+      await treasury.setOutflowLimitAbsolute(usdcAddr, USDC(5_000_000));
+
+      await expect(
+        treasury.distribute(usdcAddr, recipient.address, USDC(2_000_000))
+      ).to.be.revertedWith("ArmadaTreasuryGov: outflow limit exceeded");
     });
   });
 });

--- a/test/treasury_outflow.ts
+++ b/test/treasury_outflow.ts
@@ -139,8 +139,8 @@ describe("Treasury Outflow Rate Limits", function () {
 
     // WHY: Setting the window to a longer duration is TIGHTENING (longer lookback sums
     // more past records), so it takes effect immediately under the asymmetric-delay
-    // behavior added in issue #226. The loosening direction (shorter window) is covered
-    // in the "Asymmetric Activation Delay" section below.
+    // semantics. The loosening direction (shorter window) is covered in the
+    // "Asymmetric Activation Delay" section below.
     it("should allow owner to update outflow window (tightening, immediate)", async function () {
       await treasury.setOutflowWindow(await usdc.getAddress(), 60 * ONE_DAY);
       const config = await treasury.getOutflowConfig(await usdc.getAddress());
@@ -452,10 +452,10 @@ describe("Treasury Outflow Rate Limits", function () {
       expect(config.limitAbsolute).to.equal(USDC(50_000));
     });
 
-    // WHY: Governance can still raise the limits, but under issue #226 the raises are
-    // scheduled rather than applied immediately. This test confirms there is no upper
-    // bound on what governance can request — the floor is immutable but the ceiling isn't
-    // — while the activation-delay section below confirms the delay is enforced.
+    // WHY: Governance may raise the limits, and the raises are scheduled rather than
+    // applied immediately. This test confirms there is no upper bound on what governance
+    // can request — the floor is immutable but the ceiling isn't — while the
+    // activation-delay section below confirms the delay is enforced.
     it("should allow governance to schedule limit increases without upper cap", async function () {
       await fundTreasury(USDC(5_000_000));
       await initUsdcOutflow();


### PR DESCRIPTION
## Summary

Closes #226.

- Treasury outflow parameters (`windowDuration`, `limitBps`, `limitAbsolute`) now use asymmetric activation: loosening changes land in a pending slot and activate after `LIMIT_ACTIVATION_DELAY` (24 days); tightening changes apply immediately and clear the matching pending slot.
- `ArmadaGovernor.setProposalTypeParams` now rejects Extended cycles (`votingDelay + votingPeriod + executionDelay`) that meet or exceed the 24-day delay, so governance cannot stretch Extended timing to bypass the defense.
- Directional classification across fees / steward budget / gov params is intentionally deferred and tracked in #245.

## Behavior matrix

| Setter | Loosening direction (delayed) | Tightening direction (immediate) |
|---|---|---|
| `setOutflowLimitAbsolute` | `new > active` | `new <= active` |
| `setOutflowLimitBps` | `new > active` | `new <= active` |
| `setOutflowWindow` | `new < active` (shorter lookback = more headroom) | `new >= active` |

Window direction is inverted from the limit parameters by design and documented in `OutflowConfig` / setter NatSpec.

## Implementation notes

- New internal `_lazyActivate(token)` called at the top of every setter and at the top of `_checkAndRecordOutflow`. View-only mirror `_effectiveParams` plus `getEffectiveOutflowConfig` / `getPendingOutflowConfig` for monitoring.
- Permissionless `activatePendingOutflowParams(token)`: no-op-safe, no revert, for monitoring bots that want the activation event fired at the activation timestamp.
- Governor mirrors `LIMIT_ACTIVATION_DELAY` as a local constant (`TREASURY_OUTFLOW_ACTIVATION_DELAY`) to stay under the 24576-byte mainnet deploy limit. A contract-level parity test locks in that the two constants agree.
- Per-parameter events (Scheduled / Activated / Decreased or Increased) replace the prior `OutflowWindowUpdated` / `LimitBpsUpdated` / `LimitAbsoluteUpdated` triplet. Only `test/treasury_outflow.ts` and the governance UI consumed those — the UI only uses function signatures (unchanged).

## What this does NOT fix

Per the issue's stated scope: a drain proposal submitted AFTER a loosening executes but BEFORE the pending value activates (day-24-to-day-47 gap) can still be timed so its execute call lands at or after activation, and lazy activation inside `_checkAndRecordOutflow` lets it pass at the new limit. Closing this residual gap requires proposal-time snapshotting and is scoped as a post-audit governor upgrade.

## Test plan

- [x] `npx hardhat test test/treasury_outflow.ts` — 41 passing (added 11 asymmetric-delay tests + updated 3 existing tests for new semantics)
- [x] `npx hardhat test test/governance_param_updates.ts` — 27 passing (added 6 invariant tests)
- [x] `npx hardhat test test/governance_integration.ts test/governance_adversarial.ts test/governance_veto.ts test/governance_signaling.ts test/governance_quiet_period.ts test/governance_adapter_registry.ts test/governance_upgrade.ts test/arm_token_votes.ts` — all passing
- [x] `npx hardhat test test/cross_contract_integration.ts test/fee_module_integration.ts test/revenue_counter.ts test/winddown_redemption_integration.ts` — all passing
- [x] `forge test --offline` — 561 passing across 49 suites (INV-TO4 view/activation parity added; existing INV-TO1/2/3 verified under fuzzed setter calls)
- [x] `npx hardhat compile` — governor stays under 24576-byte mainnet limit (24507 bytes with optimizer runs=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)