### PR TITLE
feat(armada-interface): honest cancel + typed tx errors + receipt timeouts

### DIFF
--- a/apps/armada-interface/src/components/flow/ErrorStep/ErrorStep.module.css
+++ b/apps/armada-interface/src/components/flow/ErrorStep/ErrorStep.module.css
@@ -31,6 +31,19 @@
   max-width: 44ch;
 }
 
+.explorerLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--primitives-spacing-1);
+  color: var(--semantic-color-brand-lavender);
+  text-decoration: underline;
+}
+
+.explorerLink:hover,
+.explorerLink:focus-visible {
+  color: var(--semantic-color-text-primary);
+}
+
 .footer {
   /* Span the dialog edges; cancel the ActionFlowShell body's 24px padding. */
   align-self: stretch;

--- a/apps/armada-interface/src/components/flow/ErrorStep/ErrorStep.test.tsx
+++ b/apps/armada-interface/src/components/flow/ErrorStep/ErrorStep.test.tsx
@@ -1,24 +1,70 @@
-// ABOUTME: Tests for ErrorStep — renders default and custom title, optional message, Try Again gated on onRetry, View Details optional.
-// ABOUTME: Try Again button always renders so the user has something to click; it's disabled when no retry handler is supplied.
+// ABOUTME: Tests for ErrorStep — category-aware title/body from `error.code`, explorer link when txHash is supplied, Try Again gating, View Details optional, fallback to `message` when no typed error.
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ErrorStep } from './ErrorStep'
 
 describe('<ErrorStep>', () => {
-  it('renders the default title', () => {
+  it('renders the default fallback title when no error or message is supplied', () => {
     render(<ErrorStep />)
     expect(screen.getByText('Something went wrong')).toBeInTheDocument()
   })
 
-  it('renders a custom title', () => {
-    render(<ErrorStep title="Withdraw failed" />)
-    expect(screen.getByText('Withdraw failed')).toBeInTheDocument()
+  it('uses category-specific copy for POLL_TIMEOUT', () => {
+    // Distinct from "Failed" — POLL_TIMEOUT means the tx may still complete on chain. We need
+    // the user to understand the difference so they don't assume their funds are lost.
+    render(<ErrorStep error={{ code: 'POLL_TIMEOUT', message: 'raw lib msg' }} />)
+    expect(screen.getByText('Lost track of your transaction')).toBeInTheDocument()
+    expect(screen.getByText(/may still complete/i)).toBeInTheDocument()
   })
 
-  it('renders the message when provided', () => {
+  it('uses category-specific copy for DISMISSED', () => {
+    // The user explicitly stopped tracking a post-broadcast tx. Different copy from CANCELLED
+    // (which means "no tx was sent at all").
+    render(<ErrorStep error={{ code: 'DISMISSED', message: '' }} />)
+    expect(screen.getByText('Stopped tracking')).toBeInTheDocument()
+  })
+
+  it('uses category-specific copy for TX_REVERTED', () => {
+    render(<ErrorStep error={{ code: 'TX_REVERTED', message: 'execution reverted' }} />)
+    expect(screen.getByText('Transaction failed on chain')).toBeInTheDocument()
+  })
+
+  it('uses category-specific copy for USER_REJECTED', () => {
+    render(<ErrorStep error={{ code: 'USER_REJECTED', message: 'user denied' }} />)
+    expect(screen.getByText('Action declined')).toBeInTheDocument()
+  })
+
+  it('renders the raw error.message when the code is OTHER and no body is preset', () => {
+    // OTHER has no category-specific body — fall through to the raw message so we don't hide
+    // a useful error string from the user (or developer) in production.
+    render(<ErrorStep error={{ code: 'OTHER', message: 'gas estimation failed: insufficient funds' }} />)
+    expect(screen.getByText(/insufficient funds/)).toBeInTheDocument()
+  })
+
+  it('renders the fallback `message` prop when no typed error is supplied (submit-time path)', () => {
     render(<ErrorStep message="Relayer returned 502 Bad Gateway." />)
     expect(screen.getByText('Relayer returned 502 Bad Gateway.')).toBeInTheDocument()
+  })
+
+  it('renders an explorer link when explorerUrl is supplied', () => {
+    render(
+      <ErrorStep
+        error={{ code: 'POLL_TIMEOUT', message: '', txHash: '0xabc' }}
+        explorerUrl="https://sepolia.etherscan.io/tx/0xabc"
+      />,
+    )
+    const link = screen.getByRole('link', { name: /View on block explorer/i })
+    expect(link).toHaveAttribute('href', 'https://sepolia.etherscan.io/tx/0xabc')
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+
+  it('omits the explorer link when explorerUrl is undefined', () => {
+    // POLL_TIMEOUT category itself doesn't render the link — only when the modal supplies the
+    // composed URL. Records without a known explorerUrl (e.g. local Anvil) should not show a
+    // broken anchor.
+    render(<ErrorStep error={{ code: 'POLL_TIMEOUT', message: '' }} />)
+    expect(screen.queryByRole('link')).toBeNull()
   })
 
   it('disables Try Again when onRetry is omitted', () => {

--- a/apps/armada-interface/src/components/flow/ErrorStep/ErrorStep.tsx
+++ b/apps/armada-interface/src/components/flow/ErrorStep/ErrorStep.tsx
@@ -1,15 +1,66 @@
-// ABOUTME: Shared error step — circular error icon + headline + supporting message + Try Again + View Details CTAs.
-// ABOUTME: Try Again is disabled when onRetry is omitted (signaling the failing stage was not retryable per its TxLifecycle).
+// ABOUTME: Shared error step — circular error icon + category-aware headline + message + optional explorer link + Try Again / View Details CTAs.
+// ABOUTME: Picks honest copy based on `error.code`: POLL_TIMEOUT / DISMISSED surface "may still complete" + an explorer link; TX_REVERTED is unambiguous failure; USER_REJECTED is friendly.
 
-import { AlertCircle } from 'lucide-react'
+import { AlertCircle, ExternalLink } from 'lucide-react'
 import { FlowFooter } from '../FlowFooter'
+import type { TxError } from '@/lib/tx/types'
 import styles from './ErrorStep.module.css'
 
+/**
+ * Category-specific copy for the error step. Sourced from `error.code` so the UI never reads
+ * "Something went wrong" when we actually know what happened (e.g. we lost track of a still-mining
+ * tx vs the user declined a wallet prompt).
+ *
+ * Centralized here rather than in stageCopy so the modal can stay dumb — pass the TxError, render
+ * the right copy.
+ */
+const COPY_BY_CODE: Record<TxError['code'], { title: string; body?: string }> = {
+  TX_REVERTED: {
+    title: 'Transaction failed on chain',
+    body: 'The network mined your transaction but the contract reverted. No funds were moved.',
+  },
+  POLL_TIMEOUT: {
+    title: 'Lost track of your transaction',
+    body: 'We stopped watching after the time budget elapsed. The transaction may still complete — check the explorer to confirm.',
+  },
+  RPC_ERROR: {
+    title: 'Network error',
+    body: 'We hit an error talking to the chain. Try again — your transaction may not have been submitted yet.',
+  },
+  USER_REJECTED: {
+    title: 'Action declined',
+    body: 'You declined the prompt in your wallet. Nothing was submitted.',
+  },
+  CANCELLED: {
+    title: 'Cancelled',
+    body: 'No transaction was sent.',
+  },
+  DISMISSED: {
+    title: 'Stopped tracking',
+    body: 'You asked us to stop watching this transaction. It may still complete on chain — check the explorer.',
+  },
+  OTHER: {
+    title: 'Something went wrong',
+  },
+}
+
 export interface ErrorStepProps {
-  /** Headline shown beneath the icon. Defaults to "Something went wrong". */
-  title?: string
-  /** Supporting message — from `record.artifacts.error` or the throw site. */
+  /**
+   * Categorised error to render. Wins over `message` when present — surfaces the right title,
+   * supporting copy, and (for POLL_TIMEOUT / DISMISSED) an explorer link.
+   */
+  error?: TxError | null
+  /**
+   * Fallback supporting message — used when no typed `error` is supplied (e.g. the modal caught a
+   * submit-time throw before any record was created).
+   */
   message?: string
+  /**
+   * Pre-built explorer URL (e.g. `https://sepolia.etherscan.io/tx/0x...`). Modal computes this
+   * from `error.txHash` + the appropriate chain id since ErrorStep itself doesn't know which
+   * chain the hash lives on.
+   */
+  explorerUrl?: string
   /** Try Again handler. Omit to disable the button (failing stage is not in lifecycle.retryableStages). */
   onRetry?: () => void
   /** View Details handler — typically expands the TechnicalDetailsDisclosure inside the body. */
@@ -17,18 +68,36 @@ export interface ErrorStepProps {
 }
 
 export function ErrorStep({
-  title = 'Something went wrong',
+  error,
   message,
+  explorerUrl,
   onRetry,
   onViewDetails,
 }: ErrorStepProps) {
+  const copy = error ? COPY_BY_CODE[error.code] : undefined
+  const title = copy?.title ?? 'Something went wrong'
+  // Prefer the category's stock body copy over the raw error.message — the raw message is often
+  // technical (viem stack frames, RPC payloads) and our category-specific body is more useful.
+  // If neither exists, fall back to the bare message prop (submit-time errors from modals).
+  const body = copy?.body ?? error?.message ?? message
+
   return (
     <div className={styles.root}>
       <div className={styles.icon} aria-hidden="true">
         <AlertCircle size={36} />
       </div>
       <div className={styles.title}>{title}</div>
-      {message ? <div className={styles.message}>{message}</div> : null}
+      {body ? <div className={styles.message}>{body}</div> : null}
+      {explorerUrl ? (
+        <a
+          className={styles.explorerLink}
+          href={explorerUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View on block explorer <ExternalLink size={14} aria-hidden="true" />
+        </a>
+      ) : null}
       <FlowFooter
         className={styles.footer}
         primary={{ label: 'Try again', onClick: onRetry, disabled: !onRetry }}

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/config/deployments'
 import { parseUsdcInput } from '@/lib/format'
 import { userFeeForKind } from '@/lib/relayer'
-import { txExplorerUrl } from '@/lib/explorer'
+import { displayTxHash, txExplorerUrl } from '@/lib/explorer'
 import {
   ActionFlowShell,
   ProgressStep,
@@ -230,7 +230,7 @@ export function SendModal() {
         <ErrorStep
           error={record?.artifacts.error ?? null}
           message={submitError ?? undefined}
-          explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, record?.artifacts.error?.txHash ?? record?.artifacts.sourceTxHash)}
+          explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, displayTxHash(record))}
           onRetry={errorAtStep === 'review' ? () => setStep('review') : () => activeTx?.retry()}
         />
       )}

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/config/deployments'
 import { parseUsdcInput } from '@/lib/format'
 import { userFeeForKind } from '@/lib/relayer'
+import { txExplorerUrl } from '@/lib/explorer'
 import {
   ActionFlowShell,
   ProgressStep,
@@ -227,7 +228,9 @@ export function SendModal() {
       )}
       {step === 'error' && (
         <ErrorStep
-          message={submitError ?? record?.artifacts.error ?? undefined}
+          error={record?.artifacts.error ?? null}
+          message={submitError ?? undefined}
+          explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, record?.artifacts.error?.txHash ?? record?.artifacts.sourceTxHash)}
           onRetry={errorAtStep === 'review' ? () => setStep('review') : () => activeTx?.retry()}
         />
       )}

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -10,6 +10,7 @@ import { userFeeForKind } from '@/lib/relayer'
 import { useBalances } from '@/hooks/useBalances'
 import { getNetworkConfig } from '@/config/network'
 import { parseUsdcInput } from '@/lib/format'
+import { txExplorerUrl } from '@/lib/explorer'
 import {
   ActionFlowShell,
   ProgressStep,
@@ -167,7 +168,9 @@ export function ShieldModal() {
       {step === 'complete' && <ShieldCompleteStep netAmount={netAmount} onDone={close} />}
       {step === 'error' && (
         <ErrorStep
-          message={submitError ?? record?.artifacts.error ?? undefined}
+          error={record?.artifacts.error ?? null}
+          message={submitError ?? undefined}
+          explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, record?.artifacts.error?.txHash ?? record?.artifacts.sourceTxHash)}
           onRetry={errorAtStep === 'review' ? () => setStep('review') : () => activeTx?.retry()}
         />
       )}

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -10,7 +10,7 @@ import { userFeeForKind } from '@/lib/relayer'
 import { useBalances } from '@/hooks/useBalances'
 import { getNetworkConfig } from '@/config/network'
 import { parseUsdcInput } from '@/lib/format'
-import { txExplorerUrl } from '@/lib/explorer'
+import { displayTxHash, txExplorerUrl } from '@/lib/explorer'
 import {
   ActionFlowShell,
   ProgressStep,
@@ -170,7 +170,7 @@ export function ShieldModal() {
         <ErrorStep
           error={record?.artifacts.error ?? null}
           message={submitError ?? undefined}
-          explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, record?.artifacts.error?.txHash ?? record?.artifacts.sourceTxHash)}
+          explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, displayTxHash(record))}
           onRetry={errorAtStep === 'review' ? () => setStep('review') : () => activeTx?.retry()}
         />
       )}

--- a/apps/armada-interface/src/components/tx/TxActions.tsx
+++ b/apps/armada-interface/src/components/tx/TxActions.tsx
@@ -1,21 +1,32 @@
-// ABOUTME: Per-record retry/cancel CTAs. Rendered inside History's expanded detail and inside ProgressStep (cancel only).
-// ABOUTME: Operates on TxRecord directly — no `useTx` subscription needed, calls executor module functions by id.
+// ABOUTME: Per-record retry/cancel CTAs. Stage-aware: pre-broadcast records get "Cancel" (abort safely), post-broadcast records get "Stop tracking" (the on-chain tx still runs; we just stop watching).
+// ABOUTME: Rendered inside History's expanded detail and inside ProgressStep (cancel only). Operates on TxRecord directly — no `useTx` subscription needed.
 
 import { Button } from '@armada/ui'
-import { cancelTx, canRetryTx, retryTx } from '@/lib/tx/executor'
+import { cancelTx, canRetryTx, dismissTx, retryTx } from '@/lib/tx/executor'
 import type { TxRecord } from '@/lib/tx/types'
 import styles from './TxActions.module.css'
 
 export interface TxActionsProps {
   record: TxRecord
   /**
-   * Subset of buttons to render. Default `'both'` shows Cancel + Retry depending on state.
+   * Subset of buttons to render. Default `'both'` shows Cancel/Stop + Retry depending on state.
    * Modals' Progress step uses `'cancel'` since they handle Retry via the dedicated ErrorStep.
    */
   variant?: 'both' | 'cancel'
 }
 
 const PRE_TERMINAL_STATES = new Set(['pending', 'active', 'waiting', 'retrying'])
+
+/**
+ * Decide whether the cancel/stop CTA reflects a pre-broadcast or post-broadcast record. Once a
+ * sourceTxHash is set we've already broadcast — the chain is running its own clock and a
+ * "Cancel" label would be dishonest. Switch to "Stop tracking" copy and call dismissTx, which
+ * marks the record DISMISSED instead of CANCELLED so the UI can render explorer-link copy.
+ */
+function hasBroadcast(record: TxRecord): boolean {
+  const sourceTxHash = (record.artifacts as { sourceTxHash?: `0x${string}` }).sourceTxHash
+  return Boolean(sourceTxHash)
+}
 
 export function TxActions({ record, variant = 'both' }: TxActionsProps) {
   const isInFlight = PRE_TERMINAL_STATES.has(record.executionState)
@@ -24,6 +35,23 @@ export function TxActions({ record, variant = 'both' }: TxActionsProps) {
   // Nothing to show on completed records — no Cancel (already done), no Retry (lifecycle finished).
   if (!isInFlight && !canRetry) return null
 
+  const broadcasted = hasBroadcast(record)
+  const stopLabel = broadcasted ? 'Stop tracking' : 'Cancel'
+  // Confirm before dismissing — the user is intentionally stopping us from watching an on-chain
+  // tx that will still run regardless. A bare click on the same place that previously meant
+  // "true cancel" should NOT silently drop us into the dismissed state.
+  const onStopClick = () => {
+    if (broadcasted) {
+      const ok = typeof window !== 'undefined' && typeof window.confirm === 'function'
+        ? window.confirm('Your transaction is already on chain and will continue. We will stop watching it — you can find it on the block explorer using the link in the error view.')
+        : true
+      if (!ok) return
+      dismissTx(record.id)
+    } else {
+      cancelTx(record.id)
+    }
+  }
+
   return (
     <div className={styles.row}>
       {isInFlight ? (
@@ -31,8 +59,8 @@ export function TxActions({ record, variant = 'both' }: TxActionsProps) {
           variant="secondary"
           size="sm"
           showIcon={false}
-          label="Cancel"
-          onClick={() => cancelTx(record.id)}
+          label={stopLabel}
+          onClick={onStopClick}
         />
       ) : null}
       {canRetry ? (

--- a/apps/armada-interface/src/components/tx/TxLifecycleStepper.module.css
+++ b/apps/armada-interface/src/components/tx/TxLifecycleStepper.module.css
@@ -175,3 +175,11 @@
 .error {
   color: var(--semantic-color-status-error);
 }
+
+.errorCode {
+  font-family: var(--primitives-fontFamily-mono);
+  background: rgba(248, 113, 113, 0.08);
+  border-radius: 3px;
+  padding: 0 4px;
+  margin-right: 2px;
+}

--- a/apps/armada-interface/src/components/tx/TxLifecycleStepper.test.tsx
+++ b/apps/armada-interface/src/components/tx/TxLifecycleStepper.test.tsx
@@ -78,17 +78,18 @@ describe('<TxLifecycleStepper>', () => {
     expect(currentRow?.textContent).toMatch(/Waiting for cross-chain confirmation/)
   })
 
-  it('surfaces error text inside the technical details when present', () => {
+  it('surfaces the categorised error code + message inside the technical details when present', () => {
     render(
       <TxLifecycleStepper
         record={shieldRecord({
           executionState: 'failed',
-          artifacts: { error: 'Relayer returned 502' },
+          artifacts: { error: { code: 'RPC_ERROR', message: 'Relayer returned 502' } },
         })}
         technicalDetailsDefaultOpen
       />,
     )
-    expect(screen.getByText('Relayer returned 502')).toBeInTheDocument()
+    expect(screen.getByText('RPC_ERROR')).toBeInTheDocument()
+    expect(screen.getByText(/Relayer returned 502/)).toBeInTheDocument()
   })
 
   it('shows source tx hash inside the technical details', () => {

--- a/apps/armada-interface/src/components/tx/TxLifecycleStepper.tsx
+++ b/apps/armada-interface/src/components/tx/TxLifecycleStepper.tsx
@@ -72,7 +72,7 @@ export function TxLifecycleStepper({
   return (
     <div className={cls}>
       <header className={styles.header}>
-        <TxStatusChip state={record.executionState} />
+        <TxStatusChip state={record.executionState} error={record.artifacts.error ?? null} />
         <span className={styles.eta}>Usually takes {formatDurationHint(lifecycle.estDuration.p50)}</span>
       </header>
 
@@ -183,7 +183,11 @@ export function TxLifecycleStepper({
           {record.artifacts.error ? (
             <div>
               <dt>Error</dt>
-              <dd className={styles.error}>{record.artifacts.error}</dd>
+              <dd className={styles.error}>
+                <span className={styles.errorCode}>{record.artifacts.error.code}</span>
+                {' '}
+                {record.artifacts.error.message}
+              </dd>
             </div>
           ) : null}
         </dl>

--- a/apps/armada-interface/src/components/tx/TxRow.tsx
+++ b/apps/armada-interface/src/components/tx/TxRow.tsx
@@ -79,7 +79,7 @@ export function TxRow({
         ) : null}
       </div>
       <div className={styles.meta}>
-        <TxStatusChip state={record.executionState} />
+        <TxStatusChip state={record.executionState} error={record.artifacts.error ?? null} />
         <span className={styles.time}>{formatRelativeTime(record.updatedAt)}</span>
       </div>
     </Tag>

--- a/apps/armada-interface/src/components/tx/TxStatusChip.test.tsx
+++ b/apps/armada-interface/src/components/tx/TxStatusChip.test.tsx
@@ -22,4 +22,24 @@ describe('<TxStatusChip>', () => {
     render(<TxStatusChip state={state} />)
     expect(screen.getByText(label)).toBeInTheDocument()
   })
+
+  it('renders cancelled + DISMISSED error as "Stopped tracking"', () => {
+    // The user explicitly stopped watching a post-broadcast tx. "Cancelled" would mislead them
+    // into thinking the on-chain tx didn't happen — "Stopped tracking" is the honest label.
+    render(
+      <TxStatusChip
+        state="cancelled"
+        error={{ code: 'DISMISSED', message: '', txHash: '0xabc' }}
+      />,
+    )
+    expect(screen.getByText('Stopped tracking')).toBeInTheDocument()
+    expect(screen.queryByText('Cancelled')).toBeNull()
+  })
+
+  it('still renders cancelled + CANCELLED error as "Cancelled" (pre-broadcast cancel path)', () => {
+    // When the cancel happened before broadcast (no txHash), the label is unchanged. The
+    // distinction matters only for the dismissed path.
+    render(<TxStatusChip state="cancelled" error={{ code: 'CANCELLED', message: '' }} />)
+    expect(screen.getByText('Cancelled')).toBeInTheDocument()
+  })
 })

--- a/apps/armada-interface/src/components/tx/TxStatusChip.tsx
+++ b/apps/armada-interface/src/components/tx/TxStatusChip.tsx
@@ -1,11 +1,18 @@
-// ABOUTME: TxStatusChip — maps TxExecutionState to a StatusChip variant + label.
-// ABOUTME: Consolidates pre-terminal states (pending/active/waiting/retrying) under a single "Pending" badge.
+// ABOUTME: TxStatusChip — maps TxExecutionState (+ optional TxError code) to a StatusChip variant + label.
+// ABOUTME: Consolidates pre-terminal states under "Pending"; distinguishes DISMISSED ("Stopped tracking") from plain CANCELLED so the user knows their on-chain tx is still live.
 
 import { StatusChip, type StatusChipVariant } from '../ui/StatusChip'
-import type { TxExecutionState } from '@/lib/tx/types'
+import type { TxError, TxExecutionState } from '@/lib/tx/types'
 
 export interface TxStatusChipProps {
   state: TxExecutionState
+  /**
+   * Optional error payload — used to refine the chip when execution state alone is ambiguous.
+   * Specifically, a `cancelled` record with `error.code === 'DISMISSED'` reads "Stopped tracking"
+   * because the on-chain tx is still running; without this hint we'd render "Cancelled" and
+   * mislead the user about whether their funds moved.
+   */
+  error?: TxError | null
   className?: string
 }
 
@@ -25,7 +32,13 @@ const MAP: Record<TxExecutionState, StatusDescriptor> = {
   cancelled: { variant: 'neutral', label: 'Cancelled' },
 }
 
-export function TxStatusChip({ state, className }: TxStatusChipProps) {
-  const { variant, label } = MAP[state]
+export function TxStatusChip({ state, error, className }: TxStatusChipProps) {
+  let { variant, label } = MAP[state]
+  // DISMISSED is the "user stopped tracking after broadcast" path — the chain doesn't know we
+  // gave up, so the chip should communicate "we lost track" rather than the misleading "Cancelled"
+  // which implies nothing happened.
+  if (state === 'cancelled' && error?.code === 'DISMISSED') {
+    label = 'Stopped tracking'
+  }
   return <StatusChip variant={variant} label={label} className={className} />
 }

--- a/apps/armada-interface/src/components/unshield/UnshieldModal.tsx
+++ b/apps/armada-interface/src/components/unshield/UnshieldModal.tsx
@@ -10,6 +10,7 @@ import { useFees } from '@/hooks/useFees'
 import { useSpendableSyncGate } from '@/hooks/useSpendableSyncGate'
 import { getNetworkConfig } from '@/config/network'
 import { parseUsdcInput } from '@/lib/format'
+import { txExplorerUrl } from '@/lib/explorer'
 import { userFeeForKind } from '@/lib/relayer'
 import {
   ActionFlowShell,
@@ -189,7 +190,9 @@ export function UnshieldModal() {
       )}
       {step === 'error' && (
         <ErrorStep
-          message={submitError ?? record?.artifacts.error ?? undefined}
+          error={record?.artifacts.error ?? null}
+          message={submitError ?? undefined}
+          explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, record?.artifacts.error?.txHash ?? record?.artifacts.sourceTxHash)}
           onRetry={errorAtStep === 'review' ? () => setStep('review') : () => activeTx?.retry()}
         />
       )}

--- a/apps/armada-interface/src/components/unshield/UnshieldModal.tsx
+++ b/apps/armada-interface/src/components/unshield/UnshieldModal.tsx
@@ -10,7 +10,7 @@ import { useFees } from '@/hooks/useFees'
 import { useSpendableSyncGate } from '@/hooks/useSpendableSyncGate'
 import { getNetworkConfig } from '@/config/network'
 import { parseUsdcInput } from '@/lib/format'
-import { txExplorerUrl } from '@/lib/explorer'
+import { displayTxHash, txExplorerUrl } from '@/lib/explorer'
 import { userFeeForKind } from '@/lib/relayer'
 import {
   ActionFlowShell,
@@ -192,7 +192,7 @@ export function UnshieldModal() {
         <ErrorStep
           error={record?.artifacts.error ?? null}
           message={submitError ?? undefined}
-          explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, record?.artifacts.error?.txHash ?? record?.artifacts.sourceTxHash)}
+          explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, displayTxHash(record))}
           onRetry={errorAtStep === 'review' ? () => setStep('review') : () => activeTx?.retry()}
         />
       )}

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -11,6 +11,7 @@ import { useSpendableSyncGate } from '@/hooks/useSpendableSyncGate'
 import { useYieldRate } from '@/hooks/useYieldRate'
 import { parseUsdcInput } from '@/lib/format'
 import { userFeeForKind } from '@/lib/relayer'
+import { txExplorerUrl } from '@/lib/explorer'
 import { sharesToUsdc } from '@/lib/yield'
 import {
   ActionFlowShell,
@@ -195,7 +196,9 @@ export function EarnModal() {
       )}
       {step === 'error' && (
         <ErrorStep
-          message={submitError ?? record?.artifacts.error ?? undefined}
+          error={record?.artifacts.error ?? null}
+          message={submitError ?? undefined}
+          explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, record?.artifacts.error?.txHash ?? record?.artifacts.sourceTxHash)}
           onRetry={errorAtStep === 'review' ? () => setStep('review') : () => activeTx?.retry()}
         />
       )}

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -11,7 +11,7 @@ import { useSpendableSyncGate } from '@/hooks/useSpendableSyncGate'
 import { useYieldRate } from '@/hooks/useYieldRate'
 import { parseUsdcInput } from '@/lib/format'
 import { userFeeForKind } from '@/lib/relayer'
-import { txExplorerUrl } from '@/lib/explorer'
+import { displayTxHash, txExplorerUrl } from '@/lib/explorer'
 import { sharesToUsdc } from '@/lib/yield'
 import {
   ActionFlowShell,
@@ -198,7 +198,7 @@ export function EarnModal() {
         <ErrorStep
           error={record?.artifacts.error ?? null}
           message={submitError ?? undefined}
-          explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, record?.artifacts.error?.txHash ?? record?.artifacts.sourceTxHash)}
+          explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, displayTxHash(record))}
           onRetry={errorAtStep === 'review' ? () => setStep('review') : () => activeTx?.retry()}
         />
       )}

--- a/apps/armada-interface/src/features/shield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/shield-xchain/handler.ts
@@ -7,7 +7,6 @@ import {
   readContract,
   sendTransaction,
   signMessage,
-  waitForTransactionReceipt,
   writeContract,
 } from 'wagmi/actions'
 import { erc20Abi, maxUint256 } from 'viem'
@@ -31,6 +30,9 @@ import { cctpMaxFeeForKind } from '@/lib/relayer'
 import { ensureChain } from '@/lib/network-switch'
 import { advance, markFailed, markWaiting, patchArtifacts } from '@/lib/tx/reducer'
 import { poll } from '@/lib/tx/poller'
+import { asTxError, waitForReceiptOrFail } from '@/lib/tx/receipt'
+import { classifyHandlerError } from '@/lib/tx/errors'
+import { lifecycleFor } from '@/lib/tx/lifecycles'
 import { scanCctpDeliveryWindow } from '../unshield-xchain/scan'
 import type { StageHandler } from '@/lib/tx/executor'
 import type { TxRecord } from '@/lib/tx/types'
@@ -112,8 +114,8 @@ export const shieldXchainHandler: StageHandler<'shield-xchain'> = {
         // here only if we crashed mid-walk; we're already terminal in that case.
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'shield-xchain handler failed'
-      await ctx.upsert(markFailed(record, message))
+      if (ctx.signal.aborted) return
+      await ctx.upsert(markFailed(record, classifyHandlerError(err, 'Cross-chain deposit failed.', record.artifacts.sourceTxHash)))
     }
   },
 }
@@ -220,8 +222,7 @@ async function runSubmitAndBurn(
       functionName: 'approve',
       args: [privacyPoolClientAddress as `0x${string}`, maxUint256],
     })
-    await waitForTransactionReceipt(wagmiConfig, { hash: approveHash })
-    if (ctx.signal.aborted) throw new Error('cancelled')
+    await waitForReceiptOrFail({ hash: approveHash, signal: ctx.signal, chainId: record.meta.fromChainId })
   }
 
   // 2. destinationCaller = the HUB's hookRouter, in bytes32 form. Constrains who can call
@@ -265,13 +266,16 @@ async function runSubmitAndBurn(
     value: 0n,
     chainId: record.meta.fromChainId,
   })
+  // Persist sourceTxHash before the receipt wait so any timeout / revert / cancel error carries
+  // the hash forward into the error UX (explorer link, "Stopped tracking" copy).
+  await ctx.upsert(patchArtifacts(record, { sourceTxHash: hash }))
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   // Use the client chain's public client to wait for the receipt + extract the CCTP MessageSent
-  // event. wagmi's default `waitForTransactionReceipt` is chain-agnostic but we pass chainId for
-  // clarity (and so it doesn't accidentally probe the hub).
-  const receipt = await waitForTransactionReceipt(wagmiConfig, {
+  // event. We pass chainId for clarity (and so it doesn't accidentally probe the hub).
+  const receipt = await waitForReceiptOrFail({
     hash,
+    signal: ctx.signal,
     chainId: record.meta.fromChainId,
   })
 
@@ -330,6 +334,13 @@ async function runWaitForDelivery(
     : 0n
   const maxLogRange = BigInt(getNetworkConfig().maxLogRange)
 
+  // Derive the inner poll timeout from the per-kind lifecycle cap, minus elapsed time. The
+  // hardcoded 10min that lived here previously ignored the outer 60min xchain budget — a slow
+  // Iris attestation would time us out with ~50 min still on the lifecycle clock.
+  const lifecycle = lifecycleFor(record.kind)
+  const remainingBudgetMs = record.createdAt + lifecycle.maxDurationMs - Date.now()
+  const pollTimeoutMs = Math.max(10_000, remainingBudgetMs)
+
   const result = await poll<`0x${string}`>(
     async (signal) => {
       if (signal.aborted) return null
@@ -359,17 +370,21 @@ async function runWaitForDelivery(
     {
       intervalMs: 3_000,
       jitter: 0.2,
-      timeoutMs: 10 * 60_000,
+      timeoutMs: pollTimeoutMs,
       signal: ctx.signal,
     },
   )
 
+  if (result.status === 'aborted') {
+    // Cancel/dismiss already wrote the terminal state — no-op so we don't OCC-collide.
+    return
+  }
   if (result.status !== 'done') {
-    throw new Error(
-      result.status === 'aborted'
-        ? 'cancelled'
-        : 'Timed out waiting for cross-chain delivery — check the hub chain manually.',
-    )
+    throw asTxError({
+      code: 'POLL_TIMEOUT',
+      message: 'Timed out waiting for cross-chain delivery. The hub mint may still occur — check the hub explorer.',
+      txHash: record.artifacts.sourceTxHash,
+    })
   }
 
   // Walk through the three intermediate stages with brief gaps so the stepper renders each row
@@ -378,6 +393,9 @@ async function runWaitForDelivery(
   const STAGE_VISUAL_DELAY_MS = 350
   const skipStages = ['iris-attestation-ready', 'hub-mint-pending', 'hub-mint-confirmed'] as const
   for (let i = 0; i < skipStages.length; i++) {
+    // Abort check BEFORE the upsert — cancel/dismiss may have fired during the delay below or
+    // during the upsert latency, and we don't want to clobber the already-written terminal state.
+    if (ctx.signal.aborted) return
     const next = skipStages[i]!
     cursor = advance(cursor, next, next === 'hub-mint-confirmed' ? { destTxHash: result.value } : {})
     await ctx.upsert(cursor)

--- a/apps/armada-interface/src/features/shield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/shield-xchain/handler.ts
@@ -33,6 +33,7 @@ import { poll } from '@/lib/tx/poller'
 import { asTxError, waitForReceiptOrFail } from '@/lib/tx/receipt'
 import { classifyHandlerError } from '@/lib/tx/errors'
 import { lifecycleFor } from '@/lib/tx/lifecycles'
+import { track } from '@/lib/telemetry'
 import { scanCctpDeliveryWindow } from '../unshield-xchain/scan'
 import type { StageHandler } from '@/lib/tx/executor'
 import type { TxRecord } from '@/lib/tx/types'
@@ -339,7 +340,15 @@ async function runWaitForDelivery(
   // Iris attestation would time us out with ~50 min still on the lifecycle clock.
   const lifecycle = lifecycleFor(record.kind)
   const remainingBudgetMs = record.createdAt + lifecycle.maxDurationMs - Date.now()
-  const pollTimeoutMs = Math.max(10_000, remainingBudgetMs)
+  const POLL_FLOOR_MS = 10_000
+  if (remainingBudgetMs < POLL_FLOOR_MS) {
+    track('tx.budget.tight', {
+      id: record.id,
+      kind: record.kind,
+      elapsedMs: Date.now() - record.createdAt,
+    })
+  }
+  const pollTimeoutMs = Math.max(POLL_FLOOR_MS, remainingBudgetMs)
 
   const result = await poll<`0x${string}`>(
     async (signal) => {

--- a/apps/armada-interface/src/features/shield/handler.ts
+++ b/apps/armada-interface/src/features/shield/handler.ts
@@ -4,9 +4,10 @@
 import {
   readContract,
   signMessage,
-  waitForTransactionReceipt,
   writeContract,
 } from 'wagmi/actions'
+import { waitForReceiptOrFail } from '@/lib/tx/receipt'
+import { classifyHandlerError } from '@/lib/tx/errors'
 import { erc20Abi, maxUint256 } from 'viem'
 import { wagmiConfig } from '@/config/wagmi'
 import { loadDeployments } from '@/config/deployments'
@@ -23,7 +24,7 @@ import {
   SHIELD_SIGNATURE_MESSAGE,
 } from '@/lib/railgun/shield'
 import { ensureChain } from '@/lib/network-switch'
-import { advance, markFailed } from '@/lib/tx/reducer'
+import { advance, markFailed, patchArtifacts } from '@/lib/tx/reducer'
 import type { StageHandler } from '@/lib/tx/executor'
 import type { TxRecord } from '@/lib/tx/types'
 
@@ -103,8 +104,11 @@ export const shieldHandler: StageHandler<'shield'> = {
         return
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'shield handler failed'
-      const failed = markFailed(record, message)
+      // If the user cancelled / auto-lock fired, abortAndMark already wrote the terminal state.
+      // The throw bubbling up here is the cooperative response to the abort signal — no-op so we
+      // don't clobber the cancelled/dismissed record with a failed one.
+      if (ctx.signal.aborted) return
+      const failed = markFailed(record, classifyHandlerError(err, 'Shield failed.', record.artifacts.sourceTxHash))
       await ctx.upsert(failed)
     }
   },
@@ -201,7 +205,7 @@ async function runSubmitAndConfirm(
       functionName: 'approve',
       args: [privacyPoolAddress as `0x${string}`, maxUint256],
     })
-    await waitForTransactionReceipt(wagmiConfig, { hash: approveHash })
+    await waitForReceiptOrFail({ hash: approveHash, signal: ctx.signal })
     if (ctx.signal.aborted) throw new Error('cancelled')
   }
 
@@ -227,12 +231,17 @@ async function runSubmitAndConfirm(
     functionName: 'shield',
     args: [[shieldRequestTuple], getIntegratorAddress()],
   })
+  // Persist the source tx hash immediately so any subsequent failure (timeout, revert, cancel)
+  // carries the hash for the explorer-link UX. Writing as a patch — not an `advance` — because
+  // we're still inside the submit-relayer stage waiting for the receipt.
+  await ctx.upsert(patchArtifacts(record, { sourceTxHash: shieldHash }))
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   // 3. Wait for confirmation. The SDK's merkle scan will pick up the new commitment via the
   //    onBalanceUpdate callback — but we also kick a refresh explicitly so the UI doesn't have
-  //    to wait for the SDK's poll interval.
-  await waitForTransactionReceipt(wagmiConfig, { hash: shieldHash })
+  //    to wait for the SDK's poll interval. Timeout-and-signal-aware so a wedged RPC doesn't
+  //    pin this handler for the full 10-min lifecycle cap.
+  await waitForReceiptOrFail({ hash: shieldHash, signal: ctx.signal })
 
   if (kmIsUnlocked()) {
     // Fire-and-forget — failures here are non-fatal (the periodic refresh would catch it).

--- a/apps/armada-interface/src/features/transfer-shielded/handler.ts
+++ b/apps/armada-interface/src/features/transfer-shielded/handler.ts
@@ -3,7 +3,6 @@
 
 import {
   sendTransaction,
-  waitForTransactionReceipt,
 } from 'wagmi/actions'
 import { wagmiConfig } from '@/config/wagmi'
 import { loadDeployments } from '@/config/deployments'
@@ -19,7 +18,9 @@ import {
   generateTransferProofForRecipient,
   populateTransferTransaction,
 } from '@/lib/railgun/transfer'
-import { advance, markFailed } from '@/lib/tx/reducer'
+import { advance, markFailed, patchArtifacts } from '@/lib/tx/reducer'
+import { waitForReceiptOrFail } from '@/lib/tx/receipt'
+import { classifyHandlerError } from '@/lib/tx/errors'
 import { createProofProgressWriter } from '@/lib/tx/progress'
 import type { StageHandler } from '@/lib/tx/executor'
 import type { TxRecord } from '@/lib/tx/types'
@@ -49,8 +50,8 @@ export const transferShieldedHandler: StageHandler<'transfer-shielded'> = {
       }
       // hub-confirmed is terminal; defensive no-op for resume-on-load.
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'transfer-shielded handler failed'
-      const failed = markFailed(record, message)
+      if (ctx.signal.aborted) return
+      const failed = markFailed(record, classifyHandlerError(err, 'Private send failed.', record.artifacts.sourceTxHash))
       await ctx.upsert(failed)
     }
   },
@@ -117,9 +118,10 @@ async function runSubmitAndConfirm(
     data: populated.data,
     value: populated.value,
   })
+  await ctx.upsert(patchArtifacts(record, { sourceTxHash: hash }))
   if (ctx.signal.aborted) throw new Error('cancelled')
 
-  await waitForTransactionReceipt(wagmiConfig, { hash })
+  await waitForReceiptOrFail({ hash, signal: ctx.signal })
 
   if (kmIsUnlocked()) {
     void refreshShieldedBalances(kmGetWalletId()).catch(() => {})

--- a/apps/armada-interface/src/features/unshield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/handler.ts
@@ -10,6 +10,7 @@ import {
 import { asTxError, waitForReceiptOrFail } from '@/lib/tx/receipt'
 import { classifyHandlerError } from '@/lib/tx/errors'
 import { lifecycleFor } from '@/lib/tx/lifecycles'
+import { track } from '@/lib/telemetry'
 import { wagmiConfig } from '@/config/wagmi'
 import { loadDeployments } from '@/config/deployments'
 import { getNetworkConfig } from '@/config/network'
@@ -326,8 +327,19 @@ async function runWaitForDelivery(
   const lifecycle = lifecycleFor(record.kind)
   const remainingBudgetMs = record.createdAt + lifecycle.maxDurationMs - Date.now()
   // Floor at 10s so a record that's already past its cap fails fast rather than hanging on a
-  // single tick. Above 10s we trust the lifecycle's published budget.
-  const pollTimeoutMs = Math.max(10_000, remainingBudgetMs)
+  // single tick. Above 10s we trust the lifecycle's published budget. Emit telemetry when the
+  // clamp kicks in — sustained signal here means records are landing in polling with too little
+  // budget (typically a resume-after-crash close to maxDurationMs) and the lifecycle cap or
+  // resume policy may need adjustment.
+  const POLL_FLOOR_MS = 10_000
+  if (remainingBudgetMs < POLL_FLOOR_MS) {
+    track('tx.budget.tight', {
+      id: record.id,
+      kind: record.kind,
+      elapsedMs: Date.now() - record.createdAt,
+    })
+  }
+  const pollTimeoutMs = Math.max(POLL_FLOOR_MS, remainingBudgetMs)
 
   const result = await poll<`0x${string}`>(
     async (signal) => {

--- a/apps/armada-interface/src/features/unshield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/handler.ts
@@ -6,8 +6,10 @@ import { encodeFunctionData, pad, parseAbiItem } from 'viem'
 import { getPublicClient } from 'wagmi/actions'
 import {
   sendTransaction,
-  waitForTransactionReceipt,
 } from 'wagmi/actions'
+import { asTxError, waitForReceiptOrFail } from '@/lib/tx/receipt'
+import { classifyHandlerError } from '@/lib/tx/errors'
+import { lifecycleFor } from '@/lib/tx/lifecycles'
 import { wagmiConfig } from '@/config/wagmi'
 import { loadDeployments } from '@/config/deployments'
 import { getNetworkConfig } from '@/config/network'
@@ -146,8 +148,8 @@ export const unshieldXchainHandler: StageHandler<'unshield-xchain'> = {
         // here it's a resume from a partially-completed delivery and we're already terminal.
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'unshield-xchain handler failed'
-      const failed = markFailed(record, message)
+      if (ctx.signal.aborted) return
+      const failed = markFailed(record, classifyHandlerError(err, 'Cross-chain withdraw failed.', record.artifacts.sourceTxHash))
       await ctx.upsert(failed)
     }
   },
@@ -243,9 +245,11 @@ async function runSubmitAndBurn(
     ),
     value: 0n,
   })
+  // Persist sourceTxHash immediately so cancel/timeout/revert can carry the hash forward.
+  await ctx.upsert(patchArtifacts(record, { sourceTxHash: hash }))
   if (ctx.signal.aborted) throw new Error('cancelled')
 
-  const receipt = await waitForTransactionReceipt(wagmiConfig, { hash })
+  const receipt = await waitForReceiptOrFail({ hash, signal: ctx.signal })
 
   // Extract the CCTP message reference from the hub receipt — gives us the indexed `nonce`
   // topic to filter destination events on (unique per CCTP message, eliminates false positives
@@ -315,6 +319,16 @@ async function runWaitForDelivery(
     : 0n
   const maxLogRange = BigInt(getNetworkConfig().maxLogRange)
 
+  // Derive the inner polling timeout from the per-kind lifecycle cap, minus whatever time has
+  // already been spent on earlier stages. This keeps the inner poll honest about the global
+  // budget — previously a hardcoded 10min capped delivery polling well below the 60min xchain
+  // cap, so a slow Iris attestation timed us out even though the outer record had ~50 min left.
+  const lifecycle = lifecycleFor(record.kind)
+  const remainingBudgetMs = record.createdAt + lifecycle.maxDurationMs - Date.now()
+  // Floor at 10s so a record that's already past its cap fails fast rather than hanging on a
+  // single tick. Above 10s we trust the lifecycle's published budget.
+  const pollTimeoutMs = Math.max(10_000, remainingBudgetMs)
+
   const result = await poll<`0x${string}`>(
     async (signal) => {
       if (signal.aborted) return null
@@ -349,17 +363,26 @@ async function runWaitForDelivery(
     {
       intervalMs: 3_000,
       jitter: 0.2,
-      timeoutMs: 10 * 60_000, // 10 min cap — well below the lifecycle's 60 min xchain cap
+      timeoutMs: pollTimeoutMs,
       signal: ctx.signal,
     },
   )
 
+  if (result.status === 'aborted') {
+    // Cancel/dismiss already wrote the terminal state via abortAndMark. Returning here without
+    // throwing avoids the outer catch trying to classifyHandlerError and OCC-rejecting against
+    // the already-terminal record.
+    return
+  }
   if (result.status !== 'done') {
-    throw new Error(
-      result.status === 'aborted'
-        ? 'cancelled'
-        : 'Timed out waiting for cross-chain delivery — check the destination chain manually.',
-    )
+    // Timeout: we know the sourceTxHash and that the relayer/Iris haven't delivered within the
+    // budget. The on-chain mint may still happen later — the user should check the destination
+    // explorer. POLL_TIMEOUT category surfaces that ambiguity in the UI copy.
+    throw asTxError({
+      code: 'POLL_TIMEOUT',
+      message: 'Timed out waiting for cross-chain delivery. The destination mint may still occur — check the destination chain explorer.',
+      txHash: record.artifacts.sourceTxHash,
+    })
   }
 
   // We have ONE real signal (MessageReceived observed) — the intermediate stages between hub
@@ -376,6 +399,11 @@ async function runWaitForDelivery(
   // we wrote during the scan, so each advance() composes cleanly on top of the latest seq.
   const skipStages = ['iris-attestation-ready', 'client-mint-pending', 'client-mint-confirmed'] as const
   for (let i = 0; i < skipStages.length; i++) {
+    // Cancel/dismiss may have fired since the last delay — checking BEFORE the upsert prevents
+    // us from advancing a record that abortAndMark has already moved to a terminal state.
+    // Without this guard the OCC `updatedSeq` collision would silently drop the write, but the
+    // intent is clearer when we don't even attempt it.
+    if (ctx.signal.aborted) return
     const next = skipStages[i]!
     cursor = advance(cursor, next, next === 'client-mint-confirmed' ? { destTxHash: result.value } : {})
     await ctx.upsert(cursor)

--- a/apps/armada-interface/src/features/unshield/handler.ts
+++ b/apps/armada-interface/src/features/unshield/handler.ts
@@ -3,7 +3,6 @@
 
 import {
   sendTransaction,
-  waitForTransactionReceipt,
 } from 'wagmi/actions'
 import { wagmiConfig } from '@/config/wagmi'
 import { loadDeployments } from '@/config/deployments'
@@ -19,7 +18,9 @@ import {
   generateUnshieldProofForRecipient,
   populateUnshieldTransaction,
 } from '@/lib/railgun/unshield'
-import { advance, markFailed } from '@/lib/tx/reducer'
+import { advance, markFailed, patchArtifacts } from '@/lib/tx/reducer'
+import { waitForReceiptOrFail } from '@/lib/tx/receipt'
+import { classifyHandlerError } from '@/lib/tx/errors'
 import { createProofProgressWriter } from '@/lib/tx/progress'
 import type { StageHandler } from '@/lib/tx/executor'
 import type { TxRecord } from '@/lib/tx/types'
@@ -52,8 +53,8 @@ export const unshieldLocalHandler: StageHandler<'unshield-local'> = {
       // hub-confirmed is terminal; advance() flips executionState to 'completed' so the executor
       // loop won't re-enter this handler. Defensive no-op for resume-on-load.
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'unshield-local handler failed'
-      const failed = markFailed(record, message)
+      if (ctx.signal.aborted) return
+      const failed = markFailed(record, classifyHandlerError(err, 'Unshield failed.', record.artifacts.sourceTxHash))
       await ctx.upsert(failed)
     }
   },
@@ -121,9 +122,12 @@ async function runSubmitAndConfirm(
     data: populated.data,
     value: populated.value,
   })
+  // Persist sourceTxHash before the receipt wait so a cancel/timeout that happens during the
+  // wait carries the hash forward into the error UX (explorer link / "stopped tracking" copy).
+  await ctx.upsert(patchArtifacts(record, { sourceTxHash: hash }))
   if (ctx.signal.aborted) throw new Error('cancelled')
 
-  await waitForTransactionReceipt(wagmiConfig, { hash })
+  await waitForReceiptOrFail({ hash, signal: ctx.signal })
 
   // Kick an immediate balance refresh — same fire-and-forget pattern as the shield handler.
   if (kmIsUnlocked()) {

--- a/apps/armada-interface/src/features/yield-deposit/handler.ts
+++ b/apps/armada-interface/src/features/yield-deposit/handler.ts
@@ -3,7 +3,6 @@
 
 import {
   sendTransaction,
-  waitForTransactionReceipt,
 } from 'wagmi/actions'
 import { wagmiConfig } from '@/config/wagmi'
 import { loadDeployments, loadYieldDeployment } from '@/config/deployments'
@@ -17,7 +16,9 @@ import {
 import { refreshShieldedBalances } from '@/lib/railgun/sync'
 import { buildYieldAdaptTransaction } from '@/lib/railgun/yield'
 import { ensureChain } from '@/lib/network-switch'
-import { advance, markFailed } from '@/lib/tx/reducer'
+import { advance, markFailed, patchArtifacts } from '@/lib/tx/reducer'
+import { waitForReceiptOrFail } from '@/lib/tx/receipt'
+import { classifyHandlerError } from '@/lib/tx/errors'
 import { createProofProgressWriter } from '@/lib/tx/progress'
 import type { StageHandler } from '@/lib/tx/executor'
 import type { TxRecord } from '@/lib/tx/types'
@@ -47,8 +48,8 @@ export const yieldDepositHandler: StageHandler<'yield-deposit'> = {
       }
       // hub-confirmed is terminal.
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'yield-deposit handler failed'
-      await ctx.upsert(markFailed(record, message))
+      if (ctx.signal.aborted) return
+      await ctx.upsert(markFailed(record, classifyHandlerError(err, 'Vault deposit failed.', record.artifacts.sourceTxHash)))
     }
   },
 }
@@ -119,9 +120,10 @@ async function runSubmitAndConfirm(
     data: yieldTx.data,
     value: BigInt(yieldTx.value),
   })
+  await ctx.upsert(patchArtifacts(record, { sourceTxHash: hash }))
   if (ctx.signal.aborted) throw new Error('cancelled')
 
-  await waitForTransactionReceipt(wagmiConfig, { hash })
+  await waitForReceiptOrFail({ hash, signal: ctx.signal })
 
   if (kmIsUnlocked()) {
     void refreshShieldedBalances(kmGetWalletId()).catch(() => {})

--- a/apps/armada-interface/src/features/yield-withdraw/handler.ts
+++ b/apps/armada-interface/src/features/yield-withdraw/handler.ts
@@ -3,7 +3,6 @@
 
 import {
   sendTransaction,
-  waitForTransactionReceipt,
 } from 'wagmi/actions'
 import { wagmiConfig } from '@/config/wagmi'
 import { loadDeployments, loadYieldDeployment } from '@/config/deployments'
@@ -17,7 +16,9 @@ import {
 import { refreshShieldedBalances } from '@/lib/railgun/sync'
 import { buildYieldAdaptTransaction } from '@/lib/railgun/yield'
 import { ensureChain } from '@/lib/network-switch'
-import { advance, markFailed } from '@/lib/tx/reducer'
+import { advance, markFailed, patchArtifacts } from '@/lib/tx/reducer'
+import { waitForReceiptOrFail } from '@/lib/tx/receipt'
+import { classifyHandlerError } from '@/lib/tx/errors'
 import { createProofProgressWriter } from '@/lib/tx/progress'
 import type { StageHandler } from '@/lib/tx/executor'
 import type { TxRecord } from '@/lib/tx/types'
@@ -43,8 +44,8 @@ export const yieldWithdrawHandler: StageHandler<'yield-withdraw'> = {
         return
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'yield-withdraw handler failed'
-      await ctx.upsert(markFailed(record, message))
+      if (ctx.signal.aborted) return
+      await ctx.upsert(markFailed(record, classifyHandlerError(err, 'Vault withdrawal failed.', record.artifacts.sourceTxHash)))
     }
   },
 }
@@ -115,9 +116,10 @@ async function runSubmitAndConfirm(
     data: yieldTx.data,
     value: BigInt(yieldTx.value),
   })
+  await ctx.upsert(patchArtifacts(record, { sourceTxHash: hash }))
   if (ctx.signal.aborted) throw new Error('cancelled')
 
-  await waitForTransactionReceipt(wagmiConfig, { hash })
+  await waitForReceiptOrFail({ hash, signal: ctx.signal })
 
   if (kmIsUnlocked()) {
     void refreshShieldedBalances(kmGetWalletId()).catch(() => {})

--- a/apps/armada-interface/src/lib/explorer.ts
+++ b/apps/armada-interface/src/lib/explorer.ts
@@ -1,0 +1,23 @@
+// ABOUTME: Compose block-explorer URLs from (chainId, txHash) using the per-chain explorerUrl in config/network.
+// ABOUTME: Returns null when either the chain is unknown or the chain has no explorerUrl configured — callers must handle the no-link case rather than rendering a broken anchor.
+
+import { getChainById } from '@/config/network'
+
+/**
+ * Build a tx-explorer URL for a chain we know about. Returns null when:
+ *   - chainId isn't in our config (so we have no explorerUrl to start from)
+ *   - the chain has no explorerUrl (local Anvil)
+ *   - no txHash is supplied (the common "we don't have a hash yet" case)
+ *
+ * Always returns an absolute `/tx/<hash>` URL when not null. Callers should render the link
+ * conditionally rather than show an empty anchor.
+ */
+export function txExplorerUrl(
+  chainId: number | undefined,
+  txHash: `0x${string}` | undefined,
+): string | undefined {
+  if (!chainId || !txHash) return undefined
+  const chain = getChainById(chainId)
+  if (!chain?.explorerUrl) return undefined
+  return `${chain.explorerUrl}/tx/${txHash}`
+}

--- a/apps/armada-interface/src/lib/explorer.ts
+++ b/apps/armada-interface/src/lib/explorer.ts
@@ -1,7 +1,8 @@
-// ABOUTME: Compose block-explorer URLs from (chainId, txHash) using the per-chain explorerUrl in config/network.
+// ABOUTME: Compose block-explorer URLs from (chainId, txHash) using the per-chain explorerUrl in config/network; also exposes displayTxHash to pick the right hash for a record's error UI.
 // ABOUTME: Returns null when either the chain is unknown or the chain has no explorerUrl configured — callers must handle the no-link case rather than rendering a broken anchor.
 
 import { getChainById } from '@/config/network'
+import type { TxRecord } from '@/lib/tx/types'
 
 /**
  * Build a tx-explorer URL for a chain we know about. Returns null when:
@@ -20,4 +21,22 @@ export function txExplorerUrl(
   const chain = getChainById(chainId)
   if (!chain?.explorerUrl) return undefined
   return `${chain.explorerUrl}/tx/${txHash}`
+}
+
+/**
+ * Pick the right txHash to surface in error UI for a record. Precedence:
+ *   1. `record.artifacts.error.txHash` — the typed-error-carried hash. This wins because helpers
+ *      like waitForReceiptOrFail attach a category-specific hash (e.g. the approve receipt's
+ *      hash on a POLL_TIMEOUT during approve, not the still-unsubmitted shield tx hash).
+ *   2. `record.artifacts.sourceTxHash` — the bare submitted-tx hash. Fallback for catch paths
+ *      where no typed error is attached but we still know which on-chain tx is in flight.
+ *
+ * Returns undefined when neither is present (record never broadcast / pre-submit failure).
+ */
+export function displayTxHash(record: TxRecord | null | undefined): `0x${string}` | undefined {
+  if (!record) return undefined
+  const errHash = record.artifacts.error?.txHash
+  if (errHash) return errHash
+  const sourceHash = (record.artifacts as { sourceTxHash?: `0x${string}` }).sourceTxHash
+  return sourceHash ?? undefined
 }

--- a/apps/armada-interface/src/lib/telemetry.ts
+++ b/apps/armada-interface/src/lib/telemetry.ts
@@ -36,6 +36,11 @@ export type EventRegistry = {
   'tx.failed':                { id: string; kind: TxKind; errorCode?: string }
   'tx.expired':               { id: string; kind: TxKind }
   'tx.cancelled':             { id: string; kind: TxKind }
+  // Fired when an xchain handler enters runWaitForDelivery with less than the inner-poll floor
+  // of lifecycle budget remaining. The handler clamps to a 10s minimum (rather than failing
+  // immediately) but a sustained signal here indicates records being created with too little
+  // budget headroom — typically a resume-after-crash that landed close to maxDurationMs.
+  'tx.budget.tight':          { id: string; kind: TxKind; elapsedMs: number }
 
   'tx.engine.started':        { isLeader: boolean }
   'tx.engine.no-handler':     { kind: TxKind }

--- a/apps/armada-interface/src/lib/tx/CLAUDE.md
+++ b/apps/armada-interface/src/lib/tx/CLAUDE.md
@@ -60,6 +60,27 @@ interface StageHandler<K extends TxKind> {
 - `run` MUST honour `ctx.signal`. Throwing on abort is fine.
 - `resumableFrom` lists stages this handler can safely re-enter on app reload — typically the same as `lifecycle.retryableStages`.
 
+### Outer try/catch contract
+
+Every handler's `async run` wraps its switch/dispatch in `try { ... } catch (err) { ... }`. The catch MUST follow this shape so cancel + dismiss work correctly:
+
+```ts
+} catch (err) {
+  // 1. If the signal aborted, abortAndMark (cancel/dismiss) already wrote the terminal state.
+  //    Returning here without upserting prevents us from clobbering the cancelled/dismissed
+  //    record with a failed one. OCC would silently drop the write anyway — explicit return
+  //    is clearer about intent and avoids a misleading telemetry event.
+  if (ctx.signal.aborted) return
+  // 2. Otherwise classify the thrown value into a typed TxError and write it via markFailed.
+  //    classifyHandlerError preserves branded TxErrors (POLL_TIMEOUT / TX_REVERTED from inner
+  //    helpers like waitForReceiptOrFail) so the category isn't lost in the outer catch.
+  const failed = markFailed(record, classifyHandlerError(err, '<kind> failed.', record.artifacts.sourceTxHash))
+  await ctx.upsert(failed)
+}
+```
+
+The abort-check-before-markFailed pattern is invariant across every handler. If you add a new handler, copy the shape rather than improvising.
+
 ## Polling adapters
 
 `poller.ts` exports a generic `poll(pollOnce, opts)`. Stage-specific adapters (one per polling type) call into `lib/cctp.ts`, `lib/relayer.ts`, or RPC directly via `lib/events`. Convention: the adapter function is named `poll<Source>Once(...)` (e.g. `pollIrisOnce`, `pollReceiptOnce`) and returns `Promise<T | null>` — null means "no result yet, keep polling".

--- a/apps/armada-interface/src/lib/tx/errors.test.ts
+++ b/apps/armada-interface/src/lib/tx/errors.test.ts
@@ -1,0 +1,68 @@
+// ABOUTME: Tests for classifyHandlerError — branded TxError pass-through, user-rejection detection, OTHER fallback with txHash forwarding.
+
+import { describe, it, expect } from 'vitest'
+import { classifyHandlerError } from './errors'
+import { asTxError } from './receipt'
+
+describe('classifyHandlerError', () => {
+  it('passes a branded TxError through unchanged so categorisation isn\'t lost in the outer catch', () => {
+    // The whole point: an inner helper (e.g. waitForReceiptOrFail) classifies a POLL_TIMEOUT or
+    // TX_REVERTED with its own txHash. If the outer try re-classifies as OTHER we'd lose the
+    // category AND the txHash, defeating the typed-error system.
+    const branded = asTxError({ code: 'POLL_TIMEOUT', message: 'inner timeout', txHash: '0xabc' })
+    const result = classifyHandlerError(branded, 'should not be used')
+    expect(result).toEqual({ code: 'POLL_TIMEOUT', message: 'inner timeout', txHash: '0xabc' })
+  })
+
+  it('classifies viem-style UserRejectedRequestError as USER_REJECTED', () => {
+    const err = { name: 'UserRejectedRequestError', message: 'user denied' }
+    expect(classifyHandlerError(err, 'fallback').code).toBe('USER_REJECTED')
+  })
+
+  it('classifies MetaMask code 4001 as USER_REJECTED', () => {
+    const err = { code: 4001, message: 'rejected' }
+    expect(classifyHandlerError(err, 'fallback').code).toBe('USER_REJECTED')
+  })
+
+  it('classifies ethers ACTION_REJECTED as USER_REJECTED', () => {
+    const err = { code: 'ACTION_REJECTED' }
+    expect(classifyHandlerError(err, 'fallback').code).toBe('USER_REJECTED')
+  })
+
+  it('recurses into .cause for viem-wrapped rejections', () => {
+    const inner = Object.assign(new Error('User rejected'), { code: 4001 })
+    const outer = new Error('Outer failure') as Error & { cause: unknown }
+    outer.cause = inner
+    expect(classifyHandlerError(outer, 'fallback').code).toBe('USER_REJECTED')
+  })
+
+  it('falls through to OTHER with the raw error message preserved', () => {
+    const err = new Error('insufficient funds for gas')
+    const result = classifyHandlerError(err, 'fallback')
+    expect(result.code).toBe('OTHER')
+    expect(result.message).toBe('insufficient funds for gas')
+  })
+
+  it('uses the fallback message when the thrown value has none', () => {
+    const result = classifyHandlerError('not an error', 'Handler failed.')
+    expect(result.code).toBe('OTHER')
+    expect(result.message).toBe('Handler failed.')
+  })
+
+  it('attaches the sourceTxHash when supplied — only on OTHER (USER_REJECTED has no relevant hash)', () => {
+    // Handler catches typically know the sourceTxHash at the point they classify; passing it in
+    // means OTHER errors can still surface an explorer link in the UI.
+    const result = classifyHandlerError(new Error('gas estimation failed'), 'fallback', '0xdeadbeef' as `0x${string}`)
+    expect(result.code).toBe('OTHER')
+    expect(result.txHash).toBe('0xdeadbeef')
+  })
+
+  it('does NOT overwrite a branded error\'s txHash with the outer-context hash', () => {
+    // Subtle case: inner helper threw POLL_TIMEOUT with txHash=0xabc; outer catch knows about a
+    // different hash (e.g. the user retried with a fresh submission and 0xfed is the new hash).
+    // The branded txHash from the inner classifier wins — it reflects what actually timed out.
+    const branded = asTxError({ code: 'POLL_TIMEOUT', message: 'inner timed out', txHash: '0xabc' })
+    const result = classifyHandlerError(branded, 'fallback', '0xfed' as `0x${string}`)
+    expect(result.txHash).toBe('0xabc')
+  })
+})

--- a/apps/armada-interface/src/lib/tx/errors.ts
+++ b/apps/armada-interface/src/lib/tx/errors.ts
@@ -1,0 +1,54 @@
+// ABOUTME: Shared handler-side error classification — converts any thrown value into a typed TxError so markFailed can carry an honest code + optional txHash for the UI to render category-appropriate copy.
+// ABOUTME: Handlers' outer try/catch funnels everything through `classifyHandlerError(err)` instead of `err.message` strings, so we never lose the distinction between "tx reverted" / "we lost track" / "user rejected" / "unexpected".
+
+import { extractTxError } from './receipt'
+import type { TxError } from './types'
+
+/**
+ * Detect user-declined-wallet-prompt errors across wallet stacks. Mirrors the heuristic in
+ * lib/network-switch.ts — kept independent so the tx layer doesn't take a network-switch
+ * dependency. Both copies match the same shapes; if either grows a case, mirror to the other.
+ */
+function isUserRejection(err: unknown): boolean {
+  if (!err) return false
+  const e = err as { code?: number | string; name?: string; message?: string; cause?: unknown }
+  if (e.code === 4001 || e.code === 'ACTION_REJECTED') return true
+  if (e.name === 'UserRejectedRequestError') return true
+  const msg = e.message ?? ''
+  if (/user (rejected|denied|cancelled)/i.test(msg)) return true
+  if (e.cause && e.cause !== err) return isUserRejection(e.cause)
+  return false
+}
+
+/**
+ * Convert anything thrown inside a handler into a typed TxError suitable for `markFailed`.
+ *
+ * Precedence:
+ *   1. Branded TxError (thrown by `waitForReceiptOrFail` or a handler that already classified).
+ *      Extract as-is so a POLL_TIMEOUT doesn't get re-tagged as OTHER by the outer catch.
+ *   2. User-rejected wallet prompt → USER_REJECTED.
+ *   3. Anything else → OTHER, preserving the raw message.
+ *
+ * The optional `sourceTxHash` is folded in for the categories where the UI needs it (timeout,
+ * revert) — handlers that have the hash by their catch point should pass it in so the explorer
+ * link works. For OTHER / USER_REJECTED it's typically absent and that's fine.
+ */
+export function classifyHandlerError(
+  err: unknown,
+  fallbackMessage: string,
+  sourceTxHash?: `0x${string}`,
+): TxError {
+  const branded = extractTxError(err)
+  if (branded) {
+    // Helper already classified (e.g. POLL_TIMEOUT or TX_REVERTED with its own txHash).
+    // Don't overwrite its txHash from the outer context.
+    return branded
+  }
+
+  if (isUserRejection(err)) {
+    return { code: 'USER_REJECTED', message: 'You declined the action in your wallet.' }
+  }
+
+  const message = err instanceof Error ? err.message : fallbackMessage
+  return sourceTxHash ? { code: 'OTHER', message, txHash: sourceTxHash } : { code: 'OTHER', message }
+}

--- a/apps/armada-interface/src/lib/tx/executor.ts
+++ b/apps/armada-interface/src/lib/tx/executor.ts
@@ -4,7 +4,7 @@
 import { getDefaultStore } from 'jotai'
 import { track, trackError } from '../telemetry'
 import { lifecycleFor } from './lifecycles'
-import { markCancelled, markExpired, markRetrying, shouldResume } from './reducer'
+import { markCancelled, markDismissed, markExpired, markRetrying, shouldResume } from './reducer'
 import { loadAllTx, putTxIfFresh } from './storage'
 import type { StageFor, TxKind, TxRecord } from './types'
 import { txListAtom, upsertTxAtom } from '@/state/tx'
@@ -173,8 +173,33 @@ export function retryTx(id: string): void {
   executeTx(id)
 }
 
-/** Abort the in-flight handler chain for a tx and mark the record `cancelled`. */
+/**
+ * Abort the in-flight handler chain for a pre-broadcast tx and mark it `cancelled`. Use this only
+ * when the tx hasn't yet produced a `sourceTxHash` — nothing on chain to worry about.
+ *
+ * For post-broadcast records, the on-chain tx will still run regardless of what we do here, so
+ * call `dismissTx` instead — it records that the user knowingly stopped tracking, preserves the
+ * txHash for explorer linking, and uses honest copy ("Stopped tracking" not "Cancelled").
+ *
+ * Internal cleanup paths (auto-lock, tab teardown) can use either depending on whether the record
+ * has broadcast. The UI's TxActions component picks the right one based on `sourceTxHash` presence.
+ */
 export function cancelTx(id: string): void {
+  abortAndMark(id, 'cancel')
+}
+
+/**
+ * Abort tracking of a post-broadcast tx without claiming we cancelled it. Marks the record
+ * `cancelled` (execution state) with a DISMISSED error code carrying the source tx hash so the
+ * UI can render "Stopped tracking — view on explorer" and the user can recover the tx hash.
+ *
+ * The on-chain tx will run to completion (or revert) independent of this call.
+ */
+export function dismissTx(id: string): void {
+  abortAndMark(id, 'dismiss')
+}
+
+function abortAndMark(id: string, kind: 'cancel' | 'dismiss'): void {
   const controller = running.get(id)
   if (controller) {
     controller.abort()
@@ -183,19 +208,18 @@ export function cancelTx(id: string): void {
   const store = getDefaultStore()
   const record = store.get(txListAtom).find(t => t.id === id)
   if (!record) return
-  // Don't clobber an already-terminal record. OCC accepts the bumped seq, so
-  // without this guard cancel() on a completed/failed/expired tx would rewrite
-  // its terminal state to `cancelled` in both the atom and IDB.
+  // Don't clobber an already-terminal record. OCC accepts the bumped seq, so without this guard
+  // a cancel on a completed/failed/expired tx would rewrite its terminal state in atom + IDB.
   if (record.executionState === 'completed'
     || record.executionState === 'failed'
     || record.executionState === 'expired'
     || record.executionState === 'cancelled') {
     return
   }
-  const cancelled = markCancelled(record)
-  store.set(upsertTxAtom, cancelled)
-  void putTxIfFresh(cancelled)
-  track('tx.cancelled', { id: cancelled.id, kind: cancelled.kind })
+  const next = kind === 'dismiss' ? markDismissed(record) : markCancelled(record)
+  store.set(upsertTxAtom, next)
+  void putTxIfFresh(next)
+  track('tx.cancelled', { id: next.id, kind: next.kind })
 }
 
 /* ----- Internals ----- */

--- a/apps/armada-interface/src/lib/tx/receipt.ts
+++ b/apps/armada-interface/src/lib/tx/receipt.ts
@@ -1,0 +1,132 @@
+// ABOUTME: waitForReceiptOrFail — wraps viem/wagmi's waitForTransactionReceipt with explicit timeout + cancel-signal support, throwing categorised TxErrors handlers can route into markFailed.
+// ABOUTME: Replaces every bare `await waitForTransactionReceipt(...)` in tx handlers so we never hang on a wedged RPC and we can distinguish "lost track of tx" from "tx reverted" in the UI.
+
+import { waitForTransactionReceipt } from 'wagmi/actions'
+import type { TransactionReceipt } from 'viem'
+import { wagmiConfig } from '@/config/wagmi'
+import type { TxError } from './types'
+
+/** Default per-call ceiling. Generous enough to cover Sepolia + occasional reorg jitter. */
+const DEFAULT_TIMEOUT_MS = 5 * 60_000
+
+export interface WaitForReceiptInput {
+  hash: `0x${string}`
+  /** Handler's AbortSignal — aborts the wait when the user cancels or the engine tears down. */
+  signal: AbortSignal
+  /** Optional chain id override; defaults to whatever wagmi's active chain is. */
+  chainId?: number
+  /** Hard ceiling for the wait (ms). Defaults to 5min — distinct from the lifecycle cap which is upstream. */
+  timeoutMs?: number
+}
+
+/**
+ * Wait for a transaction receipt, or throw a categorised TxError on cancel / timeout / revert.
+ *
+ * Three failure modes the caller can route via the `code` field:
+ *  - `CANCELLED`    — `ctx.signal` aborted (user clicked Cancel / Stop Tracking). No txHash in
+ *                     the error since the executor's outer catch already knows the record.
+ *  - `POLL_TIMEOUT` — `timeoutMs` elapsed without a receipt. Includes `txHash` so the UI can
+ *                     deep-link the user to the explorer. The on-chain tx MAY still succeed.
+ *  - `TX_REVERTED`  — receipt arrived with `status === 'reverted'`. Includes `txHash`.
+ *
+ * On success returns the receipt unchanged. The caller is responsible for marking the next
+ * stage via `ctx.upsert(advance(...))`.
+ *
+ * Why this lives in a helper instead of inline at each handler: viem's `waitForTransactionReceipt`
+ * doesn't expose an AbortSignal parameter, only a `timeout`. We need both — the signal so
+ * cancel/auto-lock propagates instantly, and the timeout so a wedged RPC doesn't pin a handler
+ * for the full 60-min lifecycle cap. Promise.race composes them.
+ */
+export async function waitForReceiptOrFail({
+  hash,
+  signal,
+  chainId,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}: WaitForReceiptInput): Promise<TransactionReceipt> {
+  if (signal.aborted) {
+    throw asTxError({ code: 'CANCELLED', message: 'Cancelled while waiting for receipt.' })
+  }
+
+  // viem throws `WaitForTransactionReceiptTimeoutError` (name === ...) on its own timeout. We
+  // pass `timeoutMs` so viem stops polling cleanly; we wrap the throw into a typed error below.
+  const receiptPromise = waitForTransactionReceipt(wagmiConfig, {
+    hash,
+    chainId,
+    timeout: timeoutMs,
+  })
+
+  // Promise.race the receipt against the signal so the wait abandons immediately on cancel —
+  // viem's own polling has no AbortSignal hook, so without this the handler would keep awaiting
+  // even after the user clicked Cancel.
+  const cancelPromise = new Promise<never>((_, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener('abort', onAbort)
+      reject(asTxError({ code: 'CANCELLED', message: 'Cancelled while waiting for receipt.', txHash: hash }))
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+
+  let receipt: TransactionReceipt
+  try {
+    receipt = await Promise.race([receiptPromise, cancelPromise])
+  } catch (err) {
+    if (isTxError(err)) throw err
+    if (isViemTimeout(err)) {
+      throw asTxError({
+        code: 'POLL_TIMEOUT',
+        message: `Receipt not found within ${Math.round(timeoutMs / 1000)}s. The transaction may still complete on chain.`,
+        txHash: hash,
+      })
+    }
+    const message = err instanceof Error ? err.message : 'RPC error waiting for receipt'
+    throw asTxError({ code: 'RPC_ERROR', message, txHash: hash })
+  }
+
+  if (receipt.status === 'reverted') {
+    throw asTxError({
+      code: 'TX_REVERTED',
+      message: 'The transaction was mined but reverted on chain.',
+      txHash: hash,
+    })
+  }
+
+  return receipt
+}
+
+/* ---------- typed-error plumbing ---------- */
+
+/**
+ * Brand for thrown TxErrors so handler catch blocks (and this helper itself) can distinguish
+ * "I threw a categorised error" from "something raw bubbled up". Without the brand, an inner
+ * helper's classified throw would get re-classified as RPC_ERROR by the outer try.
+ */
+const TX_ERROR_TAG = Symbol.for('armada.tx.error')
+
+interface BrandedTxError extends Error {
+  [TX_ERROR_TAG]: true
+  txError: TxError
+}
+
+export function isTxError(err: unknown): err is BrandedTxError {
+  return typeof err === 'object' && err !== null && (err as { [k: symbol]: unknown })[TX_ERROR_TAG] === true
+}
+
+export function asTxError(error: TxError): BrandedTxError {
+  const err = new Error(error.message) as unknown as BrandedTxError
+  err.name = `TxError(${error.code})`
+  err[TX_ERROR_TAG] = true
+  err.txError = error
+  return err
+}
+
+/** Pull the typed error out of a thrown branded TxError. */
+export function extractTxError(err: unknown): TxError | null {
+  if (isTxError(err)) return err.txError
+  return null
+}
+
+function isViemTimeout(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const name = (err as { name?: string }).name
+  return name === 'WaitForTransactionReceiptTimeoutError'
+}

--- a/apps/armada-interface/src/lib/tx/reducer.test.ts
+++ b/apps/armada-interface/src/lib/tx/reducer.test.ts
@@ -1,7 +1,7 @@
-// ABOUTME: Reducer tests focused on patchArtifacts — the artifact-only transition used by long-running polls to persist progress between ticks.
+// ABOUTME: Reducer tests — patchArtifacts cursor pattern + typed-error mark transitions (markFailed string|TxError, markCancelled, markDismissed).
 
 import { describe, it, expect } from 'vitest'
-import { patchArtifacts, markWaiting } from './reducer'
+import { markCancelled, markDismissed, markFailed, markWaiting, patchArtifacts } from './reducer'
 import type { TxRecord } from './types'
 
 function baseXchainRecord(): TxRecord<'unshield-xchain'> {
@@ -72,5 +72,54 @@ describe('patchArtifacts', () => {
     expect(cursor.executionState).toBe('waiting')
     // Three patches after markWaiting (which itself bumped once).
     expect(cursor.updatedSeq).toBe(7 + 1 + 3)
+  })
+})
+
+describe('markFailed — typed error', () => {
+  it('wraps a bare string as { code: "OTHER", message } for backward compatibility', () => {
+    // Legacy call sites can still pass a string; the reducer normalises rather than forcing a
+    // big-bang rewrite of every handler. Important for incremental rollout.
+    const r = markFailed(baseXchainRecord(), 'raw error from somewhere')
+    expect(r.executionState).toBe('failed')
+    expect(r.artifacts.error).toEqual({ code: 'OTHER', message: 'raw error from somewhere' })
+  })
+
+  it('passes a typed TxError through unchanged', () => {
+    // The handler classifier should be able to set POLL_TIMEOUT or TX_REVERTED with a txHash;
+    // the reducer must not lose those fields by re-wrapping.
+    const txErr = { code: 'POLL_TIMEOUT' as const, message: 'lost track', txHash: '0xfeed' as `0x${string}` }
+    const r = markFailed(baseXchainRecord(), txErr)
+    expect(r.artifacts.error).toEqual(txErr)
+  })
+})
+
+describe('markCancelled vs markDismissed', () => {
+  it('markCancelled writes a CANCELLED-coded error to distinguish from internal cleanup paths', () => {
+    // The error code differentiates "user explicitly clicked Cancel" from other cancellation
+    // origins (auto-lock, tab close). UI can choose to render specific copy.
+    const r = markCancelled(baseXchainRecord())
+    expect(r.executionState).toBe('cancelled')
+    expect(r.artifacts.error?.code).toBe('CANCELLED')
+    expect(r.artifacts.error?.txHash).toBeUndefined()
+  })
+
+  it('markDismissed writes a DISMISSED error AND carries forward sourceTxHash for explorer linking', () => {
+    // The whole point of dismiss-vs-cancel: the on-chain tx is still running. We MUST preserve
+    // the txHash so the user can find it on the explorer; otherwise dismissing post-broadcast
+    // strands them with no recovery path.
+    const r = markDismissed(baseXchainRecord()) // baseXchainRecord has sourceTxHash: '0xabc'
+    expect(r.executionState).toBe('cancelled')
+    expect(r.artifacts.error?.code).toBe('DISMISSED')
+    expect(r.artifacts.error?.txHash).toBe('0xabc')
+  })
+
+  it('markDismissed handles a record without sourceTxHash by omitting txHash from the error', () => {
+    // Edge case: dismissing a pre-broadcast record (TxActions wouldn't render the dismiss
+    // button in this state, but the reducer is defensive). Should not synthesise a bogus hash.
+    const r = baseXchainRecord()
+    delete (r.artifacts as { sourceTxHash?: `0x${string}` }).sourceTxHash
+    const dismissed = markDismissed(r)
+    expect(dismissed.artifacts.error?.code).toBe('DISMISSED')
+    expect(dismissed.artifacts.error?.txHash).toBeUndefined()
   })
 })

--- a/apps/armada-interface/src/lib/tx/reducer.ts
+++ b/apps/armada-interface/src/lib/tx/reducer.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Hooks call these and write the result back to the txListAtom + IDB. Every transition increments updatedSeq (OCC; see storage.ts).
 
 import { lifecycleFor } from './lifecycles'
-import type { ArtifactsFor, StageFor, TxKind, TxRecord } from './types'
+import type { ArtifactsFor, StageFor, TxError, TxKind, TxRecord } from './types'
 
 /** Reach the next stage. Sets executionState to `completed` if at terminalSuccess, else `active`. */
 export function advance<K extends TxKind>(
@@ -51,13 +51,22 @@ export function markRetrying<K extends TxKind>(record: TxRecord<K>): TxRecord<K>
   }
 }
 
-export function markFailed<K extends TxKind>(record: TxRecord<K>, error: string): TxRecord<K> {
+/**
+ * Mark a record `failed`. Accepts either a typed TxError or a plain string (auto-wrapped as
+ * `{ code: 'OTHER', message: string }`) so existing call sites that didn't categorize compile
+ * without change — new code should pass typed errors so the UI can pick honest copy.
+ */
+export function markFailed<K extends TxKind>(
+  record: TxRecord<K>,
+  error: TxError | string,
+): TxRecord<K> {
+  const errorObj: TxError = typeof error === 'string' ? { code: 'OTHER', message: error } : error
   return {
     ...record,
     executionState: 'failed',
     updatedSeq: record.updatedSeq + 1,
     updatedAt: Date.now(),
-    artifacts: { ...record.artifacts, error } as Partial<ArtifactsFor<K>>,
+    artifacts: { ...record.artifacts, error: errorObj } as Partial<ArtifactsFor<K>>,
   }
 }
 
@@ -70,12 +79,43 @@ export function markExpired<K extends TxKind>(record: TxRecord<K>): TxRecord<K> 
   }
 }
 
+/**
+ * User-initiated cancel of a pre-broadcast record. Sets a CANCELLED error so the UI can render
+ * honest copy ("Cancelled — no transaction was sent") and distinguish from auto-lock cleanup or
+ * other internal cancels.
+ *
+ * For post-broadcast records, use `markDismissed` instead — the on-chain tx still runs but we
+ * stopped watching it.
+ */
 export function markCancelled<K extends TxKind>(record: TxRecord<K>): TxRecord<K> {
+  const cancelError: TxError = { code: 'CANCELLED', message: 'Cancelled before submission.' }
   return {
     ...record,
     executionState: 'cancelled',
     updatedSeq: record.updatedSeq + 1,
     updatedAt: Date.now(),
+    artifacts: { ...record.artifacts, error: cancelError } as Partial<ArtifactsFor<K>>,
+  }
+}
+
+/**
+ * User "stopped tracking" a record that had already broadcast on chain. The tx will still run to
+ * completion (or revert) on chain — we just dropped it from our active polling. Persists the
+ * sourceTxHash in the error so the UI can link the user to the explorer.
+ */
+export function markDismissed<K extends TxKind>(record: TxRecord<K>): TxRecord<K> {
+  const sourceTxHash = (record.artifacts as { sourceTxHash?: `0x${string}` }).sourceTxHash
+  const dismissError: TxError = {
+    code: 'DISMISSED',
+    message: 'Stopped tracking — the transaction may still complete on chain.',
+    txHash: sourceTxHash,
+  }
+  return {
+    ...record,
+    executionState: 'cancelled',
+    updatedSeq: record.updatedSeq + 1,
+    updatedAt: Date.now(),
+    artifacts: { ...record.artifacts, error: dismissError } as Partial<ArtifactsFor<K>>,
   }
 }
 

--- a/apps/armada-interface/src/lib/tx/types.ts
+++ b/apps/armada-interface/src/lib/tx/types.ts
@@ -169,11 +169,44 @@ export type MetaFor<K extends TxKind> =
 
 /* Artifacts — opaque outputs accumulated as stages complete. */
 
+/**
+ * Categorised error codes carried on a failed/cancelled record so the UI can pick honest copy.
+ *
+ *  TX_REVERTED   — the on-chain tx was mined and reverted. Funds did not move (or moved + reverted).
+ *  POLL_TIMEOUT  — we lost track of an on-chain tx whose hash we know. It MAY still succeed; the
+ *                  user should check their wallet or the explorer. Distinct from TX_REVERTED.
+ *  RPC_ERROR     — wagmi/viem call threw before we got any tx hash. Usually safe to retry.
+ *  USER_REJECTED — the user declined a wallet signature or chain switch.
+ *  CANCELLED     — user-initiated cancel on a record that hadn't broadcast yet. Nothing on-chain.
+ *  DISMISSED     — user "stopped tracking" a record that HAD broadcast. The on-chain tx will run
+ *                  to completion; we just stopped watching it. We persist the txHash so the user
+ *                  can find it on the explorer.
+ *  OTHER         — unclassified error. Catch-all for handler bugs and unexpected throws.
+ */
+export type TxErrorCode =
+  | 'TX_REVERTED'
+  | 'POLL_TIMEOUT'
+  | 'RPC_ERROR'
+  | 'USER_REJECTED'
+  | 'CANCELLED'
+  | 'DISMISSED'
+  | 'OTHER'
+
+/**
+ * Typed error carried in `artifacts.error`. The `txHash` field is critical for POLL_TIMEOUT and
+ * DISMISSED: without it the user has no way to find their in-flight tx on the explorer.
+ */
+export interface TxError {
+  code: TxErrorCode
+  message: string
+  txHash?: `0x${string}`
+}
+
 export interface ArtifactsCommon {
-  /** Hash of the relayer-submitted transaction on the source chain. */
+  /** Hash of the user/relayer-submitted transaction on the source chain. */
   sourceTxHash?: `0x${string}`
-  /** Error message if the tx failed. */
-  error?: string
+  /** Categorised error if the record terminated unsuccessfully (failed / expired / cancelled-with-context). */
+  error?: TxError
   /**
    * ZK-proof generation progress (0–1). Set by the build-proof stage of any kind that calls
    * `generateUnshieldProof` / `generateTransferProof` / `generateProofTransactions`. Atom-only


### PR DESCRIPTION
## Summary

Three tangled tx-lifecycle issues, addressed as one PR because they share the same typed-error spine.

### 1. Cancel was dishonest after broadcast

Clicking Cancel on an in-flight record after the on-chain tx was already submitted marked the record \`cancelled\` but did nothing to the chain. The user thinks they undid something they didn't.

\`TxActions\` now picks behavior based on whether \`record.artifacts.sourceTxHash\` is set:
- **Pre-broadcast**: \"Cancel\" button → \`cancelTx\` (existing behavior, now writes a CANCELLED error code).
- **Post-broadcast**: \"Stop tracking\" button → confirmation dialog → \`dismissTx\` (new). Marks the record \`cancelled\` (execution state) but with a DISMISSED error code carrying the \`sourceTxHash\` for explorer linking.

\`TxStatusChip\` surfaces \"Stopped tracking\" for cancelled+DISMISSED so the user knows the on-chain tx is still running.

### 2. Receipt waits were unbounded

\`await waitForTransactionReceipt(wagmiConfig, { hash })\` had no timeout and no signal hook. A wedged RPC could pin a handler for the full lifecycle cap (10–60 min) with no UI signal; \`cancelTx\` couldn't interrupt the wait either.

New \`waitForReceiptOrFail\` helper (\`lib/tx/receipt.ts\`) wraps it with:
- Explicit timeout (5min default).
- \`Promise.race\` against \`ctx.signal\` so cancel propagates instantly.
- Branded \`TxError\` throws that distinguish POLL_TIMEOUT (\"may still succeed — check explorer\") from TX_REVERTED (\"mined and reverted\") from CANCELLED (\"user aborted\") from RPC_ERROR.

### 3. Typed error spine

All seven handlers now classify catches via \`classifyHandlerError\` (\`lib/tx/errors.ts\`) instead of stringifying \`err.message\`. Categories: \`TX_REVERTED\` / \`POLL_TIMEOUT\` / \`RPC_ERROR\` / \`USER_REJECTED\` / \`CANCELLED\` / \`DISMISSED\` / \`OTHER\`. The branded throw from \`waitForReceiptOrFail\` is preserved end-to-end so the outer catch doesn't re-tag a POLL_TIMEOUT as OTHER.

\`ErrorStep\` reads \`error.code\` to render category-specific title + body, plus an optional explorer-link anchor when \`explorerUrl\` is supplied. Modals compute the explorer URL from \`record.walletContext.sourceChainId\` + the error's txHash via a small new \`txExplorerUrl\` helper.

### Bonus fixes folded in

- **Xchain inner-timeout alignment**: \`runWaitForDelivery\`'s hardcoded \`10 * 60_000\` ignored the per-kind \`maxDurationMs\` (60 min for xchain). Replaced with \`createdAt + maxDurationMs - now\`, clamped to 10s minimum.
- **Xchain cancel-clobber**: the post-poll 3-stage walkthrough now checks \`ctx.signal.aborted\` before each \`advance()\`, preventing a cancel mid-walk from being overwritten by the next stage transition.
- **sourceTxHash persistence**: every handler now \`patchArtifacts\`-writes \`sourceTxHash\` immediately after \`sendTransaction\` (before the receipt wait) so any subsequent failure carries the hash forward into the error UX.

### What's NOT in scope

- The relayer-side hardening (lookback, persistent block cursor, error logging) is tracked separately — that's a relayer overhaul, not a frontend change.
- Input-validation guards (audit item 4 — \`parseUsdcInput\` truncation) are a focused follow-up PR.
- Parallel same-recipient \`unshield-xchain\` disambiguation (#287) — deferred per discussion.

## Test plan

- [x] \`npm run typecheck --workspace=@armada/interface\` — clean
- [x] \`npx vitest run\` (repo root) — 544/544 pass across 73 files (+16 tests)
- [ ] Manual on Sepolia: clicking Cancel pre-broadcast should still work as before
- [ ] Manual: click Cancel during a confirmed-but-still-progressing xchain — confirm \"Stop tracking\" prompt + record renders \"Stopped tracking\" + explorer link
- [ ] Manual: induce a receipt timeout (kill RPC connectivity briefly during \`shield\`) — confirm \"Lost track of your transaction\" copy + explorer link

🤖 Generated with [Claude Code](https://claude.com/claude-code)