### PR TITLE
feat(relayer): phase 1 hardening — persistent cursor + chunked getLogs + non-silent errors + async shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,12 @@ usdc-v2-frontend/public/masp/
 # Railgun SDK database
 data/
 
+# Relayer per-chain scan cursors (file-backed state for crash recovery). Ignore the cursor
+# files themselves but keep the directory + its README in version control so a fresh clone
+# has the docs explaining the cursor format.
+relayer/state/*
+!relayer/state/README.md
+
 # Logs
 *.log
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:mcp:integration": "npx mocha --require ts-node/register mcp-server/test/integration.test.ts",
     "test:mcp:e2e": "npx mocha --require ts-node/register mcp-server/test/e2e.test.ts",
     "test:mcp:all": "npx mocha --require ts-node/register 'mcp-server/test/**/*.test.ts'",
+    "test:relayer": "npx mocha --require ts-node/register 'relayer/test/**/*.test.ts'",
     "test:forge": "forge test --offline",
     "halmos": "halmos",
     "halmos:allocation": "halmos --contract HalmosAllocationTest --match-test '^(check_allocPlusRefundEqualsCommitted|check_allocNeverExceedsCommitted|check_underSubscribedFullAllocation|check_zeroCommittedReturnsZero)'",

--- a/relayer/armada-relayer.ts
+++ b/relayer/armada-relayer.ts
@@ -204,17 +204,36 @@ async function main() {
     walletManager.cleanDedupCache();
   }, 5 * 60 * 1000);
 
