### PR TITLE
deploy: testnet ops fixes + medi3 sepolia deployment

### DIFF
--- a/config/networks.ts
+++ b/config/networks.ts
@@ -386,6 +386,15 @@ export function getYieldDeploymentFile(): string {
 }
 
 /**
+ * Get the fee module deployment filename.
+ */
+export function getFeeModuleDeploymentFile(): string {
+  const config = getNetworkConfig();
+  const suffix = config.env === "local" ? "" : `-${config.env}`;
+  return `fee-module-hub${suffix}.json`;
+}
+
+/**
  * Get the aave mock deployment filename for a chain.
  */
 export function getAaveMockDeploymentFile(role: ChainRole): string {

--- a/deployments/aave-mock-hub-sepolia.json
+++ b/deployments/aave-mock-hub-sepolia.json
@@ -2,7 +2,7 @@
   "chainId": 11155111,
   "deployer": "0x98b1CBa0908C98c95c9C87D94e4fCdddc87C933d",
   "contracts": {
-    "mockAaveSpoke": "0xA47371e75aD346153a470660913bCa6B1001367a"
+    "mockAaveSpoke": "0x25844C20C11f842dde6BC733132b6229BC33eFAd"
   },
   "reserves": {
     "usdc": {
@@ -11,5 +11,5 @@
       "annualYieldBps": 50000
     }
   },
-  "timestamp": "2026-02-25T16:50:36.634Z"
+  "timestamp": "2026-05-21T16:47:36.979Z"
 }

--- a/deployments/client-sepolia-v3.json
+++ b/deployments/client-sepolia-v3.json
@@ -8,5 +8,5 @@
     "messageTransmitter": "0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275",
     "tokenMessenger": "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA"
   },
-  "timestamp": "2026-03-10T19:07:58.920Z"
+  "timestamp": "2026-05-21T14:23:20.330Z"
 }

--- a/deployments/clientB-sepolia-v3.json
+++ b/deployments/clientB-sepolia-v3.json
@@ -8,5 +8,5 @@
     "messageTransmitter": "0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275",
     "tokenMessenger": "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA"
   },
-  "timestamp": "2026-03-10T19:08:00.375Z"
+  "timestamp": "2026-05-21T14:23:21.863Z"
 }

--- a/deployments/crowdfund-hub-sepolia.json
+++ b/deployments/crowdfund-hub-sepolia.json
@@ -1,20 +1,20 @@
 {
   "chainId": 11155111,
   "deployer": "0x98b1CBa0908C98c95c9C87D94e4fCdddc87C933d",
-  "deployBlock": 10846573,
+  "deployBlock": 10892713,
   "contracts": {
-    "armToken": "0x7EB073eeF5953EDAC4554915bfdeFaA31217Fcd8",
+    "armToken": "0x21EEA6EE528e966c3A54f912837CdA384BFA537d",
     "usdc": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
-    "crowdfund": "0x75b775b2bBbb5fE8c32D9B82AFCBC217D872859a",
-    "treasury": "0x2Ea83D2Fc8B8Fe7b81C5aa152f54b1Da837c3310",
-    "governor": "0xAC836855C5aCF63E5173b729D1c4746B9Ad31b3b"
+    "crowdfund": "0x24b63d7C35b6Da98FbE38AE969Be790E7E396D0b",
+    "treasury": "0x91cFA0c37Df43661DE90A3aa7CBE89ae7920871C",
+    "governor": "0x36B167ee7cd1717576f445AC7a76500899691Da5"
   },
   "config": {
-    "baseSale": "1000",
-    "maxSale": "1500",
-    "minSale": "800",
+    "baseSale": "1200000",
+    "maxSale": "1800000",
+    "minSale": "1000000",
     "armPrice": "1.00",
-    "armFunded": "1500"
+    "armFunded": "1800000"
   },
-  "timestamp": "2026-05-13T18:28:25.975Z"
+  "timestamp": "2026-05-21T16:41:36.788Z"
 }

--- a/deployments/fee-module-hub-sepolia.json
+++ b/deployments/fee-module-hub-sepolia.json
@@ -1,0 +1,15 @@
+{
+  "chainId": 11155111,
+  "deployer": "0x98b1CBa0908C98c95c9C87D94e4fCdddc87C933d",
+  "contracts": {
+    "feeModuleImpl": "0x86e18EE491A5f1dd03e97b802F624358192007A9",
+    "feeModuleProxy": "0x758ca536Cd366672AeA32E095D7Ca7320180b42B"
+  },
+  "config": {
+    "owner": "0xB70D1DcD7E63E0eF7b4c7B83cAb35f5863462889",
+    "treasury": "0x91cFA0c37Df43661DE90A3aa7CBE89ae7920871C",
+    "privacyPool": "0x014aC1dfC2Bde83d4be2CFFb5bea4dE942DAD77F",
+    "yieldVault": "0x214a3c251E9b064f4420a26Cc879b362A26bAc5A"
+  },
+  "timestamp": "2026-05-21T16:57:13.313Z"
+}

