### PR TITLE
fix(governance): reclassify operational selectors as Standard (#233)

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -376,13 +376,9 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         extendedSelectors[bytes4(keccak256("setOutflowWindow(address,uint256)"))] = true;
         extendedSelectors[bytes4(keccak256("setOutflowLimitBps(address,uint256)"))] = true;
         extendedSelectors[bytes4(keccak256("setOutflowLimitAbsolute(address,uint256)"))] = true;
-        // Adapter lifecycle (on AdapterRegistry) — affects which contracts interact with shielded yield
+        // Adapter authorization (on AdapterRegistry) — loosening: grants a new contract
+        // access to the protocol's shielded yield. Deauthorization is Standard (see below).
         extendedSelectors[bytes4(keccak256("authorizeAdapter(address)"))] = true;
-        extendedSelectors[bytes4(keccak256("deauthorizeAdapter(address)"))] = true;
-        extendedSelectors[bytes4(keccak256("fullDeauthorizeAdapter(address)"))] = true;
-        // Wind-down parameter adjustments (on ArmadaWindDown) — high-impact, can extend protocol lifetime
-        extendedSelectors[bytes4(keccak256("setRevenueThreshold(uint256)"))] = true;
-        extendedSelectors[bytes4(keccak256("setWindDownDeadline(uint256)"))] = true;
         // Wrapper/forwarder deny-list — force Extended for generic relay patterns that could
         // wrap an Extended action inside a Standard-looking call. Defense-in-depth alongside
         // the fail-closed default.
@@ -406,6 +402,18 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         standardSelectors[bytes4(keccak256("removeSteward()"))] = true;
         // Permissionless crowdfund sweep — anyone can call directly, governance path is optional
         standardSelectors[bytes4(keccak256("withdrawUnallocatedArm()"))] = true;
+        // Adapter deauthorization (on AdapterRegistry) — tightening: revokes an adapter's
+        // access to the protocol. Paired with authorizeAdapter (Extended) above.
+        standardSelectors[bytes4(keccak256("deauthorizeAdapter(address)"))] = true;
+        standardSelectors[bytes4(keccak256("fullDeauthorizeAdapter(address)"))] = true;
+        // Wind-down operational parameters (on ArmadaWindDown) — routine threshold /
+        // deadline adjustments. Directional nuance (e.g. extending the deadline is
+        // loosening) is not yet enforced in code; tracked separately for future work.
+        standardSelectors[bytes4(keccak256("setRevenueThreshold(uint256)"))] = true;
+        standardSelectors[bytes4(keccak256("setWindDownDeadline(uint256)"))] = true;
+        // Non-stablecoin revenue attestation (on RevenueCounter) — governance attests
+        // USD value of non-stablecoin fees (e.g. ETH). Operational governance task.
+        standardSelectors[bytes4(keccak256("attestRevenue(uint256)"))] = true;
     }
 
     // ============ Quorum Exclusion ============

