### PR TITLE
feat(armada-interface, crowdfund-shared): honest USDC amount input

### DIFF
--- a/.claude/ARMADA_INTERFACE_POLISH.md
+++ b/.claude/ARMADA_INTERFACE_POLISH.md
@@ -92,6 +92,12 @@ _(no open items)_
 | Cross-tab leader election test | S | Only one tab runs the executor; un-tested in the multi-tab path. Would catch the `JotaiProvider` store-mismatch class of bugs again. |
 | End-to-end test against a live relayer | M | Integration test running against `npm run chains` + `npm run armada-relayer` + the new app. Validates shield → unshield round-trips. |
 
+## Shared lib / package extraction
+
+| Item | Size | Notes |
+|---|---|---|
+| Extract `parseUsdcInput` / `formatUsdc` / `formatUsdcPlain` / `truncateAddress` to `@armada/eth-utils` | M | These four helpers are currently kept in **lockstep** between `apps/armada-interface/src/lib/format.ts` and `crowdfund-ui/packages/shared/src/lib/format.ts` — any change must land in both files in the same PR (see headers in both files). The `parseUsdcInput` hardening (categorised `UsdcInputError`, no silent truncation) was done in lockstep. The right end state per Plan §19 is to extract to a shared `@armada/eth-utils` package — turning the silent-divergence risk into a typecheck-enforced single source of truth. Trigger this when a third consumer needs these helpers OR when the apps need them to diverge in non-trivial ways. Until then, the lockstep contract is documented in both file headers. |
+
 ## UI polish
 
 _(no open items)_

--- a/apps/armada-interface/src/components/payments/SendInputStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendInputStep.tsx
@@ -3,7 +3,7 @@
 
 import { AmountInput, ChainSelect, FeeSummary, RecipientInput, Tabs } from '@/components/ui'
 import { FlowFooter } from '@/components/flow/FlowFooter'
-import { parseUsdcInput } from '@/lib/format'
+import { parseUsdcInput, usdcInputErrorMessage } from '@/lib/format'
 import { isEvmAddress, isShieldedAddress } from '@/lib/address'
 import { getNetworkConfig } from '@/config/network'
 import styles from './SendInputStep.module.css'
