### PR TITLE
fix(governance): set proposal threshold to 5,000 ARM absolute (#249)

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -151,8 +151,8 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     // Proposal type parameters
     mapping(ProposalType => ProposalParams) public proposalTypeParams;
 
-    // Proposal threshold: 0.1% = 10 bps
-    uint256 public constant PROPOSAL_THRESHOLD_BPS = 10;
+    // Proposal threshold: 5,000 ARM (per GOVERNANCE.md §Proposal threshold)
+    uint256 public constant PROPOSAL_THRESHOLD = 5_000e18;
 
     // Bounds for governance-updatable proposal parameters
     uint256 public constant MIN_VOTING_DELAY = 1 days;
@@ -817,11 +817,10 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         return proposalId;
     }
 
-    /// @dev Check that proposer has enough delegated voting power (0.1% of total supply)
+    /// @dev Check that proposer has at least PROPOSAL_THRESHOLD delegated voting power
     function _checkProposalThreshold(address proposer) internal view {
         uint256 proposerVotes = armToken.getPastVotes(proposer, block.number - 1);
-        uint256 threshold = (armToken.totalSupply() * PROPOSAL_THRESHOLD_BPS) / 10000;
-        if (proposerVotes < threshold) revert Gov_BelowProposalThreshold();
+        if (proposerVotes < PROPOSAL_THRESHOLD) revert Gov_BelowProposalThreshold();
     }
 
     /// @dev Initialize proposal scalar fields
@@ -1070,8 +1069,8 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
     }
 
     /// @notice Get proposal threshold (minimum locked tokens to propose)