--- a/contracts/governance/ArmadaWindDown.sol
+++ b/contracts/governance/ArmadaWindDown.sol
@@ -192,11 +192,16 @@ contract ArmadaWindDown {
     /// @notice Update the wind-down deadline. Timelock-only. Cannot change after trigger.
     ///         Deadline must be in the future (same invariant the constructor enforces) to
     ///         prevent governance from disabling the permissionless trigger.
-    ///         DESIGN NOTE: Governance can repeatedly extend the deadline. This is accepted
-    ///         because setWindDownDeadline is an Extended selector (30% quorum, 14-day vote,
-    ///         7-day execution delay), and the Security Council can veto capture attempts.
-    ///         A hard cap was considered but rejected — protocol lifetime is uncertain and
-    ///         an artificial cap could force unnecessary wind-down.
+    ///         DESIGN NOTE: Governance can repeatedly extend the deadline. No hard cap is
+    ///         imposed because protocol lifetime is uncertain and an artificial cap could
+    ///         force unnecessary wind-down. Capture attempts are mitigated by the Security
+    ///         Council veto on any queued proposal. The selector is currently classified as
+    ///         Standard (20% quorum, 7-day vote, 2-day execution delay); extending the
+    ///         deadline is a loosening action that should eventually sit at the Extended
+    ///         bar per the asymmetric governance principle.
+    // TODO: Raise setWindDownDeadline to Extended for the extend-direction once the
+    // governor enforces directional classification (see ArmadaGovernor._initializeSelectors
+    // comment above the standard setWindDownDeadline registration).
     function setWindDownDeadline(uint256 _newDeadline) external {
         require(msg.sender == timelock, "ArmadaWindDown: not timelock");
         require(!triggered, "ArmadaWindDown: already triggered");

--- a/test/governance_adapter_registry.ts
+++ b/test/governance_adapter_registry.ts
@@ -164,8 +164,10 @@ describe("Governance Adapter Registry", function () {
 
   describe("Authorize Adapter", function () {
     it("should authorize adapter via Extended governance proposal", async function () {
-      // WHY: Adapter lifecycle selectors are Extended-classified — authorizing an adapter
-      // affects the entire shielded yield integration surface and requires higher quorum.
+      // WHY: authorizeAdapter is Extended-classified under the asymmetric principle
+      // (tightening is easy, loosening is hard): granting an adapter access to the
+      // shielded yield integration surface is a loosening action and requires the
+      // higher quorum/longer voting bar. Deauthorization is Standard (see below).
       const registryAddr = await registry.getAddress();
       const calldata = registry.interface.encodeFunctionData("authorizeAdapter", [adapterAddr]);
 
@@ -180,16 +182,19 @@ describe("Governance Adapter Registry", function () {
 
   describe("Deauthorize Adapter", function () {
     it("should deauthorize adapter to withdraw-only via governance", async function () {
+      // WHY: deauthorizeAdapter is Standard-classified — revoking an adapter's access
+      // is a tightening action, so it runs at the lower 20%/7d bar. Confirms the
+      // directional split from authorizeAdapter (Extended) actually works end-to-end.
       const registryAddr = await registry.getAddress();
 
-      // First: authorize
+      // First: authorize (Extended — loosening)
       const authCalldata = registry.interface.encodeFunctionData("authorizeAdapter", [adapterAddr]);
       await proposeVoteQueueExecute([registryAddr], [authCalldata], "Authorize adapter", ProposalType.Extended);
       expect(await registry.authorizedAdapters(adapterAddr)).to.equal(true);
 
-      // Then: deauthorize
+      // Then: deauthorize (Standard — tightening)
       const deauthCalldata = registry.interface.encodeFunctionData("deauthorizeAdapter", [adapterAddr]);
-      await proposeVoteQueueExecute([registryAddr], [deauthCalldata], "Deauthorize adapter", ProposalType.Extended);
+      await proposeVoteQueueExecute([registryAddr], [deauthCalldata], "Deauthorize adapter", ProposalType.Standard);
 
       expect(await registry.authorizedAdapters(adapterAddr)).to.equal(false);
       expect(await registry.withdrawOnlyAdapters(adapterAddr)).to.equal(true);
@@ -200,19 +205,22 @@ describe("Governance Adapter Registry", function () {
 
   describe("Full Deauthorize Adapter", function () {
     it("should fully remove adapter after withdraw-only period via governance", async function () {
+      // WHY: fullDeauthorizeAdapter is also Standard-classified (tightening). This walks
+      // the full authorize → withdraw-only → fully removed lifecycle, exercising the
+      // Standard path for both deauthorization steps.
       const registryAddr = await registry.getAddress();
 
-      // Authorize
+      // Authorize (Extended — loosening)
       const authCalldata = registry.interface.encodeFunctionData("authorizeAdapter", [adapterAddr]);
       await proposeVoteQueueExecute([registryAddr], [authCalldata], "Authorize adapter", ProposalType.Extended);
 
-      // Deauthorize (withdraw-only)
+      // Deauthorize (Standard — tightening, withdraw-only)
       const deauthCalldata = registry.interface.encodeFunctionData("deauthorizeAdapter", [adapterAddr]);
-      await proposeVoteQueueExecute([registryAddr], [deauthCalldata], "Deauthorize adapter", ProposalType.Extended);
+      await proposeVoteQueueExecute([registryAddr], [deauthCalldata], "Deauthorize adapter", ProposalType.Standard);
 
-      // Full deauthorize
+      // Full deauthorize (Standard — tightening, removes withdraw-only status)
       const fullDeauthCalldata = registry.interface.encodeFunctionData("fullDeauthorizeAdapter", [adapterAddr]);
-      await proposeVoteQueueExecute([registryAddr], [fullDeauthCalldata], "Fully remove adapter", ProposalType.Extended);
+      await proposeVoteQueueExecute([registryAddr], [fullDeauthCalldata], "Fully remove adapter", ProposalType.Standard);
 
       expect(await registry.authorizedAdapters(adapterAddr)).to.equal(false);
       expect(await registry.withdrawOnlyAdapters(adapterAddr)).to.equal(false);

--- a/test/governance_selector_classification.ts
+++ b/test/governance_selector_classification.ts
@@ -40,14 +40,13 @@ describe("Governance Selector Classification", function () {
     );
   });
 
-  // WHY: Issue #233 fixes five mis-classified selectors. Under the asymmetric
-  // governance principle ("tightening is easy, loosening is hard"), routine
-  // operational actions and tightening actions (revoking adapter access,
-  // attesting revenue, adjusting wind-down operational params) belong at the
-  // Standard bar (20% quorum / 7d). Regression-test the exact assignment so
-  // future refactors don't silently flip one back to Extended and re-raise
-  // the bar on operational governance.
-  describe("Standard-classified selectors (issue #233)", function () {
+  // WHY: Under the asymmetric governance principle ("tightening is easy,
+  // loosening is hard"), routine operational actions and tightening actions
+  // (revoking adapter access, attesting revenue, adjusting wind-down
+  // operational params) belong at the Standard bar (20% quorum / 7d). Pin
+  // the exact assignment so a refactor cannot silently flip one back to
+  // Extended and re-raise the bar on operational governance.
+  describe("Standard-classified selectors", function () {
     const standardSelectors: [string, string][] = [
       ["deauthorizeAdapter(address)", "tightening — revokes adapter access"],
       ["fullDeauthorizeAdapter(address)", "tightening — fully removes adapter"],

--- a/test/governance_selector_classification.ts
+++ b/test/governance_selector_classification.ts
@@ -1,0 +1,79 @@
+// ABOUTME: Regression tests for ArmadaGovernor.initialize() selector classification.
+// ABOUTME: Locks in the Standard vs. Extended assignment for spec-critical selectors.
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { deployGovernorProxy } from "./helpers/deploy-governor";
+
+// Inline keccak256 selector helper to avoid coupling to ABI fragments.
+function sel(sig: string): string {
+  return ethers.id(sig).slice(0, 10);
+}
+
+describe("Governance Selector Classification", function () {
+  let governor: any;
+
+  before(async function () {
+    const [deployer] = await ethers.getSigners();
+
+    // Minimal dependency set: the classification test doesn't exercise any
+    // token / treasury / timelock logic, just the mappings populated by
+    // initialize(). We still need non-zero addresses for the proxy call
+    // because initialize() stores them.
+
+    const TimelockController = await ethers.getContractFactory("TimelockController");
+    const timelock = await TimelockController.deploy(2 * 86400, [], [], deployer.address);
+    await timelock.waitForDeployment();
+
+    const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+    const token = await ArmadaToken.deploy(deployer.address, await timelock.getAddress());
+    await token.waitForDeployment();
+
+    const ArmadaTreasuryGov = await ethers.getContractFactory("ArmadaTreasuryGov");
+    const treasury = await ArmadaTreasuryGov.deploy(await timelock.getAddress());
+    await treasury.waitForDeployment();
+
+    governor = await deployGovernorProxy(
+      await token.getAddress(),
+      await timelock.getAddress(),
+      await treasury.getAddress(),
+    );
+  });
+
+  // WHY: Issue #233 fixes five mis-classified selectors. Under the asymmetric
+  // governance principle ("tightening is easy, loosening is hard"), routine
+  // operational actions and tightening actions (revoking adapter access,
+  // attesting revenue, adjusting wind-down operational params) belong at the
+  // Standard bar (20% quorum / 7d). Regression-test the exact assignment so
+  // future refactors don't silently flip one back to Extended and re-raise
+  // the bar on operational governance.
+  describe("Standard-classified selectors (issue #233)", function () {
+    const standardSelectors: [string, string][] = [
+      ["deauthorizeAdapter(address)", "tightening — revokes adapter access"],
+      ["fullDeauthorizeAdapter(address)", "tightening — fully removes adapter"],
+      ["setRevenueThreshold(uint256)", "operational wind-down parameter"],
+      ["setWindDownDeadline(uint256)", "operational wind-down parameter"],
+      ["attestRevenue(uint256)", "operational non-stablecoin revenue attestation"],
+    ];
+
+    for (const [sig, reason] of standardSelectors) {
+      it(`registers ${sig} as Standard (${reason})`, async function () {
+        expect(await governor.standardSelectors(sel(sig))).to.equal(true);
+        expect(await governor.extendedSelectors(sel(sig))).to.equal(false);
+      });
+    }
+  });
+
+  // WHY: authorizeAdapter is the loosening counterpart to deauthorize.
+  // Granting a new contract access to the shielded yield surface must stay
+  // Extended (30% quorum / 14d) per the spec's directional split. This
+  // guards the split from an over-eager refactor that moves both sides of
+  // the pair to Standard together.
+  describe("Extended-classified selectors (spec-pinned)", function () {
+    it("keeps authorizeAdapter(address) as Extended", async function () {
+      const s = sel("authorizeAdapter(address)");
+      expect(await governor.extendedSelectors(s)).to.equal(true);
+      expect(await governor.standardSelectors(s)).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Reclassifies 5 governance selectors from Extended to Standard per the GOVERNANCE.md spec (issue #233):
  - `deauthorizeAdapter(address)`, `fullDeauthorizeAdapter(address)` — tightening actions, were Extended
  - `setRevenueThreshold(uint256)`, `setWindDownDeadline(uint256)` — operational wind-down parameters, were Extended
  - `attestRevenue(uint256)` — was unregistered (fell through to Extended via the fail-closed classifier), now explicitly Standard
- `authorizeAdapter(address)` stays Extended — loosening action (grants adapter access to shielded yield surface) per the asymmetric principle confirmed in the issue discussion
- Adds a focused regression test (`test/governance_selector_classification.ts`) pinning the Standard vs. Extended assignment for these spec-critical selectors, so a future refactor can't silently flip one back
- Updates `test/governance_adapter_registry.ts` to propose `deauthorizeAdapter` / `fullDeauthorizeAdapter` via Standard (the production path), plus refreshed WHY comments on the directional split

Out of scope: the larger directional classification work (setters that should be Standard when tightening and Extended when loosening — e.g. extending `setWindDownDeadline` is still Standard here). That gap is tracked separately.

## Test plan

- [x] `npx hardhat test test/governance_selector_classification.ts test/governance_adapter_registry.ts` — 12 passing
- [x] `npx hardhat test` for param-updates / wind-down / revenue-counter / revenue-lock / adapter-registry / classification — 139 passing
- [x] `forge test --offline --match-contract "ArmadaGovernor|AdapterRegistry|ArmadaWindDown|RevenueCounter|GovernorVeto|GovernorUpgrade"` — 97 passing
- [x] `npm run test:governance` — 116 passing

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)