### PR TITLE
armada-interface: sync polish — bounded initial scan + progress UI

### DIFF
--- a/apps/armada-interface/src/components/AppLayout.tsx
+++ b/apps/armada-interface/src/components/AppLayout.tsx
@@ -5,6 +5,7 @@ import { useState, type ReactNode } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { ArmadaLogo, NavBar, type NavBarItem } from '@armada/ui'
 import { WalletConnector } from './WalletConnector'
+import { SyncBanner } from './sync'
 
 const NAV: ReadonlyArray<{ label: string; path: string }> = [
   { label: 'Dashboard', path: '/' },
@@ -50,6 +51,9 @@ export function AppLayout({ children }: { children: ReactNode }) {
         className="flex flex-1 flex-col items-center justify-center"
         style={{ paddingTop: '7rem' }}
       >
+        <div className="w-full px-6">
+          <SyncBanner />
+        </div>
         {children}
       </main>
     </div>

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -7,6 +7,7 @@ import { openModalAtom } from '@/state/ui'
 import { shieldedUsdcAtom } from '@/state/wallet'
 import { useTx } from '@/hooks/useTx'
 import { useFees } from '@/hooks/useFees'
+import { useSpendableSyncGate } from '@/hooks/useSpendableSyncGate'
 import { getNetworkConfig } from '@/config/network'
 import {
   findDeploymentForChain,
@@ -58,6 +59,9 @@ export function SendModal() {
   const max = shieldedUsdc ?? 0n
   const amount = parseUsdcInput(amountStr)
   const { quote, isStale, refresh } = useFees()
+  // Gate Confirm while the initial shielded-balance sync is incomplete. Both Send tabs
+  // (private + external) spend the user's shielded USDC, so the same gate applies.
+  const syncGate = useSpendableSyncGate()
 
   // Deployment manifests — used to validate that the chosen destination chain actually has a
   // deployment present. Otherwise the user could pick a chain that the submit step would throw on.
@@ -207,6 +211,7 @@ export function SendModal() {
           fee={fee}
           netAmount={netAmount}
           isXchain={isXchain}
+          submitBlockedReason={syncGate.reason}
           onBack={() => setStep('input')}
           onConfirm={handleSubmit}
         />

--- a/apps/armada-interface/src/components/payments/SendReviewStep.module.css
+++ b/apps/armada-interface/src/components/payments/SendReviewStep.module.css
@@ -77,6 +77,14 @@
   font-family: "Geist Mono", monospace;
 }
 
+.syncNotice {
+  background: rgba(196, 145, 229, 0.08);
+  border: 1px solid var(--semantic-color-border-lavender);
+  border-radius: calc(var(--semantic-borderRadius-input) * 1px);
+  padding: var(--primitives-spacing-3) var(--primitives-spacing-4);
+  color: var(--semantic-color-text-secondary);
+}
+
 .footer {
   align-self: stretch;
   margin: var(--primitives-spacing-4) calc(var(--primitives-spacing-6) * -1) calc(var(--primitives-spacing-6) * -1);

--- a/apps/armada-interface/src/components/payments/SendReviewStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendReviewStep.tsx
@@ -17,6 +17,7 @@ export interface SendReviewStepProps {
   fee: bigint | null
   netAmount: bigint
   isXchain: boolean
+  submitBlockedReason?: string | null
   onBack: () => void
   onConfirm: () => void
 }
@@ -38,6 +39,7 @@ export function SendReviewStep({
   fee,
   netAmount,
   isXchain,
+  submitBlockedReason,
   onBack,
   onConfirm,
 }: SendReviewStepProps) {
@@ -73,9 +75,18 @@ export function SendReviewStep({
         </div>
       </dl>
       <FeeSummary fee={fee} netAmount={netAmount} netLabel="They'll receive" />
+      {submitBlockedReason ? (
+        <div className={styles.syncNotice} role="status" aria-live="polite">
+          {submitBlockedReason}
+        </div>
+      ) : null}
       <FlowFooter
         className={styles.footer}
-        primary={{ label: 'Confirm send', onClick: onConfirm }}
+        primary={{
+          label: 'Confirm send',
+          onClick: onConfirm,
+          disabled: Boolean(submitBlockedReason),
+        }}
         secondary={{ label: 'Back', onClick: onBack }}
       />
     </div>

--- a/apps/armada-interface/src/components/sync/SyncBanner.module.css
+++ b/apps/armada-interface/src/components/sync/SyncBanner.module.css
@@ -1,0 +1,50 @@
+/* ABOUTME: SyncBanner styling — slim full-width status strip with optional progress bar. */
+/* ABOUTME: Sits in the body content area, not inside the fixed header; flows above the page content. */
+
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--primitives-spacing-4);
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: var(--primitives-spacing-3) var(--primitives-spacing-4);
+  border-radius: calc(var(--semantic-borderRadius-input) * 1px);
+  border: 1px solid var(--semantic-color-border-default);
+}
+
+.syncing {
+  background: rgba(196, 145, 229, 0.08);
+  border-color: var(--semantic-color-border-lavender);
+  color: var(--semantic-color-text-secondary);
+}
+
+.failed {
+  background: rgba(248, 113, 113, 0.08);
+  border-color: rgba(248, 113, 113, 0.24);
+  color: var(--semantic-color-status-error);
+}
+
+.message {
+  flex: 1;
+  min-width: 0;
+}
+
+.progressTrack {
+  flex-shrink: 0;
+  display: block;
+  width: 120px;
+  height: 4px;
+  background: var(--semantic-color-border-default);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progressFill {
+  display: block;
+  height: 100%;
+  background: var(--semantic-color-text-lavender);
+  border-radius: 999px;
+  transition: width 200ms ease-out;
+}

--- a/apps/armada-interface/src/components/sync/SyncBanner.tsx
+++ b/apps/armada-interface/src/components/sync/SyncBanner.tsx
@@ -1,0 +1,52 @@
+// ABOUTME: Header banner that surfaces the Railgun engine's UTXO merkletree scan state.
+// ABOUTME: Hidden when sync is idle or complete; visible (with progress bar) while syncing or after a failure.
+
+import { useAtomValue } from 'jotai'
+import { syncStateAtom } from '@/state/wallet'
+import styles from './SyncBanner.module.css'
+
+/**
+ * Thin banner that appears below the app header during initial shielded-balance sync.
+ *
+ * - `syncing` → "Loading your private balance — N%. Subsequent visits will be much faster."
+ *   Includes a progress bar driven by the SDK's MerkletreeScanStatus progress value.
+ * - `failed` → "Sync interrupted. Reload to retry." with a manual retry CTA hint.
+ * - `idle` / `complete` → not rendered (banner area collapses to nothing).
+ *
+ * Reads syncStateAtom directly because it lives at the app-chrome layer (AppLayout renders it
+ * unconditionally). Per components/CLAUDE.md, atom reads at the chrome level are fine — the
+ * "no atoms in leaf components" rule targets reusable UI primitives, not app-shell pieces.
+ */
+export function SyncBanner() {
+  const sync = useAtomValue(syncStateAtom)
+
+  if (sync.status === 'idle' || sync.status === 'complete') return null
+
+  const pct = Math.round(Math.max(0, Math.min(1, sync.progress)) * 100)
+
+  if (sync.status === 'failed') {
+    return (
+      <div className={`${styles.banner} ${styles.failed}`} role="status" aria-live="polite">
+        <span className={styles.message}>Sync interrupted. Reload the page to retry.</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className={`${styles.banner} ${styles.syncing}`} role="status" aria-live="polite">
+      <span className={styles.message}>
+        Loading your private balance — {pct}%. Subsequent visits will be much faster.
+      </span>
+      <span
+        className={styles.progressTrack}
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Shielded balance sync progress"
+      >
+        <span className={styles.progressFill} style={{ width: `${pct}%` }} />
+      </span>
+    </div>
+  )
+}

--- a/apps/armada-interface/src/components/sync/index.ts
+++ b/apps/armada-interface/src/components/sync/index.ts
@@ -1,0 +1,2 @@
+// ABOUTME: Barrel export for the sync chrome (currently just SyncBanner).
+export { SyncBanner } from './SyncBanner'

--- a/apps/armada-interface/src/components/unshield/UnshieldModal.tsx
+++ b/apps/armada-interface/src/components/unshield/UnshieldModal.tsx
@@ -7,6 +7,7 @@ import { openModalAtom } from '@/state/ui'
 import { evmAddressAtom, shieldedUsdcAtom } from '@/state/wallet'
 import { useTx } from '@/hooks/useTx'
 import { useFees } from '@/hooks/useFees'
+import { useSpendableSyncGate } from '@/hooks/useSpendableSyncGate'
 import { getNetworkConfig } from '@/config/network'
 import { parseUsdcInput } from '@/lib/format'
 import { feeForKind } from '@/lib/relayer'
@@ -52,6 +53,10 @@ export function UnshieldModal() {
   const max = shieldedUsdc ?? 0n
   const amount = parseUsdcInput(amountStr)
   const { quote, isStale, refresh } = useFees()
+  // Gate Confirm while the initial shielded-balance sync is incomplete (or failed). Reading
+  // here so the Review step always reflects the current state — if sync completes while the
+  // user is on Review, the button un-disables on the next render.
+  const syncGate = useSpendableSyncGate()
 
   // Two hooks mounted; whichever kind we submit to gets a record. The other stays idle.
   const txLocal = useTx({ kind: 'unshield-local' })
@@ -169,6 +174,7 @@ export function UnshieldModal() {
           fee={fee}
           netAmount={netAmount}
           isXchain={computedKind === 'unshield-xchain'}
+          submitBlockedReason={syncGate.reason}
           onBack={() => setStep('input')}
           onConfirm={handleSubmit}
         />

--- a/apps/armada-interface/src/components/unshield/UnshieldReviewStep.module.css
+++ b/apps/armada-interface/src/components/unshield/UnshieldReviewStep.module.css
@@ -77,6 +77,14 @@
   font-family: "Geist Mono", monospace;
 }
 
+.syncNotice {
+  background: rgba(196, 145, 229, 0.08);
+  border: 1px solid var(--semantic-color-border-lavender);
+  border-radius: calc(var(--semantic-borderRadius-input) * 1px);
+  padding: var(--primitives-spacing-3) var(--primitives-spacing-4);
+  color: var(--semantic-color-text-secondary);
+}
+
 .footer {
   align-self: stretch;
   margin: var(--primitives-spacing-4) calc(var(--primitives-spacing-6) * -1) calc(var(--primitives-spacing-6) * -1);

--- a/apps/armada-interface/src/components/unshield/UnshieldReviewStep.tsx
+++ b/apps/armada-interface/src/components/unshield/UnshieldReviewStep.tsx
@@ -14,6 +14,9 @@ export interface UnshieldReviewStepProps {
   fee: bigint | null
   netAmount: bigint
   isXchain: boolean
+  /** When set, Confirm is disabled and the reason is shown inline. Used to gate the submit
+   *  while the shielded-balance sync is still in progress. */
+  submitBlockedReason?: string | null
   onBack: () => void
   onConfirm: () => void
 }
@@ -25,6 +28,7 @@ export function UnshieldReviewStep({
   fee,
   netAmount,
   isXchain,
+  submitBlockedReason,
   onBack,
   onConfirm,
 }: UnshieldReviewStepProps) {
@@ -52,9 +56,18 @@ export function UnshieldReviewStep({
         </div>
       </dl>
       <FeeSummary fee={fee} netAmount={netAmount} netLabel="You'll receive" />
+      {submitBlockedReason ? (
+        <div className={styles.syncNotice} role="status" aria-live="polite">
+          {submitBlockedReason}
+        </div>
+      ) : null}
       <FlowFooter
         className={styles.footer}
-        primary={{ label: 'Confirm withdrawal', onClick: onConfirm }}
+        primary={{
+          label: 'Confirm withdrawal',
+          onClick: onConfirm,
+          disabled: Boolean(submitBlockedReason),
+        }}
         secondary={{ label: 'Back', onClick: onBack }}
       />
     </div>

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -7,6 +7,7 @@ import { openModalAtom, type ModalKind } from '@/state/ui'
 import { shieldedUsdcAtom, yieldSharesAtom } from '@/state/wallet'
 import { useTx } from '@/hooks/useTx'
 import { useFees } from '@/hooks/useFees'
+import { useSpendableSyncGate } from '@/hooks/useSpendableSyncGate'
 import { useYieldRate } from '@/hooks/useYieldRate'
 import { parseUsdcInput } from '@/lib/format'
 import { feeForKind } from '@/lib/relayer'
@@ -53,6 +54,9 @@ export function EarnModal() {
 
   const amount = parseUsdcInput(amountStr)
   const { quote, isStale, refresh } = useFees()
+  // Yield ops spend the user's shielded USDC (deposit) or shielded yield shares (withdraw).
+  // Either way, we need a successful first sync before letting the user submit.
+  const syncGate = useSpendableSyncGate()
   // Both yield-deposit and yield-withdraw read from the relayer's crossContract fee bucket.
   // The FeeSummary panel renders the value; the handler doesn't deduct it on the wire today
   // (user-submitted path) but exposes it for awareness.
@@ -170,6 +174,7 @@ export function EarnModal() {
           rate={yieldRate}
           fee={fee}
           netAmount={netAmount}
+          submitBlockedReason={syncGate.reason}
           onBack={() => setStep('input')}
           onConfirm={handleSubmit}
         />

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.module.css
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.module.css
@@ -60,6 +60,14 @@
   color: var(--semantic-color-text-primary);
 }
 
+.syncNotice {
+  background: rgba(196, 145, 229, 0.08);
+  border: 1px solid var(--semantic-color-border-lavender);
+  border-radius: calc(var(--semantic-borderRadius-input) * 1px);
+  padding: var(--primitives-spacing-3) var(--primitives-spacing-4);
+  color: var(--semantic-color-text-secondary);
+}
+
 .footer {
   align-self: stretch;
   margin: var(--primitives-spacing-4) calc(var(--primitives-spacing-6) * -1) calc(var(--primitives-spacing-6) * -1);

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
@@ -15,6 +15,7 @@ export interface EarnReviewStepProps {
   rate: YieldRate | null
   fee: bigint | null
   netAmount: bigint
+  submitBlockedReason?: string | null
   onBack: () => void
   onConfirm: () => void
 }
@@ -32,6 +33,7 @@ export function EarnReviewStep({
   rate,
   fee,
   netAmount,
+  submitBlockedReason,
   onBack,
   onConfirm,
 }: EarnReviewStepProps) {
@@ -59,11 +61,17 @@ export function EarnReviewStep({
         netAmount={netAmount}
         netLabel={tab === 'add' ? "You'll be earning on" : "You'll receive"}
       />
+      {submitBlockedReason ? (
+        <div className={styles.syncNotice} role="status" aria-live="polite">
+          {submitBlockedReason}
+        </div>
+      ) : null}
       <FlowFooter
         className={styles.footer}
         primary={{
           label: tab === 'add' ? 'Confirm deposit' : 'Confirm withdrawal',
           onClick: onConfirm,
+          disabled: Boolean(submitBlockedReason),
         }}
         secondary={{ label: 'Back', onClick: onBack }}
       />

--- a/apps/armada-interface/src/config/deployments.ts
+++ b/apps/armada-interface/src/config/deployments.ts
@@ -21,6 +21,13 @@ export interface PrivacyPoolHubDeployment {
     messageTransmitter: string
     usdc: string
   }
+  /**
+   * Block number the PrivacyPool router was deployed at. Used to bound the Railgun engine's
+   * initial historical scan — without it the engine starts from block 0 (Sepolia isn't in the
+   * SDK's hardcoded start-block table) and burns hundreds of getLogs calls walking empty
+   * pre-deploy chain history. Optional for backward compat with older manifests.
+   */
+  deployBlock?: number
   timestamp: string
 }
 
@@ -42,6 +49,9 @@ export interface PrivacyPoolClientDeployment {
     domain: number
     privacyPool: string
   }
+  /** Block the PrivacyPoolClient was deployed at. Optional; not consumed today (the Railgun
+   *  engine only registers the hub chain), but kept on the type for parity + future use. */
+  deployBlock?: number
   timestamp: string
 }
 

--- a/apps/armada-interface/src/hooks/useSpendableSyncGate.ts
+++ b/apps/armada-interface/src/hooks/useSpendableSyncGate.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Gates spend-flow Confirm buttons while the shielded balance sync is incomplete.
+// ABOUTME: Returns { blocked, reason } — modals disable submit + show the reason as a tooltip.
+
+import { useAtomValue } from 'jotai'
+import { shieldedUsdcAtom, syncStateAtom } from '@/state/wallet'
+
+export interface SpendableSyncGate {
+  /** True when the user should not be allowed to submit a spend-flow tx yet. */
+  readonly blocked: boolean
+  /** User-facing explanation when blocked. Null when not blocked. */
+  readonly reason: string | null
+}
+
+/**
+ * Returns whether a "spend the user's shielded balance" flow can safely proceed.
+ *
+ * The Railgun engine runs an initial historical scan the first time a wallet is unlocked on
+ * a device — until that completes, `shieldedUsdcAtom` is null (we don't know the user's actual
+ * balance). Letting the user submit a transfer/unshield/yield-deposit/yield-withdraw against
+ * "null balance" is incoherent: they'd either submit zero amount (with a confusing error) or
+ * submit using the rate they typed in (overspending the not-yet-discovered UTXOs).
+ *
+ * Block only on first-sync conditions:
+ *   - status === 'syncing' AND shieldedUsdcAtom === null  → "wait for first sync"
+ *   - status === 'failed'                                 → "sync interrupted, reload"
+ *
+ * Don't block when:
+ *   - The wallet has already seen at least one successful scan (shieldedUsdcAtom !== null),
+ *     even if a background refresh is currently in flight. The user knows what they have.
+ *   - Shield flows: they don't depend on the shielded balance — they ADD to it. Modals
+ *     that wrap shield should NOT call this gate. (ShieldModal doesn't.)
+ */
+export function useSpendableSyncGate(): SpendableSyncGate {
+  const sync = useAtomValue(syncStateAtom)
+  const shielded = useAtomValue(shieldedUsdcAtom)
+
+  if (sync.status === 'failed') {
+    return {
+      blocked: true,
+      reason: 'Shielded-balance sync was interrupted. Reload the page to retry before submitting.',
+    }
+  }
+
+  if (sync.status === 'syncing' && shielded === null) {
+    return {
+      blocked: true,
+      reason: 'Loading your private balance — please wait for the initial sync to finish.',
+    }
+  }
+
+  return { blocked: false, reason: null }
+}

--- a/apps/armada-interface/src/lib/railgun/init.ts
+++ b/apps/armada-interface/src/lib/railgun/init.ts
@@ -9,8 +9,6 @@ import { getDefaultStore } from 'jotai'
 import { createWebDatabase } from './database'
 import { createBrowserArtifactStore } from './artifacts'
 import { initializeProver } from './prover'
-import { loadDeployments } from '@/config/deployments'
-import { trackError } from '@/lib/telemetry'
 import { syncStateAtom } from '@/state/wallet'
 
 const ENGINE_DB_NAME = 'armada-shielded'
@@ -125,18 +123,6 @@ async function doInit(): Promise<void> {
   const db = createWebDatabase(ENGINE_DB_NAME)
   const artifactStore = await createBrowserArtifactStore()
 
-  // Patch the engine's per-chain V2 start block to our PrivacyPool deploy block. The SDK's
-  // hardcoded ENGINE_V2_START_BLOCK_NUMBERS_EVM table only has entries for the legacy Railgun
-  // mainnet deploys; for any new chain (e.g. Sepolia 11155111) it falls through to 0 and the
-  // initial Shield/Transact/Unshield event scan walks the entire chain history (hundreds of
-  // empty getLogs chunks on public RPCs → rate-limited and sync fails silently). We read the
-  // deploy block from the manifest written by deploy_privacy_pool.ts (ship-armada/armada-poc#278)
-  // and mutate the SDK's mutable constants object before the first scan runs.
-  //
-  // Non-fatal on failure: if the deep import or the manifest read goes wrong, we leave the
-  // constant at 0. Sync will work — just slowly — and we'll see a telemetry error.
-  await patchEngineStartBlock()
-
   await startRailgunEngine(
     ENGINE_WALLET_SOURCE,
     db as never, // level-js export shape isn't typed; SDK accepts the leveldown-compatible API
@@ -198,51 +184,6 @@ async function doInit(): Promise<void> {
 
 export function isRailgunEngineInitialized(): boolean {
   return initialized
-}
-
-/**
- * Mutate the engine's per-chain V2 start-block constants so the initial scan starts at our
- * PrivacyPool deploy block instead of block 0. Idempotent — safe to call from doInit each time.
- *
- * Implementation note: the constant object lives at `@railgun-community/engine/dist/utils/constants`
- * and is not re-exported from the package's main entry. The deep import works under Vite + node
- * resolution today; if a future SDK version tightens its `exports` map and blocks this path, the
- * try/catch swallows the failure and sync falls back to scanning from block 0 (slower but correct).
- */
-async function patchEngineStartBlock(): Promise<void> {
-  try {
-    const deployments = await loadDeployments()
-    const chainId = deployments.hub.chainId
-    const deployBlock = deployments.hub.deployBlock
-    if (typeof deployBlock !== 'number' || deployBlock <= 0) {
-      // Manifest didn't include a deploy block (older deploys, or local mode). Skip.
-      return
-    }
-    // Deep import. The engine package restricts its `exports` field to the main entry, but
-    // tsc + Vite resolve filesystem paths inside node_modules without enforcing that field for
-    // legacy packages — so this Just Works at both compile time and runtime. The narrow cast
-    // captures the shape we depend on; a future SDK rewrite could break this and the try/catch
-    // around the whole function would surface a telemetry error.
-    type EngineConstants = {
-      ENGINE_V2_START_BLOCK_NUMBERS_EVM?: Record<number, number>
-      ENGINE_V2_SHIELD_EVENT_UPDATE_03_09_23_BLOCK_NUMBERS_EVM?: Record<number, number>
-    }
-    // @ts-expect-error - deep import; engine package's exports field hides this path from tsc
-    const constants = (await import('@railgun-community/engine/dist/utils/constants')) as EngineConstants
-    if (constants.ENGINE_V2_START_BLOCK_NUMBERS_EVM) {
-      constants.ENGINE_V2_START_BLOCK_NUMBERS_EVM[chainId] = deployBlock
-    }
-    if (constants.ENGINE_V2_SHIELD_EVENT_UPDATE_03_09_23_BLOCK_NUMBERS_EVM) {
-      // Our shield event uses the post-Mar-23 format (no legacy variant). Setting this to the
-      // same deploy block ensures the scanner never wastes time looking for legacy shield events.
-      constants.ENGINE_V2_SHIELD_EVENT_UPDATE_03_09_23_BLOCK_NUMBERS_EVM[chainId] = deployBlock
-    }
-  } catch (err) {
-    trackError('railgun.init.patchEngineStartBlock', err, {
-      scope: 'engine.init',
-      message: 'failed to patch engine V2 start block — sync will scan from block 0',
-    })
-  }
 }
 
 export function getRailgunInitError(): Error | null {

--- a/apps/armada-interface/src/lib/railgun/init.ts
+++ b/apps/armada-interface/src/lib/railgun/init.ts
@@ -5,9 +5,13 @@
 // module-load under jsdom. We `import()` at call time so test files that transitively pull
 // in this module don't blow up before any user code runs. Production cost: one extra microtask
 // the first time initRailgunEngine() runs.
+import { getDefaultStore } from 'jotai'
 import { createWebDatabase } from './database'
 import { createBrowserArtifactStore } from './artifacts'
 import { initializeProver } from './prover'
+import { loadDeployments } from '@/config/deployments'
+import { trackError } from '@/lib/telemetry'
+import { syncStateAtom } from '@/state/wallet'
 
 const ENGINE_DB_NAME = 'armada-shielded'
 const ENGINE_WALLET_SOURCE = 'armadainf' // ≤16 chars, lowercase, no special chars — SDK constraint
@@ -94,9 +98,14 @@ export async function initRailgunEngine(): Promise<void> {
 }
 
 async function doInit(): Promise<void> {
-  const [{ startRailgunEngine, setLoggers }, { POI }] = await Promise.all([
+  const [
+    { startRailgunEngine, setLoggers, setOnUTXOMerkletreeScanCallback },
+    { POI },
+    { MerkletreeScanStatus },
+  ] = await Promise.all([
     import('@railgun-community/wallet'),
     import('@railgun-community/engine'),
+    import('@railgun-community/shared-models'),
   ])
 
   // SDK logging — wire to console for v1, but never inside a function that handles secrets.
@@ -116,6 +125,18 @@ async function doInit(): Promise<void> {
   const db = createWebDatabase(ENGINE_DB_NAME)
   const artifactStore = await createBrowserArtifactStore()
 
+  // Patch the engine's per-chain V2 start block to our PrivacyPool deploy block. The SDK's
+  // hardcoded ENGINE_V2_START_BLOCK_NUMBERS_EVM table only has entries for the legacy Railgun
+  // mainnet deploys; for any new chain (e.g. Sepolia 11155111) it falls through to 0 and the
+  // initial Shield/Transact/Unshield event scan walks the entire chain history (hundreds of
+  // empty getLogs chunks on public RPCs → rate-limited and sync fails silently). We read the
+  // deploy block from the manifest written by deploy_privacy_pool.ts (ship-armada/armada-poc#278)
+  // and mutate the SDK's mutable constants object before the first scan runs.
+  //
+  // Non-fatal on failure: if the deep import or the manifest read goes wrong, we leave the
+  // constant at 0. Sync will work — just slowly — and we'll see a telemetry error.
+  await patchEngineStartBlock()
+
   await startRailgunEngine(
     ENGINE_WALLET_SOURCE,
     db as never, // level-js export shape isn't typed; SDK accepts the leveldown-compatible API
@@ -127,6 +148,28 @@ async function doInit(): Promise<void> {
     undefined, // customPOILists
     true, // verboseScanLogging
   )
+
+  // Wire SDK merkletree scan progress into syncStateAtom so the UI can show a banner +
+  // progress bar during the initial historical scan. The SDK emits one of four statuses;
+  // we map them to our SyncState shape. Progress is 0..1.
+  const store = getDefaultStore()
+  setOnUTXOMerkletreeScanCallback((event) => {
+    const { scanStatus, progress } = event
+    switch (scanStatus) {
+      case MerkletreeScanStatus.Started:
+        store.set(syncStateAtom, { status: 'syncing', progress: 0 })
+        break
+      case MerkletreeScanStatus.Updated:
+        store.set(syncStateAtom, { status: 'syncing', progress: progress ?? 0 })
+        break
+      case MerkletreeScanStatus.Complete:
+        store.set(syncStateAtom, { status: 'complete', progress: 1 })
+        break
+      case MerkletreeScanStatus.Incomplete:
+        store.set(syncStateAtom, { status: 'failed', progress: progress ?? 0 })
+        break
+    }
+  })
 
   // Wire snarkjs as the Groth16 prover implementation. Unshield / transfer proofs throw
   // "Requires groth16 full prover implementation" without this. Shield doesn't need it
@@ -155,6 +198,51 @@ async function doInit(): Promise<void> {
 
 export function isRailgunEngineInitialized(): boolean {
   return initialized
+}
+
+/**
+ * Mutate the engine's per-chain V2 start-block constants so the initial scan starts at our
+ * PrivacyPool deploy block instead of block 0. Idempotent — safe to call from doInit each time.
+ *
+ * Implementation note: the constant object lives at `@railgun-community/engine/dist/utils/constants`
+ * and is not re-exported from the package's main entry. The deep import works under Vite + node
+ * resolution today; if a future SDK version tightens its `exports` map and blocks this path, the
+ * try/catch swallows the failure and sync falls back to scanning from block 0 (slower but correct).
+ */
+async function patchEngineStartBlock(): Promise<void> {
+  try {
+    const deployments = await loadDeployments()
+    const chainId = deployments.hub.chainId
+    const deployBlock = deployments.hub.deployBlock
+    if (typeof deployBlock !== 'number' || deployBlock <= 0) {
+      // Manifest didn't include a deploy block (older deploys, or local mode). Skip.
+      return
+    }
+    // Deep import. The engine package restricts its `exports` field to the main entry, but
+    // tsc + Vite resolve filesystem paths inside node_modules without enforcing that field for
+    // legacy packages — so this Just Works at both compile time and runtime. The narrow cast
+    // captures the shape we depend on; a future SDK rewrite could break this and the try/catch
+    // around the whole function would surface a telemetry error.
+    type EngineConstants = {
+      ENGINE_V2_START_BLOCK_NUMBERS_EVM?: Record<number, number>
+      ENGINE_V2_SHIELD_EVENT_UPDATE_03_09_23_BLOCK_NUMBERS_EVM?: Record<number, number>
+    }
+    // @ts-expect-error - deep import; engine package's exports field hides this path from tsc
+    const constants = (await import('@railgun-community/engine/dist/utils/constants')) as EngineConstants
+    if (constants.ENGINE_V2_START_BLOCK_NUMBERS_EVM) {
+      constants.ENGINE_V2_START_BLOCK_NUMBERS_EVM[chainId] = deployBlock
+    }
+    if (constants.ENGINE_V2_SHIELD_EVENT_UPDATE_03_09_23_BLOCK_NUMBERS_EVM) {
+      // Our shield event uses the post-Mar-23 format (no legacy variant). Setting this to the
+      // same deploy block ensures the scanner never wastes time looking for legacy shield events.
+      constants.ENGINE_V2_SHIELD_EVENT_UPDATE_03_09_23_BLOCK_NUMBERS_EVM[chainId] = deployBlock
+    }
+  } catch (err) {
+    trackError('railgun.init.patchEngineStartBlock', err, {
+      scope: 'engine.init',
+      message: 'failed to patch engine V2 start block — sync will scan from block 0',
+    })
+  }
 }
 
 export function getRailgunInitError(): Error | null {

--- a/apps/armada-interface/src/lib/railgun/network.ts
+++ b/apps/armada-interface/src/lib/railgun/network.ts
@@ -31,11 +31,16 @@ function sdkPollIntervalMs(): number {
 }
 
 /**
- * Deployment block of our PrivacyPool — the SDK scans events from this block forward.
- * Local Anvil = 0 (full history is tiny); Sepolia = ~deployment block to avoid scanning millions
- * of empty blocks. Update when the Sepolia deployment moves.
+ * Sepolia fallback when the deployment manifest doesn't carry a `deployBlock` field (older
+ * manifests). Local Anvil = 0 (full history is tiny). This is purely defensive — the manifest
+ * value takes precedence whenever it's present.
+ *
+ * The SDK uses NETWORK_CONFIG.<name>.deploymentBlock to bound the initial historical scan in
+ * RailgunEngine.getStartScanningBlock — see node_modules/@railgun-community/engine/dist/
+ * railgun-engine.js. A stale or wrong value here means the SDK walks all blocks from the
+ * stored value to current head, which on a public RPC trips rate limits.
  */
-function deploymentBlock(): number {
+function fallbackDeploymentBlock(): number {
   return getNetworkConfig().mode === 'sepolia' ? 10_321_000 : 0
 }
 
@@ -46,6 +51,7 @@ function patchNetworkConfig(
   networkConfig: Record<string, Record<string, unknown>>,
   privacyPoolAddress: string,
   relayAdaptContract: string | undefined,
+  deployBlock: number,
 ): void {
   if (networkConfigPatched) return
 
@@ -57,7 +63,7 @@ function patchNetworkConfig(
   target.proxyContract = privacyPoolAddress
   target.relayAdaptContract = relayAdaptContract ?? ethers.ZeroAddress
   target.relayAdaptHistory = relayAdaptContract ? [relayAdaptContract] : ['']
-  target.deploymentBlock = deploymentBlock()
+  target.deploymentBlock = deployBlock
   target.poseidonMerkleAccumulatorV3Contract = ethers.ZeroAddress
   target.poseidonMerkleVerifierV3Contract = ethers.ZeroAddress
   target.tokenVaultV3Contract = ethers.ZeroAddress
@@ -104,10 +110,16 @@ export async function loadHubNetwork(): Promise<void> {
   // We don't currently surface a yield adapter through the new app's deployment schema; pass
   // ZeroAddress for the relayAdapt entry. When the Yield modal needs adapt-based proofs we'll
   // wire the address through deployments.ts and re-patch here.
+  //
+  // Deploy block: prefer the manifest field (recorded by deploy_privacy_pool.ts at deploy time),
+  // fall back to a hardcoded sepolia value for older manifests. The SDK reads this via
+  // NETWORK_CONFIG.<name>.deploymentBlock to bound the initial historical scan.
+  const deployBlock = deployments.hub.deployBlock ?? fallbackDeploymentBlock()
   patchNetworkConfig(
     NETWORK_CONFIG as unknown as Record<string, Record<string, unknown>>,
     privacyPool,
     undefined,
+    deployBlock,
   )
 
   // Sanity check: the configured RPC must respond with PrivacyPool bytecode at the expected

--- a/apps/armada-interface/src/lib/railgun/network.ts
+++ b/apps/armada-interface/src/lib/railgun/network.ts
@@ -159,3 +159,24 @@ export function resetNetworkLoaderState(): void {
 export function getHubChainDescriptor(): { type: 0; id: number } {
   return { type: 0, id: getNetworkConfig().hub.chainId }
 }
+
+/**
+ * Fetch the current block number on the hub chain. Used at wallet enroll to seed the
+ * Railgun SDK's `creationBlockNumbers` — tells the engine "this wallet didn't exist before
+ * block N, skip decryption attempts on commitments older than that."
+ *
+ * Spins up a one-shot JsonRpcProvider. Cheap; not worth caching since the result changes.
+ */
+export async function getCurrentHubBlock(): Promise<number | null> {
+  const hubChain = getNetworkConfig().hub
+  const primaryRpc = hubChain.rpcUrls[0]
+  if (!primaryRpc) return null
+  try {
+    const provider = new ethers.JsonRpcProvider(primaryRpc)
+    return await provider.getBlockNumber()
+  } catch {
+    // Non-fatal — wallet enroll proceeds without creationBlockNumbers, engine just does
+    // slightly more decryption work on the first scan. No correctness impact.
+    return null
+  }
+}

--- a/apps/armada-interface/src/lib/railgun/wallet.test.ts
+++ b/apps/armada-interface/src/lib/railgun/wallet.test.ts
@@ -26,6 +26,10 @@ vi.mock('./network', () => ({
   isHubNetworkLoaded: vi.fn(() => true),
   resetNetworkLoaderState: vi.fn(),
   getHubChainDescriptor: vi.fn(() => ({ type: 0 as const, id: 31337 })),
+  // Returns null so wallet.ts passes undefined to createRailgunWallet — same as the prior
+  // behavior before Phase 1.4 added creationBlockNumbers wiring. Tests don't exercise the
+  // creation-block side of things; that's a runtime optimization verified on testnet.
+  getCurrentHubBlock: vi.fn(async () => null),
 }))
 
 import {

--- a/apps/armada-interface/src/lib/railgun/wallet.ts
+++ b/apps/armada-interface/src/lib/railgun/wallet.ts
@@ -29,7 +29,7 @@ import {
   setUnlocked,
 } from './keyManager'
 import { initRailgunEngine } from './init'
-import { loadHubNetwork } from './network'
+import { getCurrentHubBlock, loadHubNetwork } from './network'
 
 /**
  * Ensure the Railgun engine is initialized + the hub network is loaded before issuing an SDK
@@ -371,12 +371,21 @@ async function createSdkWalletFromRoot(rootSecret: Uint8Array): Promise<{
 }> {
   const sdkEncryptionKey = deriveSdkEncryptionKeyHex(rootSecret)
   const mnemonic = deriveInternalMnemonic(rootSecret)
+  // creationBlockNumbers tells the engine "this wallet was created at block N, skip
+  // decryption attempts on commitments older than that". Best-effort: if the RPC read fails
+  // we pass undefined and the engine treats the wallet as having existed since chain genesis
+  // (slower first scan but correct).
+  //
+  // Important: keyed by SDK NetworkName, not chain id. We patch NETWORK_CONFIG.Hardhat to mean
+  // our hub chain (see lib/railgun/network.ts), so the key here is literally 'Hardhat'.
+  const currentBlock = await getCurrentHubBlock()
+  const creationBlockNumbers = currentBlock != null ? { Hardhat: currentBlock } : undefined
   try {
     const { createRailgunWallet } = await railgunSdk()
     const info = await createRailgunWallet(
       sdkEncryptionKey,
       mnemonic,
-      undefined, // creationBlockNumbers — fresh wallet, no historical scan range
+      creationBlockNumbers,
       0, // railgunWalletDerivationIndex — fixed at 0 for Phase 1 (one identity per spec)
     )
     return { walletId: info.id, railgunAddress: info.railgunAddress }

--- a/apps/armada-interface/src/state/wallet.ts
+++ b/apps/armada-interface/src/state/wallet.ts
@@ -52,3 +52,21 @@ export const yieldSharesAtom = atom<bigint | null>(null)
  * Written by `useAutoLock` on each arming/reset; read by Settings for the live countdown.
  */
 export const autoLockDeadlineAtom = atom<number | null>(null)
+
+/**
+ * Shielded balance sync state. Reflects the Railgun engine's UTXO merkletree scan progress.
+ *
+ *   idle      — no scan has been triggered yet (engine not running, or no wallet unlocked)
+ *   syncing   — a scan is in progress; `progress` runs 0..1
+ *   complete  — most recent scan finished successfully
+ *   failed    — the scan reported MerkletreeScanStatus.Incomplete (RPC failures, etc.)
+ *
+ * Written by the SDK's setOnUTXOMerkletreeScanCallback handler in lib/railgun/init.ts and
+ * consumed by the SyncBanner UI + per-modal "block submit while sync is incomplete" gates.
+ */
+export interface SyncState {
+  readonly status: 'idle' | 'syncing' | 'complete' | 'failed'
+  readonly progress: number
+}
+
+export const syncStateAtom = atom<SyncState>({ status: 'idle', progress: 0 })

--- a/apps/armada-interface/vite.config.ts
+++ b/apps/armada-interface/vite.config.ts
@@ -193,17 +193,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
-      // Deep-import alias for the Railgun engine's internal constants module. The engine
-      // package restricts its `exports` field to the main entry, so Vite's resolver rejects
-      // `import('@railgun-community/engine/dist/utils/constants')` at runtime. We need that
-      // module specifically to patch the per-chain V2 start block (see lib/railgun/init.ts —
-      // patchEngineStartBlock). Alias resolves the path directly via the filesystem and
-      // sidesteps the exports check. If a future SDK rewrite renames the file, the alias
-      // throws at build time — which is exactly when we want to be told.
-      '@railgun-community/engine/dist/utils/constants': path.resolve(
-        __dirname,
-        '../../node_modules/@railgun-community/engine/dist/utils/constants.js',
-      ),
     },
   },
   optimizeDeps: {

--- a/apps/armada-interface/vite.config.ts
+++ b/apps/armada-interface/vite.config.ts
@@ -193,6 +193,17 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
+      // Deep-import alias for the Railgun engine's internal constants module. The engine
+      // package restricts its `exports` field to the main entry, so Vite's resolver rejects
+      // `import('@railgun-community/engine/dist/utils/constants')` at runtime. We need that
+      // module specifically to patch the per-chain V2 start block (see lib/railgun/init.ts —
+      // patchEngineStartBlock). Alias resolves the path directly via the filesystem and
+      // sidesteps the exports check. If a future SDK rewrite renames the file, the alias
+      // throws at build time — which is exactly when we want to be told.
+      '@railgun-community/engine/dist/utils/constants': path.resolve(
+        __dirname,
+        '../../node_modules/@railgun-community/engine/dist/utils/constants.js',
+      ),
     },
   },
   optimizeDeps: {

--- a/apps/armada-interface/vitest.config.ts
+++ b/apps/armada-interface/vitest.config.ts
@@ -8,6 +8,13 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
+      // Mirror the deep-import alias from vite.config.ts so tests that pull in
+      // lib/railgun/init.ts can resolve the engine's internal constants module despite its
+      // restrictive exports field. (See comment in vite.config.ts for the full reasoning.)
+      '@railgun-community/engine/dist/utils/constants': path.resolve(
+        __dirname,
+        '../../node_modules/@railgun-community/engine/dist/utils/constants.js',
+      ),
     },
   },
   define: {

--- a/apps/armada-interface/vitest.config.ts
+++ b/apps/armada-interface/vitest.config.ts
@@ -8,13 +8,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
-      // Mirror the deep-import alias from vite.config.ts so tests that pull in
-      // lib/railgun/init.ts can resolve the engine's internal constants module despite its
-      // restrictive exports field. (See comment in vite.config.ts for the full reasoning.)
-      '@railgun-community/engine/dist/utils/constants': path.resolve(
-        __dirname,
-        '../../node_modules/@railgun-community/engine/dist/utils/constants.js',
-      ),
     },
   },
   define: {

--- a/deployments/privacy-pool-client-sepolia.json
+++ b/deployments/privacy-pool-client-sepolia.json
@@ -15,5 +15,6 @@
     "domain": 0,
     "privacyPool": "0x014aC1dfC2Bde83d4be2CFFb5bea4dE942DAD77F"
   },
+  "deployBlock": 41806838,
   "timestamp": "2026-05-21T16:46:06.441Z"
 }

--- a/deployments/privacy-pool-clientB-sepolia.json
+++ b/deployments/privacy-pool-clientB-sepolia.json
@@ -15,5 +15,6 @@
     "domain": 0,
     "privacyPool": "0x014aC1dfC2Bde83d4be2CFFb5bea4dE942DAD77F"
   },
+  "deployBlock": 269983413,
   "timestamp": "2026-05-21T16:46:13.060Z"
 }

--- a/deployments/privacy-pool-hub-sepolia.json
+++ b/deployments/privacy-pool-hub-sepolia.json
@@ -15,5 +15,6 @@
     "messageTransmitter": "0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275",
     "usdc": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
   },
+  "deployBlock": 10893598,
   "timestamp": "2026-05-21T16:46:00.788Z"
 }


### PR DESCRIPTION
## Summary

Three coordinated changes to make the shielded-balance sync usable on public RPCs and visible to the user.

### 1. Bound the initial chain scan to the deploy block

The Railgun engine's `ENGINE_V2_START_BLOCK_NUMBERS_EVM` table doesn't include Sepolia, so the initial event scan falls through to block 0 and burns ~1000 `getLogs` chunks walking pre-deploy chain history. On public RPCs this trips rate limits and the scan silently fails.

`lib/railgun/init.ts::patchEngineStartBlock` reads `deployBlock` from the privacy-pool manifest (recorded by #278 in this repo, backfilled for `demo1` in ship-armada/armada-deployments#3) and mutates the SDK's start-block constant before `startRailgunEngine` runs.

The constant lives in `@railgun-community/engine/dist/utils/constants` — a path the engine's restrictive `exports` field hides from Vite's runtime resolver. `resolve.alias` entries in `vite.config.ts` + `vitest.config.ts` point directly at the file inside `node_modules`. If a future SDK version moves it, the alias throws at build time.

**Estimated saving**: ~99% of getLogs calls on first sync (~1000 → ~5-10 on a freshly-deployed chain).

### 2. Pass `creationBlockNumbers` at enroll

Smaller complementary win. Tells the engine "this wallet didn't exist before block N, skip per-wallet decryption attempts on commitments older than that." Read via a new `getCurrentHubBlock()` helper in `lib/railgun/network.ts`. Best-effort: if the RPC read fails we pass undefined and fall back to the prior behavior.

### 3. Sync state in the UI

- **`syncStateAtom`** (`{ status, progress }`) driven by the SDK's `setOnUTXOMerkletreeScanCallback`.
- **`SyncBanner`** in the body chrome: shows during sync (0-100% progress bar) or after a failure (reload guidance). Hidden when idle/complete.
- **`useSpendableSyncGate()`** exposes `{ blocked, reason }` and is wired into the three spend-flow modals (Unshield, Send, Earn). When blocked, Confirm is disabled and an inline notice explains why. ShieldModal is intentionally NOT gated — shield adds to the shielded balance, doesn't spend it.

## Files

- `lib/railgun/init.ts` — engine start-block patch + scan-callback wiring
- `lib/railgun/network.ts` — `getCurrentHubBlock()` helper
- `lib/railgun/wallet.ts` — pass `creationBlockNumbers` at enroll
- `config/deployments.ts` — add optional `deployBlock` to manifest type
- `state/wallet.ts` — `syncStateAtom` + `SyncState` shape
- `hooks/useSpendableSyncGate.ts` — new
- `components/sync/SyncBanner.tsx` — new
- `components/AppLayout.tsx` — render the banner
- `components/{unshield,payments,yield}/{Modal,ReviewStep}.tsx` — gate threading
- `vite.config.ts` + `vitest.config.ts` — deep-import alias

## Test plan

- [x] `npm run typecheck --workspace=@armada/interface` clean
- [x] `npm run test --workspace=@armada/interface` — 460 tests passing
- [ ] Manual against demo1: open the app on a fresh browser profile, watch the SyncBanner go 0→100% in seconds (not minutes). Verify Confirm is disabled in spend modals during sync and re-enabled after.
- [ ] Spot-check on the deployed Netlify build with the demo1 manifests pulled at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)