-    function proposalThreshold() external view returns (uint256) {
-        return (armToken.totalSupply() * PROPOSAL_THRESHOLD_BPS) / 10000;
+    function proposalThreshold() external pure returns (uint256) {
+        return PROPOSAL_THRESHOLD;
     }
 
     // ============ Internal ============

--- a/docs/GOVERNANCE_ACTIVATION.md
+++ b/docs/GOVERNANCE_ACTIVATION.md
@@ -105,7 +105,7 @@ Example with POC defaults:
 - **Immutable treasury:** The crowdfund's treasury destination cannot be redirected after deployment. This is intentional — it prevents admin from diverting funds.
 - **One-time quorum exclusion:** The governor's excluded addresses list locks after the first `setExcludedAddresses` call. Future crowdfund rounds would need to be included in the initial call or require a governance proposal to add a new exclusion mechanism.
 - **Fixed ARM supply:** 12M total, no mint/burn. All distribution decisions are final once tokens are transferred.
-- **Proposal threshold:** 0.1% of total supply = 12,000 ARM. This is absolute (not based on eligible supply), ensuring a minimum skin-in-the-game regardless of distribution.
+- **Proposal threshold:** 5,000 ARM (per GOVERNANCE.md). This is an absolute constant (not a fraction of supply), ensuring a minimum skin-in-the-game regardless of distribution.
 
 ## Future: Protocol Fee Capture
 

--- a/docs/governance-state-machine.md
+++ b/docs/governance-state-machine.md
@@ -75,7 +75,7 @@ flowchart TD
     G --> H
 ```
 
-- **Proposal threshold**: 0.1% of total supply = 12,000 ARM (absolute, not eligible supply)
+- **Proposal threshold**: 5,000 ARM (absolute constant, not a fraction of supply — see GOVERNANCE.md §Proposal threshold)
 - **Auto-classification**: Function selectors in `extendedSelectors` mapping force Extended type. `distribute()` calls exceeding 5% of treasury balance also force Extended.
 - **Quiet period**: Configurable cooldown after a failed proposal to prevent spam
 

--- a/test/cross_contract_integration.ts
+++ b/test/cross_contract_integration.ts
@@ -324,48 +324,34 @@ describe("Cross-Contract Integration (Phase 6)", function () {
       expect(quorum).to.equal(expectedQuorum);
     });
 
-    it("proposal threshold (0.1% of total supply) is reachable by crowdfund participants", async function () {
-      await runCrowdfundAndClaim();
-
+    it("proposal threshold (5,000 ARM) is reachable by a single crowdfund participant", async function () {
+      // WHY: GOVERNANCE.md specifies a flat 5,000 ARM proposal threshold so
+      // typical crowdfund seeds can submit proposals without forming pools.
       // With BASE_SALE ($1.2M), hop-0 ceiling = 70% of netRaise = 70% of $1.14M = $798K.
       // 80 seeds * $15K = $1.2M demand > $798K ceiling → pro-rata.
-      // Each seed gets (15K * 798K) / 1.2M = $9,975 = 9,975 ARM.
-      // Threshold = 0.1% of total supply.
+      // Each seed gets (15K * 798K) / 1.2M = $9,975 = 9,975 ARM, which clears the 5,000 ARM threshold.
+      await runCrowdfundAndClaim();
 
       const threshold = await governor.proposalThreshold();
-      const INITIAL_SUPPLY = await armToken.INITIAL_SUPPLY();
-      expect(threshold).to.equal((INITIAL_SUPPLY * 10n) / 10000n); // 0.1% = 10 bps
+      expect(threshold).to.equal(ethers.parseUnits("5000", 18));
 
-      // Single seed's ARM balance
-      const seedBalance = await armToken.balanceOf(seeds[0].address);
-      expect(seedBalance).to.be.lt(threshold); // single seed can't propose
-
-      // 11 seeds pooling tokens: transfer to one address
-      // Whitelist seeds so they can transfer ARM to the pooled address
-      for (let i = 0; i < 11; i++) {
-        await armToken.addToWhitelist(seeds[i].address);
-      }
-      const pooledSeed = seeds[0];
-      for (let i = 1; i < 11; i++) {
-        const bal = await armToken.balanceOf(seeds[i].address);
-        await armToken.connect(seeds[i]).transfer(pooledSeed.address, bal);
-      }
-
-      const pooledBalance = await armToken.balanceOf(pooledSeed.address);
-      expect(pooledBalance).to.be.gte(threshold); // pooled seeds can propose
+      // A single seed clears the threshold on their own — no pooling required.
+      const seed = seeds[0];
+      const seedBalance = await armToken.balanceOf(seed.address);
+      expect(seedBalance).to.be.gte(threshold);
 
       // Delegate and propose
-      await armToken.connect(pooledSeed).delegate(pooledSeed.address);
+      await armToken.connect(seed).delegate(seed.address);
       await mine(1);
 
       const dummyCalldata = treasuryGov.interface.encodeFunctionData("distribute", [await usdc.getAddress(), deployer.address, 1]);
       await expect(
-        governor.connect(pooledSeed).propose(
+        governor.connect(seed).propose(
           ProposalType.Standard,
           [await treasuryGov.getAddress()],
           [0],
           [dummyCalldata],
-          "Crowdfund participants' first proposal"
+          "Crowdfund participant's first proposal"
         )
       ).to.not.be.reverted;
     });

--- a/test/governance_adversarial.ts
+++ b/test/governance_adversarial.ts
@@ -261,16 +261,14 @@ describe("Governance Adversarial", function () {
     });
 
     it("propose with exactly threshold voting power succeeds", async function () {
-      // Threshold = 0.1% of total supply
-      // Alice has 20% of supply locked, well above threshold. She can propose.
-      // Transfer from alice (who has locked tokens) — she needs to unlock first.
-      // Simpler: alice already has enough, just verify she can propose.
+      // WHY: proposal threshold gates who can submit proposals. This confirms
+      // both the absolute value (5,000 ARM per GOVERNANCE.md) and that a
+      // well-above-threshold delegate (alice @ 20% of supply) can propose.
       const proposalId = await createProposal(alice);
       expect(proposalId).to.equal(1);
 
-      // Verify the threshold value (0.1% of total supply)
       const threshold = await governor.proposalThreshold();
-      expect(threshold).to.equal((TOTAL_SUPPLY * 10n) / 10000n);
+      expect(threshold).to.equal(ethers.parseUnits("5000", 18));
     });
 
     it("propose with no voting power reverts", async function () {


### PR DESCRIPTION
## Summary

Closes #249. `ArmadaGovernor` was enforcing a 0.1%-of-total-supply proposal threshold (12,000 ARM), but GOVERNANCE.md and ARM_TOKEN.md now specify a flat **5,000 ARM** threshold. This PR syncs the contract with the spec by replacing the bps-based calculation with an absolute `PROPOSAL_THRESHOLD = 5_000e18` constant.

- `PROPOSAL_THRESHOLD_BPS = 10` → `PROPOSAL_THRESHOLD = 5_000e18` (contracts/governance/ArmadaGovernor.sol:154-155)
- `_checkProposalThreshold` no longer multiplies by `totalSupply()` (L820-L824)
- `proposalThreshold()` returns the constant directly and is now `external pure` (L1072-L1074)
- Docs: `docs/GOVERNANCE_ACTIVATION.md`, `docs/governance-state-machine.md` refreshed to quote the new threshold
- Tests updated for the new value; `cross_contract_integration.ts` "pooling needed" scenario restructured since a single crowdfund seed (~9,975 ARM) now clears the 5,000 ARM threshold on its own

## Why absolute (Option B)

5,000 ARM of 12M ≈ 4.17 bps — no integer bps expresses it exactly. Matching the spec's framing ("5,000 ARM") avoids rounding ambiguity and decouples the threshold from hypothetical `totalSupply()` changes.

## Test plan

- [x] `forge test --offline --match-path "test-foundry/Governor*"` — 148/148 passing
- [x] `npx hardhat test test/governance_adversarial.ts` — 50/50 passing
- [x] `npx hardhat test test/cross_contract_integration.ts` — 18/18 passing
- [x] `npx hardhat test test/governance_integration.ts test/governance_veto.ts test/governance_signaling.ts test/governance_upgrade.ts test/governance_param_updates.ts test/governance_adapter_registry.ts` — 125/125 passing

## Out of scope

Per issue #249: the directional classification gap (loosening vs. tightening for parameter setters) noted in recent GOVERNANCE.md revisions remains tracked separately. Historical `audit-reports/` references to the old threshold were left intact as they represent an audit-time snapshot.

## Note

Supersedes PR #252 — that PR was auto-closed when the source branch was renamed from `iskay/issue-249` to `iskay/prop-threshold-249`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)