### PR TITLE
armada-interface: auto-switch wallet network before user signatures

### DIFF
--- a/apps/armada-interface/src/features/shield/handler.ts
+++ b/apps/armada-interface/src/features/shield/handler.ts
@@ -22,6 +22,7 @@ import {
   deriveShieldPrivateKey,
   SHIELD_SIGNATURE_MESSAGE,
 } from '@/lib/railgun/shield'
+import { ensureChain } from '@/lib/network-switch'
 import { advance, markFailed } from '@/lib/tx/reducer'
 import type { StageHandler } from '@/lib/tx/executor'
 import type { TxRecord } from '@/lib/tx/types'
@@ -126,6 +127,12 @@ async function runBuildProof(
 
   if (ctx.signal.aborted) throw new Error('cancelled')
 
+  // Ensure the wallet is on the chain we're shielding FROM before any signature. Today the
+  // handler only supports hub-to-hub shield (so meta.fromChainId == hub); once cross-chain
+  // shield lands the same call will switch to the originating client chain instead.
+  await ensureChain(record.meta.fromChainId)
+  if (ctx.signal.aborted) throw new Error('cancelled')
+
   // Sign 'RAILGUN_SHIELD' through wagmi. The active wallet client = the user's MetaMask.
   // signMessage prompts the user; rejection bubbles up as a Viem error.
   const sigHex = await signMessage(wagmiConfig, { message: SHIELD_SIGNATURE_MESSAGE })
@@ -165,6 +172,10 @@ async function runSubmitAndConfirm(
   if (!shieldRequest || !privacyPoolAddress || !usdcAddress) {
     throw new Error('Shield artifacts missing — re-run build-proof stage.')
   }
+
+  // The user may have changed networks between build-proof and submit; re-assert here.
+  await ensureChain(record.meta.fromChainId)
+  if (ctx.signal.aborted) throw new Error('cancelled')
 
   // 1. Ensure USDC allowance. We use the connected wallet's address (looked up via wagmi's
   //    getAccount under writeContract's hood). readContract is synchronous-ish; signal-checked

--- a/apps/armada-interface/src/features/transfer-shielded/handler.ts
+++ b/apps/armada-interface/src/features/transfer-shielded/handler.ts
@@ -7,6 +7,8 @@ import {
 } from 'wagmi/actions'
 import { wagmiConfig } from '@/config/wagmi'
 import { loadDeployments } from '@/config/deployments'
+import { getNetworkConfig } from '@/config/network'
+import { ensureChain } from '@/lib/network-switch'
 import {
   getSdkEncryptionKey as kmGetSdkEncryptionKey,
   getWalletId as kmGetWalletId,
@@ -104,6 +106,10 @@ async function runSubmitAndConfirm(
     recipient: record.meta.recipient,
     amount: record.meta.amount,
   })
+  if (ctx.signal.aborted) throw new Error('cancelled')
+
+  // Hub-side transact() — ensure the wallet is on the hub before signing.
+  await ensureChain(getNetworkConfig().hub.chainId)
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   const hash = await sendTransaction(wagmiConfig, {

--- a/apps/armada-interface/src/features/unshield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/handler.ts
@@ -25,6 +25,7 @@ import {
   extractCctpMessageFromReceipt,
 } from '@/lib/cctp'
 import { fetchFees, feeForKind } from '@/lib/relayer'
+import { ensureChain } from '@/lib/network-switch'
 
 // MessageReceived event signature parsed for viem's typed log filter — accepts indexed-arg
 // filters via `args.nonce`. Mirrors the on-chain event verbatim (see contracts/cctp/MockCCTPV2.sol).
@@ -224,6 +225,12 @@ async function runSubmitAndBurn(
   // Review step shows the same fee to the user (via feeForKind on the cached quote).
   const feeQuote = await fetchFees()
   const maxFee = feeForKind(feeQuote, 'unshield-xchain')
+
+  // Hub-side atomicCrossChainUnshield() — the only user-signed leg of this flow. The
+  // destination-side receiveMessage is relayer-submitted, so we never need the user on the
+  // client chain.
+  await ensureChain(getNetworkConfig().hub.chainId)
+  if (ctx.signal.aborted) throw new Error('cancelled')
 
   const hash = await sendTransaction(wagmiConfig, {
     to: privacyPoolAddress as `0x${string}`,

--- a/apps/armada-interface/src/features/unshield/handler.ts
+++ b/apps/armada-interface/src/features/unshield/handler.ts
@@ -7,6 +7,8 @@ import {
 } from 'wagmi/actions'
 import { wagmiConfig } from '@/config/wagmi'
 import { loadDeployments } from '@/config/deployments'
+import { getNetworkConfig } from '@/config/network'
+import { ensureChain } from '@/lib/network-switch'
 import {
   getSdkEncryptionKey as kmGetSdkEncryptionKey,
   getWalletId as kmGetWalletId,
@@ -106,6 +108,10 @@ async function runSubmitAndConfirm(
     recipient: record.meta.recipient,
     amount: record.meta.amount,
   })
+  if (ctx.signal.aborted) throw new Error('cancelled')
+
+  // Hub-side transact() — ensure the wallet is on the hub before signing.
+  await ensureChain(getNetworkConfig().hub.chainId)
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   // Submit via the connected wallet. The populated `to` is the PrivacyPool address; `data` is

--- a/apps/armada-interface/src/features/yield-deposit/handler.ts
+++ b/apps/armada-interface/src/features/yield-deposit/handler.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/railgun/keyManager'
 import { refreshShieldedBalances } from '@/lib/railgun/sync'
 import { buildYieldAdaptTransaction } from '@/lib/railgun/yield'
+import { ensureChain } from '@/lib/network-switch'
 import { advance, markFailed } from '@/lib/tx/reducer'
 import { createProofProgressWriter } from '@/lib/tx/progress'
 import type { StageHandler } from '@/lib/tx/executor'
@@ -108,6 +109,10 @@ async function runSubmitAndConfirm(
   if (!yieldTx) {
     throw new Error('Yield adapt-proof tx missing — re-run build-proof stage.')
   }
+
+  // Adapter call lives on the hub.
+  await ensureChain(getNetworkConfig().hub.chainId)
+  if (ctx.signal.aborted) throw new Error('cancelled')
 
   const hash = await sendTransaction(wagmiConfig, {
     to: yieldTx.to,

--- a/apps/armada-interface/src/features/yield-withdraw/handler.ts
+++ b/apps/armada-interface/src/features/yield-withdraw/handler.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/railgun/keyManager'
 import { refreshShieldedBalances } from '@/lib/railgun/sync'
 import { buildYieldAdaptTransaction } from '@/lib/railgun/yield'
+import { ensureChain } from '@/lib/network-switch'
 import { advance, markFailed } from '@/lib/tx/reducer'
 import { createProofProgressWriter } from '@/lib/tx/progress'
 import type { StageHandler } from '@/lib/tx/executor'
@@ -104,6 +105,10 @@ async function runSubmitAndConfirm(
   if (!yieldTx) {
     throw new Error('Yield adapt-proof tx missing — re-run build-proof stage.')
   }
+
+  // Adapter call lives on the hub.
+  await ensureChain(getNetworkConfig().hub.chainId)
+  if (ctx.signal.aborted) throw new Error('cancelled')
 
   const hash = await sendTransaction(wagmiConfig, {
     to: yieldTx.to,

--- a/apps/armada-interface/src/lib/network-switch.test.ts
+++ b/apps/armada-interface/src/lib/network-switch.test.ts
@@ -1,0 +1,110 @@
+// ABOUTME: Unit tests for ensureChain — wallet network auto-switching before user signatures.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Hoisted mocks so `vi.mock` factories below can reference them.
+const { getAccountMock, switchChainMock } = vi.hoisted(() => ({
+  getAccountMock: vi.fn(),
+  switchChainMock: vi.fn(),
+}))
+
+vi.mock('wagmi/actions', () => ({
+  getAccount: getAccountMock,
+  switchChain: switchChainMock,
+}))
+
+vi.mock('@/config/wagmi', () => ({
+  wagmiConfig: { _mock: true },
+}))
+
+vi.mock('@/config/network', () => ({
+  getChainById: (id: number) => {
+    if (id === 11155111) return { chainId: 11155111, name: 'Ethereum Sepolia' }
+    if (id === 84532) return { chainId: 84532, name: 'Base Sepolia' }
+    return undefined
+  },
+}))
+
+import { ensureChain, _isUserRejection } from './network-switch'
+
+beforeEach(() => {
+  getAccountMock.mockReset()
+  switchChainMock.mockReset()
+})
+
+describe('ensureChain', () => {
+  it('no-ops when already on the target chain', async () => {
+    getAccountMock.mockReturnValue({ isConnected: true, chainId: 11155111 })
+    await ensureChain(11155111)
+    expect(switchChainMock).not.toHaveBeenCalled()
+  })
+
+  it('calls switchChain when on a different chain', async () => {
+    getAccountMock.mockReturnValue({ isConnected: true, chainId: 84532 })
+    switchChainMock.mockResolvedValueOnce(undefined)
+    await ensureChain(11155111)
+    expect(switchChainMock).toHaveBeenCalledWith({ _mock: true }, { chainId: 11155111 })
+  })
+
+  it('throws a friendly error when no wallet is connected', async () => {
+    getAccountMock.mockReturnValue({ isConnected: false, chainId: undefined })
+    await expect(ensureChain(11155111)).rejects.toThrow(/no wallet connected/i)
+    expect(switchChainMock).not.toHaveBeenCalled()
+  })
+
+  it('throws an actionable error when the user rejects the switch', async () => {
+    getAccountMock.mockReturnValue({ isConnected: true, chainId: 84532 })
+    const rejection = Object.assign(new Error('User rejected the request.'), { code: 4001 })
+    switchChainMock.mockRejectedValue(rejection)
+    // Two assertions = two invocations of ensureChain; use sticky mockRejectedValue (not Once).
+    await expect(ensureChain(11155111)).rejects.toThrow(/network switch declined/i)
+    await expect(ensureChain(11155111)).rejects.toThrow(/Ethereum Sepolia/)
+  })
+
+  it('wraps unknown switch errors with chain context', async () => {
+    getAccountMock.mockReturnValue({ isConnected: true, chainId: 84532 })
+    switchChainMock.mockRejectedValue(new Error('chain not configured'))
+    await expect(ensureChain(11155111)).rejects.toThrow(/Could not switch to Ethereum Sepolia/)
+    await expect(ensureChain(11155111)).rejects.toThrow(/chain not configured/)
+  })
+
+  it('falls back to a chain-id label when the chain is unknown to our config', async () => {
+    getAccountMock.mockReturnValue({ isConnected: true, chainId: 84532 })
+    switchChainMock.mockRejectedValue(Object.assign(new Error('rejected'), { code: 4001 }))
+    await expect(ensureChain(9999)).rejects.toThrow(/chain 9999/)
+  })
+})
+
+describe('isUserRejection', () => {
+  it('matches viem UserRejectedRequestError by name', () => {
+    expect(_isUserRejection({ name: 'UserRejectedRequestError', message: '' })).toBe(true)
+  })
+
+  it('matches code 4001 (MetaMask user rejection)', () => {
+    expect(_isUserRejection({ code: 4001, message: 'rejected' })).toBe(true)
+  })
+
+  it('matches ethers ACTION_REJECTED code', () => {
+    expect(_isUserRejection({ code: 'ACTION_REJECTED' })).toBe(true)
+  })
+
+  it('matches "User rejected/denied/cancelled" message patterns', () => {
+    expect(_isUserRejection(new Error('User rejected the request'))).toBe(true)
+    expect(_isUserRejection(new Error('User denied transaction'))).toBe(true)
+    expect(_isUserRejection(new Error('User cancelled'))).toBe(true)
+  })
+
+  it('recurses into the .cause chain (viem wraps provider errors)', () => {
+    const inner = Object.assign(new Error('rejected'), { code: 4001 })
+    const outer = new Error('Switch failed')
+    ;(outer as Error & { cause: unknown }).cause = inner
+    expect(_isUserRejection(outer)).toBe(true)
+  })
+
+  it('does NOT match unrelated errors', () => {
+    expect(_isUserRejection(new Error('network unreachable'))).toBe(false)
+    expect(_isUserRejection(new Error('insufficient funds'))).toBe(false)
+    expect(_isUserRejection(null)).toBe(false)
+    expect(_isUserRejection(undefined)).toBe(false)
+  })
+})

--- a/apps/armada-interface/src/lib/network-switch.ts
+++ b/apps/armada-interface/src/lib/network-switch.ts
@@ -1,0 +1,61 @@
+// ABOUTME: Ensures the connected wallet is on a specific chain before a user-signed transaction; prompts to switch otherwise.
+// ABOUTME: Called by tx handlers at their first user-signature point. Throws a friendly error on user rejection so the tx record carries actionable copy.
+
+import { getAccount, switchChain } from 'wagmi/actions'
+import { wagmiConfig } from '@/config/wagmi'
+import { getChainById } from '@/config/network'
+
+function chainLabel(chainId: number): string {
+  return getChainById(chainId)?.name ?? `chain ${chainId}`
+}
+
+/**
+ * Heuristic for user-rejected-request errors across wallet stacks. viem throws
+ * `UserRejectedRequestError` (code 4001). MetaMask sometimes surfaces it with code 4001 or as
+ * a plain Error with "User rejected" / "User denied" in the message. Cover all the common
+ * shapes — false positives here are harmless (we throw a friendlier message anyway).
+ */
+function isUserRejection(err: unknown): boolean {
+  if (!err) return false
+  const e = err as { code?: number | string; name?: string; message?: string; cause?: unknown }
+  if (e.code === 4001 || e.code === 'ACTION_REJECTED') return true
+  if (e.name === 'UserRejectedRequestError') return true
+  const msg = e.message ?? ''
+  if (/user (rejected|denied|cancelled)/i.test(msg)) return true
+  // viem wraps the underlying provider error in `.cause`; recurse one level.
+  if (e.cause && e.cause !== err) return isUserRejection(e.cause)
+  return false
+}
+
+/**
+ * Ensure the connected EVM wallet is on `targetChainId` before signing. No-op if already on
+ * the right chain. Otherwise prompts the user to switch (via wagmi → wallet → MetaMask) and
+ * waits for the switch to settle.
+ *
+ * Throws a friendly user-facing message on rejection or unknown wallet errors so the tx
+ * record's `error` field is actionable. Throws if no wallet is connected at all.
+ *
+ * Use at the top of each handler's first user-signed step. The handler's outer try/catch
+ * captures the thrown error and routes it into the tx record via `markFailed`.
+ */
+export async function ensureChain(targetChainId: number): Promise<void> {
+  const account = getAccount(wagmiConfig)
+  if (!account.isConnected) {
+    throw new Error('No wallet connected — connect a wallet before submitting a transaction.')
+  }
+  if (account.chainId === targetChainId) return
+  try {
+    await switchChain(wagmiConfig, { chainId: targetChainId })
+  } catch (err) {
+    if (isUserRejection(err)) {
+      throw new Error(
+        `Network switch declined. Approve the switch to ${chainLabel(targetChainId)} in your wallet and try again.`,
+      )
+    }
+    const msg = err instanceof Error ? err.message : 'unknown error'
+    throw new Error(`Could not switch to ${chainLabel(targetChainId)}: ${msg}`)
+  }
+}
+
+// Internal — exported for tests only. Do not import from app code.
+export { isUserRejection as _isUserRejection }


### PR DESCRIPTION
## Summary

Wraps user-signed RPC calls with `ensureChain(targetChainId)` so the wallet auto-switches to the right chain before any signature prompt. Removes the "MetaMask buried the network switcher; users get stuck on Wrong Network in the header" friction.

## Behaviour

- **Already on the target chain** → no-op, no prompt.
- **On a different supported chain** → wagmi's `switchChain` triggers MetaMask's switch prompt; we wait for it to settle.
- **User rejects the switch** → normalized to a friendly tx-record error: *"Network switch declined. Approve the switch to <chain name> in your wallet and try again."* — surfaced in the History row and ProgressStep.
- **No wallet connected** → throws *"No wallet connected — connect a wallet before submitting a transaction."*

## Call sites

| Handler | `ensureChain(…)` argument | Notes |
|---|---|---|
| shield (build-proof + submit) | `meta.fromChainId` | Today always = hub. Cross-chain shield (when it lands) will pass the client chain id and the helper Just Works. |
| unshield | `hub.chainId` | |
| unshield-xchain | `hub.chainId` | Hub burn is the only user-signed leg. Destination-side `receiveMessage` is relayer-submitted. |
| transfer-shielded | `hub.chainId` | |
| yield-deposit | `hub.chainId` | |
| yield-withdraw | `hub.chainId` | |

## Test coverage

`src/lib/network-switch.test.ts` — 12 tests:
- No-op when already on target chain
- Explicit `switchChain` call on mismatch
- No-wallet-connected → friendly throw
- User-rejection normalization (covers viem `UserRejectedRequestError`, MetaMask code 4001, ethers `ACTION_REJECTED`, plain message patterns, viem `.cause` chain recursion)
- Unknown errors wrapped with chain-name context
- Chain-id fallback label for chains outside our config

All 487 interface tests pass; typecheck clean.

## Why prototype-level switching rather than auto-switch on page load

The user may be browsing balances on Base/Arb Sepolia (we poll USDC on all three chains). Auto-switching on page load is hostile. Per-tx switching is the "just works" path with no surprise wallet activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)