### PR TITLE
feat(armada-interface): offer Restore as escape hatch from first-run onboarding

### DIFF
--- a/apps/armada-interface/src/App.tsx
+++ b/apps/armada-interface/src/App.tsx
@@ -78,6 +78,11 @@ export function App() {
   const setShieldedWallets = useSetAtom(shieldedWalletsAtom)
   const setActiveWalletId = useSetAtom(activeRailgunWalletIdAtom)
   const [mode, setMode] = useState<GuardMode>('pre-init')
+  // Sticky flag: true when this device boot started with NO persisted walletId. Drives whether
+  // we offer the bidirectional Onboarding ↔ Unlock fork. A returning user (had a wallet at boot)
+  // never sees the "Create new" link in UnlockFlow — preventing accidental orphaning of their
+  // existing wallet. A new-device user (no persisted wallet at boot) sees both fork links.
+  const [hadPersistedWalletAtBoot, setHadPersistedWalletAtBoot] = useState(false)
 
   // Cold-boot hydration + initial mode derivation, in one pass to avoid a race between
   // separate effects (the mode effect would otherwise read a stale `wallet.status` before the
@@ -88,7 +93,7 @@ export function App() {
   // Three cases:
   //   - `wallet.status === 'unlocked'`: HMR re-mount, atoms already populated → straight to app.
   //   - persisted walletId in localStorage: returning user → seed `locked` entry → UnlockFlow.
-  //   - neither: first run → OnboardingFlow.
+  //   - neither: first run → OnboardingFlow (with Restore escape hatch — see below).
   useEffect(() => {
     if (mode !== 'pre-init') return
     if (wallet.status === 'unlocked') {
@@ -97,6 +102,7 @@ export function App() {
     }
     const persistedId = readStoredWalletId()
     if (persistedId) {
+      setHadPersistedWalletAtBoot(true)
       setShieldedWallets(prev =>
         prev[persistedId] ? prev : { ...prev, [persistedId]: { id: persistedId, status: 'locked' } },
       )
@@ -119,11 +125,22 @@ export function App() {
   }
 
   if (mode === 'onboarding') {
-    return <OnboardingFlow onDone={() => setMode('app')} />
+    // Always offer the Restore escape hatch — the onboarding flow has no way to know whether
+    // the user is genuinely new vs. arriving on a new device with an existing backup. The link
+    // is harmless for genuinely new users (they ignore it) and load-bearing for the second case.
+    return <OnboardingFlow onDone={() => setMode('app')} onRestore={() => setMode('unlock')} />
   }
 
   if (mode === 'unlock') {
-    return <UnlockFlow onUnlocked={() => setMode('app')} />
+    // Only expose the Create-new link when there's no persisted wallet on this device. A
+    // returning user (had a persisted wallet at boot) MUST go through Unlock — accidentally
+    // starting Create would orphan their existing IDB-stored wallet without recovery.
+    return (
+      <UnlockFlow
+        onUnlocked={() => setMode('app')}
+        onCreateNew={hadPersistedWalletAtBoot ? undefined : () => setMode('onboarding')}
+      />
+    )
   }
 
   return (

--- a/apps/armada-interface/src/components/onboarding/CLAUDE.md
+++ b/apps/armada-interface/src/components/onboarding/CLAUDE.md
@@ -20,8 +20,12 @@ First-run setup + returning-user unlock. Mounted by the top-level guard in `App.
 
 `App.tsx` tracks a local `mode` state (`pre-init` / `onboarding` / `unlock` / `app`). It initializes from `shieldedWalletAtom.status` on mount, then transitions explicitly:
 - `onboarding` → `app` when the user clicks Done in `CompleteStep`.
+- `onboarding` → `unlock` when the user clicks the **Restore** secondary CTA on `WelcomeStep` (escape hatch for new-device users who already have a backup).
+- `unlock` → `onboarding` when the user clicks the **Create new account** link, *only when there was no persisted walletId at boot*. App.tsx tracks this via the sticky `hadPersistedWalletAtBoot` flag so a returning user can't orphan their existing wallet by misclicking.
 - `app` → `unlock` when the atom flips to `locked` (auto-lock timer).
 - `unlock` → `app` when an unlock path resolves and `UnlockFlow` calls `onUnlocked`.
+
+The Restore CTA is offered unconditionally in onboarding — the flow can't know whether a given visitor is genuinely new or arriving on a new device. The link is inert for genuinely-new users and load-bearing for the second case.
 
 Why a local mode state instead of reading the atom directly? Because `useShieldedWallet().enroll()` writes to atoms BEFORE the user reaches Complete (the wallet is unlocked from the moment of Sign). If the guard read the atom directly, the post-sign screens would never render — the atom flip would unmount `OnboardingFlow` immediately. The local mode shields the flow until the user explicitly clicks through Complete.
 

--- a/apps/armada-interface/src/components/onboarding/OnboardingFlow.tsx
+++ b/apps/armada-interface/src/components/onboarding/OnboardingFlow.tsx
@@ -27,9 +27,15 @@ const TOTAL_STEPS = 6
 export interface OnboardingFlowProps {
   /** Called when the user clicks Done on the final step. Parent should swap App-level mode to "app". */
   onDone: () => void
+  /**
+   * Optional escape hatch on the Welcome step — switches to the restore-from-backup flow. Parent
+   * supplies this when the user is on first-run-onboarding but might already have a wallet
+   * (e.g. new device or cleared storage).
+   */
+  onRestore?: () => void
 }
 
-export function OnboardingFlow({ onDone }: OnboardingFlowProps) {
+export function OnboardingFlow({ onDone, onRestore }: OnboardingFlowProps) {
   const { state, enroll, exportBackup } = useShieldedWallet()
   const [step, setStep] = useState<Step>('welcome')
 
@@ -45,7 +51,7 @@ export function OnboardingFlow({ onDone }: OnboardingFlowProps) {
       totalSteps={TOTAL_STEPS}
     >
       {step === 'welcome' && (
-        <WelcomeStep onContinue={() => setStep('sign')} />
+        <WelcomeStep onContinue={() => setStep('sign')} onRestore={onRestore} />
       )}
 
       {step === 'sign' && (

--- a/apps/armada-interface/src/components/onboarding/UnlockFlow.module.css
+++ b/apps/armada-interface/src/components/onboarding/UnlockFlow.module.css
@@ -59,3 +59,24 @@
   align-self: stretch;
   margin: var(--primitives-spacing-6) calc(var(--primitives-spacing-6) * -1) calc(var(--primitives-spacing-6) * -1);
 }
+
+.createNew {
+  text-align: center;
+  color: var(--semantic-color-text-muted);
+  margin-top: var(--primitives-spacing-3);
+}
+
+.createNewLink {
+  background: none;
+  border: 0;
+  padding: 0;
+  color: var(--semantic-color-brand-lavender);
+  cursor: pointer;
+  text-decoration: underline;
+  font: inherit;
+}
+
+.createNewLink:hover,
+.createNewLink:focus-visible {
+  color: var(--semantic-color-text-primary);
+}

--- a/apps/armada-interface/src/components/onboarding/UnlockFlow.test.tsx
+++ b/apps/armada-interface/src/components/onboarding/UnlockFlow.test.tsx
@@ -22,12 +22,12 @@ vi.mock('@/hooks/useShieldedWallet', () => ({
   }),
 }))
 
-function renderWith() {
+function renderWith(opts?: { onCreateNew?: () => void }) {
   const store = createStore()
   const onUnlocked = vi.fn()
   render(
     <Provider store={store}>
-      <UnlockFlow onUnlocked={onUnlocked} />
+      <UnlockFlow onUnlocked={onUnlocked} onCreateNew={opts?.onCreateNew} />
     </Provider>,
   )
   return { onUnlocked }
@@ -117,5 +117,33 @@ describe('<UnlockFlow> — mode switching', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Backup file' }))
     fireEvent.click(screen.getByRole('tab', { name: 'Paste secret' }))
     expect(screen.getByLabelText(/Recovery secret/)).toHaveValue('')
+  })
+})
+
+describe('<UnlockFlow> — Create-new escape hatch', () => {
+  it('does NOT render the Create-new link when onCreateNew is not supplied', () => {
+    // The returning-user case (had a wallet on this device): we don't show the link so a
+    // misclick can't orphan their existing wallet.
+    renderWith()
+    expect(screen.queryByRole('button', { name: /create a new account/i })).toBeNull()
+  })
+
+  it('renders the Create-new link when onCreateNew is supplied and fires it on click', () => {
+    // The new-device-no-backup case: user might have arrived here via the WelcomeStep Restore
+    // CTA but then realised they don't have a backup. The link lets them switch back.
+    const onCreateNew = vi.fn()
+    renderWith({ onCreateNew })
+    const link = screen.getByRole('button', { name: /create a new account/i })
+    fireEvent.click(link)
+    expect(onCreateNew).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the Create-new link in both paste and backup tab modes', () => {
+    // The link lives outside the per-mode form so it stays visible regardless of which tab is
+    // selected — switching tabs while looking for the link shouldn't make it disappear.
+    renderWith({ onCreateNew: vi.fn() })
+    expect(screen.getByRole('button', { name: /create a new account/i })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('tab', { name: 'Paste secret' }))
+    expect(screen.getByRole('button', { name: /create a new account/i })).toBeInTheDocument()
   })
 })

--- a/apps/armada-interface/src/components/onboarding/UnlockFlow.tsx
+++ b/apps/armada-interface/src/components/onboarding/UnlockFlow.tsx
@@ -12,6 +12,12 @@ import styles from './UnlockFlow.module.css'
 export interface UnlockFlowProps {
   /** Called when unlock succeeds. Parent flips App-level mode to "app". */
   onUnlocked: () => void
+  /**
+   * Optional escape hatch — switches to the create-new-account flow. App.tsx only passes this
+   * when there's no persisted walletId on this device, so a returning user (who has a real
+   * wallet locally) can't accidentally orphan it by starting over.
+   */
+  onCreateNew?: () => void
 }
 
 type Mode = 'backup' | 'paste'
@@ -24,7 +30,7 @@ const MODES: ReadonlyArray<{ id: Mode; label: string }> = [
   { id: 'paste', label: 'Paste secret' },
 ]
 
-export function UnlockFlow({ onUnlocked }: UnlockFlowProps) {
+export function UnlockFlow({ onUnlocked, onCreateNew }: UnlockFlowProps) {
   const { unlockByPaste, unlockByBackup } = useShieldedWallet()
   const [mode, setMode] = useState<Mode>('backup')
   const [submitting, setSubmitting] = useState(false)
@@ -179,6 +185,19 @@ export function UnlockFlow({ onUnlocked }: UnlockFlowProps) {
             />
           </form>
         )}
+
+        {onCreateNew ? (
+          <p className={styles.createNew}>
+            Don't have a backup?{' '}
+            <button
+              type="button"
+              className={styles.createNewLink}
+              onClick={onCreateNew}
+            >
+              Create a new account instead
+            </button>
+          </p>
+        ) : null}
       </div>
     </OnboardingShell>
   )

--- a/apps/armada-interface/src/components/onboarding/steps/WelcomeStep.test.tsx
+++ b/apps/armada-interface/src/components/onboarding/steps/WelcomeStep.test.tsx
@@ -16,4 +16,20 @@ describe('<WelcomeStep>', () => {
     fireEvent.click(screen.getByRole('button', { name: /Create account/ }))
     expect(onContinue).toHaveBeenCalledTimes(1)
   })
+
+  it('hides the Restore secondary CTA when onRestore is not supplied', () => {
+    render(<WelcomeStep onContinue={() => {}} />)
+    expect(screen.queryByRole('button', { name: /restore/i })).toBeNull()
+  })
+
+  it('renders the Restore CTA when onRestore is supplied and fires it on click', () => {
+    // Covers the "new device / cleared storage but I already have a backup" path: App.tsx
+    // unconditionally supplies onRestore in onboarding mode, so this CTA is the escape hatch
+    // that prevents a returning-user-on-a-new-device from being forced into creating a fresh
+    // (orphaning) account.
+    const onRestore = vi.fn()
+    render(<WelcomeStep onContinue={() => {}} onRestore={onRestore} />)
+    fireEvent.click(screen.getByRole('button', { name: /restore/i }))
+    expect(onRestore).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/armada-interface/src/components/onboarding/steps/WelcomeStep.tsx
+++ b/apps/armada-interface/src/components/onboarding/steps/WelcomeStep.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Step 1 of onboarding — welcomes the user and explains the private account before any keys are generated.
-// ABOUTME: Single primary CTA "Create account"; no secondary action since there's nowhere to go back to.
+// ABOUTME: Primary CTA "Create account"; optional secondary "Restore from backup" surfaces when onRestore is supplied (new device / cleared storage path).
 
 import { ShieldCheck } from 'lucide-react'
 import { FlowFooter } from '@/components/flow/FlowFooter'
@@ -7,9 +7,15 @@ import styles from './WelcomeStep.module.css'
 
 export interface WelcomeStepProps {
   onContinue: () => void
+  /**
+   * Switch to the restore-from-backup flow. Only passed by App.tsx when the user has no
+   * existing wallet on this device — handles the "new device" / "cleared storage" case where
+   * the user already has a backup but the app would otherwise route them through Create.
+   */
+  onRestore?: () => void
 }
 
-export function WelcomeStep({ onContinue }: WelcomeStepProps) {
+export function WelcomeStep({ onContinue, onRestore }: WelcomeStepProps) {
   return (
     <div className={styles.root}>
       <div className={styles.icon} aria-hidden="true">
@@ -24,6 +30,7 @@ export function WelcomeStep({ onContinue }: WelcomeStepProps) {
       <FlowFooter
         className={styles.footer}
         primary={{ label: 'Create account', onClick: onContinue }}
+        secondary={onRestore ? { label: 'I have a backup — restore', onClick: onRestore } : undefined}
       />
     </div>
   )


### PR DESCRIPTION
## Problem

A new-device or cleared-storage visit looks identical to a genuine first-run visit — `localStorage` is empty in both cases, so `App.tsx`'s mode-derivation routes both to `OnboardingFlow`. The user with an existing wallet on another device has no way to restore from their backup; they'd have to either (a) sign through Create and produce a fresh-and-different wallet, or (b) inspect IDB / localStorage to figure out what's wrong. Both are bad UX.

## Fix

Bidirectional fork between Onboarding and Unlock, with one safety asymmetry:

- **`WelcomeStep`** gets an "I have a backup — restore" secondary CTA when an `onRestore` prop is supplied. `App.tsx` supplies it **unconditionally** in onboarding mode — we can't tell at boot whether a visitor is genuinely new or arriving on a new device.
- **`UnlockFlow`** gets a "Create a new account instead" link when an `onCreateNew` prop is supplied. `App.tsx` supplies it **only when `hadPersistedWalletAtBoot === false`** — a returning user (had a persisted walletId at boot) MUST go through Unlock. The asymmetry prevents a misclick from orphaning an existing IDB-stored wallet.

After the user successfully restores via UnlockFlow, `storeWalletId` (already called inside `unlockByPaste` / `unlockByBackup`) persists the walletId to localStorage. Subsequent loads route through UnlockFlow normally.

## Test plan

- [x] `npm run typecheck --workspace=@armada/interface` — clean
- [x] `npx vitest run --root=apps/armada-interface` — 515/515 pass (+5: 2 WelcomeStep, 3 UnlockFlow)
- [ ] Manual: clear browser storage, reload — Welcome step shows both CTAs; clicking Restore lands on Unlock; UnlockFlow shows the Create-new link in both paste/backup tabs; clicking it returns to Welcome
- [ ] Manual: complete a Create flow normally, reload — `UnlockFlow` renders WITHOUT the Create-new link (returning-user safety)

🤖 Generated with [Claude Code](https://claude.com/claude-code)