--- a/deployments/governance-hub-sepolia.json
+++ b/deployments/governance-hub-sepolia.json
@@ -1,26 +1,26 @@
 {
   "chainId": 11155111,
   "deployer": "0x98b1CBa0908C98c95c9C87D94e4fCdddc87C933d",
-  "deployBlock": 10846557,
+  "deployBlock": 10892674,
   "contracts": {
-    "timelockController": "0xB5D1360102B4f6B4B48DDc7F41B7c612B88d624e",
-    "armToken": "0x7EB073eeF5953EDAC4554915bfdeFaA31217Fcd8",
-    "treasury": "0x2Ea83D2Fc8B8Fe7b81C5aa152f54b1Da837c3310",
-    "governor": "0xAC836855C5aCF63E5173b729D1c4746B9Ad31b3b",
-    "governorImpl": "0x0734e81c0C2583633885d3bDfD879F2D17bcEAb7",
-    "steward": "0x93CE54dF0ab4cDc8AC1Ef70eb6DbBF6e7712f155",
-    "adapterRegistry": "0xC9B00444b0781b1aD774d5d4c179Eff5f916e54a",
-    "revenueCounter": "0x9290Ad6530Af05EDc759a5961bBe1FA7181fc3CB",
-    "revenueCounterImpl": "0x9036990C2468dd9BC6A3B845805b03888dc003F1",
-    "revenueLock": "0x66B5030eB82DCDEB938446dB390cD3E128fac477",
-    "shieldPauseController": "0x2132D8727cdF6187d526ad19C5187C455af87928",
-    "redemption": "0x9b16C9401eAE84d5A54488008B8c045A5d3b1dea",
-    "windDown": "0x9CaebdC15AE17Dd01FB74DD16fce86d013b5A861"
+    "timelockController": "0xB70D1DcD7E63E0eF7b4c7B83cAb35f5863462889",
+    "armToken": "0x21EEA6EE528e966c3A54f912837CdA384BFA537d",
+    "treasury": "0x91cFA0c37Df43661DE90A3aa7CBE89ae7920871C",
+    "governor": "0x36B167ee7cd1717576f445AC7a76500899691Da5",
+    "governorImpl": "0x9524151a4f1Ad88FFE00cEc339813dC38d53E511",
+    "steward": "0xB68EE7dF8c268C0e53b3D7a67980E5e584f3a250",
+    "adapterRegistry": "0xbA5D04B538864593a0eEc2995aCE6502CC93aCb5",
+    "revenueCounter": "0x94F81936cDb66352D3Dd23dDDcB1ad1c034C692c",
+    "revenueCounterImpl": "0xF874d11F14D53597ee224F8A46BEF3A912c6b3dB",
+    "revenueLock": "0xDfee98948B27B6FD09c49042068DC83f8890ef26",
+    "shieldPauseController": "0xE1DF99eb19Af0d8c25e8EE01a519C176E3E5B35d",
+    "redemption": "0x0748bF61369f20976Fc92A8c541B3E0D197f640c",
+    "windDown": "0x7a90F7A802751ec1164B2fEE8690D33Ba60fA8E5"
   },
   "config": {
     "timelockMinDelay": 60,
-    "totalSupply": "10000",
-    "treasuryAllocation": "6500"
+    "totalSupply": "12000000",
+    "treasuryAllocation": "7800000"
   },
-  "timestamp": "2026-05-13T18:24:36.508Z"
+  "timestamp": "2026-05-21T16:31:12.737Z"
 }

--- a/deployments/hub-sepolia-v3.json
+++ b/deployments/hub-sepolia-v3.json
@@ -8,5 +8,5 @@
     "messageTransmitter": "0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275",
     "tokenMessenger": "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA"
   },
-  "timestamp": "2026-04-27T15:36:01.888Z"
+  "timestamp": "2026-05-21T14:23:18.589Z"
 }

--- a/deployments/privacy-pool-client-sepolia.json
+++ b/deployments/privacy-pool-client-sepolia.json
@@ -3,8 +3,8 @@
   "domain": 6,
   "deployer": "0x98b1CBa0908C98c95c9C87D94e4fCdddc87C933d",
   "contracts": {
-    "privacyPoolClient": "0x8c3216Cc6ba35e9afC930C457bd58eAA964a875C",
-    "hookRouter": "0xF14E775221EC0A9543e24873789A47Eb31eDdD84"
+    "privacyPoolClient": "0x83C80Fa61c5dA2A716326871025a5d0c2B9bD43f",
+    "hookRouter": "0xd30f241c9C7ac65F2A4838Fb44A0BAFeeD3f63Be"
   },
   "cctp": {
     "tokenMessenger": "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
@@ -13,7 +13,7 @@
   },
   "hub": {
     "domain": 0,
-    "privacyPool": "0xb0441C2Ef9Fd9C82102cCfed68c8f0F79a3cc20A"
+    "privacyPool": "0x014aC1dfC2Bde83d4be2CFFb5bea4dE942DAD77F"
   },
-  "timestamp": "2026-03-10T19:11:52.762Z"
+  "timestamp": "2026-05-21T16:46:06.441Z"
 }

--- a/deployments/privacy-pool-clientB-sepolia.json
+++ b/deployments/privacy-pool-clientB-sepolia.json
@@ -3,8 +3,8 @@
   "domain": 3,
   "deployer": "0x98b1CBa0908C98c95c9C87D94e4fCdddc87C933d",
   "contracts": {
-    "privacyPoolClient": "0xA0C90b935984fD2B72c0c66Fc516B7D1F99BDF0d",
-    "hookRouter": "0xa4fc6E50b2b6e409Fbbd28B0CDf7d405270df29b"
+    "privacyPoolClient": "0xd76105dC158de8d3a1B32AFcAD22C55feC69716d",
+    "hookRouter": "0xb3a0A6A3C5fDbAB3e46fE5Bd1e168b623Cc17DA1"
   },
   "cctp": {
     "tokenMessenger": "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
@@ -13,7 +13,7 @@
   },
   "hub": {
     "domain": 0,
-    "privacyPool": "0xb0441C2Ef9Fd9C82102cCfed68c8f0F79a3cc20A"
+    "privacyPool": "0x014aC1dfC2Bde83d4be2CFFb5bea4dE942DAD77F"
   },
-  "timestamp": "2026-03-10T19:11:59.268Z"
+  "timestamp": "2026-05-21T16:46:13.060Z"
 }

--- a/deployments/privacy-pool-hub-sepolia.json
+++ b/deployments/privacy-pool-hub-sepolia.json
@@ -3,17 +3,17 @@
   "domain": 0,
   "deployer": "0x98b1CBa0908C98c95c9C87D94e4fCdddc87C933d",
   "contracts": {
-    "privacyPool": "0xb0441C2Ef9Fd9C82102cCfed68c8f0F79a3cc20A",
-    "merkleModule": "0x3E16112290fd7740311B1d290DEf61311bDa308D",
-    "verifierModule": "0xD665d5f7a349dB3B32681d226726c506c8d2D16B",
-    "shieldModule": "0x37349a13be2009846aA3027387bae61B1401D5dE",
-    "transactModule": "0xc77ae88Aa87f8C3C5D20744e3a1ffD5dCADE3BAF",
-    "hookRouter": "0xa2c422024650f26815e4194CCBd849a5C6104717"
+    "privacyPool": "0x014aC1dfC2Bde83d4be2CFFb5bea4dE942DAD77F",
+    "merkleModule": "0xDf7F0C5875FF371fcC5bb81678f43F202b93986a",
+    "verifierModule": "0xAf60145070c33cA9F575b884c3c435D84c392239",
+    "shieldModule": "0x52cDe1613D776654583747aaBEE4F614e91ca0EB",
+    "transactModule": "0x5570c8504DfB61f6B3DD72c631452aC1b8f6af46",
+    "hookRouter": "0xd215524bFC1adb2F91D49566677D82DDA7D7d5EB"
   },
   "cctp": {
     "tokenMessenger": "0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA",
     "messageTransmitter": "0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275",
     "usdc": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
   },
-  "timestamp": "2026-03-10T19:11:48.359Z"
+  "timestamp": "2026-05-21T16:46:00.788Z"
 }