@@ -54,9 +54,10 @@ export function SendInputStep({
   const hubChainId = getNetworkConfig().hub.chainId
   const isXchain = tab === 'external' && destChainId !== hubChainId
 
-  const amount = parseUsdcInput(amountStr)
+  const { value: amount, error: parseError } = parseUsdcInput(amountStr)
   const tooMuch = amount > max
-  const amountError = tooMuch ? 'Amount exceeds your private balance.' : undefined
+  const amountError = usdcInputErrorMessage(parseError)
+    ?? (tooMuch ? 'Amount exceeds your private balance.' : undefined)
 
   const recipientTrimmed = recipient.trim()
   const recipientValid =
@@ -68,7 +69,7 @@ export function SendInputStep({
       : 'Enter a valid EVM address (0x… 42 chars).'
     : undefined
 
-  const isValid = amount > 0n && !tooMuch && recipientValid && !destDeploymentError
+  const isValid = amount > 0n && !tooMuch && !parseError && recipientValid && !destDeploymentError
 
   return (
     <div className={styles.root}>

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -58,7 +58,7 @@ export function SendModal() {
   // Source data
   const shieldedUsdc = useAtomValue(shieldedUsdcAtom)
   const max = shieldedUsdc ?? 0n
-  const amount = parseUsdcInput(amountStr)
+  const { value: amount } = parseUsdcInput(amountStr)
   const { quote, isStale, refresh } = useFees()
   // Gate Confirm while the initial shielded-balance sync is incomplete. Both Send tabs
   // (private + external) spend the user's shielded USDC, so the same gate applies.

--- a/apps/armada-interface/src/components/shield/ShieldInputStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldInputStep.tsx
@@ -3,7 +3,7 @@
 
 import { AmountInput, ChainSelect, FeeSummary } from '@/components/ui'
 import { FlowFooter } from '@/components/flow/FlowFooter'
-import { parseUsdcInput } from '@/lib/format'
+import { parseUsdcInput, usdcInputErrorMessage } from '@/lib/format'
 import { getNetworkConfig } from '@/config/network'
 import styles from './ShieldInputStep.module.css'
 
@@ -35,9 +35,13 @@ export function ShieldInputStep({
 }: ShieldInputStepProps) {
   const hubChainId = getNetworkConfig().hub.chainId
   const isXchain = fromChainId !== hubChainId
-  const amount = parseUsdcInput(amountStr)
+  const { value: amount, error: amountError } = parseUsdcInput(amountStr)
   const tooMuch = amount > max
-  const isValid = amount > 0n && !tooMuch
+  // Parser-side errors (too-many-decimals etc) take precedence over balance-bound errors —
+  // a malformed value can't meaningfully be compared to max anyway. Surfaced via AmountInput.
+  const errorMessage = usdcInputErrorMessage(amountError)
+    ?? (tooMuch ? 'Amount exceeds your available balance.' : undefined)
+  const isValid = amount > 0n && !tooMuch && !amountError
 
   return (
     <div className={styles.root}>
@@ -58,7 +62,7 @@ export function ShieldInputStep({
         value={amountStr}
         onValueChange={onAmountChange}
         max={max}
-        error={tooMuch ? 'Amount exceeds your available balance.' : undefined}
+        error={errorMessage}
       />
       <FeeSummary
         fee={fee}

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -48,7 +48,7 @@ export function ShieldModal() {
 
   const balances = useBalances()
   const max = balances.unshielded[fromChainId] ?? 0n
-  const amount = parseUsdcInput(amountStr)
+  const { value: amount } = parseUsdcInput(amountStr)
 
   // useFees stays plumbed in for the relayer-submit path (need cacheId at submit time even
   // though the display fee no longer comes from the quote).

--- a/apps/armada-interface/src/components/ui/AmountInput/AmountInput.module.css
+++ b/apps/armada-interface/src/components/ui/AmountInput/AmountInput.module.css
@@ -16,6 +16,12 @@
   margin-top: var(--primitives-spacing-2);
 }
 
+.helperText {
+  color: var(--semantic-color-text-dim);
+  font-size: calc(var(--primitives-fontSize-xs) * 1px);
+  margin-top: var(--primitives-spacing-2);
+}
+
 /* Display variant */
 .displayRoot {
   display: flex;

--- a/apps/armada-interface/src/components/ui/AmountInput/AmountInput.test.tsx
+++ b/apps/armada-interface/src/components/ui/AmountInput/AmountInput.test.tsx
@@ -63,4 +63,63 @@ describe('<AmountInput>', () => {
     rerender(<AmountInput value="1" onValueChange={() => {}} variant="compact" unit="USDC" />)
     expect(screen.queryByText('USDC')).toBeNull()
   })
+
+  describe('keystroke sanitizer', () => {
+    // The sanitizer is the first line of defence against invalid input. parseUsdcInput's
+    // categorised errors are the safety net for paths the sanitizer can't catch (programmatic
+    // state writes, edge-case pastes). These tests cover the sanitizer surface; the parser
+    // surface is tested separately in lib/format.test.ts.
+
+    it('strips letters and symbols silently — the offending key never updates state', () => {
+      const onValueChange = vi.fn()
+      render(<AmountInput value="" onValueChange={onValueChange} label="Amount" variant="display" />)
+      // Typing "abc12d" → sanitizer keeps only the digits.
+      fireEvent.change(screen.getByLabelText('Amount'), { target: { value: 'abc12d' } })
+      expect(onValueChange).toHaveBeenCalledWith('12')
+    })
+
+    it('rejects a second decimal point (no-op state update)', () => {
+      const onValueChange = vi.fn()
+      // Starting from "1.5", typing another "." should not register.
+      render(<AmountInput value="1.5" onValueChange={onValueChange} label="Amount" variant="display" />)
+      fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '1.5.' } })
+      // The second dot is stripped; result equals the previous value, so onValueChange isn't called.
+      expect(onValueChange).not.toHaveBeenCalled()
+    })
+
+    it('caps the fractional portion at 6 chars on paste', () => {
+      const onValueChange = vi.fn()
+      render(<AmountInput value="" onValueChange={onValueChange} label="Amount" variant="display" />)
+      // Pasting "1.123456789" gets truncated to "1.123456" (USDC precision).
+      fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '1.123456789' } })
+      expect(onValueChange).toHaveBeenCalledWith('1.123456')
+    })
+
+    it('rejects a 7th decimal keystroke (state stays at the 6-decimal value)', () => {
+      const onValueChange = vi.fn()
+      render(<AmountInput value="1.123456" onValueChange={onValueChange} label="Amount" variant="display" />)
+      // Typing one more digit at the end → sanitizer truncates to the existing value → no-op.
+      fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '1.1234567' } })
+      expect(onValueChange).not.toHaveBeenCalled()
+    })
+
+    it('allows transitional states like "0." and "1." so the user can type forward', () => {
+      const onValueChange = vi.fn()
+      render(<AmountInput value="" onValueChange={onValueChange} label="Amount" variant="display" />)
+      fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '1.' } })
+      expect(onValueChange).toHaveBeenCalledWith('1.')
+    })
+
+    it('strips formatting characters from pasted amounts (e.g. "$1,500.50" → "1500.50")', () => {
+      const onValueChange = vi.fn()
+      render(<AmountInput value="" onValueChange={onValueChange} label="Amount" variant="display" />)
+      fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '$1,500.50' } })
+      expect(onValueChange).toHaveBeenCalledWith('1500.50')
+    })
+
+    it('renders the "USDC has up to 6 decimal places" helper text on the display variant', () => {
+      render(<AmountInput value="" onValueChange={() => {}} variant="display" label="Amount" />)
+      expect(screen.getByText(/6 decimal places/i)).toBeInTheDocument()
+    })
+  })
 })

--- a/apps/armada-interface/src/components/ui/AmountInput/AmountInput.tsx
+++ b/apps/armada-interface/src/components/ui/AmountInput/AmountInput.tsx
@@ -1,11 +1,14 @@
-// ABOUTME: USDC amount input with `display` (big serif numeral) and `compact` variants, MAX shortcut, AVAILABLE caption, and inline errors.
-// ABOUTME: Display variant matches the committer mockup's "How much USDC?" style; compact is the standard form-input shape.
+// ABOUTME: USDC amount input with `display` (big serif numeral) and `compact` variants, MAX shortcut, AVAILABLE caption, inline errors, AND a keystroke sanitizer that rejects characters that wouldn't form a valid USDC amount.
+// ABOUTME: Sanitizer is the first line of defence; parseUsdcInput's categorised errors are the safety net for programmatic/paste paths the sanitizer can't catch.
 
 import { useId } from 'react'
 import { formatUsdcAmount, formatUsdcPlain } from '@/lib/format'
 import styles from './AmountInput.module.css'
 
 export type AmountInputVariant = 'compact' | 'display'
