### PR TITLE
chore(armada-interface): audit-cleanup pass — record-watcher deps, silent failure logging, stage-name doc

### DIFF
--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -17,6 +17,7 @@ import {
 import { parseUsdcInput } from '@/lib/format'
 import { userFeeForKind } from '@/lib/relayer'
 import { displayTxHash, txExplorerUrl } from '@/lib/explorer'
+import { trackError } from '@/lib/telemetry'
 import {
   ActionFlowShell,
   ProgressStep,
@@ -72,7 +73,16 @@ export function SendModal() {
     let cancelled = false
     void loadDeployments()
       .then(d => { if (!cancelled) setDeployments(d) })
-      .catch(() => { /* leave null — gate stays neutral, submit will surface the real error */ })
+      .catch(err => {
+        // Leave `deployments` null — `destHasDeployment` below stays `true` until the manifest
+        // is known, so the user can still proceed through the form; the submit step's own
+        // error path will surface the real failure if it persists. Telemetry is the only signal
+        // we have here, since the user wouldn't otherwise know loadDeployments tried and failed.
+        trackError('SendModal.loadDeployments', err, {
+          scope: 'send.deployments',
+          message: 'failed to load deployment manifests for destination-chain check',
+        })
+      })
     return () => { cancelled = true }
   }, [isOpen])
   const destHasDeployment =
@@ -115,7 +125,9 @@ export function SendModal() {
     }
   }, [isOpen])
 
-  // Watch the submitted record for terminal transitions.
+  // Watch the submitted record for terminal transitions. Dep is `record?.executionState` rather
+  // than `record` so artifact patches during xchain polling don't re-fire this needlessly — the
+  // body only branches on executionState.
   useEffect(() => {
     if (!record) return
     if (record.executionState === 'completed') setStep('complete')
@@ -123,7 +135,7 @@ export function SendModal() {
       setStep('error')
       setErrorAtStep('progress')
     }
-  }, [record])
+  }, [record?.executionState])
 
   function close() {
     setOpenModal(null)

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -84,6 +84,9 @@ export function ShieldModal() {
   }, [isOpen])
 
   // Once the tx record exists and reaches a terminal state, transition step accordingly.
+  // Dep is `record?.executionState` rather than `record` so artifact patches (e.g. proofProgress
+  // ticks, log-scan cursor advances on xchain) don't re-fire the effect needlessly. The body
+  // only branches on executionState.
   useEffect(() => {
     if (!record) return
     if (record.executionState === 'completed') setStep('complete')
@@ -91,7 +94,7 @@ export function ShieldModal() {
       setStep('error')
       setErrorAtStep('progress')
     }
-  }, [record])
+  }, [record?.executionState])
 
   function close() {
     setOpenModal(null)

--- a/apps/armada-interface/src/components/unshield/UnshieldModal.tsx
+++ b/apps/armada-interface/src/components/unshield/UnshieldModal.tsx
@@ -93,7 +93,9 @@ export function UnshieldModal() {
     }
   }, [isOpen])
 
