### PR TITLE
deploy: capture privacy pool deploy block in manifest

### DIFF
--- a/scripts/deploy_privacy_pool.ts
+++ b/scripts/deploy_privacy_pool.ts
@@ -59,6 +59,11 @@ interface HubDeploymentInfo {
     messageTransmitter: string;
     usdc: string;
   };
+  /** Block number the PrivacyPool router contract was deployed at. Used by the
+   *  armada-interface to bound the Railgun engine's initial Shield/Transact/Unshield
+   *  event scan — without it the engine starts from block 0 and burns through ~10M
+   *  unnecessary getLogs calls on public RPCs. */
+  deployBlock: number;
   timestamp: string;
 }
 
@@ -79,6 +84,10 @@ interface ClientDeploymentInfo {
     domain: number;
     privacyPool: string;
   };
+  /** Block number the PrivacyPoolClient was deployed at. Less load-bearing than the
+   *  hub's deployBlock — clients don't host the Railgun merkletree — but useful for
+   *  any future tooling that scans client-chain events from the contract's birth. */
+  deployBlock: number;
   timestamp: string;
 }
 
@@ -174,9 +183,11 @@ async function deployHub(): Promise<HubDeploymentInfo> {
   console.log("\n6. Deploying PrivacyPool (router)...");
   const PrivacyPool = await ethers.getContractFactory("PrivacyPool");
   const privacyPool = await PrivacyPool.deploy(nm.override());
-  await privacyPool.deploymentTransaction()!.wait();
+  const privacyPoolReceipt = await privacyPool.deploymentTransaction()!.wait();
   const privacyPoolAddress = await privacyPool.getAddress();
-  console.log(`   PrivacyPool: ${privacyPoolAddress}`);
+  // Capture for the manifest — interface uses this to bound initial event scan.
+  const privacyPoolDeployBlock = privacyPoolReceipt!.blockNumber;
+  console.log(`   PrivacyPool: ${privacyPoolAddress} (block ${privacyPoolDeployBlock})`);
 
   // 7. Resolve treasury address and initialize PrivacyPool
   // Priority: env var > governance manifest (ArmadaTreasuryGov) > deployer (local only)
@@ -257,6 +268,7 @@ async function deployHub(): Promise<HubDeploymentInfo> {
       messageTransmitter: messageTransmitterAddress,
       usdc: usdcAddress,
     },
+    deployBlock: privacyPoolDeployBlock,
     timestamp: new Date().toISOString(),
   };
 
@@ -323,9 +335,10 @@ async function deployClient(role: ChainRole): Promise<ClientDeploymentInfo> {
   console.log("1. Deploying PrivacyPoolClient...");
   const PrivacyPoolClient = await ethers.getContractFactory("PrivacyPoolClient");
   const privacyPoolClient = await PrivacyPoolClient.deploy(nm.override());
-  await privacyPoolClient.deploymentTransaction()!.wait();
+  const clientReceipt = await privacyPoolClient.deploymentTransaction()!.wait();
   const clientAddress = await privacyPoolClient.getAddress();
-  console.log(`   PrivacyPoolClient: ${clientAddress}`);
+  const clientDeployBlock = clientReceipt!.blockNumber;
+  console.log(`   PrivacyPoolClient: ${clientAddress} (block ${clientDeployBlock})`);
 
   // 2. Initialize PrivacyPoolClient
   console.log("\n2. Initializing PrivacyPoolClient...");
@@ -367,6 +380,7 @@ async function deployClient(role: ChainRole): Promise<ClientDeploymentInfo> {
       domain: hubDomain,
       privacyPool: hubPoolAddress,
     },
+    deployBlock: clientDeployBlock,
     timestamp: new Date().toISOString(),
   };
 


### PR DESCRIPTION
## Summary

Records the `deployBlock` for `PrivacyPool` and `PrivacyPoolClient` deploys into their respective manifests (`privacy-pool-{hub,client,clientB}-*.json`). Captured directly from the deployment-tx receipt.

## Why

The Railgun engine's V2 event scanner uses a hardcoded per-chain start block (`ENGINE_V2_START_BLOCK_NUMBERS_EVM` in `@railgun-community/engine`). Sepolia (chainId 11155111) isn't in that table, so on a fresh wallet the engine falls through to block 0 and walks ~10M empty blocks of `eth_getLogs` before reaching anything relevant. On public RPCs that trips rate limits and the sync silently fails.

To fix it, the interface needs to know our deploy block at startup so it can monkey-patch the SDK's start-block constant before `startRailgunEngine` runs. This PR captures the data; the interface read happens in a follow-up PR.

## Follow-ups

- Manual: backfill `deployBlock` into the `demo1` manifests in `ship-armada/armada-deployments` (separate PR there).
- Interface PR: read the new field and patch `ENGINE_V2_START_BLOCK_NUMBERS_EVM` + thread `creationBlockNumbers` at wallet enroll.

## Test plan

- [ ] Next sepolia deploy emits manifests with `deployBlock: N` populated.
- [ ] Existing typecheck / hardhat compile pass (verified locally — no new errors).