+
+/** USDC has 6 decimals; if you ever want a non-USDC amount input, generalise this prop instead of forking the component. */
+const DEFAULT_MAX_DECIMALS = 6
 
 export interface AmountInputProps {
   /** Controlled raw input string (free typing). Use parseUsdcInput to convert before submit. */
@@ -25,6 +28,55 @@ export interface AmountInputProps {
   onBlur?: () => void
 }
 
+/**
+ * Sanitize a candidate value (typed or pasted) into a valid USDC input string. Returns null if
+ * the candidate cannot be coerced (caller should reject the keystroke entirely).
+ *
+ *  - Strips characters outside `[0-9.]`
+ *  - Allows at most one decimal point (extras are dropped)
+ *  - Truncates the fractional portion to `maxDecimals` chars
+ *  - Allows intermediate states the user needs to type forward: `''`, `'.'` (becomes `'0.'`),
+ *    `'1.'`, `'0.'`
+ *
+ * Pasting "1.123456789" returns "1.123456" — silent truncation only on paste, which matches
+ * browser conventions for similar number-like inputs. Typing a 7th decimal character returns
+ * null and the keystroke is rejected (no state update, cursor doesn't move).
+ */
+function sanitizeAmountInput(
+  candidate: string,
+  previous: string,
+  maxDecimals: number,
+): string | null {
+  // Strip everything outside digits and decimal points. Doing this BEFORE the dot check lets us
+  // accept pastes like "$1.50" or "1,500.00" — the formatting characters are dropped and we
+  // keep the numeric content. Comma is intentionally NOT treated as a decimal separator (locale
+  // ambiguity would silently misparse European amounts).
+  const stripped = candidate.replace(/[^0-9.]/g, '')
+
+  // Reduce multiple decimal points to one — keeps the first occurrence so typing "1.5" then
+  // hitting "." again is a no-op rather than rewriting the value.
+  const firstDot = stripped.indexOf('.')
+  const normalised = firstDot === -1
+    ? stripped
+    : stripped.slice(0, firstDot + 1) + stripped.slice(firstDot + 1).replace(/\./g, '')
+
+  if (firstDot !== -1) {
+    const fractional = normalised.slice(firstDot + 1)
+    if (fractional.length > maxDecimals) {
+      // Pasted-too-many-decimals: truncate the fractional portion to the limit. Typing the 7th
+      // character explicitly would also land here; either way we return the truncated value so
+      // the user sees their intent partially honoured (the leading content is preserved).
+      // Reject (return null) only when the truncation would produce no change from the previous
+      // value — that's the "user hit a key that did nothing" case and we want React to skip the
+      // state update so cursor position doesn't jitter.
+      const truncated = normalised.slice(0, firstDot + 1 + maxDecimals)
+      return truncated === previous ? null : truncated
+    }
+  }
+
+  return normalised === previous ? null : normalised
+}
+
 export function AmountInput({
   value,
   onValueChange,
@@ -38,6 +90,15 @@ export function AmountInput({
 }: AmountInputProps) {
   const id = useId()
   const hasMax = max !== undefined
+  const helperTextId = useId()
+
+  function handleChange(raw: string) {
+    const sanitized = sanitizeAmountInput(raw, value, DEFAULT_MAX_DECIMALS)
+    // null = the keystroke would have been a no-op after sanitization; skip the state update so
+    // the cursor stays put and the user gets the standard "this key didn't do anything" UX.
+    if (sanitized === null) return
+    onValueChange(sanitized)
+  }
 
   function setMax() {
     if (max === undefined) return
@@ -59,13 +120,17 @@ export function AmountInput({
             type="text"
             inputMode="decimal"
             value={value}
-            onChange={e => onValueChange(e.target.value)}
+            onChange={e => handleChange(e.target.value)}
             onBlur={onBlur}
             disabled={disabled}
             placeholder="0"
             aria-label={label ?? 'Amount'}
+            aria-describedby={helperTextId}
           />
           <span className={styles.unit}>{unit}</span>
+        </div>
+        <div className={styles.helperText} id={helperTextId}>
+          USDC has up to 6 decimal places
         </div>
         {hasMax ? (
           <div className={styles.captions}>
@@ -106,7 +171,7 @@ export function AmountInput({
           type="text"
           inputMode="decimal"
           value={value}
-          onChange={e => onValueChange(e.target.value)}
+          onChange={e => handleChange(e.target.value)}
           onBlur={onBlur}
           disabled={disabled}
           placeholder="0.00"

--- a/apps/armada-interface/src/components/unshield/UnshieldInputStep.tsx
+++ b/apps/armada-interface/src/components/unshield/UnshieldInputStep.tsx
@@ -3,7 +3,7 @@
 
 import { AmountInput, ChainSelect, FeeSummary, RecipientInput } from '@/components/ui'
 import { FlowFooter } from '@/components/flow/FlowFooter'
-import { parseUsdcInput } from '@/lib/format'
+import { parseUsdcInput, usdcInputErrorMessage } from '@/lib/format'
 import { isEvmAddress } from '@/lib/address'
 import { getNetworkConfig } from '@/config/network'
 import styles from './UnshieldInputStep.module.css'
@@ -41,9 +41,11 @@ export function UnshieldInputStep({
   const hubChainId = getNetworkConfig().hub.chainId
   const isXchain = destChainId !== hubChainId
 
-  const amount = parseUsdcInput(amountStr)
+  const { value: amount, error: parseError } = parseUsdcInput(amountStr)
   const tooMuch = amount > max
-  const amountError = tooMuch ? 'Amount exceeds your private balance.' : undefined
+  // Parser-side errors (too-many-decimals etc) take precedence over balance-bound errors.
+  const amountError = usdcInputErrorMessage(parseError)
+    ?? (tooMuch ? 'Amount exceeds your private balance.' : undefined)
 
   const recipientTrimmed = recipient.trim()
   // Empty recipient is allowed (no error shown); validation only kicks in once the user types something.
@@ -53,6 +55,7 @@ export function UnshieldInputStep({
   const isValid =
     amount > 0n &&
     !tooMuch &&
+    !parseError &&
     isEvmAddress(recipientTrimmed)
 
   return (

--- a/apps/armada-interface/src/components/unshield/UnshieldModal.tsx
+++ b/apps/armada-interface/src/components/unshield/UnshieldModal.tsx
@@ -52,7 +52,7 @@ export function UnshieldModal() {
   // Source data.
   const shieldedUsdc = useAtomValue(shieldedUsdcAtom)
   const max = shieldedUsdc ?? 0n
-  const amount = parseUsdcInput(amountStr)
+  const { value: amount } = parseUsdcInput(amountStr)
   const { quote, isStale, refresh } = useFees()
   // Gate Confirm while the initial shielded-balance sync is incomplete (or failed). Reading
   // here so the Review step always reflects the current state — if sync completes while the

--- a/apps/armada-interface/src/components/yield/EarnInputStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.tsx
@@ -3,7 +3,7 @@
 
 import { AmountInput, FeeSummary, Tabs } from '@/components/ui'
 import { FlowFooter } from '@/components/flow/FlowFooter'
-import { parseUsdcInput } from '@/lib/format'
+import { parseUsdcInput, usdcInputErrorMessage } from '@/lib/format'
 import { rateToApy } from '@/lib/yield'
 import type { YieldRate } from '@/hooks/useYieldRate'
 import styles from './EarnInputStep.module.css'
@@ -51,15 +51,17 @@ export function EarnInputStep({
   onCancel,
   onContinue,
 }: EarnInputStepProps) {
-  const amount = parseUsdcInput(amountStr)
+  const { value: amount, error: parseError } = parseUsdcInput(amountStr)
   const tooMuch = amount > max
-  const amountError = tooMuch
-    ? tab === 'add'
-      ? 'Amount exceeds your private balance.'
-      : 'Amount exceeds your earning balance.'
-    : undefined
+  const amountError =
+    usdcInputErrorMessage(parseError)
+    ?? (tooMuch
+      ? tab === 'add'
+        ? 'Amount exceeds your private balance.'
+        : 'Amount exceeds your earning balance.'
+      : undefined)
 
-  const isValid = amount > 0n && !tooMuch
+  const isValid = amount > 0n && !tooMuch && !parseError
 
   return (
     <div className={styles.root}>

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -53,7 +53,7 @@ export function EarnModal() {
     yieldShares !== null && yieldRate !== null ? sharesToUsdc(yieldShares, yieldRate.rate) : null
   const max = tab === 'add' ? shieldedUsdc ?? 0n : earningUsdc ?? 0n
 
-  const amount = parseUsdcInput(amountStr)
+  const { value: amount } = parseUsdcInput(amountStr)
   const { quote, isStale, refresh } = useFees()
   // Yield ops spend the user's shielded USDC (deposit) or shielded yield shares (withdraw).
   // Either way, we need a successful first sync before letting the user submit.

--- a/apps/armada-interface/src/lib/format.test.ts
+++ b/apps/armada-interface/src/lib/format.test.ts
@@ -9,6 +9,7 @@ import {
   parseUsdcInput,
   truncateAddress,
   formatRelativeTime,
+  usdcInputErrorMessage,
 } from './format'
 
 describe('formatUsdc', () => {
@@ -37,20 +38,58 @@ describe('formatUsdcAmount', () => {
 })
 
 describe('parseUsdcInput', () => {
-  it('parses a decimal string to raw 6-decimal bigint', () => {
-    expect(parseUsdcInput('1')).toBe(1_000_000n)
-    expect(parseUsdcInput('0.5')).toBe(500_000n)
+  it('parses a decimal string to raw 6-decimal bigint with no error', () => {
+    expect(parseUsdcInput('1')).toEqual({ value: 1_000_000n })
+    expect(parseUsdcInput('0.5')).toEqual({ value: 500_000n })
+    expect(parseUsdcInput('1.123456')).toEqual({ value: 1_123_456n })
   })
-  it('returns 0 for invalid or negative input', () => {
-    expect(parseUsdcInput('abc')).toBe(0n)
-    expect(parseUsdcInput('-5')).toBe(0n)
+
+  it('returns { value: 0n } with no error for the empty / whitespace input (user hasn\'t typed yet)', () => {
+    // Critical: empty input is NOT an error — it's the initial state. Modals gate Continue on
+    // `value > 0n`; setting error here would surface a spurious "invalid number" before the
+    // user has even typed anything.
+    expect(parseUsdcInput('')).toEqual({ value: 0n })
+    expect(parseUsdcInput('   ')).toEqual({ value: 0n })
   })
-  it('returns 0 for non-finite values (Infinity, NaN, very large exponents)', () => {
+
+  it('reports too-many-decimals BEFORE numeric truncation would silently lose precision', () => {
+    // The whole reason for the new API: previously "1.1234567" silently parsed as 1_123_456n
+    // (loses the trailing 7). Now it surfaces an error so UI can prompt the user instead.
+    expect(parseUsdcInput('1.1234567')).toEqual({ value: 0n, error: 'too-many-decimals' })
+    expect(parseUsdcInput('0.0000001')).toEqual({ value: 0n, error: 'too-many-decimals' })
+  })
+
+  it('accepts exactly 6 decimal places (boundary)', () => {
+    expect(parseUsdcInput('1.123456')).toEqual({ value: 1_123_456n })
+    expect(parseUsdcInput('0.000001')).toEqual({ value: 1n })
+  })
+
+  it('reports invalid for non-numeric input', () => {
+    expect(parseUsdcInput('abc')).toEqual({ value: 0n, error: 'invalid' })
+    expect(parseUsdcInput('NaN')).toEqual({ value: 0n, error: 'invalid' })
+  })
+
+  it('reports negative for negative numbers', () => {
+    expect(parseUsdcInput('-5')).toEqual({ value: 0n, error: 'negative' })
+    expect(parseUsdcInput('-0.01')).toEqual({ value: 0n, error: 'negative' })
+  })
+
+  it('reports invalid for non-finite values (Infinity, very large exponents)', () => {
     // parseFloat accepts these silently; without the isFinite guard, BigInt(Infinity) throws.
-    expect(parseUsdcInput('Infinity')).toBe(0n)
-    expect(parseUsdcInput('-Infinity')).toBe(0n)
-    expect(parseUsdcInput('1e500')).toBe(0n)
-    expect(parseUsdcInput('NaN')).toBe(0n)
+    expect(parseUsdcInput('Infinity')).toEqual({ value: 0n, error: 'invalid' })
+    expect(parseUsdcInput('1e500')).toEqual({ value: 0n, error: 'invalid' })
+  })
+})
+
+describe('usdcInputErrorMessage', () => {
+  it('returns undefined for the no-error case so callers can chain `?? otherError`', () => {
+    expect(usdcInputErrorMessage(undefined)).toBeUndefined()
+  })
+
+  it('maps each error code to user-visible copy', () => {
+    expect(usdcInputErrorMessage('too-many-decimals')).toMatch(/6 decimal/)
+    expect(usdcInputErrorMessage('negative')).toMatch(/negative/i)
+    expect(usdcInputErrorMessage('invalid')).toMatch(/valid number/i)
   })
 })
 

--- a/apps/armada-interface/src/lib/format.ts
+++ b/apps/armada-interface/src/lib/format.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Address + USDC formatters. Duplicated from @armada/crowdfund-shared/lib/format.ts.
-// ABOUTME: Extract to @armada/eth-utils when both apps need to evolve these helpers.
+// ABOUTME: Address + USDC formatters. Kept in LOCKSTEP with crowdfund-ui/packages/shared/src/lib/format.ts (parseUsdcInput, formatUsdc, formatUsdcPlain, truncateAddress) — any change to those four must land in both files in the same PR.
+// ABOUTME: Once a third consumer needs these or the apps need to diverge, extract to @armada/eth-utils per Plan §19. Tracked in .claude/ARMADA_INTERFACE_POLISH.md.
 
 /** Format a USDC raw amount (6 decimals) as a dollar string, e.g. "$1,200,000". */
 export function formatUsdc(amount: bigint): string {
@@ -25,13 +25,71 @@ export function formatUsdcAmount(amount: bigint, options?: { decimals?: number }
   })
 }
 
-/** Parse a USDC input string (e.g. "150" or "150.50") to 6-decimal raw bigint. */
-export function parseUsdcInput(input: string): bigint {
-  const num = parseFloat(input)
-  // Reject non-finite (NaN, ±Infinity, "1e500") and negatives. parseFloat accepts
-  // "Infinity" silently; without the isFinite guard, BigInt(Infinity) throws RangeError.
-  if (!Number.isFinite(num) || num < 0) return 0n
-  return BigInt(Math.floor(num * 1e6))
+/**
+ * Categorised parse error returned from {@link parseUsdcInput}. Surfaced via the result's
+ * `error` field; `value` is always present (0n on error) so the common UI gating pattern
+ * `value > 0n` still works without immediate caller changes.
+ *
+ *  'invalid'           — not a number (NaN, "abc", empty, scientific overflow like "1e500")
+ *  'negative'          — number is negative
+ *  'too-many-decimals' — input has more than 6 fractional digits; truncation would lose precision
+ */
+export type UsdcInputError = 'invalid' | 'negative' | 'too-many-decimals'
+
+export interface UsdcInputResult {
+  /** Parsed raw 6-decimal bigint. Always 0n when `error` is set. */
+  value: bigint
+  /** Categorised parse error; undefined when the input is a valid USDC amount. */
+  error?: UsdcInputError
+}
+
+/**
+ * Parse a USDC input string into a 6-decimal raw bigint with categorised errors.
+ *
+ * Unlike the previous string-truncating impl, this version distinguishes "the user hasn't typed
+ * yet" (empty/0 → `{ value: 0n }`) from "the user typed something invalid" (e.g. >6dp →
+ * `{ value: 0n, error: 'too-many-decimals' }`). UI surfaces the error via a dedicated inline
+ * message instead of silently rounding.
+ *
+ * `AmountInput`'s keystroke sanitizer should prevent invalid input from reaching here in the
+ * normal flow; this parser is the defence-in-depth layer (programmatic submission, malformed
+ * paste, future API surfaces).
+ */
+export function parseUsdcInput(input: string): UsdcInputResult {
+  const trimmed = input.trim()
+  if (trimmed === '') return { value: 0n }
+
+  // Decimal-precision check happens BEFORE numeric parse so "1.1234567" reports 'too-many-decimals'
+  // rather than silently rounding to 1.123456 via Math.floor below.
+  const dot = trimmed.indexOf('.')
+  if (dot !== -1 && trimmed.length - dot - 1 > 6) {
+    return { value: 0n, error: 'too-many-decimals' }
+  }
+
+  const num = parseFloat(trimmed)
+  // Reject non-finite (NaN, ±Infinity, "1e500"). parseFloat accepts "Infinity" silently;
+  // without the isFinite guard, BigInt(Infinity) throws RangeError.
+  if (!Number.isFinite(num)) return { value: 0n, error: 'invalid' }
+  if (num < 0) return { value: 0n, error: 'negative' }
+  return { value: BigInt(Math.floor(num * 1e6)) }
+}
+
+/**
+ * Map a {@link UsdcInputError} to the user-visible copy we surface in AmountInput. Armada-local
+ * helper — copy may differ across apps so this isn't part of the lockstep contract with
+ * crowdfund-shared. Returns undefined when no error so the caller can pass it through to
+ * AmountInput.error without an extra conditional.
+ *
+ * Defensive: AmountInput's keystroke sanitizer prevents these errors in the normal flow. Users
+ * see this copy only when bypassing the sanitizer (programmatic state injection, future surfaces).
+ */
+export function usdcInputErrorMessage(error: UsdcInputError | undefined): string | undefined {
+  switch (error) {
+    case 'too-many-decimals': return 'USDC has at most 6 decimal places.'
+    case 'negative': return 'Amount cannot be negative.'
+    case 'invalid': return 'Enter a valid number.'
+    case undefined: return undefined
+  }
 }
 
 /** Truncate an Ethereum address to "0x1234...abcd" (mockup convention: 6 chars before, 4 after). */

--- a/crowdfund-ui/packages/committer/src/components/CommitTab.tsx
+++ b/crowdfund-ui/packages/committer/src/components/CommitTab.tsx
@@ -89,7 +89,26 @@ function makeCommitSchema(positions: HopPosition[], balance: bigint) {
       for (const pos of positions) {
         const raw = data.amounts[String(pos.hop)] ?? ''
         if (!raw.trim()) continue
-        const parsed = parseUsdcInput(raw)
+        const { value: parsed, error: parseError } = parseUsdcInput(raw)
+        // Surface parser errors as their own issue — without this, a too-many-decimals input
+        // would silently parse as 0n and fall through the `continue` below, leaving the user
+        // with no feedback about why their typed amount was ignored.
+        if (parseError === 'too-many-decimals') {
+          ctx.addIssue({
+            path: ['amounts', String(pos.hop)],
+            code: 'custom',
+            message: 'Maximum 6 decimal places.',
+          })
+          continue
+        }
+        if (parseError === 'invalid' || parseError === 'negative') {
+          ctx.addIssue({
+            path: ['amounts', String(pos.hop)],
+            code: 'custom',
+            message: 'Enter a valid positive amount.',
+          })
+          continue
+        }
         if (parsed === 0n) continue
         if (parsed < CROWDFUND_CONSTANTS.MIN_COMMIT) {
           ctx.addIssue({
@@ -214,7 +233,7 @@ export function CommitTab(props: CommitTabProps) {
     const m = new Map<number, bigint>()
     for (const pos of positions) {
       const raw = amountsValues?.[String(pos.hop)] ?? ''
-      const parsed = parseUsdcInput(raw)
+      const { value: parsed } = parseUsdcInput(raw)
       if (parsed > 0n) m.set(pos.hop, parsed)
     }
     return m

--- a/crowdfund-ui/packages/committer/src/components/InviteLinkRedemption.tsx
+++ b/crowdfund-ui/packages/committer/src/components/InviteLinkRedemption.tsx
@@ -76,8 +76,16 @@ function makeRedeemSchema(opts: { hopCap: bigint; balance: bigint; targetHop: nu
         })
         return
       }
-      const parsed = parseUsdcInput(raw)
-      if (parsed <= 0n) {
+      const { value: parsed, error: parseError } = parseUsdcInput(raw)
+      if (parseError === 'too-many-decimals') {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['amount'],
+          message: 'Maximum 6 decimal places.',
+        })
+        return
+      }
+      if (parseError === 'invalid' || parseError === 'negative' || parsed <= 0n) {
         ctx.addIssue({
           code: 'custom',
           path: ['amount'],
@@ -155,7 +163,7 @@ export function InviteLinkRedemption() {
   })
 
   const amountValue = form.watch('amount')
-  const parsedAmount = useMemo(() => parseUsdcInput(amountValue ?? ''), [amountValue])
+  const parsedAmount = useMemo(() => parseUsdcInput(amountValue ?? '').value, [amountValue])
 
   // Load deployment + provider
   useEffect(() => {
@@ -265,7 +273,7 @@ export function InviteLinkRedemption() {
   const onSubmit = useCallback(
     async (values: RedeemFormValues) => {
       if (!inviteData || !deployment) return
-      const amount = parseUsdcInput(values.amount.trim())
+      const { value: amount } = parseUsdcInput(values.amount.trim())
       if (amount === 0n) return
 
       // Step 1: Approve if needed

--- a/crowdfund-ui/packages/shared/src/lib/format.test.ts
+++ b/crowdfund-ui/packages/shared/src/lib/format.test.ts
@@ -47,25 +47,41 @@ describe('formatUsdcPlain', () => {
 })
 
 describe('parseUsdcInput', () => {
+  // New result-type API kept in lockstep with apps/armada-interface/src/lib/format.ts.
+  // See that file's tests for the full rationale; cases here mirror the same matrix so any
+  // future divergence is caught immediately.
+
   it('parses whole numbers', () => {
-    expect(parseUsdcInput('15000')).toBe(15_000n * 10n ** 6n)
+    expect(parseUsdcInput('15000')).toEqual({ value: 15_000n * 10n ** 6n })
   })
 
   it('parses decimal amounts', () => {
-    expect(parseUsdcInput('15000.50')).toBe(15_000_500_000n)
+    expect(parseUsdcInput('15000.50')).toEqual({ value: 15_000_500_000n })
   })
 
-  it('returns 0n for invalid input', () => {
-    expect(parseUsdcInput('abc')).toBe(0n)
-    expect(parseUsdcInput('')).toBe(0n)
+  it('returns no error for empty / whitespace (user hasn\'t typed yet)', () => {
+    expect(parseUsdcInput('')).toEqual({ value: 0n })
+    expect(parseUsdcInput('   ')).toEqual({ value: 0n })
   })
 
-  it('returns 0n for negative input', () => {
-    expect(parseUsdcInput('-100')).toBe(0n)
+  it('reports invalid for non-numeric input', () => {
+    expect(parseUsdcInput('abc')).toEqual({ value: 0n, error: 'invalid' })
+  })
+
+  it('reports negative for negative numbers', () => {
+    expect(parseUsdcInput('-100')).toEqual({ value: 0n, error: 'negative' })
+  })
+
+  it('reports too-many-decimals before silent truncation would lose precision', () => {
+    expect(parseUsdcInput('1.1234567')).toEqual({ value: 0n, error: 'too-many-decimals' })
+  })
+
+  it('accepts exactly 6 decimal places (boundary)', () => {
+    expect(parseUsdcInput('1.123456')).toEqual({ value: 1_123_456n })
   })
 
   it('parses zero', () => {
-    expect(parseUsdcInput('0')).toBe(0n)
+    expect(parseUsdcInput('0')).toEqual({ value: 0n })
   })
 })
 

--- a/crowdfund-ui/packages/shared/src/lib/format.ts
+++ b/crowdfund-ui/packages/shared/src/lib/format.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Formatting utilities for USDC amounts, ARM tokens, addresses, and countdowns.
-// ABOUTME: Pure functions with no React or ethers dependency.
+// ABOUTME: Formatting utilities for USDC amounts, ARM tokens, addresses, and countdowns. Pure functions, no React or ethers dependency.
+// ABOUTME: parseUsdcInput / formatUsdc / formatUsdcPlain / truncateAddress are kept in LOCKSTEP with apps/armada-interface/src/lib/format.ts — any change must land in both files in the same PR. Tracked for eth-utils extraction in .claude/ARMADA_INTERFACE_POLISH.md.
 
 /** Format a USDC amount (6 decimals) as a dollar string, e.g. "$1,200,000" */
 export function formatUsdc(amount: bigint): string {
@@ -12,11 +12,49 @@ export function formatUsdcPlain(amount: bigint): string {
   return (Number(amount) / 1e6).toString()
 }
 
-/** Parse a USDC amount string (e.g. "15000" or "15000.50") to 6-decimal bigint */
-export function parseUsdcInput(input: string): bigint {
-  const num = parseFloat(input)
-  if (isNaN(num) || num < 0) return 0n
-  return BigInt(Math.floor(num * 1e6))
+/**
+ * Categorised parse error returned from {@link parseUsdcInput}. Surfaced via the result's
+ * `error` field; `value` is always present (0n on error) so the common UI gating pattern
+ * `value > 0n` still works.
+ *
+ *  'invalid'           — not a number (NaN, "abc", empty, scientific overflow like "1e500")
+ *  'negative'          — number is negative
+ *  'too-many-decimals' — input has more than 6 fractional digits; truncation would lose precision
+ */
+export type UsdcInputError = 'invalid' | 'negative' | 'too-many-decimals'
+
+export interface UsdcInputResult {
+  /** Parsed raw 6-decimal bigint. Always 0n when `error` is set. */
+  value: bigint
+  /** Categorised parse error; undefined when the input is a valid USDC amount. */
+  error?: UsdcInputError
+}
+
+/**
+ * Parse a USDC input string into a 6-decimal raw bigint with categorised errors.
+ *
+ * Unlike the previous string-truncating impl, this version distinguishes "the user hasn't typed
+ * yet" (empty/0 → `{ value: 0n }`) from "the user typed something invalid" (e.g. >6dp →
+ * `{ value: 0n, error: 'too-many-decimals' }`). UI surfaces the error via a dedicated inline
+ * message instead of silently rounding.
+ */
+export function parseUsdcInput(input: string): UsdcInputResult {
+  const trimmed = input.trim()
+  if (trimmed === '') return { value: 0n }
+
+  // Decimal-precision check happens BEFORE numeric parse so "1.1234567" reports 'too-many-decimals'
+  // rather than silently rounding to 1.123456 via Math.floor below.
+  const dot = trimmed.indexOf('.')
+  if (dot !== -1 && trimmed.length - dot - 1 > 6) {
+    return { value: 0n, error: 'too-many-decimals' }
+  }
+
+  const num = parseFloat(trimmed)
+  // Reject non-finite (NaN, ±Infinity, "1e500"). parseFloat accepts "Infinity" silently;
+  // without the isFinite guard, BigInt(Infinity) throws RangeError.
+  if (!Number.isFinite(num)) return { value: 0n, error: 'invalid' }
+  if (num < 0) return { value: 0n, error: 'negative' }
+  return { value: BigInt(Math.floor(num * 1e6)) }
 }
 
 /** Format an ARM amount (18 decimals) as a token string, e.g. "1,200,000 ARM" */


### PR DESCRIPTION
## Summary

Two-layer defence against the silent input-truncation bug: previously, typing or pasting \`\"1.1234567\"\` parsed as \`1_123_456n\` (drops the trailing 7) with no UI signal.

### 1. `lib/format.ts` — `parseUsdcInput` returns a typed result

\`parseUsdcInput\` now returns \`{ value: bigint, error?: 'too-many-decimals' | 'invalid' | 'negative' }\`. The empty/whitespace input is intentionally NOT an error (it's the \"user hasn't typed yet\" state). The decimal-precision check runs **before** the numeric parse so the >6dp case can't slip through \`Math.floor\`'s silent rounding.

This change is applied in **lockstep** to both copies (see \`apps/armada-interface/src/lib/format.ts\` and \`crowdfund-ui/packages/shared/src/lib/format.ts\` headers). Both copies' headers now document the contract. The eth-utils package extraction is tracked in \`.claude/ARMADA_INTERFACE_POLISH.md\` under a new \"Shared lib / package extraction\" section.

### 2. \`AmountInput\` keystroke sanitizer (armada-interface only)

The component's onChange now sanitises typed/pasted input before updating state:
- Strips chars outside \`[0-9.]\`
- Allows only one decimal point
- Caps fractional portion at 6 chars
- Allows transitional states (\"1.\", \"0.\") so the user can type forward
- Pasting \"\$1,500.50\" → \"1500.50\"; 7th-decimal keystrokes return null so state stays put and cursor doesn't jitter

\"USDC has up to 6 decimal places\" helper text on the display variant, linked via \`aria-describedby\`.

### 3. All 13 callers migrated to the destructured API

Modals (\`{ value: amount }\`), input steps (\`{ value: amount, error: parseError }\` + UI surfacing), crowdfund-committer zod superRefine validators (gain a new \`too-many-decimals\` ctx.addIssue). Modal input steps merge the parser error with their existing balance-bound errors so parser code takes precedence over \"insufficient balance\" copy.

A small armada-local helper \`usdcInputErrorMessage(error)\` maps the typed enum to UI copy — kept armada-local rather than lockstepped because crowdfund may want different phrasing.

## What this is NOT

- **Not the eth-utils extraction.** Per Plan §19 we don't pre-extract — we lockstep the two copies and document the future merge. Both file headers now read \"any change to these helpers must land in both files in the same PR\". When a third consumer arrives or the apps need to diverge, the extraction becomes a focused \"merge the two copies\" task.
- **Not a behaviour change for the user pre-sanitizer.** A user who never pastes invalid input or hits >6 decimals sees identical behaviour to before; this is defensive.

## Test plan

- [x] \`npm run typecheck\` clean: \`@armada/interface\`, \`@armada/crowdfund-shared\`, \`@armada/crowdfund-committer\`
- [x] \`armada-interface\`: 73 files / 557 tests pass (+13 new — parser error matrix + sanitizer behaviour + helper text)
- [x] \`crowdfund-shared\`: 17 files / 156 tests pass
- [x] \`crowdfund-committer\`: 8 files / 69 tests pass
- [ ] Manual sweep on Sepolia: shield amount input, try \"1.1234567\" (should reject the 7), try pasting \"\$1,500.50\" (should clean to \"1500.50\"), try typing letters (should not appear), confirm helper text reads correctly
- [ ] Manual on crowdfund-committer: try \"1.1234567\" in a commit amount field — zod validation surfaces \"Maximum 6 decimal places.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)