--- a/deployments/yield-hub-sepolia.json
+++ b/deployments/yield-hub-sepolia.json
@@ -2,15 +2,15 @@
   "chainId": 11155111,
   "deployer": "0x98b1CBa0908C98c95c9C87D94e4fCdddc87C933d",
   "contracts": {
-    "armadaTreasury": "0x33CAC04FA29d91874A95DB43766dB455bf9d333F",
-    "armadaYieldVault": "0x2DfeFc00D0d4eAB815cfB43F2fFCBf38A5c9F62C",
-    "armadaYieldAdapter": "0x78aA586Cb6fEAF189EB8A6bf01Efd5E7747212d6"
+    "armadaYieldVault": "0x214a3c251E9b064f4420a26Cc879b362A26bAc5A",
+    "armadaYieldAdapter": "0x148A6A4588062dB433Fa8847017DB42bAc506458"
   },
   "config": {
     "usdc": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
-    "mockAaveSpoke": "0xA47371e75aD346153a470660913bCa6B1001367a",
+    "mockAaveSpoke": "0x25844C20C11f842dde6BC733132b6229BC33eFAd",
     "reserveId": 0,
-    "yieldFeeBps": 1000
+    "yieldFeeBps": 1000,
+    "treasury": "0x91cFA0c37Df43661DE90A3aa7CBE89ae7920871C"
   },
-  "timestamp": "2026-02-25T16:51:25.451Z"
+  "timestamp": "2026-05-21T16:48:24.909Z"
 }

--- a/lib/artifacts.ts
+++ b/lib/artifacts.ts
@@ -136,17 +136,25 @@ export function formatVKeyForSolidity(
  * @param contract - RailgunSmartWallet contract instance (attached to proxy)
  * @param configs - Array of circuit configurations to load (default: testing subset)
  * @param logProgress - Whether to log progress (default: true)
+ * @param txOverrides - Optional callback returning tx overrides (e.g. nonce). Invoked once per
+ *   tx. Threading this in lets callers integrate with their own nonce manager so subsequent
+ *   deploy steps don't drift out of sync. Local/Anvil callers can omit it (ethers manages
+ *   nonces automatically); public-testnet deploys with manual nonce tracking must pass it.
  */
 export async function loadVerificationKeys(
+  // Loosely-typed so this helper accepts both the typechain-generated contract type and the
+  // minimal mock used in unit tests. The fourth argument carries ethers tx overrides.
   contract: {
     setVerificationKey: (
       nullifiers: number,
       commitments: number,
-      vkey: SolidityVerifyingKey
-    ) => Promise<{ wait: () => Promise<void> }>;
+      vkey: SolidityVerifyingKey,
+      ...rest: unknown[]
+    ) => Promise<{ wait: () => Promise<unknown> }>;
   },
   configs: ArtifactConfig[] = TESTING_ARTIFACT_CONFIGS,
