### PR TITLE
fix(armada-interface): correct fee display for user-submitted tx flows

### DIFF
--- a/.claude/ARMADA_INTERFACE_POLISH.md
+++ b/.claude/ARMADA_INTERFACE_POLISH.md
@@ -66,7 +66,7 @@ _(no open items)_
 | Item | Size | Notes |
 |---|---|---|
 | `submitRelay()` HTTP client | M | `lib/relayer.ts::submitRelay` still throws. Needed for the relayer-mediated submit path that hides the second MetaMask prompt. The other endpoints (`fetchFees`, `pollStatus`) are wired. |
-| Shield-xchain fee display + relayer compensation | M | Tackle AFTER `submitRelay()` lands. Two tangled issues. **(a) Display bug:** the modal shows the relayer's hub-side gas cost (`feeForKind('shield-xchain')` in `lib/relayer.ts` returns `quote.fees.crossChainShield`) but the actual on-chain deduction is Iris's CCTP fast-transfer fee (~1–2 bps of amount, set independently of `maxFee`). User saw $1.45 quoted vs $0.02 deducted on Sepolia. Fix is to show a fast-fee estimate (`amount × 2 / 10000` or relayer-computed) and pass a proper bound as CCTP's `maxFee`. **(b) Architecture gap:** shield-xchain has no relayer-compensation path — the relayer pays hub-side `relayWithHook` gas out-of-pocket. Needs an explicit design decision (integrator slice? caller-deducted fee on hub side? subsidy is fine for POC but not production). |
+| Shield-xchain relayer compensation | M | Tackle alongside `submitRelay()` for hub-tx kinds. Today the relayer pays the hub-side `relayWithHook` gas out of pocket for shield-xchain — there's no integrator slice, no caller-deducted fee, no on-chain reimbursement path. Subsidy is fine for POC but not production. Needs an explicit design decision (integrator-slice via the unused `integrator` arg on `crossChainShield`? caller-deducted fee on the hub `shield()` entry? meta-tx style fee from the user's shielded balance?). Independent of the relayer-mediated submit path for hub `transact()` kinds. |
 
 ## Debug page
 

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -15,7 +15,7 @@ import {
   type ResolvedDeployments,
 } from '@/config/deployments'
 import { parseUsdcInput } from '@/lib/format'