-  // Watch the submitted record for terminal transitions.
+  // Watch the submitted record for terminal transitions. Dep is `record?.executionState` rather
+  // than `record` so artifact patches during xchain polling don't re-fire this needlessly — the
+  // body only branches on executionState.
   useEffect(() => {
     if (!record) return
     if (record.executionState === 'completed') setStep('complete')
@@ -101,7 +103,7 @@ export function UnshieldModal() {
       setStep('error')
       setErrorAtStep('progress')
     }
-  }, [record])
+  }, [record?.executionState])
 
   function close() {
     setOpenModal(null)

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -91,7 +91,10 @@ export function EarnModal() {
 
   // Watch the submitted record for terminal transitions. On completed, refresh the rate so the
   // post-tx balance / APY view reflects the new vault state immediately (rather than waiting up
-  // to 5 min for the next poll tick).
+  // to 5 min for the next poll tick). Dep is `record?.executionState` rather than `record` so
+  // artifact patches during proof-progress updates don't re-fire — the body only branches on
+  // executionState. The `refreshYieldRate` reference is intentionally elided from deps (same as
+  // the open-side effect above) since its identity can churn without semantic change.
   useEffect(() => {
     if (!record) return
     if (record.executionState === 'completed') {
@@ -103,7 +106,7 @@ export function EarnModal() {
       setErrorAtStep('progress')
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [record])
+  }, [record?.executionState])
 
   function close() {
     setOpenModal(null)

--- a/apps/armada-interface/src/lib/tx/CLAUDE.md
+++ b/apps/armada-interface/src/lib/tx/CLAUDE.md
@@ -45,6 +45,12 @@ Key behaviour:
 - **Resume on cold load.** `startEngine()` walks `txListAtom`, finds non-terminal records, calls `shouldResume(record)` (per-kind expiry cap). Either resumes (calls `executeTx(record.id)`) or marks `expired`.
 - **AbortController per running tx.** `cancelTx(id)` aborts the controller; the handler must check `ctx.signal` and propagate. Stage handlers wire `ctx.signal` into their pollers.
 
+### Stage naming caveat — `'submit-relayer'` is a framework label
+
+The `'submit-relayer'` stage exists in every kind's lifecycle (`shield`, `unshield-local`, `transfer-shielded`, `yield-deposit`, `yield-withdraw`, `unshield-xchain`, `shield-xchain`). The name suggests the relayer submits the tx — that's the eventual model when `submitRelay` is wired (see `lib/relayer.ts`), but **today every handler submits via the user's own wallet** through `wagmi/actions::sendTransaction` / `writeContract`. The stage name is a stable framework label for "tx-on-the-wire," not an indicator of who sends it.
+
+This matters when scoping work like fee display, ETA estimation, or stage copy — don't assume `'submit-relayer'` means we're in relayer-mediated mode. Per-kind handler is the source of truth for submission shape.
+
 ### Stage handler contract
 
 ```ts


### PR DESCRIPTION
## Summary

Three small audit-driven cleanups folded into one PR — none warrant their own PR but together they close out the remaining real items from the prior audit reviews.

### 1. Modal record-watcher useEffect deps (4 modals)

Every modal's terminal-transition useEffect was depending on `record` (the whole object), but the body only branches on `record.executionState`. On xchain flows, the handler patches artifacts (proofProgress, log-scan cursor) every ~3s during polling — each patch produced a fresh record reference and re-fired the effect for no semantic change.

Narrowed to `[record?.executionState]`. Effect re-runs only on terminal transitions. Real perf win during xchain polling.

### 2. SendModal silent loadDeployments failure

`loadDeployments().catch(() => {})` at SendModal:75 was swallowing failures with no signal. Replaced with `trackError('SendModal.loadDeployments', ...)`. User-facing behaviour unchanged (gate stays neutral until the manifest is known, submit step would surface the real error if it persists), but the failure is now visible in monitoring rather than disappearing.

### 3. `lib/tx/CLAUDE.md` — `'submit-relayer'` stage-name note

The stage name suggests \"the relayer submits this\" but today every handler submits via the user's own wallet through `wagmi/actions`. The label is preserved for the future relayer-mediated model (when `submitRelay` is wired) but readers shouldn't assume the name means what it looks like. Documented so the next person scoping fee / ETA / copy work doesn't fall into the same misread I did when reviewing.

## What's NOT in scope (deliberately skipped from the audit)

- **useAutoLock timer leak** — looked, didn't find it. Cleanup correctly clears the timer; closure reassignment is sound; ref pattern protects against stale fires. False positive.
- **RecipientInput clipboard error feedback** — clipboard failures only happen in iframes / insecure contexts, and the user can still type. Adding inline \"Couldn't paste\" feedback for a near-impossible failure mode is defensive UX of negative value.
- **parseUsdcInput whitespace** — already handled in #289 (`trim()` is the first thing the parser does).

## Test plan

- [x] `npm run typecheck --workspace=@armada/interface` — clean
- [x] `npx vitest run` (armada-interface) — 73 files / 557 tests pass, no changes needed
- [ ] Manual: run an xchain unshield on Sepolia with React DevTools profiler open; confirm the modal's terminal-watcher effect doesn't re-fire on every poll tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)