### PR TITLE
fix(ci): catch oversized contracts + bring ArmadaGovernor under EIP-170

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,8 @@ jobs:
       - uses: foundry-rs/foundry-toolchain@v1
       - run: forge test
 
-  # Contract size check (EVM limit: 24576 bytes)
+  # Contract size check (EIP-170 limit: 24576 bytes).
+  # Reads Hardhat artifacts so the measured bytecode matches what actually deploys.
   contract-sizes:
     name: Contract Size Check
     runs-on: ubuntu-latest
@@ -69,26 +70,8 @@ jobs:
           node-version: "20"
           cache: "npm"
       - run: npm ci --legacy-peer-deps
-      - uses: foundry-rs/foundry-toolchain@v1
-      - name: Check contract sizes
-        run: |
-          OUTPUT=$(forge build --sizes 2>&1) || true
-          echo "$OUTPUT"
-          # Extract sizes and check for any contract exceeding 24576 bytes (24 KB EVM limit)
-          OVERSIZED=$(echo "$OUTPUT" | awk -F'|' '
-            NR > 2 && NF >= 4 {
-              gsub(/^[ \t]+|[ \t]+$/, "", $2)  # contract name
-              gsub(/^[ \t]+|[ \t]+$/, "", $3)  # size
-              if ($3+0 > 24576 && $2 != "") print $2 " (" $3 " bytes)"
-            }
-          ')
-          if [[ -n "$OVERSIZED" ]]; then
-            echo ""
-            echo "ERROR: The following contracts exceed the 24576-byte EVM size limit:"
-            echo "$OVERSIZED"
-            exit 1
-          fi
-          echo "All contracts within size limits."
+      - run: npm run compile
+      - run: npm run check:sizes
 
   # Slither static analysis (non-blocking until existing findings are triaged)
   slither:

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -34,6 +34,7 @@ const config: HardhatUserConfig = {
             enabled: true,
             runs: 1,
           },
+          viaIR: true,
         },
       },
     },

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "verify:snark:sepolia": "hardhat run scripts/verify_snark_mode.ts --network sepoliaHub",
     "prepare": "git config core.hooksPath .githooks",
     "check:anvil-addresses": "./scripts/check-anvil-addresses.sh",
+    "check:sizes": "node scripts/check-contract-sizes.js",
     "slither": "slither . --config-file slither.config.json",
     "verify": "hardhat run scripts/verify_deployment.ts --network hub",
     "verify:sepolia": "hardhat run scripts/verify_deployment.ts --network sepoliaHub"

--- a/scripts/check-contract-sizes.js
+++ b/scripts/check-contract-sizes.js
@@ -1,0 +1,61 @@
+// ABOUTME: Reads Hardhat artifacts and reports deployed bytecode sizes.
+// ABOUTME: Exits with code 1 if any contract exceeds the EIP-170 24,576-byte limit.
+
+const fs = require("fs");
+const path = require("path");
+
+const EIP_170_LIMIT = 24576;
+const ARTIFACTS_DIR = path.join(__dirname, "..", "artifacts", "contracts");
+
+function walkArtifacts(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkArtifacts(full));
+    } else if (entry.name.endsWith(".json") && !entry.name.endsWith(".dbg.json")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+if (!fs.existsSync(ARTIFACTS_DIR)) {
+  console.error(`Artifacts directory not found: ${ARTIFACTS_DIR}`);
+  console.error("Run `npm run compile` first.");
+  process.exit(1);
+}
+
+const sizes = [];
+for (const file of walkArtifacts(ARTIFACTS_DIR)) {
+  const artifact = JSON.parse(fs.readFileSync(file, "utf8"));
+  const hex = (artifact.deployedBytecode || "").replace(/^0x/, "");
+  if (hex.length === 0) continue; // interfaces, abstract contracts, libraries without code
+  const bytes = hex.length / 2;
+  sizes.push({ name: artifact.contractName, source: artifact.sourceName, bytes });
+}
+
+sizes.sort((a, b) => b.bytes - a.bytes);
+
+const oversized = sizes.filter((s) => s.bytes > EIP_170_LIMIT);
+
+const nameWidth = Math.max(...sizes.map((s) => s.name.length), 8);
+console.log(`${"Contract".padEnd(nameWidth)}  ${"Bytes".padStart(7)}  Margin`);
+console.log(`${"-".repeat(nameWidth)}  ${"-".repeat(7)}  ${"-".repeat(7)}`);
+for (const s of sizes) {
+  const margin = EIP_170_LIMIT - s.bytes;
+  const flag = margin < 0 ? " !! OVER LIMIT" : "";
+  console.log(`${s.name.padEnd(nameWidth)}  ${String(s.bytes).padStart(7)}  ${String(margin).padStart(7)}${flag}`);
+}
+
+if (oversized.length > 0) {
+  console.error("");
+  console.error(`ERROR: ${oversized.length} contract(s) exceed the ${EIP_170_LIMIT}-byte EIP-170 limit:`);
+  for (const s of oversized) {
+    console.error(`  ${s.name} (${s.source}): ${s.bytes} bytes (${s.bytes - EIP_170_LIMIT} over)`);
+  }
+  process.exit(1);
+}
+
+console.log("");
+console.log(`All ${sizes.length} contracts are within the ${EIP_170_LIMIT}-byte limit.`);


### PR DESCRIPTION
## Summary

- Enable `viaIR: true` on `ArmadaGovernor.sol` (already had `runs: 1`), dropping it from 26,445 → 23,435 bytes (1,141 bytes of headroom under EIP-170's 24,576 limit).
- Rewrite the CI contract-size check to read Hardhat artifacts instead of parsing `forge build --sizes`.

## Why the old CI check missed this

Two compounding bugs made the old check green-no-matter-what:

1. **Awk comma-parsing bug.** `forge build --sizes` formats sizes with thousands separators (e.g. `48,675`). The script compared `\$3+0 > 24576`, but `\$3+0` stops parsing at the comma, so `48,675` coerces to `48`. No contract ever tripped the threshold.
2. **Wrong compile settings.** `foundry.toml` doesn't configure the optimizer, so Foundry compiled without optimization. Even if bug #1 were fixed, the reported sizes wouldn't match what Hardhat actually deploys (e.g. Foundry reports ArmadaCrowdfund at 34,928 bytes vs Hardhat's 19,484).

## New check

`scripts/check-contract-sizes.js` walks `artifacts/contracts/` and measures `deployedBytecode` directly — unambiguously the bytecode that ships. The CI step becomes `npm run compile && npm run check:sizes`. Also runnable locally via `npm run check:sizes`.

## Test plan

- [x] `npm run compile && npm run check:sizes` — passes, all 50 contracts under limit, ArmadaGovernor at 23,435 with 1,141 margin
- [x] Patched ArmadaGovernor artifact to 30,000 bytes → script exits 1 with clear error, then recompile restores
- [x] `npm run test:governance` — 116/116 pass with viaIR build
- [x] `npm run test:crowdfund` — 125/125 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)