### PR TITLE
feat(armada-interface): yield APY + slippage + RPC quota polish

### DIFF
--- a/.claude/ARMADA_INTERFACE_POLISH.md
+++ b/.claude/ARMADA_INTERFACE_POLISH.md
@@ -58,8 +58,7 @@ _(no open items)_
 
 | Item | Size | Notes |
 |---|---|---|
-| `rateToApy()` actual APY computation | S | `lib/yield.ts` returns 0. Need to derive APY from the spoke's `annualYieldBps` or sample rate-over-time. |
-| Slippage protection on withdraw | S | Modal computes shares from a locally-cached rate; if the rate moves between quote and execution, the user gets slightly more/less than requested. Add a min-out check at the adapter call or surface the slippage on the Review step. |
+| Contract-enforced min-out on withdraw | S–M | Frontend now refreshes the vault rate immediately before submit and recomputes `shares` from the freshest value, reducing the slippage window to ~1 block. For belt-and-braces protection against a same-block rate move, the `ArmadaYieldAdapter.redeemAndShield` entry point would need a `minUsdcOut` parameter the proof binds to. Out of scope for v1; track as a follow-up if observed slippage exceeds tolerance. |
 
 ## Fees & relayer integration
 
@@ -77,7 +76,6 @@ _(no open items)_
 | Item | Size | Notes |
 |---|---|---|
 | Real telemetry sink | S | Console-only today (`lib/telemetry.ts`). Swap with PostHog / Statsig / etc. when product analytics is needed. The EventRegistry contract should remain the privacy gate. |