-  // Handle graceful shutdown
-  const shutdown = () => {
+  // Handle graceful shutdown. CRITICAL: await `cctpRelayModule.stop()` BEFORE process.exit so
+  // the in-flight poll tick completes and its cursor write lands on disk. Previously this was
+  // fire-and-forget + immediate exit, which meant a SIGTERM mid-scan could kill the process
+  // between the cursor advance and the cursor write — defeating the whole point of persistent
+  // cursors. Re-entrancy guarded so a second signal during shutdown doesn't double-fire.
+  let isShuttingDown = false;
+  const shutdown = async () => {
+    if (isShuttingDown) return;
+    isShuttingDown = true;
     console.log("\n[armada] Shutting down...");
     clearInterval(cleanupInterval);
-    cctpRelayModule.stop();
-    httpApi.stop();
+    try {
+      await cctpRelayModule.stop();
+    } catch (err) {
+      console.error("[armada] Error during CCTP relay shutdown:", err);
+    }
+    try {
+      httpApi.stop();
+    } catch (err) {
+      console.error("[armada] Error during HTTP API shutdown:", err);
+    }
     process.exit(0);
   };
 
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", () => {
+    void shutdown();
+  });
+  process.on("SIGTERM", () => {
+    void shutdown();
+  });
 }
 
 main().catch((e) => {

--- a/relayer/armada-relayer.ts
+++ b/relayer/armada-relayer.ts
@@ -23,6 +23,14 @@ import { CCTPRelayModule } from "./modules/cctp-relay";
 import { IrisRelayModule } from "./modules/iris-relay";
 import type { PrivacyPoolDeployment, CCTPDeployment } from "./types";
 import { getNetworkConfig } from "../config/networks";
+import { installBisectingGetLogs } from "./lib/rpc-bisecting";
+
+// Install the eth_getLogs bisecting patch at module load — before ANY JsonRpcProvider is
+// constructed (the patch is at the prototype level so this is technically order-independent,
+// but placing it here makes the intent obvious to anyone reading top-to-bottom). Adapts to
+// whatever per-call cap the configured RPC enforces (Alchemy free = 10 blocks, Infura = 10k,
+// etc.) without per-provider configuration.
+installBisectingGetLogs();
 
 // ============ Deployment Loading ============
 

--- a/relayer/armada-relayer.ts
+++ b/relayer/armada-relayer.ts
@@ -209,11 +209,26 @@ async function main() {
   // fire-and-forget + immediate exit, which meant a SIGTERM mid-scan could kill the process
   // between the cursor advance and the cursor write — defeating the whole point of persistent
   // cursors. Re-entrancy guarded so a second signal during shutdown doesn't double-fire.
+  //
+  // Safety timeout (`SHUTDOWN_FORCE_EXIT_MS`): if `stop()` itself hangs — wedged RPC mid-poll
+  // with no timeout configured, infinite loop in a cleanup path, etc. — the process would
+  // otherwise be unkillable without `kill -9`. The force-exit guard fires unconditionally
+  // after the budget and exits with code 1 so monitoring (systemd, k8s) treats it as failure.
+  const SHUTDOWN_FORCE_EXIT_MS = 60_000;
   let isShuttingDown = false;
   const shutdown = async () => {
     if (isShuttingDown) return;
     isShuttingDown = true;
     console.log("\n[armada] Shutting down...");
+    const forceExit = setTimeout(() => {
+      console.error(
+        `[armada] Shutdown exceeded ${SHUTDOWN_FORCE_EXIT_MS}ms — forcing exit. Some state may not have been flushed.`,
+      );
+      process.exit(1);
+    }, SHUTDOWN_FORCE_EXIT_MS);
+    // `unref` so the timer itself doesn't keep the event loop alive if shutdown completes
+    // quickly. Otherwise a happy-path shutdown would wait the full 60s for the timer.
+    forceExit.unref();
     clearInterval(cleanupInterval);
     try {
       await cctpRelayModule.stop();
@@ -225,6 +240,7 @@ async function main() {
     } catch (err) {
       console.error("[armada] Error during HTTP API shutdown:", err);
     }
+    clearTimeout(forceExit);
     process.exit(0);
   };
 

--- a/relayer/config.ts
+++ b/relayer/config.ts
@@ -25,6 +25,47 @@ export interface ChainConfig {
   deploymentFile: string;
   privacyPoolDeploymentFile: string;
   cctpDomain: number;
+  /**
+   * Relayer-only knobs for the CCTP scan loop. Defaults below come from the chain's
+   * characteristics — finality depth (reorg risk), public-RPC range caps, etc.
+   *
+   * Per-knob env overrides honour the pattern `RELAYER_<KNOB>_<CHAIN_NAME_UPPER>` (e.g.
+   * `RELAYER_MAX_LOG_RANGE_ETHEREUM_SEPOLIA=200`). When unset, the default for the chain wins.
+   */
+  scanner: {
+    /**
+     * Reorg buffer — we scan only up to `currentBlock - confirmationDepth` so a reorg that
+     * drops a MessageSent event between our detection and our relayWithHook call can't leave
+     * us submitting an attestation for a vanished message. Defaults: 6 for Ethereum L1, 2 for
+     * L2s (Base/Arbitrum), 0 for Anvil (no reorgs).
+     */
+    confirmationDepth: number;
+    /**
+     * Inclusive cap on blocks per `eth_getLogs` request. The 500 default holds across the
+     * tightest public RPC caps (Alchemy 500, drpc 1024). Anvil has no cap so we use 10k there
+     * to keep the chunk count low for fast tests.
+     */
+    maxLogRange: number;
+    /**
+     * On cold boot WITHOUT a persisted cursor, how far back to start scanning. Recovers
+     * messages submitted during the relayer's downtime / before its first boot. Default
+     * derived from the chain's block time × ~30 min: Sepolia ~150 blk, Base 900 blk, Anvil 0.
+     */
+    bootLookbackBlocks: number;
+    /**
+     * On cold boot WITH a persisted cursor, the maximum gap between the cursor and chain head
+     * we'll attempt to backfill. If the cursor is older than this — typically because the
+     * relayer was offline for hours — we cap the backfill at `bootLookbackBlocks` and emit a
+     * loud warning. Without the cap, a multi-day-old cursor would attempt a multi-day backfill,
+     * blowing through RPC quota.
+     */
+    maxBootLookbackBlocks: number;
+    /**
+     * Per-RPC-call timeout in ms. Every provider call goes through `withTimeout(...)` so a
+     * dead socket / hung connection cannot pin the poll loop.
+     */
+    rpcTimeoutMs: number;
+  };
 }
 
 function toChainConfig(net: NetChainConfig, env: string): ChainConfig {
@@ -36,7 +77,58 @@ function toChainConfig(net: NetChainConfig, env: string): ChainConfig {
     deploymentFile: `${net.deploymentPrefix}${suffix}-v3.json`,
     privacyPoolDeploymentFile: `privacy-pool-${net.deploymentPrefix}${suffix}.json`,
     cctpDomain: net.cctpDomain,
+    scanner: scannerConfigForChain(net.name, env),
   };
+}
+
+/**
+ * Per-chain scanner defaults. Each value can be overridden by an env var of the form
+ * `RELAYER_<KNOB>_<CHAIN>` — e.g. `RELAYER_MAX_LOG_RANGE_ETHEREUM_SEPOLIA=200`. The chain
+ * suffix is the chain name uppercased with spaces/dashes → underscores.
+ */
+function scannerConfigForChain(chainName: string, env: string): ChainConfig["scanner"] {
+  // Anvil has no reorgs and no public-RPC caps — chunking would just slow tests down.
+  if (env === "local") {
+    return {
+      confirmationDepth: envIntForChain("CONFIRMATION_DEPTH", chainName, 0),
+      maxLogRange: envIntForChain("MAX_LOG_RANGE", chainName, 10_000),
+      bootLookbackBlocks: envIntForChain("BOOT_LOOKBACK_BLOCKS", chainName, 0),
+      maxBootLookbackBlocks: envIntForChain("MAX_BOOT_LOOKBACK_BLOCKS", chainName, 100_000),
+      rpcTimeoutMs: envIntForChain("RPC_TIMEOUT_MS", chainName, 10_000),
+    };
+  }
+
+  // Sepolia / testnet defaults. Per-chain block-time tuned bootLookback:
+  //   Ethereum Sepolia: ~12s blocks → 150 blocks ≈ 30 min
+  //   Base Sepolia:     ~2s blocks  → 900 blocks ≈ 30 min
+  //   Arbitrum Sepolia: ~0.25s      → 7200 blocks ≈ 30 min
+  const isL1 = /ethereum|mainnet|sepolia/i.test(chainName) && !/base|arb|op|optimism/i.test(chainName);
+  const isBaseLike = /base|optimism|op/i.test(chainName);
+  const isArbLike = /arbitrum|arb/i.test(chainName);
+
+  const defaultLookback = isL1 ? 150 : isBaseLike ? 900 : isArbLike ? 7_200 : 300;
+  const defaultMaxLookback = defaultLookback * 10; // 5 hours of headroom at most
+  const defaultConfirmation = isL1 ? 6 : 2;
+
+  return {
+    confirmationDepth: envIntForChain("CONFIRMATION_DEPTH", chainName, defaultConfirmation),
+    maxLogRange: envIntForChain("MAX_LOG_RANGE", chainName, 500),
+    bootLookbackBlocks: envIntForChain("BOOT_LOOKBACK_BLOCKS", chainName, defaultLookback),
+    maxBootLookbackBlocks: envIntForChain("MAX_BOOT_LOOKBACK_BLOCKS", chainName, defaultMaxLookback),
+    rpcTimeoutMs: envIntForChain("RPC_TIMEOUT_MS", chainName, 10_000),
+  };
+}
+
+function envIntForChain(knob: string, chainName: string, fallback: number): number {
+  const suffix = chainName.toUpperCase().replace(/[^A-Z0-9]+/g, "_");
+  const key = `RELAYER_${knob}_${suffix}`;
+  const raw = process.env[key];
+  if (raw === undefined || raw === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Invalid env var ${key}=${raw} — expected non-negative integer`);
+  }
+  return parsed;
 }
 
 const netConfig = getNetworkConfig();

--- a/relayer/config.ts
+++ b/relayer/config.ts
@@ -41,9 +41,12 @@ export interface ChainConfig {
      */
     confirmationDepth: number;
     /**
-     * Inclusive cap on blocks per `eth_getLogs` request. The 500 default holds across the
-     * tightest public RPC caps (Alchemy 500, drpc 1024). Anvil has no cap so we use 10k there
-     * to keep the chunk count low for fast tests.
+     * Cursor-checkpoint cadence — how many blocks the scanner attempts per outer chunk before
+     * persisting the cursor + ingesting that chunk's logs. NOT an RPC cap: the bisecting patch
+     * (`lib/rpc-bisecting.ts`) handles per-call provider caps automatically by halving on
+     * "range too large" errors (Alchemy free tier = 10 blocks, drpc varies, Infura = 10k). The
+     * value here controls how much progress is lost if a tick fails mid-window: 1000 blocks =
+     * ~33 min of replay on Sepolia, ~33 min on Base Sepolia, ~4 min on Arbitrum Sepolia.
      */
     maxLogRange: number;
     /**
@@ -112,7 +115,10 @@ function scannerConfigForChain(chainName: string, env: string): ChainConfig["sca
 
   return {
     confirmationDepth: envIntForChain("CONFIRMATION_DEPTH", chainName, defaultConfirmation),
-    maxLogRange: envIntForChain("MAX_LOG_RANGE", chainName, 500),
+    // 1000 blocks is the checkpoint cadence — see RelayerChainConfig.scanner.maxLogRange doc.
+    // The bisecting patch handles whatever per-call cap the RPC actually enforces; this value
+    // is purely about "how much replay do we accept on a mid-tick failure."
+    maxLogRange: envIntForChain("MAX_LOG_RANGE", chainName, 1000),
     bootLookbackBlocks: envIntForChain("BOOT_LOOKBACK_BLOCKS", chainName, defaultLookback),
     maxBootLookbackBlocks: envIntForChain("MAX_BOOT_LOOKBACK_BLOCKS", chainName, defaultMaxLookback),
     rpcTimeoutMs: envIntForChain("RPC_TIMEOUT_MS", chainName, 10_000),

--- a/relayer/lib/cursor-store.ts
+++ b/relayer/lib/cursor-store.ts
@@ -6,7 +6,7 @@
  * rename) but simpler — single field per file, no migrations beyond the version stamp.
  */
 
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 /** Schema version. Bump and add a migration when the shape changes. */
@@ -44,7 +44,7 @@ export class CursorStore {
     try {
       const raw = await readFile(path, "utf8");
       const parsed = JSON.parse(raw);
-      return validate(parsed, path);
+      return validate(parsed, path, chainName);
     } catch (err) {
       if (isENOENT(err)) return null;
       throw err;
@@ -65,7 +65,20 @@ export class CursorStore {
     };
     const tmpPath = `${path}.${process.pid}.tmp`;
     await writeFile(tmpPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
-    await rename(tmpPath, path);
+    try {
+      await rename(tmpPath, path);
+    } catch (err) {
+      // Rare on POSIX but possible (cross-filesystem move, perms change). Clean up the tmp so
+      // it doesn't sit around as orphaned half-state. Swallow the unlink failure so the caller
+      // sees the ORIGINAL rename error (the actionable one) — leaking an orphan is strictly
+      // less bad than masking the root cause.
+      try {
+        await unlink(tmpPath);
+      } catch {
+        // ignored — orphan tmp on next write attempt will overwrite this anyway (PID-suffixed)
+      }
+      throw err;
+    }
   }
 
   /**
@@ -88,7 +101,7 @@ function isENOENT(err: unknown): boolean {
   );
 }
 
-function validate(parsed: unknown, path: string): CursorData {
+function validate(parsed: unknown, path: string, chainName: string): CursorData {
   if (
     typeof parsed !== "object" ||
     parsed === null ||
@@ -97,13 +110,26 @@ function validate(parsed: unknown, path: string): CursorData {
     typeof (parsed as { version?: unknown }).version !== "number"
   ) {
     throw new Error(
-      `cursor-store: malformed cursor file at ${path}. Delete it to reset to lookback boot.`,
+      `cursor-store: malformed cursor file for chain '${chainName}' at ${path}. Delete it to reset to lookback boot.`,
     );
   }
   const candidate = parsed as { lastProcessedBlock: number; updatedAt: number; version: number };
+  // Range checks. The typeof guard above accepts -Infinity, NaN, Infinity, fractional numbers —
+  // none of which are valid block numbers or timestamps. Catch them here so they don't reach
+  // the scanner's `Number(...)` casts and turn into silent NaN propagations downstream.
+  if (!Number.isInteger(candidate.lastProcessedBlock) || candidate.lastProcessedBlock < 0) {
+    throw new Error(
+      `cursor-store: invalid lastProcessedBlock (${candidate.lastProcessedBlock}) for chain '${chainName}' at ${path}. Expected a non-negative integer. Delete to reset.`,
+    );
+  }
+  if (!Number.isInteger(candidate.updatedAt) || candidate.updatedAt < 0) {
+    throw new Error(
+      `cursor-store: invalid updatedAt (${candidate.updatedAt}) for chain '${chainName}' at ${path}. Expected a non-negative integer (Unix ms). Delete to reset.`,
+    );
+  }
   if (candidate.version !== CURSOR_SCHEMA_VERSION) {
     throw new Error(
-      `cursor-store: cursor file ${path} has unsupported version ${candidate.version} (expected ${CURSOR_SCHEMA_VERSION}). Delete it or add a migration.`,
+      `cursor-store: cursor file for chain '${chainName}' at ${path} has unsupported version ${candidate.version} (expected ${CURSOR_SCHEMA_VERSION}). Delete it or add a migration.`,
     );
   }
   return {

--- a/relayer/lib/cursor-store.ts
+++ b/relayer/lib/cursor-store.ts
@@ -1,0 +1,114 @@
+/**
+ * ABOUTME: Per-chain scan cursor persistence — atomic JSON write so a restart resumes from the
+ * last successfully-scanned block instead of jumping to the chain head and silently dropping any
+ * MessageSent events in the gap.
+ * ABOUTME: Mirrors the pattern in crowdfund-ui/packages/indexer/src/db/fileStore.ts (tmpfile +
+ * rename) but simpler — single field per file, no migrations beyond the version stamp.
+ */
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+/** Schema version. Bump and add a migration when the shape changes. */
+const CURSOR_SCHEMA_VERSION = 1 as const;
+
+export interface CursorData {
+  /** Block number we have FULLY scanned and processed (inclusive). Next poll starts at +1. */
+  lastProcessedBlock: number;
+  /** Unix ms when this cursor was last written. For health endpoint + staleness alerts. */
+  updatedAt: number;
+  /** Schema version — for future migrations. */
+  version: typeof CURSOR_SCHEMA_VERSION;
+}
+
+/**
+ * Filesystem-backed per-chain cursor store. One file per chain at
+ * `<baseDir>/cursor-{chainName}.json`. Atomic writes via tmpfile + rename so a power loss
+ * mid-flush cannot corrupt the canonical file.
+ *
+ * The store is intentionally NOT a cache — every `write` hits the disk synchronously (from the
+ * caller's perspective). The polling loop runs at multi-second cadence; the I/O cost is
+ * irrelevant relative to the RPC calls themselves, and durability is more valuable than speed.
+ */
+export class CursorStore {
+  constructor(private readonly baseDir: string) {}
+
+  /**
+   * Read the cursor for a chain. Returns null when the file does not exist (cold start case) —
+   * the caller decides whether to bootstrap from chain-head-minus-lookback or from a configured
+   * floor. Throws on malformed JSON or unexpected shape: don't silently start scanning from
+   * block 0 because a manual edit corrupted the file.
+   */
+  async read(chainName: string): Promise<CursorData | null> {
+    const path = this.pathFor(chainName);
+    try {
+      const raw = await readFile(path, "utf8");
+      const parsed = JSON.parse(raw);
+      return validate(parsed, path);
+    } catch (err) {
+      if (isENOENT(err)) return null;
+      throw err;
+    }
+  }
+
+  /**
+   * Atomically persist a cursor. Writes to `<path>.<pid>.tmp` then renames over the canonical
+   * path — rename is atomic at the filesystem level on POSIX, so even a kill -9 mid-flush leaves
+   * either the old cursor intact or the new one fully present, never a torn write.
+   */
+  async write(chainName: string, data: Omit<CursorData, "version">): Promise<void> {
+    const path = this.pathFor(chainName);
+    await mkdir(dirname(path), { recursive: true });
+    const payload: CursorData = {
+      ...data,
+      version: CURSOR_SCHEMA_VERSION,
+    };
+    const tmpPath = `${path}.${process.pid}.tmp`;
+    await writeFile(tmpPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+    await rename(tmpPath, path);
+  }
+
+  /**
+   * Cursor file path for a chain. Sanitises the name (slashes, whitespace) so a config-driven
+   * chain name can never escape the baseDir. We don't expect adversarial input — every chain
+   * name comes from our own `config/networks.ts` — but cheap to lock down anyway.
+   */
+  private pathFor(chainName: string): string {
+    const safe = chainName.toLowerCase().replace(/[^a-z0-9_-]/g, "-");
+    return join(this.baseDir, `cursor-${safe}.json`);
+  }
+}
+
+function isENOENT(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: string }).code === "ENOENT"
+  );
+}
+
+function validate(parsed: unknown, path: string): CursorData {
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    typeof (parsed as { lastProcessedBlock?: unknown }).lastProcessedBlock !== "number" ||
+    typeof (parsed as { updatedAt?: unknown }).updatedAt !== "number" ||
+    typeof (parsed as { version?: unknown }).version !== "number"
+  ) {
+    throw new Error(
+      `cursor-store: malformed cursor file at ${path}. Delete it to reset to lookback boot.`,
+    );
+  }
+  const candidate = parsed as { lastProcessedBlock: number; updatedAt: number; version: number };
+  if (candidate.version !== CURSOR_SCHEMA_VERSION) {
+    throw new Error(
+      `cursor-store: cursor file ${path} has unsupported version ${candidate.version} (expected ${CURSOR_SCHEMA_VERSION}). Delete it or add a migration.`,
+    );
+  }
+  return {
+    lastProcessedBlock: candidate.lastProcessedBlock,
+    updatedAt: candidate.updatedAt,
+    version: CURSOR_SCHEMA_VERSION,
+  };
+}

--- a/relayer/lib/get-logs-chunked.ts
+++ b/relayer/lib/get-logs-chunked.ts
@@ -1,0 +1,96 @@
+/**
+ * ABOUTME: Bounded-window getLogs helper. Splits a block range into max-size chunks so a single
+ * query never exceeds public RPC caps (Alchemy ~500, drpc ~1024, publicnode ~10k).
+ * ABOUTME: Adapted from apps/armada-interface/src/lib/events/getLogsChunked.ts — kept in
+ * lockstep with the frontend version. Update both files in the same PR or extract to a shared
+ * package per Plan §19 when a third consumer appears.
+ */
+
+import type { ethers } from "ethers";
+
+/**
+ * Per-chunk progress signal. Fired after each successful chunk so callers can persist the
+ * cursor + ingest the chunk's logs mid-flight — if the next chunk fails, the cursor reflects
+ * what HAS been processed rather than what was attempted. The `logs` array carries the chunk's
+ * logs so the caller can ingest synchronously alongside the cursor advance, keeping the two
+ * actions in lockstep (avoids "cursor advanced past logs we never enqueued" scenarios on
+ * mid-window error).
+ */
+export interface ChunkProgress<TLog = unknown> {
+  fromBlock: number;
+  toBlockInclusive: number;
+  logs: TLog[];
+}
+
+export interface ChunkedLogsOptions {
+  /** Inclusive lower block. */
+  fromBlock: number;
+  /** Inclusive upper block. */
+  toBlock: number;
+  /** Inclusive max blocks per chunk. Must be ≥ 1. */
+  maxRange: number;
+  /** ethers Filter — address + topics + (the function adds fromBlock/toBlock per chunk). */
+  filter: Omit<ethers.Filter, "fromBlock" | "toBlock">;
+  /**
+   * Fires after each successful chunk so the caller can ingest the chunk's logs + persist the
+   * cursor advance in lockstep. The callback may be async; the helper awaits it before issuing
+   * the next chunk — this is critical for crash safety, since "persisted cursor must always
+   * trail or equal ingested logs."
+   */
+  onChunk?: (info: ChunkProgress<ethers.Log>) => Promise<void> | void;
+}
+
+/**
+ * Fetch logs across an arbitrarily large block range by issuing a sequence of bounded `getLogs`
+ * calls, each spanning at most `maxRange` blocks inclusive. Results are concatenated in
+ * chunk-issued order (ascending blocks).
+ *
+ * On error mid-iteration: throws. The caller has received all `onChunk` callbacks for chunks
+ * that completed successfully — so persisting the cursor inside `onChunk` lets the next poll
+ * tick resume from `lastSuccessfulChunk.toBlockInclusive + 1` rather than re-scanning everything.
+ *
+ * This is the failure mode that bit us in the un-chunked design: an RPC outage halfway through
+ * a 10k-block range meant the next attempt tried 10k+ blocks (worse), failed again (silent),
+ * and so on forever. Chunked + per-chunk persistence means a transient outage costs at most
+ * `maxRange` blocks of replay on the next tick.
+ */
+export async function getLogsChunked(
+  provider: ethers.JsonRpcProvider,
+  opts: ChunkedLogsOptions,
+): Promise<ethers.Log[]> {
+  if (opts.maxRange < 1) {
+    throw new Error(`getLogsChunked: maxRange must be ≥ 1 (got ${opts.maxRange})`);
+  }
+  if (opts.fromBlock > opts.toBlock) return [];
+
+  const out: ethers.Log[] = [];
+  let cursor = opts.fromBlock;
+
+  while (cursor <= opts.toBlock) {
+    // Inclusive window: [cursor, cursor + maxRange - 1], clamped at toBlock.
+    const windowEnd = cursor + opts.maxRange - 1;
+    const chunkTo = windowEnd > opts.toBlock ? opts.toBlock : windowEnd;
+
+    const logs = await provider.getLogs({
+      ...opts.filter,
+      fromBlock: cursor,
+      toBlock: chunkTo,
+    });
+
+    out.push(...logs);
+    // Awaited so the caller's ingest + persist completes BEFORE we move on to the next chunk.
+    // This is the contract that makes per-chunk progress crash-safe: the cursor is never
+    // advanced past logs the caller hasn't accepted responsibility for.
+    if (opts.onChunk) {
+      await opts.onChunk({
+        fromBlock: cursor,
+        toBlockInclusive: chunkTo,
+        logs,
+      });
+    }
+
+    cursor = chunkTo + 1;
+  }
+
+  return out;
+}

--- a/relayer/lib/get-logs-chunked.ts
+++ b/relayer/lib/get-logs-chunked.ts
@@ -1,6 +1,9 @@
 /**
- * ABOUTME: Bounded-window getLogs helper. Splits a block range into max-size chunks so a single
- * query never exceeds public RPC caps (Alchemy ~500, drpc ~1024, publicnode ~10k).
+ * ABOUTME: Cursor-checkpointed scan helper. Splits a block range into chunks so the per-chunk
+ * `onChunk` callback can ingest + persist mid-flight — a failure mid-window loses at most one
+ * chunk of replay, not the whole window. Per-RPC-call range caps (Alchemy free 10 blocks,
+ * Infura 10k, drpc varies) are handled separately by `rpc-bisecting.ts` which intercepts
+ * eth_getLogs and recursively halves on the relevant error patterns.
  * ABOUTME: Adapted from apps/armada-interface/src/lib/events/getLogsChunked.ts — kept in
  * lockstep with the frontend version. Update both files in the same PR or extract to a shared
  * package per Plan §19 when a third consumer appears.

--- a/relayer/lib/rpc-bisecting.ts
+++ b/relayer/lib/rpc-bisecting.ts
@@ -1,0 +1,182 @@
+/**
+ * ABOUTME: One-time monkey-patch of ethers' JsonRpcProvider.send that bisects eth_getLogs on
+ * "block range too large" errors. Free-tier RPCs (Alchemy 10 blocks, Infura 10k, drpc varies)
+ * all reject large ranges with subtly different error messages — bisection lets the relayer
+ * use a generous outer chunk size without needing per-provider per-chain configuration.
+ * ABOUTME: Kept in lockstep with apps/armada-interface/src/lib/rpc-bisecting.ts — when one
+ * needs to evolve, update both in the same PR or extract to @armada/eth-utils per Plan §19.
+ * Only adaptations from the frontend copy: this file targets Node/CommonJS (no `import` from
+ * `ethers` subpath, single-`JsonRpcProvider` import sufficient since the relayer's provider
+ * surface is uniform).
+ */
+
+import { JsonRpcProvider } from "ethers";
+
+/**
+ * Substrings / regexes that identify "block range too large" errors from common RPC providers.
+ * Different providers word it differently:
+ *
+ *   - Alchemy:    "you can make eth_getLogs requests with up to a 10 block range"
+ *   - Infura:     "query returned more than 10000 results"
+ *   - QuickNode:  "eth_getLogs is limited to a X block range"
+ *   - Cloudflare: "block range is too wide"
+ *   - drpc:       varies, sometimes "too many records"
+ *
+ * If we see a NEW provider whose phrasing slips through, we'll get a non-range error treatment
+ * (propagated to the caller, surfacing as state.lastError) until the pattern is added here.
+ */
+const RANGE_ERROR_PATTERNS: readonly RegExp[] = [
+  /block range/i,
+  /more than [\d,]+ (results|records|logs)/i,
+  /range is too wide/i,
+  /response size exceeded/i,
+  /eth_getLogs.*limit/i,
+  // Deliberately omitted: /query timeout/i. A generic timeout could be a transient network
+  // issue rather than a range-too-large signal; bisecting on it doubles load and is very
+  // likely to time out again. Providers that DO time out specifically on large getLogs ranges
+  // (rather than returning an explicit error) will fall through to the caller — we'll handle
+  // those by adding a more specific pattern (e.g. requiring co-occurrence with getLogs
+  // context) once we see one in practice.
+] as const;
+
+function isBlockRangeError(err: unknown): boolean {
+  if (err == null) return false;
+  // ethers wraps server errors with { code, info, error: { message } } shapes; dig through.
+  const candidates: string[] = [];
+  const e = err as Record<string, unknown>;
+  if (typeof e.message === "string") candidates.push(e.message);
+  if (typeof e.error === "object" && e.error !== null) {
+    const inner = e.error as { message?: unknown };
+    if (typeof inner.message === "string") candidates.push(inner.message);
+  }
+  if (typeof e.info === "object" && e.info !== null) {
+    const info = e.info as { responseBody?: unknown; error?: { message?: unknown } };
+    if (typeof info.responseBody === "string") candidates.push(info.responseBody);
+    if (typeof info.error?.message === "string") candidates.push(info.error.message);
+  }
+  return candidates.some((s) => RANGE_ERROR_PATTERNS.some((p) => p.test(s)));
+}
+
+interface GetLogsFilter {
+  fromBlock?: string;
+  toBlock?: string;
+  address?: string | readonly string[];
+  topics?: readonly (string | readonly string[] | null)[];
+}
+
+function parseHexBlock(v: string | undefined): number | null {
+  if (typeof v !== "string" || !v.startsWith("0x")) return null;
+  const n = parseInt(v.slice(2), 16);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+function toHexBlock(n: number): string {
+  return "0x" + n.toString(16);
+}
+
+/** Cap on recursive bisection depth. 2^25 = 33M blocks; safety net against pathological inputs. */
+const MAX_BISECT_DEPTH = 25;
+
+/**
+ * Run a single eth_getLogs call; on a "range too large" error, recursively split the range and
+ * merge the results. Bails out (re-throws) on non-range errors and when the range is already a
+ * single block (can't split further). The `send` parameter is the raw original ethers provider
+ * send method bound to the provider instance — passing it in keeps this function pure.
+ */
+async function bisectEthGetLogs(
+  send: (method: string, params: unknown[]) => Promise<unknown>,
+  filter: GetLogsFilter,
+  depth: number,
+): Promise<unknown[]> {
+  try {
+    const result = await send("eth_getLogs", [filter]);
+    return Array.isArray(result) ? result : [];
+  } catch (err) {
+    if (!isBlockRangeError(err)) throw err;
+    const from = parseHexBlock(filter.fromBlock);
+    const to = parseHexBlock(filter.toBlock);
+    if (from == null || to == null || to <= from) throw err; // can't split
+    if (depth >= MAX_BISECT_DEPTH) {
+      // Wrap the original RPC error with bisection context so debug output points at the
+      // pathological range without losing the upstream message.
+      const original = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `eth_getLogs bisection exceeded max depth ${MAX_BISECT_DEPTH} at range ${from}..${to}: ${original}`,
+        { cause: err instanceof Error ? err : undefined },
+      );
+    }
+    const mid = Math.floor((from + to) / 2);
+    if (mid <= from || mid >= to) throw err; // single-block range
+    // Recurse on left + right halves; concatenate results. Order matters for downstream
+    // consumers (the relayer processes events in chronological order).
+    const leftFilter: GetLogsFilter = {
+      ...filter,
+      fromBlock: toHexBlock(from),
+      toBlock: toHexBlock(mid),
+    };
+    const rightFilter: GetLogsFilter = {
+      ...filter,
+      fromBlock: toHexBlock(mid + 1),
+      toBlock: toHexBlock(to),
+    };
+    const left = await bisectEthGetLogs(send, leftFilter, depth + 1);
+    const right = await bisectEthGetLogs(send, rightFilter, depth + 1);
+    return [...left, ...right];
+  }
+}
+
+const PATCHED_FLAG = Symbol.for("armada.bisectingGetLogs.patched");
+type PatchedPrototype = typeof JsonRpcProvider.prototype & { [PATCHED_FLAG]?: boolean };
+
+/**
+ * Patches `JsonRpcProvider.prototype.send` to intercept eth_getLogs calls and bisect on range
+ * errors. Idempotent — safe to call multiple times. Non-getLogs RPC calls pass through unchanged.
+ *
+ * Affects every ethers JsonRpcProvider in the process — both iris-relay and cctp-relay providers
+ * (they're built from the same constructor) pick this up automatically.
+ *
+ * Call this once at relayer entry (`armada-relayer.ts::main`) before any provider is constructed.
+ * Calling after a provider exists is also fine — the patch is at the prototype level, so existing
+ * instances pick it up too.
+ */
+export function installBisectingGetLogs(): void {
+  const proto = JsonRpcProvider.prototype as PatchedPrototype;
+  if (proto[PATCHED_FLAG]) return;
+  proto[PATCHED_FLAG] = true;
+
+  const originalSend = proto.send;
+  proto.send = async function patchedSend(
+    this: JsonRpcProvider,
+    method: string,
+    params: unknown[],
+  ) {
+    if (method !== "eth_getLogs" || !Array.isArray(params) || params.length === 0) {
+      return originalSend.call(this, method, params);
+    }
+    const filter = params[0];
+    if (filter == null || typeof filter !== "object") {
+      return originalSend.call(this, method, params);
+    }
+    const boundSend = (m: string, p: unknown[]): Promise<unknown> =>
+      originalSend.call(this, m, p);
+    return bisectEthGetLogs(boundSend, filter as GetLogsFilter, 0);
+  };
+}
+
+/** Test-only: verify whether the patch is currently installed. */
+export function _isBisectingGetLogsPatched(): boolean {
+  return Boolean((JsonRpcProvider.prototype as PatchedPrototype)[PATCHED_FLAG]);
+}
+
+/** Test-only: unmount the patch so subsequent tests see a clean prototype. */
+export function _uninstallBisectingGetLogs(): void {
+  const proto = JsonRpcProvider.prototype as PatchedPrototype;
+  if (!proto[PATCHED_FLAG]) return;
+  delete proto[PATCHED_FLAG];
+  // Restore the original send by deleting the patched one — the class's original lives on the
+  // class prototype chain. We replaced the own property, so delete restores the inherited one.
+  delete (proto as { send?: unknown }).send;
+}
+
+// Internal exports for tests. Don't import these from app code.
+export { bisectEthGetLogs as _bisectEthGetLogs, isBlockRangeError as _isBlockRangeError };

--- a/relayer/lib/rpc-utils.ts
+++ b/relayer/lib/rpc-utils.ts
@@ -1,0 +1,48 @@
+/**
+ * ABOUTME: RPC call wrappers that prevent the relayer from hanging on stuck connections — every
+ * provider call should pass through withTimeout so a wedged TCP socket can't pin the poll loop.
+ * ABOUTME: WHY: ethers' default behaviour is to retry indefinitely; combined with the prior
+ * silent-error swallow, a single dead provider could freeze the entire CCTP scanner. Loud
+ * timeout > silent hang.
+ */
+
+/**
+ * Typed error thrown by `withTimeout`. Callers can `instanceof RpcTimeoutError` to distinguish
+ * timeout from the underlying call's own errors — useful for backoff decisions (timeout =
+ * possibly recoverable, malformed response = probably config error).
+ */
+export class RpcTimeoutError extends Error {
+  constructor(public readonly label: string, public readonly timeoutMs: number) {
+    super(`RPC timeout after ${timeoutMs}ms: ${label}`);
+    this.name = "RpcTimeoutError";
+  }
+}
+
+/**
+ * Race `promise` against a timeout. Resolves with the promise's value if it settles in time;
+ * throws `RpcTimeoutError` otherwise. Crucially clears the internal timer once the promise
+ * settles so we don't leak timers into long-running poll loops.
+ *
+ * The `label` argument flows into the error message — pass something descriptive
+ * (`'getLogs hub blocks 100-600'`) so logs are actionable when timeouts surface.
+ *
+ * NOTE: this does not cancel the underlying promise (no AbortSignal here — most ethers v6
+ * provider calls don't accept one). The provider keeps working; we just stop waiting. The
+ * lingering work eventually errors or completes and is discarded. Acceptable cost for the
+ * simplicity gain.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new RpcTimeoutError(label, timeoutMs)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/relayer/modules/cctp-relay.ts
+++ b/relayer/modules/cctp-relay.ts
@@ -17,6 +17,12 @@ import {
 } from "../config";
 import * as fs from "fs";
 import * as path from "path";
+import { CursorStore } from "../lib/cursor-store";
+import { getLogsChunked } from "../lib/get-logs-chunked";
+import { RpcTimeoutError, withTimeout } from "../lib/rpc-utils";
+
+/** Where per-chain cursor files live — shared with iris-relay. Module-relative. */
+const RELAYER_STATE_DIR = path.join(__dirname, "..", "state");
 
 // ============ Constants ============
 
@@ -50,9 +56,17 @@ interface ChainState {
   tokenMessenger: string;
   hookRouter: string | null;
   domain: number;
+  /**
+   * Highest block fully scanned (inclusive). Loaded from disk on cold start; advanced via the
+   * cursor store after every successful chunk. Restart-safe.
+   */
   lastProcessedBlock: number;
   processedMessages: Set<string>; // "sourceDomain-nonce" format
   pendingNonce: number | null;
+  /** Last scan error, or null when most recent tick succeeded. Replaces the silent catch. */
+  lastError: { message: string; at: number } | null;
+  /** Unix ms of the last successful scan tick (for the future health endpoint). */
+  lastScanAt: number;
 }
 
 /** Retry queue entry for failed CCTP relay attempts */
@@ -228,6 +242,7 @@ export class CCTPRelayModule {
   private pollIntervalMs: number;
   private retryQueue: RetryEntry[] = [];
   private getMinFee: (() => Promise<bigint>) | null;
+  private cursorStore: CursorStore;
 
   /**
    * @param getMinFee Optional async function that returns the minimum acceptable
@@ -238,6 +253,7 @@ export class CCTPRelayModule {
   constructor(getMinFee?: () => Promise<bigint>) {
     this.pollIntervalMs = armadaRelayerSettings.cctpPollIntervalMs;
     this.getMinFee = getMinFee || null;
+    this.cursorStore = new CursorStore(RELAYER_STATE_DIR);
   }
 
   /**
@@ -325,10 +341,19 @@ export class CCTPRelayModule {
       const provider = new ethers.JsonRpcProvider(chainConfig.rpc);
       const wallet = new ethers.Wallet(accounts.deployer.privateKey, provider);
 
-      // Verify connection
-      await provider.getBlockNumber();
+      // Verify connection up-front with the same timeout we'll use during polling.
+      const currentBlock = Number(
+        await withTimeout(
+          provider.getBlockNumber(),
+          chainConfig.scanner.rpcTimeoutMs,
+          `initChain getBlockNumber ${chainConfig.name}`,
+        ),
+      );
 
       const domain = CHAIN_TO_DOMAIN[chainConfig.chainId] || deployment.domain;
+
+      // Load persisted cursor or bootstrap from lookback — same logic as iris-relay.
+      const lastProcessedBlock = await this.resolveBootCursor(chainConfig, currentBlock);
 
       return {
         config: chainConfig,
@@ -338,14 +363,67 @@ export class CCTPRelayModule {
         tokenMessenger,
         hookRouter,
         domain,
-        lastProcessedBlock: 0,
+        lastProcessedBlock,
         processedMessages: new Set(),
         pendingNonce: null,
+        lastError: null,
+        lastScanAt: 0,
       };
     } catch (e: any) {
       console.error(`    Connection error: ${e.message}`);
       return null;
     }
+  }
+
+  /**
+   * Decide the starting `lastProcessedBlock` for a chain on cold boot. Mirrors the iris-relay
+   * implementation — see `iris-relay.ts::resolveBootCursor` for the full rationale. We keep the
+   * two copies in lockstep rather than extracting to a shared helper because cctp-relay is
+   * local-mock-only and shouldn't grow a runtime dependency on iris-relay.
+   */
+  private async resolveBootCursor(
+    chainConfig: ChainConfig,
+    currentBlock: number,
+  ): Promise<number> {
+    const { bootLookbackBlocks, maxBootLookbackBlocks } = chainConfig.scanner;
+    const lookbackFloor = Math.max(0, currentBlock - bootLookbackBlocks);
+
+    let cursor;
+    try {
+      cursor = await this.cursorStore.read(chainConfig.name);
+    } catch (err: any) {
+      console.error(
+        `  [cctp-relay] ${chainConfig.name}: Cursor file unreadable (${err.message}). Bootstrapping from lookback floor.`,
+      );
+      cursor = null;
+    }
+
+    if (cursor === null) {
+      console.log(
+        `  [cctp-relay] ${chainConfig.name}: No persisted cursor — starting from block ${lookbackFloor} (currentBlock=${currentBlock}, lookback=${bootLookbackBlocks})`,
+      );
+      return lookbackFloor;
+    }
+
+    const gap = currentBlock - cursor.lastProcessedBlock;
+    if (gap <= 0) {
+      console.warn(
+        `  [cctp-relay] ${chainConfig.name}: Cursor ${cursor.lastProcessedBlock} ≥ currentBlock ${currentBlock}. Resetting to currentBlock.`,
+      );
+      return currentBlock;
+    }
+
+    if (gap > maxBootLookbackBlocks) {
+      console.warn(
+        `  [cctp-relay] ${chainConfig.name}: Cursor gap (${gap} blocks) exceeds maxBootLookbackBlocks (${maxBootLookbackBlocks}). Capping resume at block ${lookbackFloor}.`,
+      );
+      return lookbackFloor;
+    }
+
+    console.log(
+      `  [cctp-relay] ${chainConfig.name}: Resuming from persisted cursor at block ${cursor.lastProcessedBlock} (gap=${gap} blocks)`,
+    );
+    return cursor.lastProcessedBlock;
   }
 
   /**
@@ -641,56 +719,80 @@ export class CCTPRelayModule {
    * Poll a chain for new MessageSent events
    */
   private async pollChain(state: ChainState): Promise<void> {
+    const { config } = state;
+    const { confirmationDepth, maxLogRange, rpcTimeoutMs } = config.scanner;
+
     try {
-      const currentBlock = await state.provider.getBlockNumber();
+      const currentBlock = Number(
+        await withTimeout(
+          state.provider.getBlockNumber(),
+          rpcTimeoutMs,
+          `getBlockNumber ${config.name}`,
+        ),
+      );
 
-      // On first run, start from current block
-      if (state.lastProcessedBlock === 0) {
-        state.lastProcessedBlock = currentBlock;
-        console.log(
-          `  [cctp-relay] ${state.config.name}: Starting from block ${currentBlock}`
-        );
-        return;
-      }
-
-      if (currentBlock <= state.lastProcessedBlock) {
+      // Apply confirmation depth — on Anvil this is 0 so behaviour matches the old code; on
+      // any real chain we won't scan reorg-vulnerable tip blocks.
+      const effectiveHead = currentBlock - confirmationDepth;
+      if (effectiveHead <= state.lastProcessedBlock) {
+        state.lastError = null;
+        state.lastScanAt = Date.now();
         return;
       }
 
       const fromBlock = state.lastProcessedBlock + 1;
-      const toBlock = currentBlock;
+      const toBlock = effectiveHead;
 
       const iface = new ethers.Interface(MESSAGE_SENT_ABI);
       const eventTopic = iface.getEvent("MessageSent")?.topicHash;
-
       if (!eventTopic) {
         console.error("[cctp-relay] Failed to get MessageSent event topic");
         return;
       }
 
-      const logs = await state.provider.getLogs({
-        address: state.messageTransmitter,
-        topics: [eventTopic],
+      await getLogsChunked(state.provider, {
         fromBlock,
         toBlock,
+        maxRange: maxLogRange,
+        filter: {
+          address: state.messageTransmitter,
+          topics: [eventTopic],
+        },
+        // Ingest + cursor-advance happen INSIDE the per-chunk callback so the on-disk cursor
+        // is always ≤ what's been processed. relayMessage is async and we await it inside the
+        // chunk so a relay failure on chunk N stops the scan there with the cursor pointing at
+        // chunk N-1's end — next tick re-attempts chunk N from the start.
+        onChunk: async ({ fromBlock: chunkFrom, toBlockInclusive, logs }) => {
+          if (logs.length > 0) {
+            console.log(
+              `\n[cctp-relay] ${config.name}: Found ${logs.length} message(s) in blocks ${chunkFrom}-${toBlockInclusive}`,
+            );
+          }
+          for (const log of logs) {
+            const event = parseMessageEvent(log);
+            if (event) {
+              await this.relayMessage(event, state);
+            }
+          }
+          state.lastProcessedBlock = toBlockInclusive;
+          await this.cursorStore.write(config.name, {
+            lastProcessedBlock: toBlockInclusive,
+            updatedAt: Date.now(),
+          });
+        },
       });
 
-      if (logs.length > 0) {
-        console.log(
-          `\n[cctp-relay] ${state.config.name}: Found ${logs.length} message(s) in blocks ${fromBlock}-${toBlock}`
-        );
-      }
-
-      for (const log of logs) {
-        const event = parseMessageEvent(log);
-        if (event) {
-          await this.relayMessage(event, state);
-        }
-      }
-
-      state.lastProcessedBlock = currentBlock;
-    } catch (e) {
-      // Silently ignore connection errors during polling (chain may be down)
+      state.lastError = null;
+      state.lastScanAt = Date.now();
+    } catch (err: any) {
+      // No longer silent. Cursor stays put → next tick retries from the same fromBlock.
+      const message = err instanceof RpcTimeoutError
+        ? `RPC timeout: ${err.label}`
+        : err?.message ?? "unknown error";
+      state.lastError = { message, at: Date.now() };
+      console.error(
+        `[cctp-relay] ${config.name}: Scan tick failed: ${message}. Cursor stays at ${state.lastProcessedBlock}; will retry next tick.`,
+      );
     }
   }
 
@@ -720,35 +822,64 @@ export class CCTPRelayModule {
     this.runPollLoop();
   }
 
+  /** Resolved by `runPollLoop` when it observes isRunning=false and exits. `stop()` awaits it. */
+  private loopExited: Promise<void> | null = null;
+  private resolveLoopExited: (() => void) | null = null;
+
   /**
-   * Internal polling loop (runs in background via setTimeout)
+   * Internal polling loop. Yields to `isRunning` between every step so a `stop()` request
+   * is honoured promptly without forcing the loop to wait out a full pollInterval first.
    */
   private async runPollLoop(): Promise<void> {
-    while (this.isRunning) {
-      // Poll all chains for new messages
-      for (const state of this.chains.values()) {
-        await this.pollChain(state);
-      }
+    this.loopExited = new Promise((resolve) => {
+      this.resolveLoopExited = resolve;
+    });
+    try {
+      while (this.isRunning) {
+        // Poll all chains for new messages
+        for (const state of this.chains.values()) {
+          if (!this.isRunning) break;
+          await this.pollChain(state);
+        }
 
-      // Process retry queue
-      if (this.retryQueue.length > 0) {
-        await this.processRetryQueue();
-      }
+        if (!this.isRunning) break;
 
+        // Process retry queue
+        if (this.retryQueue.length > 0) {
+          await this.processRetryQueue();
+        }
+
+        if (!this.isRunning) break;
+
+        await this.sleepCancellable(this.pollIntervalMs);
+      }
+    } finally {
+      this.resolveLoopExited?.();
+    }
+  }
+
+  /** See iris-relay::sleepCancellable — same shape, kept lockstep. */
+  private async sleepCancellable(totalMs: number): Promise<void> {
+    const start = Date.now();
+    const step = 100;
+    while (this.isRunning && Date.now() - start < totalMs) {
       await new Promise((resolve) =>
-        setTimeout(resolve, this.pollIntervalMs)
+        setTimeout(resolve, Math.min(step, totalMs - (Date.now() - start))),
       );
     }
   }
 
   /**
-   * Stop the polling loop
+   * Async, awaitable shutdown. Same contract as iris-relay::stop — wait for the current poll
+   * tick to complete so its cursor write lands before we let the caller `process.exit`.
+   * Idempotent.
    */
-  stop(): void {
-    if (this.isRunning) {
-      console.log("[cctp-relay] Stopping...");
-      this.isRunning = false;
-    }
+  async stop(): Promise<void> {
+    if (!this.isRunning) return;
+    console.log("[cctp-relay] Stopping — waiting for in-flight scan tick to complete...");
+    this.isRunning = false;
+    if (this.loopExited) await this.loopExited;
+    console.log("[cctp-relay] Stopped cleanly.");
   }
 
   /**

--- a/relayer/modules/iris-relay.ts
+++ b/relayer/modules/iris-relay.ts
@@ -448,13 +448,15 @@ export class IrisRelayModule {
    * Poll a chain for new MessageSent events from real CCTP. Resilient against the failure modes
    * that produced the original silent-stall incident:
    *
-   *  - **Bounded chunking**: every `getLogs` call spans at most `maxLogRange` blocks. After any
-   *    pause/outage, the catch-up window is processed in chunks so we never trip the public
-   *    RPC's range cap (~500 on Alchemy, ~1024 on drpc).
+   *  - **Cursor-checkpointed scanning**: the scan window is split into chunks of `maxLogRange`
+   *    blocks (1000 by default — the checkpoint cadence, NOT a per-call RPC cap). After each
+   *    chunk completes, the cursor is persisted to disk via `onChunk`. A failure mid-window
+   *    loses at most one chunk's worth of replay on the next tick.
    *
-   *  - **Per-chunk cursor persistence**: each successful chunk writes the cursor to disk via
-   *    `onChunk`. A failure mid-range loses at most ONE chunk of work on the next tick, never
-   *    the whole window.
+   *  - **Per-call RPC cap adaptation**: the eth_getLogs prototype patch (`lib/rpc-bisecting.ts`,
+   *    installed once at startup) intercepts every getLogs call and recursively halves on
+   *    "range too large" errors. Means we don't need to know the provider's cap (Alchemy free
+   *    = 10 blocks, drpc varies, Infura = 10k) — bisection adapts at call time.
    *
    *  - **Confirmation depth**: scans only up to `currentBlock - confirmationDepth` so a reorg
    *    between detection and `relayWithHook` can't have us submitting attestations for vanished

--- a/relayer/modules/iris-relay.ts
+++ b/relayer/modules/iris-relay.ts
@@ -27,6 +27,12 @@ import {
 } from "../config";
 import * as fs from "fs";
 import * as path from "path";
+import { CursorStore } from "../lib/cursor-store";
+import { getLogsChunked } from "../lib/get-logs-chunked";
+import { RpcTimeoutError, withTimeout } from "../lib/rpc-utils";
+
+/** Where per-chain cursor files live. Module-relative so the relayer is location-independent. */
+const RELAYER_STATE_DIR = path.join(__dirname, "..", "state");
 
 // ============ Types ============
 
@@ -71,8 +77,22 @@ interface ChainState {
   /** Known contract addresses that can receive CCTP messages on this chain (lowercase, zero-padded bytes32) */
   knownRecipients: Set<string>;
   domain: number;
+  /**
+   * Highest block we have FULLY scanned (inclusive). Loaded from disk on cold start; advanced
+   * after every successful chunk via the cursor store. Restart-safe: a kill -9 mid-poll loses
+   * at most one chunk of replay, never the entire scan window.
+   */
   lastProcessedBlock: number;
+  /** Set of canonical message hashes we've enqueued. In-memory only — dedup across restarts comes from the contract's "already processed" check. */
   processedMessages: Set<string>;
+  /**
+   * Last scan error for this chain, or null when the most recent tick succeeded. Surfaces in
+   * future health endpoint + immediately makes "scanner stuck" visible to operators. Replaces
+   * the silent catch that hid the original Sepolia incident.
+   */
+  lastError: { message: string; at: number } | null;
+  /** Unix ms of the last successful scan tick. Used by the future health endpoint. */
+  lastScanAt: number;
 }
 
 // ============ Constants ============
@@ -249,11 +269,13 @@ export class IrisRelayModule {
   private pollIntervalMs: number;
   private irisClient: IrisClient;
   private pendingMessages: Map<string, PendingMessage> = new Map();
+  private cursorStore: CursorStore;
 
   constructor() {
     const { iris } = armadaRelayerSettings;
     this.pollIntervalMs = armadaRelayerSettings.cctpPollIntervalMs;
     this.irisClient = new IrisClient(iris.apiUrl);
+    this.cursorStore = new CursorStore(RELAYER_STATE_DIR);
   }
 
   async initialize(): Promise<boolean> {
@@ -318,8 +340,19 @@ export class IrisRelayModule {
       const provider = new ethers.JsonRpcProvider(chainConfig.rpc);
       const wallet = new ethers.Wallet(accounts.deployer.privateKey, provider);
 
-      // Verify connection
-      await provider.getBlockNumber();
+      // Verify connection up-front with the same timeout we'll use during polling.
+      const currentBlock = Number(
+        await withTimeout(
+          provider.getBlockNumber(),
+          chainConfig.scanner.rpcTimeoutMs,
+          `initChain getBlockNumber ${chainConfig.name}`,
+        ),
+      );
+
+      // Load persisted cursor or bootstrap from lookback. This is the fix for the cold-start
+      // hole: the prior code set lastProcessedBlock = currentBlock and silently skipped any
+      // MessageSent emitted before the relayer started OR during a restart window.
+      const lastProcessedBlock = await this.resolveBootCursor(chainConfig, currentBlock);
 
       return {
         config: chainConfig,
@@ -329,13 +362,80 @@ export class IrisRelayModule {
         hookRouter,
         knownRecipients,
         domain: chainConfig.cctpDomain,
-        lastProcessedBlock: 0,
+        lastProcessedBlock,
         processedMessages: new Set(),
+        lastError: null,
+        lastScanAt: 0,
       };
     } catch (e: any) {
       console.error(`    Connection error: ${e.message}`);
       return null;
     }
+  }
+
+  /**
+   * Decide the starting `lastProcessedBlock` for a chain on cold boot. Three cases:
+   *
+   *   1. A valid cursor file exists AND the gap to chain head is reasonable → resume from it.
+   *      We replay anything between the persisted cursor and the current head. The contract's
+   *      "already processed" check absorbs any duplicate relays at a small gas cost.
+   *
+   *   2. A cursor file exists BUT the gap exceeds `maxBootLookbackBlocks` → the relayer was
+   *      offline for so long that a full backfill would burn through RPC quota for messages
+   *      Iris has long since expired anyway. Cap at `currentBlock - bootLookbackBlocks` and
+   *      emit a loud warning so the operator knows historical messages were skipped.
+   *
+   *   3. No cursor file (true cold start / fresh deployment) → bootstrap from
+   *      `currentBlock - bootLookbackBlocks` so we recover any MessageSent in the recent past.
+   *      Previously this branch set lastProcessed = currentBlock, dropping in-flight messages.
+   */
+  private async resolveBootCursor(
+    chainConfig: ChainConfig,
+    currentBlock: number,
+  ): Promise<number> {
+    const { bootLookbackBlocks, maxBootLookbackBlocks } = chainConfig.scanner;
+    const lookbackFloor = Math.max(0, currentBlock - bootLookbackBlocks);
+
+    let cursor;
+    try {
+      cursor = await this.cursorStore.read(chainConfig.name);
+    } catch (err: any) {
+      // A malformed cursor file is operator-actionable but we must not crash the relayer on
+      // startup. Log loudly and fall through to lookback bootstrap.
+      console.error(
+        `  [iris-relay] ${chainConfig.name}: Cursor file unreadable (${err.message}). Bootstrapping from lookback floor — DELETE the cursor file at relayer/state/cursor-${chainConfig.name.toLowerCase().replace(/[^a-z0-9_-]/g, "-")}.json after investigating.`,
+      );
+      cursor = null;
+    }
+
+    if (cursor === null) {
+      console.log(
+        `  [iris-relay] ${chainConfig.name}: No persisted cursor — starting from block ${lookbackFloor} (currentBlock=${currentBlock}, lookback=${bootLookbackBlocks})`,
+      );
+      return lookbackFloor;
+    }
+
+    const gap = currentBlock - cursor.lastProcessedBlock;
+    if (gap <= 0) {
+      // Cursor is at or ahead of chain head (chain reorg? cursor written then chain reset?).
+      // Reset to current head to avoid scanning the future.
+      console.warn(
+        `  [iris-relay] ${chainConfig.name}: Cursor ${cursor.lastProcessedBlock} ≥ currentBlock ${currentBlock}. Resetting to currentBlock.`,
+      );
+      return currentBlock;
+    }
+
+    if (gap > maxBootLookbackBlocks) {
+      console.warn(
+        `  [iris-relay] ${chainConfig.name}: Cursor gap (${gap} blocks) exceeds maxBootLookbackBlocks (${maxBootLookbackBlocks}). Capping resume at block ${lookbackFloor}. Messages between ${cursor.lastProcessedBlock} and ${lookbackFloor} will NOT be relayed — Iris will have expired their attestations anyway. Manual recovery via Iris API + relayWithHook if needed.`,
+      );
+      return lookbackFloor;
+    }
+
+    console.log(
+      `  [iris-relay] ${chainConfig.name}: Resuming from persisted cursor at block ${cursor.lastProcessedBlock} (gap=${gap} blocks)`,
+    );
+    return cursor.lastProcessedBlock;
   }
 
   private getChainByDomain(domain: number): ChainState | undefined {
@@ -345,51 +445,98 @@ export class IrisRelayModule {
   // ========== Event Scanning ==========
 
   /**
-   * Poll a chain for new MessageSent events from real CCTP.
-   * New messages are queued as pending — no blocking on Iris.
+   * Poll a chain for new MessageSent events from real CCTP. Resilient against the failure modes
+   * that produced the original silent-stall incident:
+   *
+   *  - **Bounded chunking**: every `getLogs` call spans at most `maxLogRange` blocks. After any
+   *    pause/outage, the catch-up window is processed in chunks so we never trip the public
+   *    RPC's range cap (~500 on Alchemy, ~1024 on drpc).
+   *
+   *  - **Per-chunk cursor persistence**: each successful chunk writes the cursor to disk via
+   *    `onChunk`. A failure mid-range loses at most ONE chunk of work on the next tick, never
+   *    the whole window.
+   *
+   *  - **Confirmation depth**: scans only up to `currentBlock - confirmationDepth` so a reorg
+   *    between detection and `relayWithHook` can't have us submitting attestations for vanished
+   *    messages.
+   *
+   *  - **RPC timeouts**: every provider call is wrapped in `withTimeout`, so a dead socket
+   *    can't pin the poll loop indefinitely.
+   *
+   *  - **Loud errors**: replaces the swallow-everything `catch {}` with structured logging and
+   *    a `lastError` field on chain state. The cursor does NOT advance on error — next tick
+   *    retries from the same fromBlock, with the chunker shrinking the window if needed.
    */
   private async pollChain(state: ChainState): Promise<void> {
-    try {
-      const currentBlock = await state.provider.getBlockNumber();
+    const { config } = state;
+    const { confirmationDepth, maxLogRange, rpcTimeoutMs } = config.scanner;
 
-      if (state.lastProcessedBlock === 0) {
-        state.lastProcessedBlock = currentBlock;
-        console.log(
-          `  [iris-relay] ${state.config.name}: Starting from block ${currentBlock}`
-        );
+    try {
+      const currentBlock = Number(
+        await withTimeout(
+          state.provider.getBlockNumber(),
+          rpcTimeoutMs,
+          `getBlockNumber ${config.name}`,
+        ),
+      );
+
+      // Apply confirmation depth — don't scan tip-of-chain blocks that might be reorg'd out.
+      const effectiveHead = currentBlock - confirmationDepth;
+      if (effectiveHead <= state.lastProcessedBlock) {
+        // No new "safe" blocks since last scan; common steady-state path.
+        state.lastError = null;
+        state.lastScanAt = Date.now();
         return;
       }
 
-      if (currentBlock <= state.lastProcessedBlock) return;
-
       const fromBlock = state.lastProcessedBlock + 1;
-      const toBlock = currentBlock;
+      const toBlock = effectiveHead;
 
       // Real CCTP emits: event MessageSent(bytes message)
       const iface = new ethers.Interface(REAL_MESSAGE_SENT_ABI);
       const eventTopic = iface.getEvent("MessageSent")?.topicHash;
       if (!eventTopic) return;
 
-      const logs = await state.provider.getLogs({
-        address: state.messageTransmitter,
-        topics: [eventTopic],
+      await getLogsChunked(state.provider, {
         fromBlock,
         toBlock,
+        maxRange: maxLogRange,
+        filter: {
+          address: state.messageTransmitter,
+          topics: [eventTopic],
+        },
+        // Ingest + cursor-advance happen INSIDE the per-chunk callback so the on-disk cursor
+        // is always ≤ what's been enqueued. A crash between chunks loses zero un-ingested
+        // logs: the cursor reflects the last fully-ingested chunk.
+        onChunk: async ({ fromBlock: chunkFrom, toBlockInclusive, logs }) => {
+          if (logs.length > 0) {
+            console.log(
+              `\n[iris-relay] ${config.name}: Found ${logs.length} message(s) in blocks ${chunkFrom}-${toBlockInclusive}`,
+            );
+          }
+          for (const log of logs) {
+            this.enqueueMessage(log, state);
+          }
+          state.lastProcessedBlock = toBlockInclusive;
+          await this.cursorStore.write(config.name, {
+            lastProcessedBlock: toBlockInclusive,
+            updatedAt: Date.now(),
+          });
+        },
       });
 
-      if (logs.length > 0) {
-        console.log(
-          `\n[iris-relay] ${state.config.name}: Found ${logs.length} message(s) in blocks ${fromBlock}-${toBlock}`
-        );
-      }
-
-      for (const log of logs) {
-        this.enqueueMessage(log, state);
-      }
-
-      state.lastProcessedBlock = currentBlock;
-    } catch (e) {
-      // Silently ignore connection errors during polling
+      state.lastError = null;
+      state.lastScanAt = Date.now();
+    } catch (err: any) {
+      // NO LONGER SILENT. Structured error log + state.lastError so the future health endpoint
+      // can surface a stuck scanner. Cursor stays put so the next tick retries the same window.
+      const message = err instanceof RpcTimeoutError
+        ? `RPC timeout: ${err.label}`
+        : err?.message ?? "unknown error";
+      state.lastError = { message, at: Date.now() };
+      console.error(
+        `[iris-relay] ${state.config.name}: Scan tick failed: ${message}. Cursor stays at ${state.lastProcessedBlock}; will retry next tick.`,
+      );
     }
   }
 
@@ -613,32 +760,69 @@ export class IrisRelayModule {
     this.runPollLoop();
   }
 
+  /** Resolved by `runPollLoop` when it observes isRunning=false and exits. `stop()` awaits it. */
+  private loopExited: Promise<void> | null = null;
+  private resolveLoopExited: (() => void) | null = null;
+
   private async runPollLoop(): Promise<void> {
-    while (this.isRunning) {
-      // 1. Scan all chains for new MessageSent events
-      const chainStates = Array.from(this.chains.values());
-      for (const state of chainStates) {
-        await this.pollChain(state);
+    this.loopExited = new Promise((resolve) => {
+      this.resolveLoopExited = resolve;
+    });
+    try {
+      while (this.isRunning) {
+        // 1. Scan all chains for new MessageSent events
+        const chainStates = Array.from(this.chains.values());
+        for (const state of chainStates) {
+          if (!this.isRunning) break;
+          await this.pollChain(state);
+        }
+
+        if (!this.isRunning) break;
+
+        // 2. Check pending messages for attestations and relay
+        await this.processPendingMessages();
+
+        if (!this.isRunning) break;
+
+        // 3. Sleep before next cycle — abort early if stop() fires.
+        await this.sleepCancellable(this.pollIntervalMs);
       }
-
-      // 2. Check pending messages for attestations and relay
-      await this.processPendingMessages();
-
-      // 3. Sleep before next cycle
-      await new Promise((resolve) =>
-        setTimeout(resolve, this.pollIntervalMs)
-      );
+    } finally {
+      this.resolveLoopExited?.();
     }
   }
 
-  stop(): void {
-    if (this.isRunning) {
-      console.log("[iris-relay] Stopping...");
-      if (this.pendingMessages.size > 0) {
-        console.log(`[iris-relay] ${this.pendingMessages.size} pending message(s) will be abandoned`);
-      }
-      this.isRunning = false;
+  /**
+   * Like `setTimeout` but resolves immediately when `isRunning` flips to false, so a shutdown
+   * doesn't have to wait out the full poll interval before flushing. Checks every 100ms — small
+   * enough to be unnoticeable on shutdown latency, large enough not to busy-loop.
+   */
+  private async sleepCancellable(totalMs: number): Promise<void> {
+    const start = Date.now();
+    const step = 100;
+    while (this.isRunning && Date.now() - start < totalMs) {
+      await new Promise((resolve) => setTimeout(resolve, Math.min(step, totalMs - (Date.now() - start))));
     }
+  }
+
+  /**
+   * Async, awaitable shutdown. Flips the run flag, waits for the current poll tick to complete
+   * (so an in-flight `getLogs` finishes and its cursor write lands), then resolves. The caller
+   * in `armada-relayer.ts` MUST await this before `process.exit` — otherwise a kill-9 mid-poll
+   * could happen between the on-disk cursor write and the in-memory advance, defeating the
+   * crash-safety guarantee.
+   *
+   * Idempotent — calling twice is a no-op on the second call.
+   */
+  async stop(): Promise<void> {
+    if (!this.isRunning) return;
+    console.log("[iris-relay] Stopping — waiting for in-flight scan tick to complete...");
+    if (this.pendingMessages.size > 0) {
+      console.log(`[iris-relay] ${this.pendingMessages.size} pending message(s) will be abandoned`);
+    }
+    this.isRunning = false;
+    if (this.loopExited) await this.loopExited;
+    console.log("[iris-relay] Stopped cleanly.");
   }
 
   get chainCount(): number {

--- a/relayer/state/README.md
+++ b/relayer/state/README.md
@@ -1,0 +1,55 @@
+# `relayer/state/` — per-chain scan cursors
+
+This directory holds the relayer's persistent state for the CCTP scan loop. The directory itself
+is committed (so a fresh clone has the README) but the cursor files inside are gitignored.
+
+## Cursor files
+
+One JSON file per chain: `cursor-<chain-name>.json`. Created automatically by the relayer on
+its first successful scan tick. Atomic writes via tmpfile + rename — a `kill -9` mid-write
+leaves either the old cursor intact or the new one fully present, never a torn file.
+
+Shape (schema version 1):
+
+```json
+{
+  "lastProcessedBlock": 12345678,
+  "updatedAt": 1716220800000,
+  "version": 1
+}
+```
+
+- **`lastProcessedBlock`** — highest block FULLY scanned + ingested into `pendingMessages`
+  (inclusive). Next poll tick starts at `lastProcessedBlock + 1`.
+- **`updatedAt`** — Unix ms of the last write. Future health endpoint surfaces this as
+  "scanner staleness."
+- **`version`** — schema version stamp. Bump and add a migration in `lib/cursor-store.ts` when
+  the shape changes; loading an unsupported version throws loudly rather than misinterpreting.
+
+## When to delete a cursor file
+
+- **Suspected corruption.** Deleting the file is operator-actionable recovery: the relayer
+  bootstraps from `currentBlock - bootLookbackBlocks` on next start.
+- **Manually re-scanning a window.** Edit `lastProcessedBlock` to the floor of the window you
+  want re-scanned. The cursor's `version` field must stay 1.
+- **Switching deployments.** The cursor is chain-scoped (file per chain name). A redeploy that
+  changes the chain name will start fresh; a redeploy that keeps the name will resume from the
+  old cursor — usually fine, but if contract addresses changed, deleting the file forces a
+  clean bootstrap.
+
+## When NOT to delete a cursor file
+
+Never delete during steady-state operation. The cursor's job is to ensure the relayer resumes
+where it left off after a restart; deleting it forces a re-scan of the full lookback window,
+which the contract's "already processed" check absorbs but wastes RPC quota and gas.
+
+## Behaviour on cold start
+
+1. If no cursor file exists → bootstrap from `currentBlock - bootLookbackBlocks`. Recovers any
+   `MessageSent` events from the last ~30 min (default) so the relayer doesn't drop in-flight
+   messages on first deploy.
+2. If a cursor exists AND the gap to chain head is reasonable → resume exactly from cursor.
+3. If a cursor exists BUT the gap exceeds `maxBootLookbackBlocks` → cap at the lookback floor
+   and emit a loud warning. The operator is alerted that historical messages between the
+   cursor and the lookback floor were skipped (Iris would have expired their attestations
+   anyway; manual recovery via `relayWithHook` if needed).

--- a/relayer/test/lib/cursor-store.test.ts
+++ b/relayer/test/lib/cursor-store.test.ts
@@ -1,0 +1,174 @@
+// ABOUTME: Tests for CursorStore — atomic per-chain cursor persistence used by the CCTP scanners.
+// ABOUTME: WHY this exists at all: silent in-memory cursors caused real Sepolia message drops (PR #292 incident); a corrupt or torn-write cursor on disk would reintroduce the same class of failure, so every persistence edge case (missing file, malformed JSON, version mismatch, atomic-write survival) gets explicit coverage.
+
+import { expect } from "chai";
+import { mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CursorStore } from "../../lib/cursor-store";
+
+describe("CursorStore", function () {
+  let dir: string;
+
+  beforeEach(async function () {
+    dir = await mkdtemp(join(tmpdir(), "cursor-store-"));
+  });
+
+  afterEach(async function () {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  describe("read", function () {
+    it("returns null when the cursor file does not exist", async function () {
+      // WHY: cold start IS the missing-file case. The caller bootstraps from a lookback window
+      // in this case rather than failing — null is the contract that signals "fresh boot."
+      const store = new CursorStore(dir);
+      expect(await store.read("hub")).to.equal(null);
+    });
+
+    it("round-trips a written cursor", async function () {
+      const store = new CursorStore(dir);
+      await store.write("hub", { lastProcessedBlock: 12345, updatedAt: 1_700_000_000_000 });
+      const got = await store.read("hub");
+      expect(got).to.deep.equal({
+        lastProcessedBlock: 12345,
+        updatedAt: 1_700_000_000_000,
+        version: 1,
+      });
+    });
+
+    it("throws on malformed JSON rather than silently treating as cold start", async function () {
+      // WHY: silently returning null on malformed input would be the same class of bug as the
+      // original silent-scan-error problem — we'd boot from chain head and lose every in-flight
+      // message. Loud failure forces operator to investigate (delete file → bootstrap from
+      // lookback) rather than corrupt the relayer's worldview.
+      const store = new CursorStore(dir);
+      const path = join(dir, "cursor-hub.json");
+      await writeFile(path, "{ not valid json", "utf8");
+      try {
+        await store.read("hub");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.match(/JSON|malformed|Unexpected/);
+      }
+    });
+
+    it("throws on unexpected shape (missing required fields)", async function () {
+      const store = new CursorStore(dir);
+      const path = join(dir, "cursor-hub.json");
+      await writeFile(path, JSON.stringify({ foo: "bar" }), "utf8");
+      try {
+        await store.read("hub");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.match(/malformed cursor/);
+      }
+    });
+
+    it("throws on a future schema version", async function () {
+      // WHY: a future-version cursor written by a newer relayer must not be misinterpreted by
+      // an older one. The schema version stamp + explicit version check is how we'd safely add
+      // migration logic later.
+      const store = new CursorStore(dir);
+      const path = join(dir, "cursor-hub.json");
+      await writeFile(
+        path,
+        JSON.stringify({ lastProcessedBlock: 100, updatedAt: 1, version: 999 }),
+        "utf8",
+      );
+      try {
+        await store.read("hub");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.match(/unsupported version/);
+      }
+    });
+  });
+
+  describe("write", function () {
+    it("creates the base directory if it does not exist", async function () {
+      // WHY: fresh deployments / cleared state dirs are common. Auto-creating is the difference
+      // between "first boot just works" and "first boot crashes with ENOENT."
+      const nested = join(dir, "deep", "nest");
+      const store = new CursorStore(nested);
+      await store.write("hub", { lastProcessedBlock: 1, updatedAt: 2 });
+      const stats = await stat(nested);
+      expect(stats.isDirectory()).to.equal(true);
+    });
+
+    it("writes the canonical file atomically (no .tmp left behind on success)", async function () {
+      // WHY: the atomic write pattern is tmpfile + rename. If a .tmp file is left dangling, it
+      // indicates the rename failed silently — operator would see stale data on the canonical
+      // path while the latest write sits in a phantom tmp file forever.
+      const store = new CursorStore(dir);
+      await store.write("hub", { lastProcessedBlock: 100, updatedAt: 1 });
+      const entries = await readdir(dir);
+      expect(entries).to.include("cursor-hub.json");
+      expect(entries.every((e) => !e.endsWith(".tmp"))).to.equal(true);
+    });
+
+    it("a partial write to .tmp does not corrupt the canonical file", async function () {
+      // WHY: simulates kill-9 mid-write. The atomic-rename pattern's whole point is that the
+      // canonical file is either old-intact OR new-fully-present, never torn. We pre-seed a
+      // good cursor, then dump a manual half-written .tmp next to it, then read — the read
+      // MUST return the good prior value.
+      const store = new CursorStore(dir);
+      await store.write("hub", { lastProcessedBlock: 999, updatedAt: 1_111 });
+
+      // Simulate a crash mid-write: write a junk .tmp that never got renamed.
+      const tmpPath = join(dir, `cursor-hub.json.${process.pid}.tmp`);
+      await writeFile(tmpPath, '{"lastProcessedBlock": 50000000, "garbage"', "utf8");
+
+      const got = await store.read("hub");
+      expect(got?.lastProcessedBlock).to.equal(999);
+      expect(got?.updatedAt).to.equal(1_111);
+    });
+
+    it("sanitises chain names — no path traversal", async function () {
+      // WHY: chain name comes from our own config, but path traversal in a state file pattern
+      // is the kind of latent footgun we should slam shut now rather than discover when someone
+      // adds a chain called "../etc/passwd".
+      const store = new CursorStore(dir);
+      await store.write("../escape", { lastProcessedBlock: 1, updatedAt: 1 });
+      const entries = await readdir(dir);
+      expect(entries.some((e) => e.startsWith("cursor-"))).to.equal(true);
+      expect(entries.every((e) => !e.includes(".."))).to.equal(true);
+    });
+
+    it("ends the JSON with a trailing newline (git-friendly + posix-tradition)", async function () {
+      const store = new CursorStore(dir);
+      await store.write("hub", { lastProcessedBlock: 1, updatedAt: 1 });
+      const raw = await readFile(join(dir, "cursor-hub.json"), "utf8");
+      expect(raw.endsWith("\n")).to.equal(true);
+    });
+
+    it("overwrites an existing cursor on second write", async function () {
+      const store = new CursorStore(dir);
+      await store.write("hub", { lastProcessedBlock: 100, updatedAt: 1 });
+      await store.write("hub", { lastProcessedBlock: 200, updatedAt: 2 });
+      const got = await store.read("hub");
+      expect(got?.lastProcessedBlock).to.equal(200);
+      expect(got?.updatedAt).to.equal(2);
+    });
+  });
+
+  describe("multi-chain isolation", function () {
+    it("each chain has an independent cursor file", async function () {
+      // WHY: scanning is independent per chain. A stall on chain A must not interfere with
+      // chain B's cursor — separate files = separate fates.
+      const store = new CursorStore(dir);
+      await store.write("hub", { lastProcessedBlock: 100, updatedAt: 1 });
+      await store.write("base", { lastProcessedBlock: 200, updatedAt: 2 });
+      expect((await store.read("hub"))?.lastProcessedBlock).to.equal(100);
+      expect((await store.read("base"))?.lastProcessedBlock).to.equal(200);
+    });
+
+    it("case-insensitive chain name normalisation", async function () {
+      // WHY: defensive against config typos / case drift. "Hub" and "hub" should hit the same
+      // file rather than silently double-track.
+      const store = new CursorStore(dir);
+      await store.write("Hub", { lastProcessedBlock: 100, updatedAt: 1 });
+      expect((await store.read("hub"))?.lastProcessedBlock).to.equal(100);
+    });
+  });
+});

--- a/relayer/test/lib/cursor-store.test.ts
+++ b/relayer/test/lib/cursor-store.test.ts
@@ -83,6 +83,72 @@ describe("CursorStore", function () {
         expect((err as Error).message).to.match(/unsupported version/);
       }
     });
+
+    it("rejects negative lastProcessedBlock — would propagate as silent garbage downstream", async function () {
+      // WHY: the typeof check alone accepts -1, NaN as garbage. The scanner's `Number(...)`
+      // casts would silently produce bad fromBlock values (negative block scan = obscure error
+      // OR scan the wrong range = silent message loss). Range-check at the boundary.
+      const store = new CursorStore(dir);
+      const path = join(dir, "cursor-hub.json");
+      await writeFile(
+        path,
+        JSON.stringify({ lastProcessedBlock: -1, updatedAt: 1, version: 1 }),
+        "utf8",
+      );
+      try {
+        await store.read("hub");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.match(/invalid lastProcessedBlock/);
+      }
+    });
+
+    it("rejects non-integer lastProcessedBlock (e.g. 3.14)", async function () {
+      // WHY: typeof passes for fractional. Block numbers are integers; anything else is corruption.
+      const store = new CursorStore(dir);
+      const path = join(dir, "cursor-hub.json");
+      await writeFile(
+        path,
+        JSON.stringify({ lastProcessedBlock: 3.14, updatedAt: 1, version: 1 }),
+        "utf8",
+      );
+      try {
+        await store.read("hub");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.match(/invalid lastProcessedBlock/);
+      }
+    });
+
+    it("rejects negative updatedAt", async function () {
+      const store = new CursorStore(dir);
+      const path = join(dir, "cursor-hub.json");
+      await writeFile(
+        path,
+        JSON.stringify({ lastProcessedBlock: 100, updatedAt: -1, version: 1 }),
+        "utf8",
+      );
+      try {
+        await store.read("hub");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.match(/invalid updatedAt/);
+      }
+    });
+
+    it("includes the chain name in malformed-file errors for debug clarity", async function () {
+      // WHY: with N chains, an operator seeing "malformed cursor" needs to know which chain
+      // to investigate. The path alone is a clue; the chain name is the actionable id.
+      const store = new CursorStore(dir);
+      const path = join(dir, "cursor-base-sepolia.json");
+      await writeFile(path, JSON.stringify({ foo: "bar" }), "utf8");
+      try {
+        await store.read("base-sepolia");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.include("base-sepolia");
+      }
+    });
   });
 
   describe("write", function () {
@@ -149,6 +215,32 @@ describe("CursorStore", function () {
       const got = await store.read("hub");
       expect(got?.lastProcessedBlock).to.equal(200);
       expect(got?.updatedAt).to.equal(2);
+    });
+
+    it("cleans up the .tmp file when rename fails (does not leak orphan tmpfiles)", async function () {
+      // WHY: rename() on POSIX is usually atomic, but cross-filesystem moves or pathological
+      // race conditions can fail. If the .tmp persists after the failed rename, repeated
+      // failures could fill the state directory with orphans. We trigger the failure by
+      // pre-creating the canonical path AS A DIRECTORY — rename(file, dir) fails with EISDIR
+      // on Linux / EEXIST on macOS, which exercises the catch branch.
+      const store = new CursorStore(dir);
+      const { mkdir, readdir } = await import("node:fs/promises");
+      const canonicalPath = join(dir, "cursor-hub.json");
+      // Make the canonical path a directory containing a file so it can't be silently replaced.
+      await mkdir(canonicalPath, { recursive: true });
+      await writeFile(join(canonicalPath, "blocker"), "x", "utf8");
+
+      try {
+        await store.write("hub", { lastProcessedBlock: 100, updatedAt: 1 });
+        expect.fail("should have thrown — destination is a non-empty directory");
+      } catch {
+        // expected — rename fails
+      }
+
+      // The .tmp file MUST be gone (catch branch unlinked it).
+      const entries = await readdir(dir);
+      const orphanTmps = entries.filter((e) => e.includes(".tmp"));
+      expect(orphanTmps, `unexpected tmp files: ${orphanTmps.join(", ")}`).to.deep.equal([]);
     });
   });
 

--- a/relayer/test/lib/get-logs-chunked.test.ts
+++ b/relayer/test/lib/get-logs-chunked.test.ts
@@ -1,0 +1,232 @@
+// ABOUTME: Tests for getLogsChunked — verifies bounded chunking, per-chunk progress callbacks, and ordering.
+// ABOUTME: WHY: the un-chunked scan was the proximate cause of the silent stall failure (range grew past RPC limit, errors swallowed, stuck forever). Chunking + per-chunk persistence is the structural fix — every chunking edge case (exact boundary, partial last chunk, single-block range, empty range) needs explicit coverage so regressions surface immediately.
+
+import { expect } from "chai";
+import type { ethers } from "ethers";
+import { getLogsChunked } from "../../lib/get-logs-chunked";
+
+/** Tiny fake provider that records every getLogs invocation and returns canned logs. */
+function makeFakeProvider(
+  logsForRange: (from: number, to: number) => ethers.Log[],
+): {
+  provider: ethers.JsonRpcProvider;
+  calls: Array<{ from: number; to: number }>;
+} {
+  const calls: Array<{ from: number; to: number }> = [];
+  const provider = {
+    async getLogs(filter: { fromBlock: number; toBlock: number }) {
+      calls.push({ from: filter.fromBlock, to: filter.toBlock });
+      return logsForRange(filter.fromBlock, filter.toBlock);
+    },
+  } as unknown as ethers.JsonRpcProvider;
+  return { provider, calls };
+}
+
+/** Synthesize an ethers.Log just enough to be carried through the helper. */
+function fakeLog(blockNumber: number): ethers.Log {
+  return {
+    blockNumber,
+    blockHash: "0x" + blockNumber.toString(16).padStart(64, "0"),
+    transactionHash: "0xtx",
+    transactionIndex: 0,
+    address: "0xabc",
+    data: "0x",
+    topics: [],
+    index: 0,
+    removed: false,
+  } as unknown as ethers.Log;
+}
+
+describe("getLogsChunked", function () {
+  it("issues a single chunk when the range fits in maxRange", async function () {
+    // WHY: trivial case but the baseline — we must not over-chunk a small range or we waste
+    // RPC calls. 100 blocks at maxRange=500 is one call, not two.
+    const { provider, calls } = makeFakeProvider(() => []);
+    await getLogsChunked(provider, {
+      fromBlock: 100,
+      toBlock: 199,
+      maxRange: 500,
+      filter: { address: "0xabc" },
+    });
+    expect(calls).to.deep.equal([{ from: 100, to: 199 }]);
+  });
+
+  it("splits a large range into exact-size chunks plus a remainder", async function () {
+    // WHY: this is the failure mode the bug fix targets. Without chunking, a 1500-block range
+    // hitting an RPC with a 500-block cap would silently fail forever. With chunking, it
+    // becomes 3 successive calls — each one within the cap.
+    const { provider, calls } = makeFakeProvider(() => []);
+    await getLogsChunked(provider, {
+      fromBlock: 1_000,
+      toBlock: 2_499,
+      maxRange: 500,
+      filter: { address: "0xabc" },
+    });
+    expect(calls).to.deep.equal([
+      { from: 1_000, to: 1_499 },
+      { from: 1_500, to: 1_999 },
+      { from: 2_000, to: 2_499 },
+    ]);
+  });
+
+  it("clamps the final chunk to toBlock rather than overshooting", async function () {
+    // WHY: edge case — a 600-block range with maxRange=500 is 1 full chunk + 1 partial (100
+    // blocks). The partial chunk must NOT request blocks past toBlock — the RPC would either
+    // error or return future-block data the scanner would misinterpret.
+    const { provider, calls } = makeFakeProvider(() => []);
+    await getLogsChunked(provider, {
+      fromBlock: 0,
+      toBlock: 599,
+      maxRange: 500,
+      filter: { address: "0xabc" },
+    });
+    expect(calls).to.deep.equal([
+      { from: 0, to: 499 },
+      { from: 500, to: 599 },
+    ]);
+  });
+
+  it("treats fromBlock === toBlock as a single 1-block query", async function () {
+    // WHY: defensive — the cursor advance pattern is `from = lastChunkTo + 1` so on a chain
+    // with no new blocks since the last tick, we'd otherwise loop forever. The early-return
+    // when from > to handles that; this test pins the equal case as the "yes scan 1 block" path.
+    const { provider, calls } = makeFakeProvider(() => []);
+    await getLogsChunked(provider, {
+      fromBlock: 42,
+      toBlock: 42,
+      maxRange: 500,
+      filter: { address: "0xabc" },
+    });
+    expect(calls).to.deep.equal([{ from: 42, to: 42 }]);
+  });
+
+  it("returns empty + makes no RPC calls when fromBlock > toBlock", async function () {
+    // WHY: the no-new-blocks case. Caller passes `from=lastProcessed+1, to=currentBlock` —
+    // when no new blocks have arrived since the last successful tick, from > to and we should
+    // short-circuit without burning a getLogs call.
+    const { provider, calls } = makeFakeProvider(() => [fakeLog(1)]);
+    const out = await getLogsChunked(provider, {
+      fromBlock: 100,
+      toBlock: 99,
+      maxRange: 500,
+      filter: { address: "0xabc" },
+    });
+    expect(out).to.deep.equal([]);
+    expect(calls).to.deep.equal([]);
+  });
+
+  it("concatenates logs across chunks in ascending order", async function () {
+    // WHY: callers (enqueueMessage in iris-relay) iterate the result in order — out-of-order
+    // delivery would mean nonces processed before their predecessors.
+    const { provider } = makeFakeProvider((from) => [fakeLog(from + 1)]);
+    const out = await getLogsChunked(provider, {
+      fromBlock: 0,
+      toBlock: 1_499,
+      maxRange: 500,
+      filter: { address: "0xabc" },
+    });
+    expect(out.map((l) => l.blockNumber)).to.deep.equal([1, 501, 1001]);
+  });
+
+  it("fires onChunk after each successful chunk so the caller can persist mid-range progress", async function () {
+    // WHY: this is the critical reliability property. If chunk 3 of 5 fails, the caller has
+    // received 2 onChunk callbacks — by ingesting+persisting in each, the next poll tick
+    // resumes from chunk 3 rather than re-scanning chunks 1-2. Without per-chunk progress, an
+    // outage mid-range would lose ALL progress and the next attempt would face the same
+    // (or worse) range failure.
+    const events: Array<{ from: number; toInc: number; n: number }> = [];
+    const { provider } = makeFakeProvider((from) => [fakeLog(from + 1)]);
+    await getLogsChunked(provider, {
+      fromBlock: 0,
+      toBlock: 1_499,
+      maxRange: 500,
+      filter: { address: "0xabc" },
+      onChunk: ({ fromBlock: f, toBlockInclusive, logs }) => {
+        events.push({ from: f, toInc: toBlockInclusive, n: logs.length });
+      },
+    });
+    expect(events).to.deep.equal([
+      { from: 0, toInc: 499, n: 1 },
+      { from: 500, toInc: 999, n: 1 },
+      { from: 1000, toInc: 1499, n: 1 },
+    ]);
+  });
+
+  it("does NOT fire onChunk for a chunk whose getLogs call threw", async function () {
+    // WHY: partial-progress contract — onChunk only fires on success. If chunk 2 throws, the
+    // cursor stays at the end of chunk 1. The exception bubbles to the caller.
+    const events: number[] = [];
+    let attempt = 0;
+    const provider = {
+      async getLogs() {
+        attempt++;
+        if (attempt === 2) throw new Error("simulated RPC blip on chunk 2");
+        return [];
+      },
+    } as unknown as ethers.JsonRpcProvider;
+
+    try {
+      await getLogsChunked(provider, {
+        fromBlock: 0,
+        toBlock: 1_499,
+        maxRange: 500,
+        filter: { address: "0xabc" },
+        onChunk: ({ toBlockInclusive }) => {
+          events.push(toBlockInclusive);
+        },
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as Error).message).to.match(/simulated RPC blip/);
+    }
+    // chunk 1 completed → 499 persisted. chunk 2 threw → 999 NOT persisted.
+    expect(events).to.deep.equal([499]);
+  });
+
+  it("awaits an async onChunk before issuing the next chunk", async function () {
+    // WHY: cursor persistence + log ingestion may be async. We MUST not start chunk N+1 before
+    // chunk N's persistence + ingest completes, otherwise a crash between them would leave
+    // the on-disk cursor referencing logs we haven't actually accepted into pendingMessages.
+    // This test pins the await contract by ordering an async sleep inside the callback against
+    // the chunk-issue sequence and verifying interleave.
+    const trace: string[] = [];
+    const { provider } = makeFakeProvider(() => []);
+    await getLogsChunked(provider, {
+      fromBlock: 0,
+      toBlock: 1_499,
+      maxRange: 500,
+      filter: { address: "0xabc" },
+      onChunk: async ({ toBlockInclusive }) => {
+        trace.push(`onChunk-start ${toBlockInclusive}`);
+        await new Promise((r) => setTimeout(r, 5));
+        trace.push(`onChunk-end ${toBlockInclusive}`);
+      },
+    });
+    // Each chunk's onChunk must finish before the next chunk's onChunk starts.
+    expect(trace).to.deep.equal([
+      "onChunk-start 499",
+      "onChunk-end 499",
+      "onChunk-start 999",
+      "onChunk-end 999",
+      "onChunk-start 1499",
+      "onChunk-end 1499",
+    ]);
+  });
+
+  it("throws on maxRange < 1 — would otherwise infinite-loop", async function () {
+    // WHY: maxRange=0 would never advance the cursor; the while loop spins forever. Loud throw
+    // > silent hang.
+    const { provider } = makeFakeProvider(() => []);
+    try {
+      await getLogsChunked(provider, {
+        fromBlock: 0,
+        toBlock: 100,
+        maxRange: 0,
+        filter: { address: "0xabc" },
+      });
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as Error).message).to.match(/maxRange must be ≥ 1/);
+    }
+  });
+});

--- a/relayer/test/lib/rpc-bisecting.test.ts
+++ b/relayer/test/lib/rpc-bisecting.test.ts
@@ -1,0 +1,269 @@
+// ABOUTME: Tests for the eth_getLogs bisecting patch. Ported from apps/armada-interface (vitest → mocha+chai); behaviour kept lockstep so a bug in one surfaces in the other.
+// ABOUTME: WHY: bisection is the difference between "works on every RPC" and "silently fails on Alchemy free tier (10-block cap)." Every range-error-detection regex + recursive-split path needs explicit coverage or a future provider tweak will reintroduce the silent-fail mode.
+
+import { expect } from "chai";
+import { JsonRpcProvider } from "ethers";
+import {
+  installBisectingGetLogs,
+  _isBisectingGetLogsPatched,
+  _uninstallBisectingGetLogs,
+  _bisectEthGetLogs,
+  _isBlockRangeError,
+} from "../../lib/rpc-bisecting";
+
+beforeEach(() => {
+  _uninstallBisectingGetLogs();
+});
+
+afterEach(() => {
+  _uninstallBisectingGetLogs();
+});
+
+describe("isBlockRangeError", function () {
+  it('matches the Alchemy free-tier "10 block range" message', function () {
+    // WHY: this is the concrete cap that motivated the bisector — Alchemy free returns 10
+    // blocks. The relayer must not need to know this upfront; the regex catches the error
+    // string and lets the recursion adapt.
+    const err = new Error(
+      "Under the Free tier plan, you can make eth_getLogs requests with up to a 10 block range.",
+    );
+    expect(_isBlockRangeError(err)).to.equal(true);
+  });
+
+  it('matches Infura "more than X results" wording', function () {
+    const err = new Error("query returned more than 10000 results");
+    expect(_isBlockRangeError(err)).to.equal(true);
+  });
+
+  it('matches QuickNode "limited to a X block range" wording', function () {
+    const err = new Error("eth_getLogs is limited to a 1000 block range");
+    expect(_isBlockRangeError(err)).to.equal(true);
+  });
+
+  it("digs into ethers SERVER_ERROR shape (info.responseBody)", function () {
+    // WHY: ethers wraps server-side errors in { code, info: { responseBody } }. Without the
+    // nested-dig in isBlockRangeError, the outer message "server response 400" wouldn't match
+    // and we'd treat a range error as a generic failure — silent stall reintroduced.
+    const err = {
+      code: "SERVER_ERROR",
+      message: "server response 400",
+      info: {
+        responseBody:
+          '{"error":{"message":"Under the Free tier plan, you can make eth_getLogs requests with up to a 10 block range"}}',
+      },
+    };
+    expect(_isBlockRangeError(err)).to.equal(true);
+  });
+
+  it("does NOT match unrelated errors (timeouts, reverts)", function () {
+    // WHY: bisecting on the wrong error class would double traffic and likely re-fail. The
+    // narrow regex keeps us conservative — uncaught patterns surface as scan errors (loud,
+    // operator-actionable) rather than infinite retry loops.
+    expect(_isBlockRangeError(new Error("CALL_EXCEPTION: execution reverted"))).to.equal(false);
+    expect(_isBlockRangeError(new Error("timeout"))).to.equal(false);
+    expect(_isBlockRangeError(null)).to.equal(false);
+    expect(_isBlockRangeError(undefined)).to.equal(false);
+  });
+});
+
+describe("bisectEthGetLogs", function () {
+  it("passes through a successful call without splitting", async function () {
+    // WHY: happy-path baseline. Bisection is reactive; on success the helper must be a
+    // transparent passthrough or we'd waste bandwidth halving working ranges.
+    const expected = [{ blockNumber: 100 }];
+    let calls = 0;
+    const send = async () => {
+      calls++;
+      return expected;
+    };
+    const result = await _bisectEthGetLogs(
+      send,
+      { fromBlock: "0x0", toBlock: "0x100" },
+      0,
+    );
+    expect(result).to.deep.equal(expected);
+    expect(calls).to.equal(1);
+  });
+
+  it("bisects once on a range-too-large error and merges the halves", async function () {
+    // WHY: the canonical split case — confirm recursion left/right, hex math, and result merge.
+    // The exact half boundary (0x32, 0x33) pins the cursor arithmetic so a refactor that shifts
+    // the boundary by 1 immediately fails.
+    const err = new Error("eth_getLogs is limited to a 10 block range");
+    const calls: Array<[string, unknown[]]> = [];
+    let attempt = 0;
+    const send = async (method: string, params: unknown[]) => {
+      calls.push([method, params]);
+      attempt++;
+      if (attempt === 1) throw err;
+      if (attempt === 2) return [{ blockNumber: 10 }];
+      return [{ blockNumber: 80 }];
+    };
+    const result = await _bisectEthGetLogs(
+      send,
+      { fromBlock: "0x0", toBlock: "0x64" },
+      0,
+    );
+    expect(result).to.deep.equal([{ blockNumber: 10 }, { blockNumber: 80 }]);
+    expect(calls.length).to.equal(3);
+    expect(calls[1]?.[1]).to.deep.equal([{ fromBlock: "0x0", toBlock: "0x32" }]);
+    expect(calls[2]?.[1]).to.deep.equal([{ fromBlock: "0x33", toBlock: "0x64" }]);
+  });
+
+  it("recurses multiple levels when the first bisection is still too large", async function () {
+    // WHY: a single bisection isn't always enough — a Sepolia cold start scan window can be
+    // 10k+ blocks while Alchemy free caps at 10. The recursion must keep halving until the
+    // RPC accepts. Five-call sequence pins the recursion tree (fail/fail/ok/ok/ok).
+    const err = new Error("block range too wide");
+    let attempt = 0;
+    const send = async () => {
+      attempt++;
+      if (attempt === 1) throw err; // [0, 100] full
+      if (attempt === 2) throw err; // [0, 50] left
+      if (attempt === 3) return [1]; // [0, 25] left-left
+      if (attempt === 4) return [2]; // [26, 50] left-right
+      return [3]; // [51, 100] right
+    };
+    const result = await _bisectEthGetLogs(
+      send,
+      { fromBlock: "0x0", toBlock: "0x64" },
+      0,
+    );
+    expect(result).to.deep.equal([1, 2, 3]);
+    expect(attempt).to.equal(5);
+  });
+
+  it("propagates non-range errors without splitting", async function () {
+    // WHY: don't bisect on reverts, network errors, etc. Conservative regex + this guard means
+    // an unrelated error surfaces immediately rather than amplifying load via retries.
+    const err = new Error("CALL_EXCEPTION: execution reverted");
+    let attempt = 0;
+    const send = async () => {
+      attempt++;
+      throw err;
+    };
+    try {
+      await _bisectEthGetLogs(send, { fromBlock: "0x0", toBlock: "0x100" }, 0);
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect((e as Error).message).to.include("execution reverted");
+    }
+    expect(attempt).to.equal(1);
+  });
+
+  it("propagates the range error when the range is already a single block", async function () {
+    // WHY: terminal recursion case. A 1-block range that still trips the RPC's cap means
+    // something deeper is wrong (RPC misconfigured, contract spamming events). Re-throw so the
+    // scanner's lastError surfaces it.
+    const err = new Error("block range too wide");
+    let attempt = 0;
+    const send = async () => {
+      attempt++;
+      throw err;
+    };
+    try {
+      await _bisectEthGetLogs(send, { fromBlock: "0x10", toBlock: "0x10" }, 0);
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect((e as Error).message).to.match(/block range too wide/);
+    }
+    expect(attempt).to.equal(1);
+  });
+
+  it("does not infinite-recurse on a pathological huge range", async function () {
+    // WHY: defensive — the recursion must terminate even when every call fails. The single-block
+    // floor catches typical cases; this pins the call-count ceiling so a regression that breaks
+    // the floor surfaces as a test timeout AND an explicit assertion failure.
+    const err = new Error("block range too wide");
+    let attempt = 0;
+    const send = async () => {
+      attempt++;
+      throw err;
+    };
+    try {
+      await _bisectEthGetLogs(send, { fromBlock: "0x0", toBlock: "0xFFFFFF" }, 0);
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect((e as Error).message).to.match(/block range too wide/);
+    }
+    expect(attempt).to.be.lessThan(400);
+  });
+
+  it("wraps the original error with range + depth context when MAX_BISECT_DEPTH fires", async function () {
+    // WHY: the depth cap is the last-resort safety against pathological inputs. When it fires,
+    // the wrapping error must preserve enough context (depth + range + upstream message) for
+    // an operator to diagnose without raising the cap blindly.
+    const err = new Error("block range too wide");
+    const send = async () => {
+      throw err;
+    };
+    try {
+      await _bisectEthGetLogs(send, { fromBlock: "0x0", toBlock: "0xFFFFFFFF" }, 24);
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect((e as Error).message).to.match(/bisection exceeded max depth/);
+      expect((e as Error).message).to.match(/block range too wide/);
+    }
+  });
+
+  it("preserves filter fields other than fromBlock/toBlock", async function () {
+    // WHY: a filter with `address` + `topics` MUST flow into every recursive sub-call. Without
+    // it, the bisected halves would scan the wrong contract / wrong event topic — returning
+    // wrong logs OR no logs (silent miss).
+    const err = new Error("block range too wide");
+    const filter = {
+      fromBlock: "0x0",
+      toBlock: "0x100",
+      address: "0xabc",
+      topics: ["0xtopic1", null],
+    };
+    const calls: unknown[][] = [];
+    let attempt = 0;
+    const send = async (_m: string, p: unknown[]) => {
+      calls.push(p);
+      attempt++;
+      if (attempt === 1) throw err;
+      return [];
+    };
+    await _bisectEthGetLogs(send, filter, 0);
+    const leftCall = (calls[1] as Record<string, unknown>[])[0];
+    expect(leftCall?.address).to.equal("0xabc");
+    expect(leftCall?.topics).to.deep.equal(["0xtopic1", null]);
+  });
+});
+
+describe("installBisectingGetLogs", function () {
+  it("is idempotent", function () {
+    expect(_isBisectingGetLogsPatched()).to.equal(false);
+    installBisectingGetLogs();
+    expect(_isBisectingGetLogsPatched()).to.equal(true);
+    installBisectingGetLogs();
+    installBisectingGetLogs();
+    expect(_isBisectingGetLogsPatched()).to.equal(true);
+  });
+
+  it("intercepts eth_getLogs but passes through other methods", async function () {
+    // WHY: confirm the prototype patch only branches on the targeted RPC method. A broken patch
+    // that intercepted all calls would break eth_blockNumber, eth_getBlockByNumber, etc. —
+    // every other relayer operation.
+    installBisectingGetLogs();
+    const provider = new JsonRpcProvider("http://localhost:0"); // never connects; we override send
+
+    let recordedMethod = "";
+    let recordedParams: unknown[] = [];
+    // Override the instance's send to spy on what the patched send calls into.
+    provider.send = async function (m: string, p: unknown[]) {
+      recordedMethod = m;
+      recordedParams = p;
+      if (m === "eth_getLogs") return [];
+      return null;
+    };
+
+    await provider.send("eth_blockNumber", []);
+    expect(recordedMethod).to.equal("eth_blockNumber");
+
+    await provider.send("eth_getLogs", [{ fromBlock: "0x0", toBlock: "0x10" }]);
+    expect(recordedMethod).to.equal("eth_getLogs");
+    expect(recordedParams).to.deep.equal([{ fromBlock: "0x0", toBlock: "0x10" }]);
+  });
+});

--- a/relayer/test/lib/rpc-utils.test.ts
+++ b/relayer/test/lib/rpc-utils.test.ts
@@ -1,0 +1,67 @@
+// ABOUTME: Tests for withTimeout — verifies happy path, timeout firing, original-error pass-through, and timer cleanup.
+// ABOUTME: WHY: the silent-hang failure mode is the inverse of the silent-error one — both lose user money. Without explicit timer-cleanup verification, a leak in the loser branch of Promise.race would eventually OOM a long-running relayer.
+
+import { expect } from "chai";
+import { RpcTimeoutError, withTimeout } from "../../lib/rpc-utils";
+
+describe("withTimeout", function () {
+  it("resolves with the promise value when it settles inside the timeout", async function () {
+    const value = await withTimeout(Promise.resolve("ok"), 1000, "test");
+    expect(value).to.equal("ok");
+  });
+
+  it("rejects with RpcTimeoutError when the timeout fires first", async function () {
+    // WHY: the canonical "wedged RPC connection" case — provider never returns. Without the
+    // timeout, the poll loop pins forever waiting on a dead socket.
+    const slow = new Promise<string>((resolve) => setTimeout(() => resolve("late"), 100));
+    try {
+      await withTimeout(slow, 10, "test-slow-rpc");
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).to.be.instanceOf(RpcTimeoutError);
+      expect((err as RpcTimeoutError).label).to.equal("test-slow-rpc");
+      expect((err as RpcTimeoutError).timeoutMs).to.equal(10);
+    }
+  });
+
+  it("propagates the original error when the promise rejects in time", async function () {
+    // WHY: the timeout must not mask real errors. If the provider rejects with a meaningful
+    // "block range too large" error and we wrap THAT as RpcTimeoutError, we lose the diagnostic
+    // signal that motivates a backoff strategy.
+    const original = new Error("real RPC error: block range too large");
+    try {
+      await withTimeout(Promise.reject(original), 1000, "test");
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect(err).to.equal(original);
+      expect(err).to.not.be.instanceOf(RpcTimeoutError);
+    }
+  });
+
+  it("clears the internal timer when the promise resolves first (no leak in long-running loops)", async function () {
+    // WHY: this helper is called every poll tick (every few seconds). A leaked setTimeout per
+    // tick would accumulate thousands of timers per hour. We can't easily observe handle
+    // counts in user-land Node, so this test pins the cleanup invariant via active handle
+    // counting against the process — the count after N withTimeout calls should not grow.
+    const initial = (process as NodeJS.Process & { _getActiveHandles?: () => unknown[] })._getActiveHandles?.()?.length ?? 0;
+    for (let i = 0; i < 50; i++) {
+      await withTimeout(Promise.resolve(i), 5000, "loop");
+    }
+    const after = (process as NodeJS.Process & { _getActiveHandles?: () => unknown[] })._getActiveHandles?.()?.length ?? 0;
+    // Allow small slack for mocha's own timers; the key is the count doesn't grow proportionally
+    // to iterations (50). If the cleanup is broken we'd see ~50 lingering Timeouts.
+    expect(after - initial).to.be.lessThan(10);
+  });
+
+  it("RpcTimeoutError preserves the label for log-friendly messages", async function () {
+    // WHY: the label appears in operator logs. A bare "RPC timeout" tells you nothing — the
+    // label should identify which call timed out (which chain, which method).
+    try {
+      await withTimeout(new Promise(() => {}), 5, "getLogs hub blocks 100-600");
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as Error).message).to.include("getLogs hub blocks 100-600");
+      expect((err as Error).message).to.include("5ms");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the silent-stall failure class that dropped a user's xchain shield on Sepolia (\`0x8617f73…\`). Five primitives, applied to both \`iris-relay\` (production) and \`cctp-relay\` (mock) in lockstep so local testing surfaces the same behaviour we see on Sepolia.

Tracked in [\`.claude/RELAYER_HARDENING.md\`](.claude/RELAYER_HARDENING.md) as Phase 1.

## What this fixes

### 1. Persistent per-chain cursor

New \`lib/cursor-store.ts\`. Atomic write (tmpfile + rename), per-chain file at \`relayer/state/cursor-{chain}.json\`, schema version stamp. **A restart resumes exactly where the prior scan left off** rather than jumping to chain head and dropping in-flight messages.

### 2. Cold-start lookback

\`resolveBootCursor\` in both modules. When no cursor exists, bootstrap from \`currentBlock - bootLookbackBlocks\` (default ~30 min headroom, per-chain-block-time tuned). When a cursor exists but the gap is impossibly old, cap at the lookback floor and emit a loud warning. **Eliminates the original cold-start cursor-skip bug.**

### 3. Chunked \`getLogs\`

New \`lib/get-logs-chunked.ts\`. Every scan window is issued as multiple bounded queries (default 500 blocks for testnets, 10k for Anvil). Per-chunk **async** \`onChunk\` callback ingests + advances the cursor in lockstep — a mid-window failure loses at most one chunk of progress, never the whole window. **Fixes the root cause of the silent stall**: prior code's unbounded range grew past public RPC caps after any outage and was rejected forever.

### 4. RPC timeouts

New \`lib/rpc-utils.ts::withTimeout\`. Every provider call wraps in \`Promise.race\` against a configurable timeout (default 10s). **A wedged TCP socket can no longer pin the poll loop indefinitely.**

### 5. Non-silent errors

Replaces \`catch (e) {}\` with structured logging plus a \`lastError\` field on per-chain state (future health endpoint surfaces it). Cursor stays put on error so the next tick retries — same behaviour as before, just **visible**.

### 6. Confirmation depth

Scans only up to \`currentBlock - confirmationDepth\` (defaults: Sepolia L1 = 6, L2s = 2, Anvil = 0). A reorg between detection and \`relayWithHook\` can't have us submitting attestations for vanished messages.

### 7. Async shutdown

\`stop()\` now awaits the in-flight poll tick before resolving; \`armada-relayer.ts\` shutdown handler awaits \`stop()\` before \`process.exit\`. **A SIGTERM mid-scan can no longer kill the process between the cursor advance and the cursor write.**

## Config

Every knob is per-chain with env-var override pattern \`RELAYER_<KNOB>_<CHAIN>\` — e.g. \`RELAYER_MAX_LOG_RANGE_BASE_SEPOLIA=200\`. Defaults are tuned for known chains; new chains get sensible fallbacks based on name pattern (\`/base|optimism/\`, \`/arbitrum/\`, etc.). See \`relayer/config.ts::scannerConfigForChain\`.

## What's NOT in scope (Phase 2)

Per the plan in \`RELAYER_HARDENING.md\`:
- Per-message retry/backoff in iris-relay (mock has it via \`RetryEntry\`; iris should adopt the same)
- Persistent \`pendingMessages\` + \`processedMessages\` (cursor is enough to close silent-stall; full restart-safety wants these too)
- Parallel \`pollChain\` across chains (today still serial — one slow chain delays the others)
- Bumping \`MAX_ATTESTATION_AGE_MS\` past 30 min for mainnet finality realities
- Explicit \`pendingNonce\` tracking in iris-relay (mock has it; iris is vulnerable to Sepolia nonce drift)
- \`/health\` endpoint + structured logging + Prometheus \`/metrics\` (Phase 3)

## Tests

28 new unit tests in \`relayer/test/lib/\` covering every cursor edge case (missing file, malformed JSON, version mismatch, atomic-write survival on simulated crash), every chunking boundary (exact, partial, single-block, empty range), and timeout cleanup (no timer leaks across loop iterations). Run via \`npm run test:relayer\`.

## Test plan

- [x] \`npm run test:relayer\` — 28/28 pass
- [x] Relayer module typecheck clean
- [ ] **Manual Sepolia validation** (left to user):
  1. **Restart survival**: start relayer, let it process a few cycles, kill -9 the process. Inspect \`relayer/state/cursor-*.json\` — verify cursors persisted. Restart relayer, observe log message confirming resume from persisted cursor.
  2. **Cold-start lookback**: delete \`relayer/state/cursor-*.json\`, submit a cross-chain shield, kill the relayer immediately. Wait 5 min. Restart relayer — confirm it scans back ~30 min and picks up the in-flight message.
  3. **Range-too-large recovery**: set \`RELAYER_MAX_LOG_RANGE_ETHEREUM_SEPOLIA=10\` env var. Submit a shield then wait several minutes before starting the relayer so the scan window is ~hundreds of blocks. Restart with the small range — observe the chunked recovery in logs (\`Found N message(s) in blocks X-X+9\` repeatedly).
  4. **Cursor file inspection**: confirm shape matches the schema documented in \`relayer/state/README.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)