-import { feeForKind } from '@/lib/relayer'
+import { userFeeForKind } from '@/lib/relayer'
 import {
   ActionFlowShell,
   ProgressStep,
@@ -96,11 +96,10 @@ export function SendModal() {
 
   const computedKind: SubmittedKind = computeKind(tab, destChainId, hubChainId)
   const isXchain = computedKind === 'unshield-xchain'
-  // Fee derives from the quote per the resolved kind. transfer-shielded + unshield-xchain
-  // carry meaningful quotes; unshield-local is informational today (user-submitted, no relayer
-  // leg) but exposed for parity.
-  const fee: bigint | null = quote ? feeForKind(quote, computedKind) : null
-  const netAmount = amount > 0n && fee !== null ? amount - fee : amount
+  // Display fee is a pure function of (kind, amount). transfer-shielded + unshield-local = 0
+  // (user submits via own wallet); unshield-xchain = CCTP fast-fee estimate (~2 bps).
+  const fee: bigint = userFeeForKind(computedKind, amount)
+  const netAmount = amount > fee ? amount - fee : 0n
 
   // Reset local state on close.
   useEffect(() => {

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -6,7 +6,7 @@ import { useAtom } from 'jotai'
 import { openModalAtom } from '@/state/ui'
 import { useTx } from '@/hooks/useTx'
 import { useFees } from '@/hooks/useFees'
-import { feeForKind } from '@/lib/relayer'
+import { userFeeForKind } from '@/lib/relayer'
 import { useBalances } from '@/hooks/useBalances'
 import { getNetworkConfig } from '@/config/network'
 import { parseUsdcInput } from '@/lib/format'
@@ -49,18 +49,17 @@ export function ShieldModal() {
   const max = balances.unshielded[fromChainId] ?? 0n
   const amount = parseUsdcInput(amountStr)
 
+  // useFees stays plumbed in for the relayer-submit path (need cacheId at submit time even
+  // though the display fee no longer comes from the quote).
   const { quote, isStale, refresh } = useFees()
-  // Fee derives from the resolved kind. shield = 0n (direct user submit, no relayer leg).
-  // shield-xchain = quoted relayer fee for the hub-side CCTP delivery.
+  // Display fee is a pure function of (kind, amount). Today shield = 0 (user pays own gas),
+  // shield-xchain = CCTP fast-fee estimate (~2 bps of amount).
   const computedKind: SubmittedKind = computeKind(fromChainId, hubChainId)
-  const fee: bigint | null = quote ? feeForKind(quote, computedKind) : null
-  // Floor at 0 — when amount < fee (e.g. user typed 1 USDC but cross-chain fee is 1.10) the raw
-  // subtraction would render as a negative figure in the FeeSummary. The contract enforces
-  // `maxFee < amount` and rejects on-chain anyway; clamping just keeps the UI honest until the
-  // user types a viable amount.
-  const netAmount = amount > 0n && fee !== null
-    ? (amount > fee ? amount - fee : 0n)
-    : amount
+  const fee: bigint = userFeeForKind(computedKind, amount)
+  // Floor at 0 — when amount < fee (e.g. user typed a value smaller than the CCTP fee) the raw
+  // subtraction would render as a negative figure in the FeeSummary. The contract rejects
+  // on-chain anyway; clamping just keeps the UI honest until the user types a viable amount.
+  const netAmount = amount > fee ? amount - fee : 0n
 
   // Two useTx hooks mounted; only one gets a record per flow. Pattern mirrors SendModal +
   // UnshieldModal where same-chain vs cross-chain are sibling kinds.

--- a/apps/armada-interface/src/components/ui/FeeSummary/FeeSummary.module.css
+++ b/apps/armada-interface/src/components/ui/FeeSummary/FeeSummary.module.css
@@ -48,6 +48,10 @@
   font-style: italic;
 }
 
+.zeroFee {
+  color: var(--semantic-color-text-muted);
+}
+
 .refresh {
   color: var(--semantic-color-text-dim);
 }

--- a/apps/armada-interface/src/components/ui/FeeSummary/FeeSummary.test.tsx
+++ b/apps/armada-interface/src/components/ui/FeeSummary/FeeSummary.test.tsx
@@ -35,10 +35,21 @@ describe('<FeeSummary>', () => {
     expect(screen.getByText("You'll deposit")).toBeInTheDocument()
   })
 
-  it('shows the refresh hint only when fee is non-null and isRefreshing is true', () => {
+  it('shows the refresh hint only when fee is non-null, non-zero, and isRefreshing is true', () => {
     const { rerender } = render(<FeeSummary fee={null} netAmount={0n} isRefreshing />)
     expect(screen.queryByText(/refreshing/)).toBeNull() // null fee → loading wins
+    rerender(<FeeSummary fee={0n} netAmount={0n} isRefreshing />)
+    expect(screen.queryByText(/refreshing/)).toBeNull() // zero fee → "No fee" wins; refresh hint is irrelevant
     rerender(<FeeSummary fee={1_000n} netAmount={0n} isRefreshing />)
     expect(screen.getByText(/refreshing/)).toBeInTheDocument()
+  })
+
+  it('renders "No fee" instead of a 0.00 USDC line when fee is exactly zero', () => {
+    // Many of today's flows (shield, unshield-local, transfer-shielded, yield ops) charge no
+    // USDC fee — the user pays gas in native via their wallet. "No fee" reads cleaner than
+    // "Fee: 0.00 USDC", which suggests a fee is being computed but happens to round to zero.
+    render(<FeeSummary fee={0n} netAmount={100_000_000n} />)
+    expect(screen.getByText('No fee')).toBeInTheDocument()
+    expect(screen.queryByText(/0\.00 USDC/)).toBeNull()
   })
 })

--- a/apps/armada-interface/src/components/ui/FeeSummary/FeeSummary.tsx
+++ b/apps/armada-interface/src/components/ui/FeeSummary/FeeSummary.tsx
@@ -34,12 +34,14 @@ export function FeeSummary({
         <dd className={styles.value}>
           {fee === null ? (
             <span className={styles.loading}>Loading…</span>
+          ) : fee === 0n ? (
+            <span className={styles.zeroFee}>No fee</span>
           ) : (
             <>
               {formatUsdcAmount(fee)} <span className={styles.unit}>USDC</span>
             </>
           )}
-          {isRefreshing && fee !== null ? (
+          {isRefreshing && fee !== null && fee !== 0n ? (
             <span className={styles.refresh}> (refreshing)</span>
           ) : null}
         </dd>

--- a/apps/armada-interface/src/components/unshield/UnshieldModal.tsx
+++ b/apps/armada-interface/src/components/unshield/UnshieldModal.tsx
@@ -10,7 +10,7 @@ import { useFees } from '@/hooks/useFees'
 import { useSpendableSyncGate } from '@/hooks/useSpendableSyncGate'
 import { getNetworkConfig } from '@/config/network'
 import { parseUsdcInput } from '@/lib/format'
-import { feeForKind } from '@/lib/relayer'
+import { userFeeForKind } from '@/lib/relayer'
 import {
   ActionFlowShell,
   ProgressStep,
@@ -65,11 +65,10 @@ export function UnshieldModal() {
   const record = activeTx?.record ?? null
 
   const computedKind: SubmittedKind = destChainId === hubChainId ? 'unshield-local' : 'unshield-xchain'
-  // Fee comes from the relayer's schedule per the resolved kind. Both unshield variants have
-  // a quoted fee; xchain enforces it on-chain as `maxFee`, local is informational today (user
-  // submits the tx themselves with no relayer leg).
-  const fee: bigint | null = quote ? feeForKind(quote, computedKind) : null
-  const netAmount = amount > 0n && fee !== null ? amount - fee : amount
+  // Display fee is a pure function of (kind, amount). unshield-local = 0 (user submits via own
+  // wallet, gas paid in native); unshield-xchain = CCTP fast-fee estimate (~2 bps).
+  const fee: bigint = userFeeForKind(computedKind, amount)
+  const netAmount = amount > fee ? amount - fee : 0n
 
   // Pre-fill recipient from the connected EVM wallet on the modal's rising edge only,
   // so the user can clear the field afterwards without it getting repopulated.

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -10,7 +10,7 @@ import { useFees } from '@/hooks/useFees'
 import { useSpendableSyncGate } from '@/hooks/useSpendableSyncGate'
 import { useYieldRate } from '@/hooks/useYieldRate'
 import { parseUsdcInput } from '@/lib/format'
-import { feeForKind } from '@/lib/relayer'
+import { userFeeForKind } from '@/lib/relayer'
 import { sharesToUsdc } from '@/lib/yield'
 import {
   ActionFlowShell,
@@ -57,12 +57,10 @@ export function EarnModal() {
   // Yield ops spend the user's shielded USDC (deposit) or shielded yield shares (withdraw).
   // Either way, we need a successful first sync before letting the user submit.
   const syncGate = useSpendableSyncGate()
-  // Both yield-deposit and yield-withdraw read from the relayer's crossContract fee bucket.
-  // The FeeSummary panel renders the value; the handler doesn't deduct it on the wire today
-  // (user-submitted path) but exposes it for awareness.
+  // Display fee for yield ops is 0 today — user submits via own wallet, no relayer leg.
   const yieldKind: 'yield-deposit' | 'yield-withdraw' = tab === 'add' ? 'yield-deposit' : 'yield-withdraw'
-  const fee: bigint | null = quote ? feeForKind(quote, yieldKind) : null
-  const netAmount = amount > 0n && fee !== null ? amount - fee : amount
+  const fee: bigint = userFeeForKind(yieldKind, amount)
+  const netAmount = amount > fee ? amount - fee : 0n
 
   // Two useTx hooks; only one gets a record per flow.
   const txDeposit = useTx({ kind: 'yield-deposit' })

--- a/apps/armada-interface/src/features/shield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/shield-xchain/handler.ts
@@ -27,7 +27,7 @@ import {
   SHIELD_SIGNATURE_MESSAGE,
 } from '@/lib/railgun/shield'
 import { extractCctpMessageFromReceipt } from '@/lib/cctp'
-import { fetchFees, feeForKind } from '@/lib/relayer'
+import { cctpMaxFeeForKind } from '@/lib/relayer'
 import { ensureChain } from '@/lib/network-switch'
 import { advance, markFailed, markWaiting, patchArtifacts } from '@/lib/tx/reducer'
 import { poll } from '@/lib/tx/poller'
@@ -232,11 +232,11 @@ async function runSubmitAndBurn(
     ? pad(hubHookRouter as `0x${string}`, { size: 32 })
     : `0x${'00'.repeat(32)}` as `0x${string}`
 
-  // 3. maxFee = relayer's quoted cross-chain shield fee, deducted at the CCTP layer from the
-  //    amount minted on the hub. Refetch at submit time so a stale modal doesn't bake in an
-  //    expired quote (same pattern as the inverse-direction handler).
-  const feeQuote = await fetchFees()
-  const maxFee = feeForKind(feeQuote, 'shield-xchain')
+  // 3. maxFee = upper bound CCTP's MessageTransmitter accepts for `feeExecuted`. Iris sets the
+  //    actual fee (1–1.3 bps depending on chain); we pass 2× the realistic estimate as headroom.
+  //    Computed locally from amount, no relayer round-trip needed (the relayer's gas-cost quote
+  //    isn't the relevant value here; CCTP's fast-transfer fee is independent of relayer ops).
+  const maxFee = cctpMaxFeeForKind('shield-xchain', record.meta.amount)
 
   // 4. minFinalityThreshold = FAST (1000) when env says fast mode (Sepolia testing), else 0 which
   //    the contract resolves to STANDARD as the safe default. CCTPHookRouter on the hub knows

--- a/apps/armada-interface/src/features/unshield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/handler.ts
@@ -24,7 +24,7 @@ import {
 import {
   extractCctpMessageFromReceipt,
 } from '@/lib/cctp'
-import { fetchFees, feeForKind } from '@/lib/relayer'
+import { cctpMaxFeeForKind } from '@/lib/relayer'
 import { ensureChain } from '@/lib/network-switch'
 
 // MessageReceived event signature parsed for viem's typed log filter — accepts indexed-arg
@@ -219,12 +219,12 @@ async function runSubmitAndBurn(
     ? pad(destHookRouter as `0x${string}`, { size: 32 })
     : `0x${'00'.repeat(32)}` as `0x${string}`
 
-  // maxFee = the relayer's quoted CCTP delivery fee. We re-fetch at submit time so the value
-  // is fresh; the relayer enforces a minimum and skips messages below it. Fee is deducted from
-  // the amount minted on the destination — recipient receives (amount − maxFee). The modal's
-  // Review step shows the same fee to the user (via feeForKind on the cached quote).
-  const feeQuote = await fetchFees()
-  const maxFee = feeForKind(feeQuote, 'unshield-xchain')
+  // maxFee = upper bound CCTP's MessageTransmitter accepts for `feeExecuted`. Iris sets the
+  // actual fee (1–1.3 bps depending on chain); we pass 2× the realistic estimate as headroom.
+  // Fee is deducted from the amount minted on the destination — recipient receives
+  // (amount − feeExecuted). The modal's Review step shows `userFeeForKind` (without the bound
+  // multiplier) so the user sees what they will actually pay, not the contract bound.
+  const maxFee = cctpMaxFeeForKind('unshield-xchain', record.meta.amount)
 
   // Hub-side atomicCrossChainUnshield() — the only user-signed leg of this flow. The
   // destination-side receiveMessage is relayer-submitted, so we never need the user on the

--- a/apps/armada-interface/src/lib/relayer.test.ts
+++ b/apps/armada-interface/src/lib/relayer.test.ts
@@ -1,0 +1,61 @@
+// ABOUTME: Tests for userFeeForKind + cctpMaxFeeForKind — the pure fee-resolution helpers consumed by modals (display) and xchain handlers (CCTP maxFee bound).
+
+import { describe, it, expect } from 'vitest'
+import { userFeeForKind, cctpMaxFeeForKind } from './relayer'
+
+const ONE_USDC = 1_000_000n // 6 decimals
+const HUNDRED_USDC = 100n * ONE_USDC
+
+describe('userFeeForKind', () => {
+  it.each([
+    ['shield'],
+    ['unshield-local'],
+    ['transfer-shielded'],
+    ['yield-deposit'],
+    ['yield-withdraw'],
+  ] as const)('returns 0n for %s (user pays own gas, no USDC deduction)', (kind) => {
+    expect(userFeeForKind(kind, HUNDRED_USDC)).toBe(0n)
+  })
+
+  it('returns CCTP fast-fee (2 bps of amount) for shield-xchain', () => {
+    // 2 bps of 100 USDC = 0.02 USDC = 20_000 raw
+    expect(userFeeForKind('shield-xchain', HUNDRED_USDC)).toBe(20_000n)
+  })
+
+  it('returns CCTP fast-fee (2 bps of amount) for unshield-xchain', () => {
+    expect(userFeeForKind('unshield-xchain', HUNDRED_USDC)).toBe(20_000n)
+  })
+
+  it('rounds toward zero for small amounts (bigint integer division)', () => {
+    // 2 bps of 1 USDC = 200 raw → no rounding issue here
+    expect(userFeeForKind('shield-xchain', ONE_USDC)).toBe(200n)
+    // 2 bps of 4999 raw = 9999 / 10000 = 0 (rounds down)
+    expect(userFeeForKind('shield-xchain', 4_999n)).toBe(0n)
+    // 2 bps of 5000 raw = 10000 / 10000 = 1
+    expect(userFeeForKind('shield-xchain', 5_000n)).toBe(1n)
+  })
+
+  it('returns 0n when amount is 0n for cctp kinds (no rejection, just nothing to fee)', () => {
+    expect(userFeeForKind('shield-xchain', 0n)).toBe(0n)
+    expect(userFeeForKind('unshield-xchain', 0n)).toBe(0n)
+  })
+
+  it('scales linearly with amount for cctp kinds', () => {
+    const big = HUNDRED_USDC * 10_000n // 1M USDC
+    expect(userFeeForKind('shield-xchain', big)).toBe(big * 2n / 10_000n)
+  })
+})
+
+describe('cctpMaxFeeForKind', () => {
+  it('is 2× userFeeForKind so Iris feeExecuted has headroom against the on-chain bound', () => {
+    // The contract enforces feeExecuted <= maxFee. We pass 2× the realistic estimate so the
+    // actual Iris-set fee (1–1.3 bps depending on chain) never trips the bound.
+    expect(cctpMaxFeeForKind('shield-xchain', HUNDRED_USDC)).toBe(40_000n)
+    expect(cctpMaxFeeForKind('unshield-xchain', HUNDRED_USDC)).toBe(40_000n)
+  })
+
+  it('is 0n for non-CCTP kinds (defensive; these kinds never call CCTP)', () => {
+    expect(cctpMaxFeeForKind('shield', HUNDRED_USDC)).toBe(0n)
+    expect(cctpMaxFeeForKind('unshield-local', HUNDRED_USDC)).toBe(0n)
+  })
+})

--- a/apps/armada-interface/src/lib/relayer.ts
+++ b/apps/armada-interface/src/lib/relayer.ts
@@ -19,25 +19,51 @@ export interface FeeSchedule {
 }
 
 /**
- * Map a tx kind onto the relayer's fee schedule key. Single source of truth so a future schema
- * change (e.g. splitting yield-deposit vs yield-withdraw into separate buckets) is one switch.
+ * Conservative buffer (basis points) for CCTP V2's fast-transfer fee. Mirrors the buffer used
+ * server-side in `relayer/modules/fee-calculator.ts::CCTP_FAST_FEE_BPS`. Circle charges 1 bps on
+ * Ethereum/Solana and 1.3 bps on the L2s (Arbitrum, Base, Optimism); 2 bps quoted to the user
+ * is the next round step up that holds across all supported chains. Keep in sync with the
+ * server-side constant — if the real numbers change, both move together.
  */
-export function feeForKind(quote: FeeSchedule, kind: TxKind): bigint {
+const CCTP_FAST_FEE_BPS = 2n
+
+/**
+ * Compute the USDC fee the user will actually pay for `kind` at `amount`. Today, while every
+ * stage handler submits via the user's own wallet, the only on-chain USDC fee is CCTP V2's
+ * fast-transfer fee (charged on cross-chain kinds, deducted from the minted amount at the
+ * destination). All other kinds charge $0 in USDC — the user pays gas in native token via their
+ * wallet.
+ *
+ * When the relayer-mediated submit path lands (see `submitRelay`), this function evolves to add
+ * the relayer's gas-cost reimbursement on top of the CCTP fee for hub-tx kinds. Until then,
+ * displaying the relayer's gas quote would be a lie — the relayer isn't paid by the user today.
+ *
+ * Pure function of `(kind, amount)`. The relayer's `FeeSchedule` quote is currently unused on
+ * the display path but remains plumbed through modals as `feeCacheId` so the relayer-submit
+ * wire-up doesn't require a second refactor.
+ */
+export function userFeeForKind(kind: TxKind, amount: bigint): bigint {
   switch (kind) {
-    // Direct hub shield is user-submitted — no relayer fee today. Show 0 on the Review step.
-    case 'shield': return 0n
-    // Cross-chain shield: relayer pays gas to deliver the CCTP-attested message on the hub
-    // (HookRouter.relayWithHook → MessageTransmitter.receiveMessage → PrivacyPool.shield).
-    // The user covers that gas budget via the maxFee passed to crossChainShield, deducted from
-    // the amount minted at the hub. Same fee bucket as the inverse direction (xchain unshield).
-    case 'shield-xchain': return BigInt(quote.fees.crossChainShield)
-    case 'unshield-local': return BigInt(quote.fees.unshield)
-    case 'unshield-xchain': return BigInt(quote.fees.crossChainUnshield)
-    case 'transfer-shielded': return BigInt(quote.fees.transfer)
-    // Yield ops use the cross-contract-calls fee bucket (lend/redeem-and-shield).
+    case 'shield-xchain':
+    case 'unshield-xchain':
+      return (amount * CCTP_FAST_FEE_BPS) / 10_000n
+    case 'shield':
+    case 'unshield-local':
+    case 'transfer-shielded':
     case 'yield-deposit':
-    case 'yield-withdraw': return BigInt(quote.fees.crossContract)
+    case 'yield-withdraw':
+      return 0n
   }
+}
+
+/**
+ * 2× multiple over `userFeeForKind` to use as CCTP V2's `maxFee` bound. The displayed fee is a
+ * realistic estimate (matches the server's conservative bps buffer); the on-chain bound bumps it
+ * to give Iris's `feeExecuted` headroom against per-chain variance and any future fee changes.
+ * The contract enforces `feeExecuted ≤ maxFee`, so undersized bounds silently revert.
+ */
+export function cctpMaxFeeForKind(kind: TxKind, amount: bigint): bigint {
+  return userFeeForKind(kind, amount) * 2n
 }
 
 export interface RelayRequest {


### PR DESCRIPTION
## Summary

The fee surfaced in modals previously echoed the relayer's gas quote (`feeForKind(quote, kind)` reading per-bucket values from `/fees`). That was misleading because no handler routes through the relayer today — every kind submits via the user's own wallet, paying gas in native. For cross-chain kinds the user *does* pay a USDC fee, but it's CCTP V2's Iris-set fast-transfer fee (~1–2 bps of amount), not the relayer's gas estimate. Observed gap on Sepolia: modal quoted ~\$1.45 USDC for shield-xchain, actual deduction was ~\$0.02.

This PR aligns display with reality.

## Changes

- **`lib/relayer.ts`**: replace `feeForKind(quote, kind)` with `userFeeForKind(kind, amount)`. Returns `0n` for all hub-tx-family kinds; returns CCTP fast-fee (`amount × 2 / 10000`) for `shield-xchain` and `unshield-xchain`. New `cctpMaxFeeForKind` returns 2× that value as the on-chain bound, giving Iris's `feeExecuted` headroom against the contract-enforced `feeExecuted ≤ maxFee`.
- **`features/shield-xchain/handler.ts`** + **`features/unshield-xchain/handler.ts`**: derive `maxFee` from `cctpMaxFeeForKind`, drop the now-redundant `fetchFees()` round-trip at submit time.
- **`components/{shield,unshield,payments,yield}/*Modal.tsx`**: swap `feeForKind(quote, kind)` → `userFeeForKind(kind, amount)`. Fee reactively updates as the user types. `useFees()` stays plumbed for `feeCacheId` so the eventual relayer-submit wire-up doesn't need a second pass.
- **`components/ui/FeeSummary/`**: render "No fee" when `fee === 0n` instead of a misleading "0.00 USDC" line.
- **`lib/relayer.test.ts`** (new): 12 unit tests for the fee helpers covering each kind, amount=0 edge, bigint integer-division rounding, scaling, and `cctpMaxFeeForKind` math.
- **`.claude/ARMADA_INTERFACE_POLISH.md`**: trim the shield-xchain fee entry to just the remaining architecture gap (relayer compensation for hub-side gas on cross-chain shield).

## What this PR does NOT do

The relayer-mediated submit path is still deferred — deliberately, per [scoping discussion](../issues): a partial wiring (some kinds via relayer, others not) creates a worse fee UX than today. When `submitRelay()` lands, `userFeeForKind` evolves to add relayer-gas-reimbursement on top of CCTP fees for hub-tx kinds, and the architecture-gap entry in the polish doc resolves alongside.

## Test plan

- [x] `npm run typecheck --workspace=@armada/interface` — clean
- [x] `npx vitest run --root=apps/armada-interface` — 503/503 pass (added 13 tests)
- [ ] Manual: trigger shield-xchain on Sepolia → confirm modal quote matches the actual delivered amount within tolerance
- [ ] Manual: trigger unshield-local / transfer-shielded / yield-deposit → confirm FeeSummary renders "No fee" instead of phantom \$0.00

🤖 Generated with [Claude Code](https://claude.com/claude-code)