-| Visibility-gated polling + cadence tightening | S | Three polls today burn RPC quota unnecessarily: (1) `useUsdcBalances` and `useShieldedBalanceSync` poll regardless of `tabVisibleAtom` — gate on visibility; (2) `useYieldRate` polls every 30s, but at 500% APY a 30s tick changes a $100 balance by ~$0.0005 (invisible at USDC's 2-decimal UI precision) — bump to 5 min poll + refresh on EarnModal open + invalidate after the user's own yield tx confirms; (3) optionally gate yield polling entirely on `openModalAtom`. |
 
 ## Sepolia / real-network mode
 

--- a/apps/armada-interface/src/components/balance/BalanceHero/BalanceHero.tsx
+++ b/apps/armada-interface/src/components/balance/BalanceHero/BalanceHero.tsx
@@ -12,7 +12,7 @@ import styles from './BalanceHero.module.css'
 export function BalanceHero() {
   const shielded = useAtomValue(shieldedUsdcAtom)
   const yieldShares = useAtomValue(yieldSharesAtom)
-  const yieldRate = useYieldRate()
+  const { rate: yieldRate } = useYieldRate()
 
   const earningUsdc =
     yieldShares !== null && yieldRate !== null

--- a/apps/armada-interface/src/components/yield/CLAUDE.md
+++ b/apps/armada-interface/src/components/yield/CLAUDE.md
@@ -29,20 +29,19 @@ The conversion path means the displayed "amount" is the **expected USDC output**
 
 ## APY display
 
-`useYieldRate()` returns `null` today (hook is stubbed). When real, the modal calls `rateToApy(rate.rate)` to display "~X.X%". Until then:
+`useYieldRate()` returns the vault's rate snapshot plus a net APY (`apyBps` — gross spoke yield reduced by the vault's `yieldFeeBps`). The modal renders via `rateToApy(rate.apyBps)`:
 
 - No rate yet → "syncing…" copy in the APY panel
-- Rate exists but `rateToApy` returns 0 (the current placeholder) → "unavailable while vault rate syncs"
-- Real APY → "~X.X%" with the caveat "Based on the vault's recent rate; the actual yield earned will vary."
-
-This is intentionally cautious — we'd rather show "unavailable" than a wrong number.
+- `apyBps === 0n` → "unavailable — pool currently pays no yield" (Aave reserve set to 0)
+- Otherwise → "~X.XX%" with the caveat "Based on the vault's recent rate; the actual yield earned will vary."
 
 ## What's wired now
 
 - Executor handlers for `yield-deposit` and `yield-withdraw` are registered. Submit walks `build-proof` → `submit-relayer` → `hub-confirmed` via the adapter's atomic lend/redeem entry point (`buildYieldAdaptTransaction` in `lib/railgun/yield.ts`).
-- `useYieldRate()` polls `vault.convertToAssets(1e18)` on the hub every 30s; the Withdraw tab's max and the APY hint read from it.
+- `useYieldRate()` polls `vault.convertToAssets(1e18)` + net APY (`spoke.annualYieldBps × (10_000 - vault.yieldFeeBps) / 10_000`) on the hub every 5 min (visibility-gated). EarnModal calls `refresh()` on open + post-submit so the user always sees fresh state at the moments that matter.
+- Withdraw slippage: the modal refreshes the rate immediately before computing shares to bound the slippage window to ~1 block. A `minUsdcOut` proof-bound parameter on the adapter would close the residual window — tracked in the polish doc.
 - `useShieldedBalanceSync` writes both `shieldedUsdcAtom` and `yieldSharesAtom` so the user's shielded ayUSDC balance is visible.
 
 ## Still stubbed
 
-- `rateToApy()` returns 0 — APY display is shaped but the conversion math is incomplete.
+_none_

--- a/apps/armada-interface/src/components/yield/EarnInputStep.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.test.tsx
@@ -49,9 +49,14 @@ describe('<EarnInputStep>', () => {
     expect(screen.getByText('syncing…')).toBeInTheDocument()
   })
 
-  it('shows the unavailable APY copy when rateToApy returns 0 (current stub)', () => {
-    setup({ rate: { rate: 1_000_000n, fetchedAt: 0 } })
-    expect(screen.getByText(/unavailable while vault rate syncs/)).toBeInTheDocument()
+  it('shows the unavailable APY copy when the pool currently pays no yield', () => {
+    setup({ rate: { rate: 1_000_000n, apyBps: 0n, fetchedAt: 0 } })
+    expect(screen.getByText(/unavailable — pool currently pays no yield/)).toBeInTheDocument()
+  })
+
+  it('renders the APY percentage when apyBps is populated', () => {
+    setup({ rate: { rate: 1_000_000n, apyBps: 450n, fetchedAt: 0 } })
+    expect(screen.getByText('~4.50%')).toBeInTheDocument()
   })
 
   it('disables Continue when amount exceeds max', () => {

--- a/apps/armada-interface/src/components/yield/EarnInputStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.tsx
@@ -33,8 +33,8 @@ export interface EarnInputStepProps {
 
 function formatApy(rate: YieldRate | null): string {
   if (!rate) return 'syncing…'
-  const apy = rateToApy(rate.rate)
-  if (apy === 0) return 'unavailable while vault rate syncs'
+  const apy = rateToApy(rate.apyBps)
+  if (apy === 0) return 'unavailable — pool currently pays no yield'
   return `~${apy.toFixed(2)}%`
 }
 

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -46,7 +46,7 @@ export function EarnModal() {
   // Source data
   const shieldedUsdc = useAtomValue(shieldedUsdcAtom)
   const yieldShares = useAtomValue(yieldSharesAtom)
-  const yieldRate = useYieldRate()
+  const { rate: yieldRate, refresh: refreshYieldRate } = useYieldRate()
   // Earning balance (USDC) requires both shares + rate to compute.
   const earningUsdc =
     yieldShares !== null && yieldRate !== null ? sharesToUsdc(yieldShares, yieldRate.rate) : null
@@ -72,6 +72,8 @@ export function EarnModal() {
   const record = activeTx?.record ?? null
 
   // Reset on close + sync initial tab when the entry-point modal kind changes.
+  // Also pull a fresh rate on open so the APY hint + max-balance reflect current state — the
+  // background poll only ticks every 5 min and a user opening the modal expects "now" data.
   useEffect(() => {
     if (!isOpen) {
       setStep('input')
@@ -82,17 +84,24 @@ export function EarnModal() {
       return
     }
     setTab(initialTab)
+    void refreshYieldRate()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen])
 
-  // Watch the submitted record for terminal transitions.
+  // Watch the submitted record for terminal transitions. On completed, refresh the rate so the
+  // post-tx balance / APY view reflects the new vault state immediately (rather than waiting up
+  // to 5 min for the next poll tick).
   useEffect(() => {
     if (!record) return
-    if (record.executionState === 'completed') setStep('complete')
+    if (record.executionState === 'completed') {
+      setStep('complete')
+      void refreshYieldRate()
+    }
     else if (record.executionState === 'failed' || record.executionState === 'expired') {
       setStep('error')
       setErrorAtStep('progress')
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [record])
 
   function close() {
@@ -115,12 +124,15 @@ export function EarnModal() {
         })
       } else {
         setSubmittedKind('yield-withdraw')
-        // Convert the requested USDC amount back to shares for the meta. If we have no rate yet,
-        // pass 0n shares — the executor will reject the submission when it lands; today this is moot
-        // because the stub throws regardless.
+        // Slippage protection: re-read the vault rate just before computing shares so the
+        // submitted shares reflect the freshest possible exchange ratio. The residual window
+        // (this submit-block → execution-block) is ~1 block — at any realistic APY that's well
+        // below USDC's display precision.
+        const freshRate = await refreshYieldRate()
+        const effectiveRate = freshRate ?? yieldRate
         const shares =
-          yieldRate !== null && yieldRate.rate > 0n
-            ? (amount * 1_000_000_000_000_000_000n) / yieldRate.rate
+          effectiveRate !== null && effectiveRate.rate > 0n
+            ? (amount * 1_000_000_000_000_000_000n) / effectiveRate.rate
             : 0n
         await txWithdraw.submit({
           amount,

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.module.css
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.module.css
@@ -68,6 +68,12 @@
   color: var(--semantic-color-text-secondary);
 }
 
+.slippageNotice {
+  color: var(--semantic-color-text-muted);
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  padding: 0 var(--primitives-spacing-1);
+}
+
 .footer {
   align-self: stretch;
   margin: var(--primitives-spacing-4) calc(var(--primitives-spacing-6) * -1) calc(var(--primitives-spacing-6) * -1);

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
@@ -22,7 +22,7 @@ export interface EarnReviewStepProps {
 
 function formatApy(rate: YieldRate | null): string {
   if (!rate) return 'syncing…'
-  const apy = rateToApy(rate.rate)
+  const apy = rateToApy(rate.apyBps)
   if (apy === 0) return 'unavailable'
   return `~${apy.toFixed(2)}%`
 }
@@ -61,6 +61,12 @@ export function EarnReviewStep({
         netAmount={netAmount}
         netLabel={tab === 'add' ? "You'll be earning on" : "You'll receive"}
       />
+      {tab === 'withdraw' ? (
+        <div className={styles.slippageNotice}>
+          The vault rate moves with each new block. Your final USDC may differ slightly from
+          this quote.
+        </div>
+      ) : null}
       {submitBlockedReason ? (
         <div className={styles.syncNotice} role="status" aria-live="polite">
           {submitBlockedReason}

--- a/apps/armada-interface/src/hooks/CLAUDE.md
+++ b/apps/armada-interface/src/hooks/CLAUDE.md
@@ -11,7 +11,7 @@ One concern per hook. Hooks own the React lifecycle (effects, subscriptions, tim
 | `useBalances()` | Aggregated balance view (unshielded per chain, shielded, yield shares). | Reads atoms only; shielded is now live via `useShieldedBalanceSync` |
 | `useShieldedBalanceSync()` | Subscribes to SDK balance events + drives initial scan on unlock; writes `shieldedUsdcAtom`. Mount once at App root. | Working |
 | `useRailgunEngineSync()` | Bridges `lib/railgun/init`'s lifecycle into `railgunEngineAtom`. Mount once at App root. | Working |
-| `useYieldRate()` | Polls yield vault rate via React Query (visibility-paused, 30s cadence). | Working |
+| `useYieldRate()` | Polls vault rate + net APY (gross spoke yield × vault fee) via React Query (visibility-paused, 5min cadence). Exposes `refresh()` for on-open + post-submit pulls. | Working |
 | `useFees()` | `/fees` quote via React Query — auto-refreshes near expiry, exponential cold-start backoff, dedups across consumers. | Working |
 | `useTx({ kind })` | Per-tx submit/track/retry/cancel. Multi-instance — each call owns a ulid. | Skeleton (state writes work, stage pipeline TODO) |
 | `useTxHistory()` | Hydrates `txListAtom` from IDB on mount. | Working |

--- a/apps/armada-interface/src/hooks/useYieldRate.test.tsx
+++ b/apps/armada-interface/src/hooks/useYieldRate.test.tsx
@@ -1,4 +1,4 @@
-// ABOUTME: Tests for useYieldRate — returns null until first read, mirrors rate into state, pauses refetch when tab is hidden, retains previous value on transient error.
+// ABOUTME: Tests for useYieldRate — first-read latency, hidden-tab refetch pause, no-deployment short-circuit, refresh() bypassing the cache, net APY math.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, act, waitFor } from '@testing-library/react'
@@ -23,6 +23,37 @@ const mockLoadYieldDeployment = loadYieldDeployment as unknown as ReturnType<typ
 
 const YIELD_DEPLOYMENT = {
   contracts: { armadaYieldVault: '0x0000000000000000000000000000000000000abc' },
+}
+
+const SPOKE_ADDRESS = '0x0000000000000000000000000000000000000def' as const
+
+/**
+ * Wire the per-call mocks for one happy-path queryFn invocation. The hook reads (in order):
+ * vault.convertToAssets, vault.spoke, vault.reserveId, vault.yieldFeeBps, spoke.getReserveData.
+ * The first four happen in Promise.all so the order within them is implementation-defined; we
+ * key on `functionName` to stay robust to that.
+ */
+function mockSuccessfulReadOnce(opts: {
+  rate?: bigint
+  feeBps?: bigint
+  grossAnnualBps?: bigint
+}): void {
+  const rate = opts.rate ?? 1_000_000n
+  const feeBps = opts.feeBps ?? 1_000n // 10% default
+  const grossAnnualBps = opts.grossAnnualBps ?? 500n // 5%
+  mockReadContract.mockImplementation(async (_config, args: { functionName: string }) => {
+    switch (args.functionName) {
+      case 'convertToAssets': return rate
+      case 'spoke': return SPOKE_ADDRESS
+      case 'reserveId': return 0n
+      case 'yieldFeeBps': return feeBps
+      case 'getReserveData':
+        // Tuple shape: [underlying, totalShares, totalDeposited, liquidityIndex, lastUpdate, annualYieldBps, mintableYield]
+        return ['0x0', 0n, 0n, 0n, 0n, grossAnnualBps, false]
+      default:
+        throw new Error(`unexpected functionName ${args.functionName}`)
+    }
+  })
 }
 
 function Harness({ onResult }: { onResult: (r: ReturnType<typeof useYieldRate>) => void }) {
@@ -59,43 +90,71 @@ describe('useYieldRate', () => {
     vi.clearAllMocks()
   })
 
-  it('returns null before the first read resolves', async () => {
-    let resolveRead!: (v: bigint) => void
-    mockReadContract.mockImplementationOnce(() => new Promise(res => { resolveRead = res }))
+  it('returns rate=null before the first read resolves, then the populated snapshot', async () => {
+    mockSuccessfulReadOnce({ rate: 1_010_000n, grossAnnualBps: 500n, feeBps: 1_000n })
 
     const { results } = renderHarness()
 
-    // First render call sees null (queryFn hasn't started yet — still awaiting loadYieldDeployment).
-    expect(results[0]).toBeNull()
+    // First render: rate not yet populated.
+    expect(results[0]?.rate).toBeNull()
 
-    // Wait until queryFn has invoked readContract (i.e. resolveRead is captured).
-    await waitFor(() => expect(mockReadContract).toHaveBeenCalledTimes(1))
-    await act(async () => { resolveRead(1_010_000n) })
-    await waitFor(() => expect(results.at(-1)?.rate).toBe(1_010_000n))
+    await waitFor(() => expect(results.at(-1)?.rate?.rate).toBe(1_010_000n))
+    const latest = results.at(-1)
+    // Net APY = 500 bps × (10_000 - 1_000) / 10_000 = 450 bps
+    expect(latest?.rate?.apyBps).toBe(450n)
   })
 
-  it('returns null when yield is not deployed on this network', async () => {
+  it('returns rate=null when yield is not deployed on this network', async () => {
     mockLoadYieldDeployment.mockResolvedValue(null)
     const { results } = renderHarness()
 
     await waitFor(() => expect(results.length).toBeGreaterThan(1))
-    expect(results.at(-1)).toBeNull()
+    expect(results.at(-1)?.rate).toBeNull()
     expect(mockReadContract).not.toHaveBeenCalled()
   })
 
   it('does not refetch on the interval while tab is hidden', async () => {
-    mockReadContract.mockResolvedValue(1_000_000n)
+    mockSuccessfulReadOnce({})
     const { queryClient } = renderHarness({ tabVisible: false })
 
     await waitFor(() => expect(queryClient.getQueryData(['yieldRate'])).toBeDefined())
-    expect(mockReadContract).toHaveBeenCalledTimes(1)
+    const initialCalls = mockReadContract.mock.calls.length
 
     vi.useFakeTimers({ shouldAdvanceTime: false })
     try {
-      await act(async () => { await vi.advanceTimersByTimeAsync(120_000) })
-      expect(mockReadContract).toHaveBeenCalledTimes(1)
+      // Advance past the new 5-min poll cadence. Should produce zero new reads while hidden.
+      await act(async () => { await vi.advanceTimersByTimeAsync(10 * 60_000) })
+      expect(mockReadContract.mock.calls.length).toBe(initialCalls)
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('refresh() pulls a fresh snapshot and seeds the query cache so other consumers see it', async () => {
+    // Initial mock: 5% gross / 10% fee → 450 bps net
+    mockSuccessfulReadOnce({ rate: 1_000_000n, grossAnnualBps: 500n, feeBps: 1_000n })
+    const { queryClient, results } = renderHarness()
+    await waitFor(() => expect(results.at(-1)?.rate).not.toBeNull())
+    expect(results.at(-1)?.rate?.apyBps).toBe(450n)
+
+    // After-refresh mock: 8% gross / 10% fee → 720 bps net (simulates rate change between polls)
+    mockSuccessfulReadOnce({ rate: 1_001_000n, grossAnnualBps: 800n, feeBps: 1_000n })
+    await act(async () => {
+      await results.at(-1)!.refresh()
+    })
+
+    // The cache reflects the new value — a BalanceHero re-render would pick it up immediately.
+    const cached = queryClient.getQueryData<{ rate: bigint; apyBps: bigint }>(['yieldRate'])
+    expect(cached?.rate).toBe(1_001_000n)
+    expect(cached?.apyBps).toBe(720n)
+  })
+
+  it('clamps an absurd yieldFeeBps to 10_000 so apyBps never goes negative', async () => {
+    // Defensive math — if the contract is ever misconfigured to feeBps > 10_000 we want apyBps=0,
+    // not a wrap-around or thrown subtraction.
+    mockSuccessfulReadOnce({ grossAnnualBps: 500n, feeBps: 99_999n })
+    const { results } = renderHarness()
+    await waitFor(() => expect(results.at(-1)?.rate).not.toBeNull())
+    expect(results.at(-1)?.rate?.apyBps).toBe(0n)
   })
 })

--- a/apps/armada-interface/src/hooks/useYieldRate.ts
+++ b/apps/armada-interface/src/hooks/useYieldRate.ts
@@ -1,9 +1,9 @@
-// ABOUTME: Polls the ArmadaYieldVault's shares→assets exchange rate (USDC value of 1e18 shares) via React Query — paused while tab is hidden, deduped across consumers.
-// ABOUTME: Returns null until the first successful read; the modal/BalanceHero treat null as "syncing" UX.
+// ABOUTME: Polls the ArmadaYieldVault's shares→assets exchange rate (USDC value of 1e18 shares) and the underlying Aave spoke's annualYieldBps via React Query — paused while tab is hidden, deduped across consumers.
+// ABOUTME: Returns null until the first successful read; the modal/BalanceHero treat null as "syncing" UX. Exposes refresh() so EarnModal can pull fresh state on open + post-submit slippage protection.
 
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAtomValue } from 'jotai'
-import { useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 import { readContract } from 'wagmi/actions'
 import { wagmiConfig } from '@/config/wagmi'
 import { loadYieldDeployment } from '@/config/deployments'
@@ -14,10 +14,22 @@ import { trackError } from '@/lib/telemetry'
 export interface YieldRate {
   /** USDC value (raw 6-decimal) of 1e18 shares. ConvertToShares(x) = x × 1e18 / rate. */
   rate: bigint
+  /**
+   * Net APY in basis points after the vault's yield fee — what the user actually earns. Derived
+   * as `spoke.annualYieldBps × (10_000 - vault.yieldFeeBps) / 10_000`. The displayed percentage
+   * uses this; the contract math (deposit/withdraw share conversions) uses `rate`.
+   */
+  apyBps: bigint
   fetchedAt: number
 }
 
-const POLL_INTERVAL_MS = 30_000
+/**
+ * 5-minute cadence. The earlier 30s value was wasteful: at any realistic APY the per-tick rate
+ * delta is below USDC's 2-decimal display precision, so polling that hard burned RPC quota with
+ * no UI signal. EarnModal supplements this with on-open and post-submit refreshes for the moments
+ * where freshness actually matters.
+ */
+const POLL_INTERVAL_MS = 5 * 60_000
 const ONE_SHARE = 1_000_000_000_000_000_000n // 1e18
 
 const VAULT_ABI = [
@@ -28,43 +40,151 @@ const VAULT_ABI = [
     inputs: [{ name: 'shares', type: 'uint256' }],
     outputs: [{ type: 'uint256' }],
   },
+  {
+    type: 'function',
+    name: 'spoke',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'address' }],
+  },
+  {
+    type: 'function',
+    name: 'reserveId',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'yieldFeeBps',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'uint256' }],
+  },
+] as const
+
+const SPOKE_ABI = [
+  {
+    type: 'function',
+    name: 'getReserveData',
+    stateMutability: 'view',
+    inputs: [{ name: 'reserveId', type: 'uint256' }],
+    outputs: [
+      { name: 'underlying', type: 'address' },
+      { name: 'totalShares', type: 'uint256' },
+      { name: 'totalDeposited', type: 'uint256' },
+      { name: 'liquidityIndex', type: 'uint256' },
+      { name: 'lastUpdateTimestamp', type: 'uint256' },
+      { name: 'annualYieldBps', type: 'uint256' },
+      { name: 'mintableYield', type: 'bool' },
+    ],
+  },
 ] as const
 
 export const YIELD_RATE_QUERY_KEY = ['yieldRate'] as const
 
+export interface UseYieldRateResult {
+  /** Latest rate snapshot, or null until the first successful read. */
+  rate: YieldRate | null
+  /** Force a fresh read (bypasses the React Query cache). Returns the new snapshot or null on failure. */
+  refresh: () => Promise<YieldRate | null>
+}
+
 /**
- * Polls `vault.convertToAssets(1e18)` to learn how many raw USDC units 1e18 shares are worth.
- * Consumers can convert in either direction:
+ * Polls the vault's `convertToAssets(1e18)` rate AND the underlying spoke's `annualYieldBps`.
+ *
+ * Consumers can convert in either direction using `rate`:
  *   shares = usdc × 1e18 / rate
  *   usdc   = shares × rate / 1e18
  *
- * Returns null until the first successful read. On RPC error React Query keeps the previous value
- * (placeholderData) so a transient blip doesn't blank the UI.
+ * Net APY in `apyBps` is the spoke's gross annual yield reduced by the vault's `yieldFeeBps`
+ * (which the protocol takes off the top during harvest). This matches what a user actually earns.
+ *
+ * Returns null inside `rate` until the first successful read. On RPC error React Query keeps the
+ * previous value (placeholderData) so a transient blip doesn't blank the UI.
+ *
+ * `refresh()` is exposed so EarnModal can pull fresh state on modal open + just before submit
+ * (slippage protection — `shares` is computed from the freshest rate, not whatever was cached).
  */
-export function useYieldRate(): YieldRate | null {
+export function useYieldRate(): UseYieldRateResult {
   const tabVisible = useAtomValue(tabVisibleAtom)
+  const queryClient = useQueryClient()
 
-  const query = useQuery({
-    queryKey: YIELD_RATE_QUERY_KEY,
-    queryFn: async (): Promise<YieldRate | null> => {
-      const yieldDeployment = await loadYieldDeployment()
-      if (!yieldDeployment) return null // yield not deployed on this network — silently no-op
-      const usdcPerShare = await readContract(wagmiConfig, {
-        chainId: getNetworkConfig().hub.chainId,
-        address: yieldDeployment.contracts.armadaYieldVault as `0x${string}`,
+  const queryFn = useCallback(async (): Promise<YieldRate | null> => {
+    const yieldDeployment = await loadYieldDeployment()
+    if (!yieldDeployment) return null // yield not deployed on this network — silently no-op
+    const hubChainId = getNetworkConfig().hub.chainId
+    const vaultAddress = yieldDeployment.contracts.armadaYieldVault as `0x${string}`
+
+    // Step 1: read vault-side data in parallel — rate + immutable spoke/reserveId + the fee bps.
+    const [usdcPerShare, spokeAddress, reserveId, yieldFeeBps] = await Promise.all([
+      readContract(wagmiConfig, {
+        chainId: hubChainId,
+        address: vaultAddress,
         abi: VAULT_ABI,
         functionName: 'convertToAssets',
         args: [ONE_SHARE],
-      })
-      return { rate: usdcPerShare, fetchedAt: Date.now() }
-    },
+      }),
+      readContract(wagmiConfig, {
+        chainId: hubChainId,
+        address: vaultAddress,
+        abi: VAULT_ABI,
+        functionName: 'spoke',
+      }),
+      readContract(wagmiConfig, {
+        chainId: hubChainId,
+        address: vaultAddress,
+        abi: VAULT_ABI,
+        functionName: 'reserveId',
+      }),
+      readContract(wagmiConfig, {
+        chainId: hubChainId,
+        address: vaultAddress,
+        abi: VAULT_ABI,
+        functionName: 'yieldFeeBps',
+      }),
+    ])
+
+    // Step 2: read the spoke's gross annualYieldBps.
+    const reserve = await readContract(wagmiConfig, {
+      chainId: hubChainId,
+      address: spokeAddress as `0x${string}`,
+      abi: SPOKE_ABI,
+      functionName: 'getReserveData',
+      args: [reserveId],
+    })
+    const grossAnnualBps = reserve[5] // annualYieldBps
+
+    // Net APY = gross × (10_000 - feeBps) / 10_000. Clamp feeBps to [0, 10_000] defensively.
+    const clampedFeeBps = yieldFeeBps > 10_000n ? 10_000n : yieldFeeBps
+    const apyBps = (grossAnnualBps * (10_000n - clampedFeeBps)) / 10_000n
+
+    return { rate: usdcPerShare, apyBps, fetchedAt: Date.now() }
+  }, [])
+
+  const query = useQuery({
+    queryKey: YIELD_RATE_QUERY_KEY,
+    queryFn,
     refetchInterval: tabVisible ? POLL_INTERVAL_MS : false,
     refetchIntervalInBackground: false,
-    // Keep showing the previous value through a failed refetch so the UI doesn't blank on a
-    // transient RPC blip. The first failure surfaces via the error effect below.
     placeholderData: prev => prev,
     staleTime: 0,
   })
+
+  const refresh = useCallback(async (): Promise<YieldRate | null> => {
+    try {
+      const fresh = await queryFn()
+      // Seed the cache so other consumers (BalanceHero) pick up the new value too.
+      queryClient.setQueryData(YIELD_RATE_QUERY_KEY, fresh)
+      return fresh
+    } catch (err) {
+      trackError('useYieldRate.refresh', err, {
+        scope: 'yield.rate',
+        message: 'rate refresh failed',
+      })
+      return null
+    }
+  }, [queryFn, queryClient])
 
   // Surface persistent fetch errors via telemetry. Wrapped in useEffect so we only emit once
   // per error transition rather than on every re-render while the error persists.
@@ -77,5 +197,5 @@ export function useYieldRate(): YieldRate | null {
     }
   }, [query.error])
 
-  return query.data ?? null
+  return { rate: query.data ?? null, refresh }
 }

--- a/apps/armada-interface/src/lib/yield.test.ts
+++ b/apps/armada-interface/src/lib/yield.test.ts
@@ -1,5 +1,4 @@
-// ABOUTME: Tests for lib/yield helpers — sharesToUsdc bigint math (zero, normal, large), APY placeholder.
-// ABOUTME: rateToApy is a TODO stub; we just lock its return type for now.
+// ABOUTME: Tests for lib/yield helpers — sharesToUsdc bigint math (zero, normal, large), rateToApy bps→percentage conversion.
 
 import { describe, it, expect } from 'vitest'
 import { sharesToUsdc, rateToApy } from './yield'
@@ -33,7 +32,24 @@ describe('sharesToUsdc', () => {
 })
 
 describe('rateToApy', () => {
-  it('returns 0 (TODO until useYieldRate is real)', () => {
+  it('returns 0 when bps is 0 (no yield being paid right now)', () => {
     expect(rateToApy(0n)).toBe(0)
+  })
+
+  it('converts 500 bps → 5 (a 5% APY)', () => {
+    expect(rateToApy(500n)).toBe(5)
+  })
+
+  it('converts 450 bps → 4.5 (5% gross × 90% after 10% fee)', () => {
+    expect(rateToApy(450n)).toBe(4.5)
+  })
+
+  it('handles fractional bps with appropriate decimal precision', () => {
+    expect(rateToApy(123n)).toBe(1.23)
+    expect(rateToApy(1n)).toBe(0.01)
+  })
+
+  it('handles large bps values (above 100% APY in extreme reward markets)', () => {
+    expect(rateToApy(50_000n)).toBe(500)
   })
 })

--- a/apps/armada-interface/src/lib/yield.ts
+++ b/apps/armada-interface/src/lib/yield.ts
@@ -14,14 +14,13 @@ export function sharesToUsdc(shares: bigint, rate: bigint): bigint {
 }
 
 /**
- * Convert a per-second yield rate (in basis points, scaled by 1e18) to an annualized APY percentage.
+ * Convert annual yield basis points to a percentage number (e.g. 500n → 5).
  *
- * Placeholder: the actual rate source from `useYieldRate()` is per-share USDC, not a per-second growth rate.
- * Earn modal will refine this when the source is real. Exposed now so the call sites have a stable name.
+ * Input comes from `useYieldRate().rate.apyBps`, which is the spoke's gross annualYieldBps
+ * reduced by the vault's `yieldFeeBps` — i.e. the user's net realised APY. We return a plain
+ * Number because the call sites just format to "~X.XX%" for display; precision beyond two
+ * decimal places isn't meaningful for an estimate.
  */
-export function rateToApy(_secondsRate: bigint): number {
-  // TODO: implement once useYieldRate returns the per-second growth rate. Today useYieldRate is stubbed
-  // and returns null, so this helper is unused — wiring the call site without the math lets us land
-  // BalanceHero + the Earn modal scaffold without an Earn-blocker.
-  return 0
+export function rateToApy(apyBps: bigint): number {
+  return Number(apyBps) / 100
 }


### PR DESCRIPTION
## Summary

Three intertwined items off the polish doc, all touching the yield + rate-polling surface.

### 1. Net APY display (was `rateToApy() returns 0`)

`useYieldRate` now reads three additional values from the vault in parallel — `spoke`, `reserveId`, `yieldFeeBps` — then calls the spoke's `getReserveData(reserveId)` to pull `annualYieldBps`. The hook exposes `apyBps = grossBps × (10_000 − feeBps) / 10_000` on the `YieldRate` shape: the actual net APY the user realises after the vault's protocol fee.

`rateToApy` becomes a pure converter (`bps → percentage`). `EarnInputStep` and `EarnReviewStep` render real numbers ("~4.50%") instead of the prior "unavailable while vault rate syncs" placeholder.

### 2. Withdraw slippage protection

`EarnModal.handleSubmit` (withdraw path) now `await refreshYieldRate()` before computing `shares`, so the submitted shares value reflects the freshest possible rate — bounding the rate-drift window to ~1 block at execution.

`EarnReviewStep` adds a small notice on the Withdraw tab explaining the residual variance ("The vault rate moves with each new block. Your final USDC may differ slightly from this quote.").

Contract-enforced min-out (a `minUsdcOut` parameter the proof binds to on the `ArmadaYieldAdapter.redeemAndShield` entry) is a stronger guarantee — tracked in the polish doc as a follow-up.

### 3. Yield poll cadence + freshness triggers

- `POLL_INTERVAL_MS`: 30s → 5min. At any realistic APY a 30s tick produces sub-cent rate deltas — invisible at USDC's 2-decimal precision but real RPC cost on Sepolia/mainnet. This is the largest of the three quota wins.
- `useYieldRate` exposes `refresh()`. `EarnModal` calls it on modal open (`isOpen` rising edge) and on the user's own yield tx completing — so the "moments that matter" pull fresh state without leaning on the background poll.
- Removed the stale claim from the polish doc that `useUsdcBalances` and `useShieldedBalanceSync` don't gate on `tabVisibleAtom` — the former already does (`useUsdcBalances.ts:74`), the latter is event-driven (not polled).

## Test plan

- [x] `npm run typecheck --workspace=@armada/interface` — clean
- [x] `npx vitest run --root=apps/armada-interface` — 510/510 pass (+7 from main: useYieldRate test rewrite, yield.test additions, EarnInputStep new APY-render test)
- [ ] Manual: open EarnModal, confirm APY shows a real "~X.XX%" (Anvil's mock spoke returns 500 bps gross, vault takes 10% → "~4.50%")
- [ ] Manual: deposit, then refresh on completion — Earning balance updates immediately rather than after 5 min
- [ ] Manual: withdraw, observe console for any rate-refresh errors during submit; confirm the slippage notice renders on the Review step

🤖 Generated with [Claude Code](https://claude.com/claude-code)