### PR TITLE
fix(armada-interface): bypass wagmi switchChain to avoid ConnectorChainMismatch race

### DIFF
--- a/apps/armada-interface/src/lib/network-switch.test.ts
+++ b/apps/armada-interface/src/lib/network-switch.test.ts
@@ -1,16 +1,14 @@
-// ABOUTME: Unit tests for ensureChain — wallet network auto-switching before user signatures.
+// ABOUTME: Unit tests for ensureChain — direct-EIP-1193 switching, post-switch settle loop, user-rejection + chain-not-added wrapping.
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 // Hoisted mocks so `vi.mock` factories below can reference them.
-const { getAccountMock, switchChainMock } = vi.hoisted(() => ({
+const { getAccountMock } = vi.hoisted(() => ({
   getAccountMock: vi.fn(),
-  switchChainMock: vi.fn(),
 }))
 
 vi.mock('wagmi/actions', () => ({
   getAccount: getAccountMock,
-  switchChain: switchChainMock,
 }))
 
 vi.mock('@/config/wagmi', () => ({
@@ -25,74 +23,125 @@ vi.mock('@/config/network', () => ({
   },
 }))
 
-import { ensureChain, _isUserRejection } from './network-switch'
+import { ensureChain, _isUserRejection, _isChainNotAdded } from './network-switch'
 
 beforeEach(() => {
   getAccountMock.mockReset()
-  switchChainMock.mockReset()
 })
 
-/** Test helper — build a fake getAccount() return value with a connector that reports `liveChainId`. */
-function fakeConnected(liveChainId: number): { isConnected: boolean; connector: { getChainId: () => Promise<number> } } {
+/**
+ * Build a connected-account stub with a connector that exposes:
+ *  - `getChainId()` returning a queue of chainIds (one per call). The first call is the
+ *    pre-switch read; subsequent calls are the post-switch settle loop polls.
+ *  - `getProvider()` returning an EIP-1193 provider whose `request` is `requestMock`.
+ *
+ * Once the queue is exhausted the last value is reused — keeps settle-loop tests from blowing up
+ * if they happen to poll more times than the explicit fixture sequence.
+ */
+function fakeConnected(opts: {
+  liveChainIds: number[]
+  requestMock: ReturnType<typeof vi.fn>
+}): { isConnected: boolean; connector: { getChainId: () => Promise<number>; getProvider: () => Promise<unknown> } } {
+  const queue = [...opts.liveChainIds]
+  let last = queue[0] ?? 0
   return {
     isConnected: true,
-    connector: { getChainId: async () => liveChainId },
+    connector: {
+      getChainId: async () => {
+        const next = queue.shift()
+        if (next !== undefined) {
+          last = next
+          return next
+        }
+        return last
+      },
+      getProvider: async () => ({ request: opts.requestMock }),
+    },
   }
 }
 
 describe('ensureChain', () => {
-  it('no-ops when the connector reports the target chain (live)', async () => {
-    getAccountMock.mockReturnValue(fakeConnected(11155111))
+  it('no-ops when the connector already reports the target chain', async () => {
+    const requestMock = vi.fn()
+    getAccountMock.mockReturnValue(fakeConnected({ liveChainIds: [11155111], requestMock }))
     await ensureChain(11155111)
-    expect(switchChainMock).not.toHaveBeenCalled()
+    expect(requestMock).not.toHaveBeenCalled()
   })
 
-  it('calls switchChain when the connector reports a different chain', async () => {
-    getAccountMock.mockReturnValue(fakeConnected(84532))
-    switchChainMock.mockResolvedValueOnce(undefined)
+  it('sends wallet_switchEthereumChain with the hex-encoded target when chains differ', async () => {
+    const requestMock = vi.fn().mockResolvedValueOnce(null)
+    // Pre-switch read returns 84532; post-switch settle loop returns target on the first poll.
+    getAccountMock.mockReturnValue(fakeConnected({ liveChainIds: [84532, 11155111], requestMock }))
     await ensureChain(11155111)
-    expect(switchChainMock).toHaveBeenCalledWith({ _mock: true }, { chainId: 11155111 })
-  })
-
-  it('switches even when wagmi cached chainId matches but the live connector chainId does not', async () => {
-    // This is the desync case that motivated querying live: getAccount(config).chainId could
-    // show 11155111 while the actual injected wallet reports 84532. We must trust the live read.
-    getAccountMock.mockReturnValue({
-      isConnected: true,
-      chainId: 11155111, // stale wagmi cache
-      connector: { getChainId: async () => 84532 }, // live truth
+    expect(requestMock).toHaveBeenCalledTimes(1)
+    expect(requestMock).toHaveBeenCalledWith({
+      method: 'wallet_switchEthereumChain',
+      // 11155111 → 0xaa36a7
+      params: [{ chainId: '0xaa36a7' }],
     })
-    switchChainMock.mockResolvedValueOnce(undefined)
+  })
+
+  it('settles after polling once the connector acknowledges the new chain', async () => {
+    const requestMock = vi.fn().mockResolvedValueOnce(null)
+    // Sequence: pre-switch=84532, poll1=84532 (not yet), poll2=11155111 (matched, exit).
+    getAccountMock.mockReturnValue(fakeConnected({
+      liveChainIds: [84532, 84532, 11155111],
+      requestMock,
+    }))
     await ensureChain(11155111)
-    expect(switchChainMock).toHaveBeenCalledWith({ _mock: true }, { chainId: 11155111 })
+    expect(requestMock).toHaveBeenCalledTimes(1)
   })
 
   it('throws a friendly error when no wallet is connected', async () => {
     getAccountMock.mockReturnValue({ isConnected: false, connector: undefined })
     await expect(ensureChain(11155111)).rejects.toThrow(/no wallet connected/i)
-    expect(switchChainMock).not.toHaveBeenCalled()
   })
 
   it('throws an actionable error when the user rejects the switch', async () => {
-    getAccountMock.mockReturnValue(fakeConnected(84532))
     const rejection = Object.assign(new Error('User rejected the request.'), { code: 4001 })
-    switchChainMock.mockRejectedValue(rejection)
-    // Two assertions = two invocations of ensureChain; use sticky mockRejectedValue (not Once).
+    const requestMock = vi.fn().mockRejectedValue(rejection)
+    getAccountMock.mockReturnValue(fakeConnected({ liveChainIds: [84532], requestMock }))
     await expect(ensureChain(11155111)).rejects.toThrow(/network switch declined/i)
+    // Fresh account stub for the second invocation — the queue is consumed by the first call.
+    getAccountMock.mockReturnValue(fakeConnected({ liveChainIds: [84532], requestMock }))
     await expect(ensureChain(11155111)).rejects.toThrow(/Ethereum Sepolia/)
   })
 
+  it('throws an actionable error when the wallet does not have the chain configured (4902)', async () => {
+    // EIP-3326: wallets return code 4902 when they don't know about the requested chain. The
+    // user has to add it — we don't auto-add since the RPC URL we'd suggest may differ from the
+    // user's preferred endpoint.
+    const notAdded = Object.assign(new Error('Unrecognized chain ID "0xaa36a7"'), { code: 4902 })
+    const requestMock = vi.fn().mockRejectedValueOnce(notAdded)
+    getAccountMock.mockReturnValue(fakeConnected({ liveChainIds: [84532], requestMock }))
+    await expect(ensureChain(11155111)).rejects.toThrow(/Ethereum Sepolia isn't configured in your wallet/i)
+  })
+
   it('wraps unknown switch errors with chain context', async () => {
-    getAccountMock.mockReturnValue(fakeConnected(84532))
-    switchChainMock.mockRejectedValue(new Error('chain not configured'))
+    const requestMock = vi.fn().mockRejectedValueOnce(new Error('internal RPC failure'))
+    getAccountMock.mockReturnValue(fakeConnected({ liveChainIds: [84532], requestMock }))
     await expect(ensureChain(11155111)).rejects.toThrow(/Could not switch to Ethereum Sepolia/)
-    await expect(ensureChain(11155111)).rejects.toThrow(/chain not configured/)
   })
 
   it('falls back to a chain-id label when the chain is unknown to our config', async () => {
-    getAccountMock.mockReturnValue(fakeConnected(84532))
-    switchChainMock.mockRejectedValue(Object.assign(new Error('rejected'), { code: 4001 }))
+    const requestMock = vi.fn().mockRejectedValueOnce(
+      Object.assign(new Error('rejected'), { code: 4001 }),
+    )
+    getAccountMock.mockReturnValue(fakeConnected({ liveChainIds: [84532], requestMock }))
     await expect(ensureChain(9999)).rejects.toThrow(/chain 9999/)
+  })
+
+  it('throws when the connector does not expose an EIP-1193 provider', async () => {
+    // Pathological case — we narrow at the boundary so this is the friendly path rather than a
+    // raw "request is not a function" surfacing downstream.
+    getAccountMock.mockReturnValue({
+      isConnected: true,
+      connector: {
+        getChainId: async () => 84532,
+        getProvider: async () => ({ /* no .request */ }),
+      },
+    })
+    await expect(ensureChain(11155111)).rejects.toThrow(/did not expose an EIP-1193 provider/)
   })
 })
 
@@ -127,5 +176,34 @@ describe('isUserRejection', () => {
     expect(_isUserRejection(new Error('insufficient funds'))).toBe(false)
     expect(_isUserRejection(null)).toBe(false)
     expect(_isUserRejection(undefined)).toBe(false)
+  })
+})
+
+describe('isChainNotAdded', () => {
+  it('matches EIP-3326 code 4902', () => {
+    expect(_isChainNotAdded({ code: 4902 })).toBe(true)
+  })
+
+  it('matches the "Unrecognized chain" message pattern', () => {
+    expect(_isChainNotAdded(new Error('Unrecognized chain ID "0xaa36a7"'))).toBe(true)
+  })
+
+  it('matches assorted "chain not added/configured/recognized" phrasings', () => {
+    expect(_isChainNotAdded(new Error('chain is not added to wallet'))).toBe(true)
+    expect(_isChainNotAdded(new Error('Chain not recognized'))).toBe(true)
+    expect(_isChainNotAdded(new Error('chain is not configured here'))).toBe(true)
+  })
+
+  it('recurses into .cause', () => {
+    const inner = Object.assign(new Error('Unrecognized chain'), { code: 4902 })
+    const outer = new Error('Switch failed')
+    ;(outer as Error & { cause: unknown }).cause = inner
+    expect(_isChainNotAdded(outer)).toBe(true)
+  })
+
+  it('does NOT match unrelated errors or user rejections', () => {
+    expect(_isChainNotAdded(new Error('User rejected'))).toBe(false)
+    expect(_isChainNotAdded({ code: 4001 })).toBe(false)
+    expect(_isChainNotAdded(null)).toBe(false)
   })
 })

--- a/apps/armada-interface/src/lib/network-switch.ts
+++ b/apps/armada-interface/src/lib/network-switch.ts
@@ -1,12 +1,26 @@
-// ABOUTME: Ensures the connected wallet is on a specific chain before a user-signed transaction; prompts to switch otherwise.
-// ABOUTME: Called by tx handlers at their first user-signature point. Throws a friendly error on user rejection so the tx record carries actionable copy.
+// ABOUTME: Ensures the connected wallet is on a specific chain before a user-signed transaction; prompts to switch otherwise via raw EIP-1193 request.
+// ABOUTME: Bypasses wagmi/actions::switchChain so we don't trip wagmi's ConnectorChainMismatchError when its cached state is briefly out of sync with the live connector.
 
-import { getAccount, switchChain } from 'wagmi/actions'
+import { getAccount } from 'wagmi/actions'
 import { wagmiConfig } from '@/config/wagmi'
 import { getChainById } from '@/config/network'
 
+/** Minimal EIP-1193 surface — what `connector.getProvider()` returns. */
+interface Eip1193Provider {
+  request: (args: { method: string; params?: unknown[] }) => Promise<unknown>
+}
+
+/** How long to wait for the connector to settle on the new chainId after a successful switch request. */
+const POST_SWITCH_SETTLE_TIMEOUT_MS = 3_000
+/** Polling interval while waiting for the connector to report the new chainId. */
+const POST_SWITCH_POLL_INTERVAL_MS = 100
+
 function chainLabel(chainId: number): string {
   return getChainById(chainId)?.name ?? `chain ${chainId}`
+}
+
+function toHexChainId(chainId: number): `0x${string}` {
+  return `0x${chainId.toString(16)}`
 }
 
 /**
@@ -28,42 +42,120 @@ function isUserRejection(err: unknown): boolean {
 }
 
 /**
- * Ensure the connected EVM wallet is on `targetChainId` before signing. No-op if already on
- * the right chain. Otherwise prompts the user to switch (via wagmi → wallet → MetaMask) and
- * waits for the switch to settle.
+ * Detect EIP-3326 "chain not added" — the wallet doesn't have this chain configured and the user
+ * has to add it before the switch can complete. MetaMask returns code 4902; we also accept the
+ * message pattern as a fallback for wallets that surface the underlying RPC error.
+ */
+function isChainNotAdded(err: unknown): boolean {
+  if (!err) return false
+  const e = err as { code?: number | string; message?: string; cause?: unknown }
+  if (e.code === 4902) return true
+  const msg = e.message ?? ''
+  if (/unrecognized chain|chain.*not (added|recognized|configured)/i.test(msg)) return true
+  if (e.cause && e.cause !== err) return isChainNotAdded(e.cause)
+  return false
+}
+
+/**
+ * Narrow the unknown returned by `connector.getProvider()` to our minimal EIP-1193 shape.
+ * Both injected (MetaMask) and WalletConnect connectors implement `.request`; smart-wallet
+ * connectors wrap an EIP-1193 provider with the same shape.
+ */
+function asEip1193(provider: unknown): Eip1193Provider | null {
+  if (!provider || typeof provider !== 'object') return null
+  const candidate = provider as { request?: unknown }
+  if (typeof candidate.request !== 'function') return null
+  return candidate as Eip1193Provider
+}
+
+/**
+ * Ensure the connected EVM wallet is on `targetChainId` before signing. No-op if the connector
+ * already reports the target chain. Otherwise sends `wallet_switchEthereumChain` directly to the
+ * EIP-1193 provider and waits briefly for the connector to acknowledge.
  *
- * Throws a friendly user-facing message on rejection or unknown wallet errors so the tx
- * record's `error` field is actionable. Throws if no wallet is connected at all.
+ * Throws a friendly user-facing message on rejection, missing-chain, or unknown wallet errors so
+ * the tx record's `error` field is actionable. Throws if no wallet is connected at all.
  *
  * Use at the top of each handler's first user-signed step. The handler's outer try/catch
  * captures the thrown error and routes it into the tx record via `markFailed`.
  *
- * Implementation note: we query the connector's *live* chainId via `connector.getChainId()`
- * rather than reading `getAccount(config).chainId`. The latter reflects the last
- * `chainChanged` event wagmi observed — which can be stale when wagmi's cached state desyncs
- * from the wallet (e.g. mid-flight switches, dropped events, race conditions on connector
- * reconnect). Querying live mirrors what every wagmi action does internally before throwing
- * `ConnectorChainMismatchError`, so we make the same comparison they will.
+ * Why raw EIP-1193 instead of `wagmi/actions::switchChain`: when wagmi's cached connection state
+ * briefly disagrees with the live connector (which happens on mid-flight chain changes, dropped
+ * `chainChanged` events, or connector-reconnect races), wagmi's actions throw
+ * `ConnectorChainMismatchError` at entry — BEFORE attempting the switch. The user sees a hard
+ * error instead of the MetaMask prompt. Sending the request directly to the provider sidesteps
+ * wagmi's invariant check; the wallet's subsequent `chainChanged` event lets wagmi self-correct.
+ *
+ * After the switch we poll the connector until its live `getChainId()` matches the target, so
+ * downstream wagmi calls (`signMessage`, `writeContract`) don't immediately re-throw on a
+ * still-stale wagmi cache. The poll is bounded; if it times out we still return and let the
+ * downstream call decide whether to fail.
  */
 export async function ensureChain(targetChainId: number): Promise<void> {
   const account = getAccount(wagmiConfig)
   if (!account.isConnected || !account.connector) {
     throw new Error('No wallet connected — connect a wallet before submitting a transaction.')
   }
-  const liveChainId = await account.connector.getChainId()
+  const connector = account.connector
+
+  const liveChainId = await connector.getChainId()
   if (liveChainId === targetChainId) return
+
+  const provider = asEip1193(await connector.getProvider())
+  if (!provider) {
+    throw new Error(
+      `Could not switch to ${chainLabel(targetChainId)}: connector did not expose an EIP-1193 provider.`,
+    )
+  }
+
   try {
-    await switchChain(wagmiConfig, { chainId: targetChainId })
+    await provider.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: toHexChainId(targetChainId) }],
+    })
   } catch (err) {
     if (isUserRejection(err)) {
       throw new Error(
         `Network switch declined. Approve the switch to ${chainLabel(targetChainId)} in your wallet and try again.`,
       )
     }
+    if (isChainNotAdded(err)) {
+      throw new Error(
+        `${chainLabel(targetChainId)} isn't configured in your wallet. Add the network and try again.`,
+      )
+    }
     const msg = err instanceof Error ? err.message : 'unknown error'
     throw new Error(`Could not switch to ${chainLabel(targetChainId)}: ${msg}`)
+  }
+
+  // Wait for the connector's live chainId to acknowledge the switch. wagmi listens for the
+  // wallet's `chainChanged` event and updates its cache; downstream actions check that cache.
+  // Polling against the connector tracks the same source of truth wagmi relies on, so once we
+  // see it match the target the next wagmi call is safe.
+  await waitForConnectorChainId(targetChainId, connector)
+}
+
+/**
+ * Poll `connector.getChainId()` until it matches `targetChainId` or the timeout expires. Resolves
+ * either way — if the connector hasn't acknowledged within the window we still return, letting
+ * the downstream wagmi action surface its own error. This is intentional: blocking forever on a
+ * pathological wallet would be worse UX than a clear "current chain" error from the next call.
+ */
+async function waitForConnectorChainId(
+  targetChainId: number,
+  connector: NonNullable<ReturnType<typeof getAccount>['connector']>,
+): Promise<void> {
+  const deadline = Date.now() + POST_SWITCH_SETTLE_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    try {
+      const live = await connector.getChainId()
+      if (live === targetChainId) return
+    } catch {
+      // Ignore transient errors — keep polling until the timeout.
+    }
+    await new Promise<void>(resolve => setTimeout(resolve, POST_SWITCH_POLL_INTERVAL_MS))
   }
 }
 
 // Internal — exported for tests only. Do not import from app code.
-export { isUserRejection as _isUserRejection }
+export { isUserRejection as _isUserRejection, isChainNotAdded as _isChainNotAdded }


### PR DESCRIPTION
## Problem

Submitting a shield (and any user-signed flow) from a wallet on the wrong chain fails with:

> The current chain of the connector (id: X) does not match the connection's chain (id: Y)

without a MetaMask prompt firing. Root cause: \`wagmi/actions::switchChain\` calls \`getConnectorClient\` internally, which asserts wagmi's cached chainId matches the live connector. When they disagree (after an external MetaMask switch + a dropped \`chainChanged\` event, or a connector-reconnect race), the action throws **before** attempting the switch.

Our PR #281 fix addressed the inverse: we now consult the connector live for ensureChain's early-return check, so we don't *skip* a needed switch. But we still hit wagmi's internal mismatch guard when actually calling switchChain.

## Fix

\`ensureChain\` now sends \`wallet_switchEthereumChain\` directly to the EIP-1193 provider via \`connector.getProvider()\`, sidestepping wagmi's invariant check entirely. This is the pattern the legacy \`usdc-v2-frontend\` uses (\`services/wallet/walletService.ts:134\`).

After the switch we poll \`connector.getChainId()\` for up to 3s so downstream wagmi calls (\`signMessage\`, \`writeContract\`) don't immediately re-throw on a still-stale wagmi cache. wagmi's own \`chainChanged\` listener updates its cache during that window. If the poll times out we still resolve and let the downstream call surface its own error — blocking forever on a pathological wallet would be worse UX.

Also adds a friendly wrapper for EIP-3326 code 4902 (\"chain not configured in wallet\") alongside the existing 4001/rejection handling.

## Test plan

- [x] \`npm run typecheck --workspace=@armada/interface\` — clean
- [x] \`npx vitest run --root=apps/armada-interface\` — 522/522 (network-switch suite expanded to 20)
- [ ] Manual: app on MetaMask Sepolia, switch MetaMask externally to Base Sepolia, open Shield modal, Confirm — should now prompt for the switch back to Sepolia instead of erroring out
- [ ] Manual: open Shield modal while already on Sepolia — no prompt, no switch overhead
- [ ] Manual (optional): try shielding while MetaMask doesn't have Sepolia configured — should surface \"Ethereum Sepolia isn't configured in your wallet\" instead of the raw RPC error

🤖 Generated with [Claude Code](https://claude.com/claude-code)