### PR TITLE
armada-interface: netlify deploy config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ config/secrets.env
 deployments/*.json
 !deployments/*-sepolia*.json
 
+# Build-time-fetched manifest copies (Netlify pulls these from armada-deployments
+# at build time per apps/armada-interface/netlify.toml; never commit them)
+apps/armada-interface/public/api/
+
 # ZK circuit artifacts (large binaries — download separately or build locally)
 usdc-v2-frontend/public/masp/
 *.params

--- a/apps/armada-interface/netlify.toml
+++ b/apps/armada-interface/netlify.toml
@@ -1,0 +1,58 @@
+# Netlify build config — armada-interface deploy.
+#
+# This file is picked up because the Netlify site is configured with
+# Base directory = "apps/armada-interface" in the UI. The committer app's
+# root-level netlify.toml is a separate Netlify site and isn't affected.
+#
+# Env vars set in the Netlify UI (not committed):
+#   VITE_WALLETCONNECT_PROJECT_ID  required for WalletConnect modal
+#   VITE_RELAYER_URL               public relayer endpoint when the VPS is live
+#                                  (omit until then — submit flows will error,
+#                                   but UI/flow review still works)
+#   DEPLOYMENT_INSTANCE            optional override; defaults to "demo1"
+#                                  (build-step variable only, no VITE_ prefix
+#                                   because it's never exposed to bundled JS)
+
+[build]
+  base    = "apps/armada-interface"
+  publish = "dist"
+  # Build flow:
+  #   1. cd to workspace root (npm needs the root package.json + lockfile)
+  #   2. clean any cached node_modules from a previous deploy attempt
+  #   3. install with --legacy-peer-deps (Railgun SDK peer-dep conflict)
+  #   4. fetch the selected deployment instance's manifests from the
+  #      armada-deployments repo and write them under public/api/deployments/
+  #      with the legacy filenames the interface fetches today
+  #   5. build the workspace
+  command = """
+    cd ../.. && \
+    rm -rf node_modules package-lock.json && \
+    npm install --legacy-peer-deps && \
+    cd apps/armada-interface && \
+    mkdir -p public/api/deployments && \
+    INSTANCE="${DEPLOYMENT_INSTANCE:-demo1}" && \
+    BASE="https://raw.githubusercontent.com/ship-armada/armada-deployments/main/testnet/${INSTANCE}" && \
+    echo "Fetching deployment manifests from instance: ${INSTANCE}" && \
+    curl -sfL -o public/api/deployments/hub-sepolia-v3.json               "${BASE}/sepolia/cctp.json" && \
+    curl -sfL -o public/api/deployments/client-sepolia-v3.json            "${BASE}/base-sepolia/cctp.json" && \
+    curl -sfL -o public/api/deployments/clientB-sepolia-v3.json           "${BASE}/arbitrum-sepolia/cctp.json" && \
+    curl -sfL -o public/api/deployments/privacy-pool-hub-sepolia.json     "${BASE}/sepolia/privacy-pool.json" && \
+    curl -sfL -o public/api/deployments/privacy-pool-client-sepolia.json  "${BASE}/base-sepolia/privacy-pool.json" && \
+    curl -sfL -o public/api/deployments/privacy-pool-clientB-sepolia.json "${BASE}/arbitrum-sepolia/privacy-pool.json" && \
+    curl -sfL -o public/api/deployments/yield-hub-sepolia.json            "${BASE}/sepolia/yield.json" && \
+    cd ../.. && \
+    npm run build --workspace=@armada/interface
+  """
+
+[build.environment]
+  NPM_FLAGS    = "--legacy-peer-deps"
+  NODE_VERSION = "20"
+  # Switches all network-dependent decisions in the app (manifest filename
+  # suffix, hub chain id + RPC, explorer URLs, poll cadence) to sepolia.
+  VITE_NETWORK = "sepolia"
+
+# SPA fallback — react-router serves /history, /settings, /debug, etc.
+[[redirects]]
+  from   = "/*"
+  to     = "/index.html"
+  status = 200


### PR DESCRIPTION
## Summary

Adds `apps/armada-interface/netlify.toml` so the interface can deploy to its own Netlify site without conflicting with the existing crowdfund-committer site (which uses the root-level `netlify.toml`).

## How the two sites coexist

| | Committer site | armada-interface site |
|---|---|---|
| Netlify "Base directory" | `.` | `apps/armada-interface` |
| Reads | root `netlify.toml` | `apps/armada-interface/netlify.toml` |
| Builds | `crowdfund-ui/packages/committer/dist` | `apps/armada-interface/dist` |

Netlify picks the toml inside the base directory. Two sites, two configs, zero collision.

## Build flow

1. `cd` to workspace root (npm needs the root `package.json` + lockfile)
2. `npm install --legacy-peer-deps` (Railgun SDK peer-dep)
3. Pull the selected deployment instance's manifests from the public [armada-deployments](https://github.com/ship-armada/armada-deployments) repo — defaults to `demo1`, switchable via `$DEPLOYMENT_INSTANCE` env var in the Netlify UI
4. Rename manifests into the legacy filenames the interface fetches at runtime (`privacy-pool-hub-sepolia.json` etc.) — keeps `src/config/deployments.ts` untouched
5. `npm run build --workspace=@armada/interface`

Manifest fetch was dry-run locally — all 7 files (3 CCTP, 3 privacy-pool, 1 yield) pull cleanly from `raw.githubusercontent.com/ship-armada/armada-deployments/main/testnet/demo1/`.

## Env vars to set in the Netlify UI

- `VITE_WALLETCONNECT_PROJECT_ID` — required for the WalletConnect modal
- `VITE_RELAYER_URL` — public relayer endpoint, once the VPS is live. Until then it falls back to `localhost:3001`, which means every submit Confirm errors out with "Could not fetch a current fee quote — please try again". Onboarding + navigation still work; UI/flow/copy review unblocked.
- `DEPLOYMENT_INSTANCE` (optional) — override the default `demo1`. Not `VITE_`-prefixed because it's a build-step variable, never exposed to bundled JS.

## Other changes

- `.gitignore` ignores `apps/armada-interface/public/api/` — the build-time-fetched manifest copies should never be committed.

## Test plan

- [x] Manifest URLs resolve and return real demo1 content (local dry-run).
- [ ] First Netlify deploy succeeds.
- [ ] Designer can open the deploy URL, navigate the app, complete onboarding.