-  logProgress: boolean = true
+  logProgress: boolean = true,
+  txOverrides?: () => Record<string, unknown>
 ): Promise<void> {
   if (logProgress) {
     console.log(`Loading ${configs.length} verification keys...`);
@@ -166,7 +174,8 @@ export async function loadVerificationKeys(
     const tx = await contract.setVerificationKey(
       config.nullifiers,
       config.commitments,
-      solidityVKey
+      solidityVKey,
+      txOverrides?.() ?? {}
     );
     await tx.wait();
   }

--- a/scripts/deploy-utils.ts
+++ b/scripts/deploy-utils.ts
@@ -214,9 +214,19 @@ export async function timelockCall(
   // Non-local: real schedule + wait + execute.
   const timelock = await ethers.getContractAt("TimelockController", timelockAddr);
   const ZERO_BYTES32 = "0x" + "00".repeat(32);
-  // Deterministic salt derived from the description so re-running the script produces the
-  // same operation id — gives us idempotency via isOperationDone / isOperationPending.
-  const salt = ethers.keccak256(ethers.toUtf8Bytes(description));
+  // Deterministic salt derived from (description, target, calldata) so re-running the script
+  // produces the same operation id (idempotency via isOperationDone / isOperationPending).
+  // Including target + calldata in the salt — not just the description — prevents the silent
+  // "already scheduled" false-match if two different operations were ever given the same
+  // description string (e.g. a copy-paste error in a future caller). The structural triple
+  // uniquely identifies the operation, so the salt collides only when the operations are
+  // actually the same.
+  const salt = ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["string", "address", "bytes"],
+      [description, targetAddr, calldata],
+    ),
+  );
   const value = 0n;
   const opId: string = await timelock.hashOperation(targetAddr, value, calldata, ZERO_BYTES32, salt);
 

--- a/scripts/deploy-utils.ts
+++ b/scripts/deploy-utils.ts
@@ -149,9 +149,17 @@ export function saveDeployment(filename: string, data: any): void {
 // ============================================================================
 
 /**
- * Execute a call as the timelock via Anvil impersonation (local only).
- * On non-local, logs the governance proposal needed instead.
- * Checks receipt status and throws on revert.
+ * Execute a call as the timelock.
+ *
+ * - **Local (Anvil)**: impersonates the timelock directly via `anvil_impersonateAccount`.
+ *   Bypasses the configured delay since impersonation already represents an "executed" call.
+ * - **Non-local (testnet/mainnet)**: real OZ TimelockController schedule + wait + execute.
+ *   Requires the deployer to hold PROPOSER_ROLE + EXECUTOR_ROLE on the timelock
+ *   (`deploy_governance.ts` grants these on non-local). Idempotent: if the operation has
+ *   already been executed (e.g. on a re-run after a partial deploy), returns immediately.
+ *   If already scheduled but not yet executable, waits for the remaining delay and executes.
+ *
+ * Throws on revert. Returns `true` on success / no-op.
  */
 export async function timelockCall(
   timelockAddr: string,
@@ -201,11 +209,58 @@ export async function timelockCall(
     }
     console.log(`   ${description} done`);
     return true;
-  } else {
-    console.log(`   WARNING: ${description} requires a governance proposal on non-local networks.`);
-    console.log(`     Timelock: ${timelockAddr}`);
-    console.log(`     Target:   ${targetAddr}`);
-    console.log(`     Calldata: ${calldata}`);
-    return false;
   }
+
+  // Non-local: real schedule + wait + execute.
+  const timelock = await ethers.getContractAt("TimelockController", timelockAddr);
+  const ZERO_BYTES32 = "0x" + "00".repeat(32);
+  // Deterministic salt derived from the description so re-running the script produces the
+  // same operation id — gives us idempotency via isOperationDone / isOperationPending.
+  const salt = ethers.keccak256(ethers.toUtf8Bytes(description));
+  const value = 0n;
+  const opId: string = await timelock.hashOperation(targetAddr, value, calldata, ZERO_BYTES32, salt);
+
+  if (await timelock.isOperationDone(opId)) {
+    console.log(`   ${description}: already executed (idempotent skip)`);
+    return true;
+  }
+
+  let readyTimestamp: bigint;
+  if (await timelock.isOperationPending(opId)) {
+    readyTimestamp = await timelock.getTimestamp(opId);
+    console.log(`   ${description}: already scheduled (ready at ${readyTimestamp})`);
+  } else {
+    const minDelay: bigint = await timelock.getMinDelay();
+    console.log(`   ${description}: scheduling (delay = ${minDelay}s)...`);
+    const scheduleTx = await timelock.schedule(
+      targetAddr, value, calldata, ZERO_BYTES32, salt, minDelay, nm.override()
+    );
+    const scheduleReceipt = await scheduleTx.wait();
+    if (!scheduleReceipt) throw new Error(`schedule returned no receipt for ${description}`);
+    readyTimestamp = await timelock.getTimestamp(opId);
+  }
+
+  // Wait until the operation is executable. Poll the chain's block timestamp rather than
+  // sleeping wall-clock seconds — different chains advance their clocks differently.
+  while (true) {
+    const block = await ethers.provider.getBlock("latest");
+    const nowChain = BigInt(block?.timestamp ?? 0);
+    if (nowChain >= readyTimestamp) break;
+    const remaining = readyTimestamp - nowChain;
+    console.log(`   ${description}: waiting ${remaining}s for timelock delay to elapse...`);
+    // Sleep up to 30s at a time so we surface progress on longer delays.
+    const sleepSec = Number(remaining) > 30 ? 30 : Number(remaining);
+    await new Promise(resolve => setTimeout(resolve, sleepSec * 1000));
+  }
+
+  console.log(`   ${description}: executing...`);
+  const executeTx = await timelock.execute(
+    targetAddr, value, calldata, ZERO_BYTES32, salt, nm.override()
+  );
+  const executeReceipt = await executeTx.wait();
+  if (!executeReceipt || executeReceipt.status === 0) {
+    throw new Error(`Timelock execute reverted: ${description}`);
+  }
+  console.log(`   ${description}: done`);
+  return true;
 }

--- a/scripts/deploy_fee_module.ts
+++ b/scripts/deploy_fee_module.ts
@@ -27,6 +27,7 @@
 
 import { ethers } from "hardhat";
 import {
+  getFeeModuleDeploymentFile,
   getGovernanceDeploymentFile,
   getPrivacyPoolDeploymentFile,
   getYieldDeploymentFile,
@@ -130,9 +131,9 @@ async function main() {
   await (await armadaYieldAdapter.transferOwnership(timelockAddress, nm.override())).wait();
   console.log(`   ArmadaYieldAdapter owner → ${timelockAddress}`);
 
-  // 7. Save to deployment manifest
-  const suffix = isLocal() ? "" : `-${network.name}`;
-  const feeFile = `fee-module-hub${suffix}.json`;
+  // 7. Save to deployment manifest. Use the canonical helper so the suffix is "-sepolia"
+  // (matching every other manifest) rather than hardhat's `network.name` ("sepoliaHub").
+  const feeFile = getFeeModuleDeploymentFile();
   const feeModuleDeployment = {
     chainId,
     deployer: deployer.address,

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -35,6 +35,7 @@ import {
   getNetworkConfig,
   getChainRole,
   getGovernanceDeploymentFile,
+  isLocal,
 } from "../config/networks";
 import { createNonceManager, rejectAnvilAddresses, saveDeployment } from "./deploy-utils";
 
@@ -270,6 +271,22 @@ async function main() {
   const CANCELLER_ROLE = await timelock.CANCELLER_ROLE();
   await (await timelock.grantRole(CANCELLER_ROLE, governorAddress, nm.override())).wait();
   console.log("   Granted CANCELLER_ROLE to governor (for SC veto)");
+
+  // Non-local: also grant the deployer the operational roles. The deploy + post-deploy ops
+  // pipeline (e.g. authorizing the YieldAdapter via AdapterRegistry) needs SOMEONE able to
+  // schedule + execute timelock actions, and on testnet the Governor is unusable for ops
+  // (requires ARM tokens, proposal threshold, quorum, voting period). Mainnet hardening
+  // should renounce these roles in a separate post-launch script once ops are stable.
+  // On local, Anvil impersonation covers ops and these grants are unnecessary noise.
+  if (!isLocal()) {
+    const [deployerSigner] = await ethers.getSigners();
+    await (await timelock.grantRole(PROPOSER_ROLE, deployerSigner.address, nm.override())).wait();
+    console.log("   Granted PROPOSER_ROLE to deployer (non-local ops)");
+    await (await timelock.grantRole(EXECUTOR_ROLE, deployerSigner.address, nm.override())).wait();
+    console.log("   Granted EXECUTOR_ROLE to deployer (non-local ops)");
+    await (await timelock.grantRole(CANCELLER_ROLE, deployerSigner.address, nm.override())).wait();
+    console.log("   Granted CANCELLER_ROLE to deployer (non-local ops)");
+  }
 
   // 12. Configure ARM token (one-time setters)
   console.log("12. Configuring ARM token...");

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -35,7 +35,6 @@ import {
   getNetworkConfig,
   getChainRole,
   getGovernanceDeploymentFile,
-  isLocal,
 } from "../config/networks";
 import { createNonceManager, rejectAnvilAddresses, saveDeployment } from "./deploy-utils";
 
@@ -272,20 +271,22 @@ async function main() {
   await (await timelock.grantRole(CANCELLER_ROLE, governorAddress, nm.override())).wait();
   console.log("   Granted CANCELLER_ROLE to governor (for SC veto)");
 
-  // Non-local: also grant the deployer the operational roles. The deploy + post-deploy ops
-  // pipeline (e.g. authorizing the YieldAdapter via AdapterRegistry) needs SOMEONE able to
-  // schedule + execute timelock actions, and on testnet the Governor is unusable for ops
-  // (requires ARM tokens, proposal threshold, quorum, voting period). Mainnet hardening
-  // should renounce these roles in a separate post-launch script once ops are stable.
-  // On local, Anvil impersonation covers ops and these grants are unnecessary noise.
-  if (!isLocal()) {
+  // Testnet only: grant the deployer the operational roles so the deploy + post-deploy ops
+  // pipeline (e.g. authorizing the YieldAdapter via AdapterRegistry) can schedule + execute
+  // timelock actions. The Governor is unusable for ops on testnet (requires ARM tokens,
+  // proposal threshold, quorum, voting period). Anvil covers this via impersonation; mainnet
+  // must NEVER take this branch — adding a mainnet value to DeployEnv must NOT silently
+  // grant operator roles to the deployer. The explicit allowlist below makes that invariant
+  // unmissable. Any future testnet env (goerli, holesky, base-sepolia-hub, …) is opt-in.
+  const TESTNET_OPS_ENVS: ReadonlyArray<string> = ["sepolia"];
+  if (TESTNET_OPS_ENVS.includes(config.env)) {
     const [deployerSigner] = await ethers.getSigners();
     await (await timelock.grantRole(PROPOSER_ROLE, deployerSigner.address, nm.override())).wait();
-    console.log("   Granted PROPOSER_ROLE to deployer (non-local ops)");
+    console.log(`   Granted PROPOSER_ROLE to deployer (${config.env} ops)`);
     await (await timelock.grantRole(EXECUTOR_ROLE, deployerSigner.address, nm.override())).wait();
-    console.log("   Granted EXECUTOR_ROLE to deployer (non-local ops)");
+    console.log(`   Granted EXECUTOR_ROLE to deployer (${config.env} ops)`);
     await (await timelock.grantRole(CANCELLER_ROLE, deployerSigner.address, nm.override())).wait();
-    console.log("   Granted CANCELLER_ROLE to deployer (non-local ops)");
+    console.log(`   Granted CANCELLER_ROLE to deployer (${config.env} ops)`);
   }
 
   // 12. Configure ARM token (one-time setters)

--- a/scripts/deploy_privacy_pool.ts
+++ b/scripts/deploy_privacy_pool.ts
@@ -224,10 +224,13 @@ async function deployHub(): Promise<HubDeploymentInfo> {
   const hookRouterAddress = await hookRouter.getAddress();
   console.log(`   CCTPHookRouter: ${hookRouterAddress}`);
 
-  // 9. Load verification keys for SNARK proof verification
+  // 9. Load verification keys for SNARK proof verification.
+  // Thread the nonce manager through so its N on-chain txs keep the counter in sync —
+  // omitting this leaves the manager N nonces behind once the load returns and the next
+  // override(...) call ends up with a stale nonce.
   console.log("\n9. Loading verification keys...");
   const { loadVerificationKeys, TESTING_ARTIFACT_CONFIGS } = await import("../lib/artifacts");
-  await loadVerificationKeys(privacyPool, TESTING_ARTIFACT_CONFIGS, true);
+  await loadVerificationKeys(privacyPool, TESTING_ARTIFACT_CONFIGS, true, () => nm.override());
 
   // 10. SNARK verification enabled
   console.log("\n10. SNARK verification enabled (testing mode disabled)");

--- a/scripts/deploy_sepolia.ts
+++ b/scripts/deploy_sepolia.ts
@@ -9,7 +9,10 @@
  *   Phase 2: Governance + Crowdfund (hub only)
  *   Phase 3: Privacy Pool (hub + clients) — must follow Phase 2 (needs treasury address from governance)
  *   Phase 4: Mock Aave + Yield (hub only) — must follow Phase 2 (needs adapter registry from governance)
- *   Phase 5: Cross-chain linking
+ *   Phase 5: Cross-chain linking — needs deployer to still own the YieldAdapter (setPrivacyPool)
+ *   Phase 6: Fee module + yield-ownership transfer to timelock — MUST follow Phase 5 because
+ *            deploy_fee_module.ts transfers adapter ownership at the end, after which Phase 5's
+ *            owner-gated adapter.setPrivacyPool() would revert.
  *
  * Prerequisites:
  *   - source config/sepolia.env
@@ -20,7 +23,7 @@
  *   npx ts-node scripts/deploy_sepolia.ts [--phase N] [--hub-only]
  *
  * Options:
- *   --phase N     Run only phase N (1-5)
+ *   --phase N     Run only phase N (1-6)
  *   --hub-only    Skip client chain deployments (Phase 1 hub only)
  */
 
@@ -139,9 +142,11 @@ async function main() {
     }
   }
 
-  // ========== Phase 4: Yield Infrastructure ==========
+  // ========== Phase 4: Yield Infrastructure (deploy only — no ownership transfer) ==========
   // Must follow Phase 2: deploy_yield.ts requires the governance manifest
-  // (needs AdapterRegistry address from governance deployment)
+  // (needs AdapterRegistry address from governance deployment).
+  // Fee module is deferred to Phase 6 because it transfers adapter ownership to the timelock
+  // and Phase 5's link script needs the deployer to still own the adapter.
   if (shouldRun(4)) {
     console.log("\n" + "#".repeat(60));
     console.log("  PHASE 4: Yield Infrastructure (Hub Only)");
@@ -155,13 +160,10 @@ async function main() {
       "npx hardhat run scripts/deploy_yield.ts --network sepoliaHub",
       "Deploying Yield Contracts"
     );
-    run(
-      "npx hardhat run scripts/deploy_fee_module.ts --network sepoliaHub",
-      "Deploying Fee Module"
-    );
   }
 
   // ========== Phase 5: Cross-Chain Linking ==========
+  // Calls adapter.setPrivacyPool() — requires deployer to still own the adapter.
   if (shouldRun(5)) {
     console.log("\n" + "#".repeat(60));
     console.log("  PHASE 5: Cross-Chain Linking");
@@ -170,6 +172,21 @@ async function main() {
     run(
       "npx hardhat run scripts/link_privacy_pool.ts --network sepoliaHub",
       "Linking Privacy Pools across chains"
+    );
+  }
+
+  // ========== Phase 6: Fee Module + ownership transfer ==========
+  // Runs after link so adapter ownership is still with the deployer when Phase 5 fires.
+  // deploy_fee_module.ts wires the fee module into PrivacyPool + YieldVault, then transfers
+  // yield ownership to the timelock as its final step.
+  if (shouldRun(6)) {
+    console.log("\n" + "#".repeat(60));
+    console.log("  PHASE 6: Fee Module + ownership transfer (Hub Only)");
+    console.log("#".repeat(60));
+
+    run(
+      "npx hardhat run scripts/deploy_fee_module.ts --network sepoliaHub",
+      "Deploying Fee Module"
     );
   }
 

--- a/scripts/link_privacy_pool.ts
+++ b/scripts/link_privacy_pool.ts
@@ -28,10 +28,9 @@ import {
   getPrivacyPoolDeploymentFile,
   getYieldDeploymentFile,
   isCCTPReal,
-  isLocal,
   type ChainRole,
 } from "../config/networks";
-import { createNonceManager, loadDeployment } from "./deploy-utils";
+import { createNonceManager, loadDeployment, timelockCall } from "./deploy-utils";
 
 interface LinkConfig {
   role: ChainRole;
@@ -286,62 +285,38 @@ async function main() {
     console.log("");
     console.log("Configuring ArmadaYieldAdapter...");
     const adapter = await ethers.getContractAt("ArmadaYieldAdapter", adapterAddress);
-    await (await adapter.setPrivacyPool(hubPoolAddress, nm.override())).wait();
-    console.log(`  Adapter privacy pool set to: ${hubPoolAddress}`);
+
+    // Idempotent: if the adapter is already pointing at this pool, skip the setter — the
+    // call would revert under "not owner" after Phase 6 transfers adapter ownership to the
+    // timelock, but the desired end-state is already in place so this is a clean no-op.
+    const currentPool: string = await adapter.privacyPool();
+    if (currentPool.toLowerCase() === hubPoolAddress.toLowerCase()) {
+      console.log(`  Adapter privacy pool already set to: ${hubPoolAddress} (skip)`);
+    } else {
+      await (await adapter.setPrivacyPool(hubPoolAddress, nm.override())).wait();
+      console.log(`  Adapter privacy pool set to: ${hubPoolAddress}`);
+    }
     await (await privacyPool.setPrivilegedShieldCaller(adapterAddress, true, nm.override())).wait();
     console.log(`  Adapter set as privileged shield caller (fee exemption)`);
 
-    // Authorize adapter in governance adapter registry
+    // Authorize adapter in governance adapter registry. Both local (Anvil impersonation)
+    // and non-local (real timelock schedule + wait + execute) paths are now handled inside
+    // timelockCall — see scripts/deploy-utils.ts. Non-local requires the deployer to hold
+    // PROPOSER_ROLE + EXECUTOR_ROLE on the timelock (granted in deploy_governance.ts).
     const govFilename = getGovernanceDeploymentFile();
     const govDeployment = loadDeployment(govFilename);
     if (govDeployment?.contracts?.adapterRegistry && govDeployment?.contracts?.timelockController) {
       const timelockAddr = govDeployment.contracts.timelockController;
       const registryAddr = govDeployment.contracts.adapterRegistry;
-
-      if (isLocal()) {
-        // Impersonate timelock to call authorizeAdapter directly (Anvil only).
-        // Hardhat's provider middleware intercepts eth_sendTransaction and tries to
-        // sign locally, so we bypass it entirely with raw JSON-RPC fetch to Anvil.
-        const rpcUrl = process.env.HUB_RPC || "http://localhost:8545";
-        const jsonRpc = async (method: string, params: any[] = []) => {
-          const res = await fetch(rpcUrl, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-          });
-          const json = await res.json();
-          if (json.error) throw new Error(`RPC ${method}: ${json.error.message}`);
-          return json.result;
-        };
-
-        // Fund the timelock so it can pay gas (must wait for mining before impersonated tx)
-        const [deployer] = await ethers.getSigners();
-        const fundTx = await deployer.sendTransaction({ to: timelockAddr, value: ethers.parseEther("1"), ...nm.override() });
-        await fundTx.wait();
-
-        const registry = await ethers.getContractAt("AdapterRegistry", registryAddr);
-        const calldata = registry.interface.encodeFunctionData("authorizeAdapter", [adapterAddress]);
-
-        await jsonRpc("anvil_impersonateAccount", [timelockAddr]);
-        const txHash = await jsonRpc("eth_sendTransaction", [{
-          from: timelockAddr,
-          to: registryAddr,
-          data: calldata,
-        }]);
-        // Poll for receipt since HardhatEthersProvider.waitForTransaction is not implemented
-        let receipt = null;
-        while (!receipt) {
-          receipt = await jsonRpc("eth_getTransactionReceipt", [txHash]);
-        }
-        await jsonRpc("anvil_stopImpersonatingAccount", [timelockAddr]);
-        console.log(`  Adapter authorized in adapter registry`);
-      } else {
-        console.log(`  WARNING: Adapter registry authorization requires a governance proposal on non-local networks.`);
-        console.log(`    Timelock: ${timelockAddr}`);
-        console.log(`    Registry: ${registryAddr}`);
-        console.log(`    Adapter:  ${adapterAddress}`);
-        console.log(`    Call: AdapterRegistry.authorizeAdapter(${adapterAddress})`);
-      }
+      const registry = await ethers.getContractAt("AdapterRegistry", registryAddr);
+      const calldata = registry.interface.encodeFunctionData("authorizeAdapter", [adapterAddress]);
+      await timelockCall(
+        timelockAddr,
+        registryAddr,
+        calldata,
+        "AdapterRegistry.authorizeAdapter()",
+        nm,
+      );
     }
   }
 

--- a/scripts/verify_deployment.ts
+++ b/scripts/verify_deployment.ts
@@ -25,6 +25,7 @@ import {
   getPrivacyPoolDeploymentFile,
   getGovernanceDeploymentFile,
   getYieldDeploymentFile,
+  getFeeModuleDeploymentFile,
   getCrowdfundDeploymentFile,
 } from "../config/networks";
 
@@ -706,7 +707,7 @@ async function main() {
   const yieldFile = getYieldDeploymentFile();
   const crowdfundFile = getCrowdfundDeploymentFile();
   const suffix = config.env === "local" ? "" : `-${config.env}Hub`;
-  const feeFile = config.env === "local" ? "fee-module-hub.json" : `fee-module-hub-${config.env}.json`;
+  const feeFile = getFeeModuleDeploymentFile();
 
   const hubCCTP = loadOrWarn("CCTP Wiring", hubCCTPFile);
   const hubPool = loadOrWarn("SNARK Verification", hubPoolFile);

--- a/scripts/verify_deployment.ts
+++ b/scripts/verify_deployment.ts
@@ -19,6 +19,7 @@ import { ethers } from "hardhat";
 import { loadDeployment } from "./deploy-utils";
 import {
   isLocal,
+  isCCTPReal,
   getNetworkConfig,
   getCCTPDeploymentFile,
   getPrivacyPoolDeploymentFile,
@@ -123,6 +124,15 @@ async function checkSnarkVerification(poolManifest: any) {
 
 async function checkCCTPWiring(hubCCTP: any) {
   const GROUP = "CCTP Wiring";
+
+  // Real Circle CCTP V2 contracts (CCTP_MODE=real) don't expose the mock-only `minters`
+  // mapping on USDC or the `tokenMessenger()` view on MessageTransmitter. The wiring is
+  // managed by Circle, not us, so there's nothing meaningful for this script to assert.
+  if (isCCTPReal()) {
+    pass(GROUP, "TokenMessenger ↔ USDC wiring (managed by Circle, real CCTP)");
+    pass(GROUP, "MessageTransmitter → TokenMessenger link (managed by Circle, real CCTP)");
+    return;
+  }
 
   const usdc = await ethers.getContractAt("MockUSDCV2", hubCCTP.contracts.usdc);
   const tokenMessengerAddr = hubCCTP.contracts.tokenMessenger;

--- a/scripts/verify_sepolia.ts
+++ b/scripts/verify_sepolia.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Verifies deployed Sepolia contracts on Etherscan using deployment manifests.
-// ABOUTME: Reads addresses and reconstructable constructor args from governance + crowdfund manifests.
+// ABOUTME: Chain-aware — hub verifies governance + crowdfund + privacy pool + yield + aave + fee module; clients verify their PrivacyPoolClient + CCTPHookRouter.
 
 /**
  * Verify Sepolia Contracts on Etherscan
@@ -7,17 +7,35 @@
  * Reads deployment manifests and reconstructs constructor arguments to verify
  * each contract. Requires ETHERSCAN_API_KEY in environment.
  *
- * Usage:
+ * Usage (run once per chain — same key works for all three explorers via Etherscan V2):
  *   source config/sepolia.env
  *   export ETHERSCAN_API_KEY=your_key_here
  *   npx hardhat run scripts/verify_sepolia.ts --network sepoliaHub
+ *   npx hardhat run scripts/verify_sepolia.ts --network sepoliaClientA   # Base Sepolia
+ *   npx hardhat run scripts/verify_sepolia.ts --network sepoliaClientB   # Arbitrum Sepolia
  *
  * Some contracts require values not stored in manifests (e.g. crowdfund openTimestamp).
  * These are read from the deployed contract on-chain where possible.
+ *
+ * Library-linked modules (MerkleModule, ShieldModule, TransactModule) are skipped — they
+ * depend on PoseidonT3/T4 library addresses that aren't captured in any deployment
+ * manifest. Verify them manually if needed:
+ *   npx hardhat verify --network sepoliaHub --libraries poseidon-libs.json <addr>
+ * The contract code is library-linked delegatecall so the PrivacyPool router (which IS
+ * verified) is the read-meaningful explorer surface.
  */
 
 import { ethers, run } from "hardhat";
-import { getNetworkConfig, getGovernanceDeploymentFile, getCrowdfundDeploymentFile } from "../config/networks";
+import {
+  getNetworkConfig,
+  getGovernanceDeploymentFile,
+  getCrowdfundDeploymentFile,
+  getPrivacyPoolDeploymentFile,
+  getYieldDeploymentFile,
+  getAaveMockDeploymentFile,
+  getFeeModuleDeploymentFile,
+  getCCTPDeploymentFile,
+} from "../config/networks";
 import { loadDeployment } from "./deploy-utils";
 
 interface VerifyTask {
@@ -47,15 +65,13 @@ async function verify(task: VerifyTask): Promise<boolean> {
   }
 }
 
-async function main() {
-  if (!process.env.ETHERSCAN_API_KEY) {
-    throw new Error("ETHERSCAN_API_KEY is required. Get one from https://etherscan.io/apis");
-  }
-
+/**
+ * Build governance + crowdfund tasks. Hub-only — clients don't deploy these.
+ */
+async function buildGovernanceCrowdfundTasks(): Promise<VerifyTask[]> {
   const config = getNetworkConfig();
   const gov = loadDeployment(getGovernanceDeploymentFile());
   const cf = loadDeployment(getCrowdfundDeploymentFile());
-
   if (!gov) throw new Error(`Governance manifest not found: ${getGovernanceDeploymentFile()}`);
   if (!cf) throw new Error(`Crowdfund manifest not found: ${getCrowdfundDeploymentFile()}`);
 
@@ -75,8 +91,7 @@ async function main() {
   const beneficiaryAddresses = beneficiaryConfig.map(b => b.address);
   const beneficiaryAmounts = beneficiaryConfig.map(b => ethers.parseUnits(b.amount, 18));
 
-  // Build verification tasks
-  const tasks: VerifyTask[] = [
+  return [
     // --- Governance contracts ---
     {
       name: "TimelockController",
@@ -189,9 +204,145 @@ async function main() {
       ],
     },
   ];
+}
 
-  // Run all verifications
-  console.log(`\n=== Verifying ${tasks.length} contracts on Sepolia Etherscan ===\n`);
+/**
+ * Build privacy-pool + yield + aave + fee-module tasks for the hub.
+ * Modules linked to Poseidon libraries (Merkle/Shield/Transact) are skipped because the
+ * library addresses aren't recorded in any manifest; the user-meaningful surface is the
+ * PrivacyPool router which IS verified.
+ */
+async function buildHubProtocolTasks(): Promise<VerifyTask[]> {
+  const pool = loadDeployment(getPrivacyPoolDeploymentFile("hub"));
+  const yieldD = loadDeployment(getYieldDeploymentFile());
+  const aave = loadDeployment(getAaveMockDeploymentFile("hub"));
+  const gov = loadDeployment(getGovernanceDeploymentFile());
+  const feeMod = loadDeployment(getFeeModuleDeploymentFile());
+  const cctp = loadDeployment(getCCTPDeploymentFile("hub"));
+
+  const tasks: VerifyTask[] = [];
+
+  if (pool?.contracts) {
+    const pc = pool.contracts;
+    tasks.push(
+      { name: "PrivacyPool (hub router)", address: pc.privacyPool, constructorArguments: [] },
+      { name: "VerifierModule", address: pc.verifierModule, constructorArguments: [] },
+      // hookRouter constructor: (messageTransmitter)
+      { name: "CCTPHookRouter (hub)", address: pc.hookRouter, constructorArguments: [pool.cctp.messageTransmitter] },
+    );
+  }
+
+  if (yieldD?.contracts && aave?.contracts && gov?.contracts && cctp?.contracts) {
+    const yc = yieldD.contracts;
+    const cfg = yieldD.config;
+    tasks.push(
+      // ArmadaYieldVault(mockAaveSpoke, reserveId, treasury, name, symbol)
+      {
+        name: "ArmadaYieldVault",
+        address: yc.armadaYieldVault,
+        constructorArguments: [
+          aave.contracts.mockAaveSpoke,
+          cfg.reserveId,
+          gov.contracts.treasury,
+          "Armada Yield USDC",
+          "ayUSDC",
+        ],
+      },
+      // ArmadaYieldAdapter(usdc, vault, adapterRegistry)
+      {
+        name: "ArmadaYieldAdapter",
+        address: yc.armadaYieldAdapter,
+        constructorArguments: [
+          cctp.contracts.usdc,
+          yc.armadaYieldVault,
+          gov.contracts.adapterRegistry,
+        ],
+      },
+    );
+  }
+
+  if (aave?.contracts) {
+    tasks.push({ name: "MockAaveSpoke", address: aave.contracts.mockAaveSpoke, constructorArguments: [] });
+  }
+
+  if (feeMod?.contracts && gov?.contracts && pool?.contracts && yieldD?.contracts) {
+    const ArmadaFeeModule = await ethers.getContractFactory("ArmadaFeeModule");
+    const initData = ArmadaFeeModule.interface.encodeFunctionData("initialize", [
+      gov.contracts.timelockController, // owner on non-local
+      gov.contracts.treasury,
+      pool.contracts.privacyPool,
+      yieldD.contracts.armadaYieldVault,
+    ]);
+    tasks.push(
+      { name: "ArmadaFeeModule (implementation)", address: feeMod.contracts.feeModuleImpl, constructorArguments: [] },
+      // ERC1967Proxy(implementation, data)
+      {
+        name: "ArmadaFeeModule (proxy)",
+        address: feeMod.contracts.feeModuleProxy,
+        constructorArguments: [feeMod.contracts.feeModuleImpl, initData],
+        contract: "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol:ERC1967Proxy",
+      },
+    );
+  }
+
+  return tasks;
+}
+
+/**
+ * Build PrivacyPoolClient + CCTPHookRouter tasks for a client chain.
+ * Loads the per-role manifest (clientA = Base Sepolia, clientB = Arbitrum Sepolia).
+ */
+async function buildClientChainTasks(role: "clientA" | "clientB"): Promise<VerifyTask[]> {
+  const client = loadDeployment(getPrivacyPoolDeploymentFile(role));
+  if (!client?.contracts) {
+    throw new Error(`PrivacyPoolClient manifest not found for role=${role}`);
+  }
+  const cc = client.contracts;
+  return [
+    { name: "PrivacyPoolClient", address: cc.privacyPoolClient, constructorArguments: [] },
+    // hookRouter constructor: (messageTransmitter)
+    { name: "CCTPHookRouter (client)", address: cc.hookRouter, constructorArguments: [client.cctp.messageTransmitter] },
+  ];
+}
+
+async function main() {
+  if (!process.env.ETHERSCAN_API_KEY) {
+    throw new Error("ETHERSCAN_API_KEY is required. Get one from https://etherscan.io/apis");
+  }
+
+  const network = await ethers.provider.getNetwork();
+  const chainId = Number(network.chainId);
+  const tasks: VerifyTask[] = [];
+  let label: string;
+
+  // Dispatch by chain id. Hub gets the full protocol stack; clients only their
+  // PrivacyPoolClient + CCTPHookRouter.
+  switch (chainId) {
+    case 11155111: // Ethereum Sepolia (hub)
+      label = "Sepolia (hub)";
+      tasks.push(...(await buildGovernanceCrowdfundTasks()));
+      tasks.push(...(await buildHubProtocolTasks()));
+      console.log(
+        "\nNote: MerkleModule, ShieldModule, TransactModule are skipped — they link to Poseidon\n" +
+        "libraries whose addresses aren't in the deployment manifest. The PrivacyPool router itself\n" +
+        "is verified, which is the user-facing explorer surface.",
+      );
+      break;
+    case 84532: // Base Sepolia (clientA)
+      label = "Base Sepolia (clientA)";
+      tasks.push(...(await buildClientChainTasks("clientA")));
+      break;
+    case 421614: // Arbitrum Sepolia (clientB)
+      label = "Arbitrum Sepolia (clientB)";
+      tasks.push(...(await buildClientChainTasks("clientB")));
+      break;
+    default:
+      throw new Error(
+        `Unsupported chain id ${chainId}. Run with --network sepoliaHub | sepoliaClientA | sepoliaClientB.`,
+      );
+  }
+
+  console.log(`\n=== Verifying ${tasks.length} contracts on ${label} Etherscan ===\n`);
 
   let passed = 0;
   let failed = 0;


### PR DESCRIPTION
## Summary

Hardening pass on the Sepolia deploy pipeline + a fresh, fully-verified deployment ("medi3").

**Deploy script fixes**
- Thread the nonce manager through `loadVerificationKeys` so the 5 on-chain VK loads don't leave the manager N nonces behind reality.
- Reorder `deploy_sepolia.ts`: fee module is now Phase 6 (after link), since it transfers YieldAdapter ownership to the timelock and the link script needs the deployer to still own the adapter.
- Implement real schedule + wait + execute in `timelockCall` for non-local. Previously it just warned and exited, silently skipping every timelock-gated configuration call (adapter authorization, wind-down wiring, revenue-counter fee-collector).
- Grant the deployer PROPOSER / EXECUTOR / CANCELLER roles on the timelock on non-local networks, so the above schedule + execute flow has the roles it needs. Mainnet hardening should renounce these in a separate post-launch step.
- Make `adapter.setPrivacyPool` idempotent in `link_privacy_pool.ts` so re-runs after Phase 6 (timelock-owned adapter) cleanly no-op.
- Canonical `getFeeModuleDeploymentFile()` helper — deploy was writing `fee-module-hub-sepoliaHub.json` (using `network.name`) while verify was reading `fee-module-hub-sepolia.json` (using `config.env`).
- `verify_deployment.ts` skips mock-CCTP checks under `CCTP_MODE=real` (real Circle USDC + MessageTransmitter don't expose the mock-only `minters()` / `tokenMessenger()` views).

**Live deployment**
- Sepolia manifests in `deployments/*-sepolia.json` updated to the medi3 addresses.
- Verify run is clean: 36 PASS, 0 FAIL, 3 WARN (all 3 are treasury-outflow configs explicitly deferred to a governance proposal per `deploy_governance.ts`).

## Test plan

- [x] Full `npm run setup:sepolia` end-to-end (all 6 phases) succeeded on a fresh deployer.
- [x] `npm run verify:sepolia` clean (no FAILs).
- [ ] Manual: shield → transfer-shielded → unshield-local round-trip against medi3 sepolia.
- [ ] Manual: unshield-xchain to Base Sepolia and Arbitrum Sepolia.
- [ ] Manual: yield deposit + withdraw (requires pre-funding MockAaveSpoke at `0x25844C20…BC33eFAd` with USDC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)