### PR TITLE
feat(relayer): phase 2 hardening — persistent pending state, retry/backoff, nonce tracking, parallel polling, configurable TTL

### DIFF
--- a/relayer/lib/cursor-store.ts
+++ b/relayer/lib/cursor-store.ts
@@ -2,14 +2,13 @@
  * ABOUTME: Per-chain scan cursor persistence — atomic JSON write so a restart resumes from the
  * last successfully-scanned block instead of jumping to the chain head and silently dropping any
  * MessageSent events in the gap.
- * ABOUTME: Mirrors the pattern in crowdfund-ui/packages/indexer/src/db/fileStore.ts (tmpfile +
- * rename) but simpler — single field per file, no migrations beyond the version stamp.
+ * ABOUTME: Thin wrapper over JsonStateStore — the atomic-write + schema-version machinery lives
+ * there. This file just defines the cursor's shape + validation.
  */
 
-import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { JsonStateStore } from "./json-state-store";
 
-/** Schema version. Bump and add a migration when the shape changes. */
+/** Schema version. Bump and add a migration in the JsonStateStore call below when the shape changes. */
 const CURSOR_SCHEMA_VERSION = 1 as const;
 
 export interface CursorData {
@@ -22,98 +21,44 @@ export interface CursorData {
 }
 
 /**
- * Filesystem-backed per-chain cursor store. One file per chain at
- * `<baseDir>/cursor-{chainName}.json`. Atomic writes via tmpfile + rename so a power loss
- * mid-flush cannot corrupt the canonical file.
- *
- * The store is intentionally NOT a cache — every `write` hits the disk synchronously (from the
- * caller's perspective). The polling loop runs at multi-second cadence; the I/O cost is
- * irrelevant relative to the RPC calls themselves, and durability is more valuable than speed.
+ * Filesystem-backed per-chain cursor store. Delegates to `JsonStateStore` for atomic writes +
+ * schema versioning; supplies cursor-specific validation. See JsonStateStore for the on-disk
+ * layout, atomic-rename behaviour, and ENOENT-as-null read contract.
  */
 export class CursorStore {
-  constructor(private readonly baseDir: string) {}
+  private readonly inner: JsonStateStore<CursorData>;
 
-  /**
-   * Read the cursor for a chain. Returns null when the file does not exist (cold start case) —
-   * the caller decides whether to bootstrap from chain-head-minus-lookback or from a configured
-   * floor. Throws on malformed JSON or unexpected shape: don't silently start scanning from
-   * block 0 because a manual edit corrupted the file.
-   */
+  constructor(baseDir: string) {
+    this.inner = new JsonStateStore<CursorData>({
+      baseDir,
+      filenamePrefix: "cursor",
+      expectedVersion: CURSOR_SCHEMA_VERSION,
+      validate,
+    });
+  }
+
   async read(chainName: string): Promise<CursorData | null> {
-    const path = this.pathFor(chainName);
-    try {
-      const raw = await readFile(path, "utf8");
-      const parsed = JSON.parse(raw);
-      return validate(parsed, path, chainName);
-    } catch (err) {
-      if (isENOENT(err)) return null;
-      throw err;
-    }
+    return this.inner.read(chainName);
   }
 
-  /**
-   * Atomically persist a cursor. Writes to `<path>.<pid>.tmp` then renames over the canonical
-   * path — rename is atomic at the filesystem level on POSIX, so even a kill -9 mid-flush leaves
-   * either the old cursor intact or the new one fully present, never a torn write.
-   */
   async write(chainName: string, data: Omit<CursorData, "version">): Promise<void> {
-    const path = this.pathFor(chainName);
-    await mkdir(dirname(path), { recursive: true });
-    const payload: CursorData = {
-      ...data,
-      version: CURSOR_SCHEMA_VERSION,
-    };
-    const tmpPath = `${path}.${process.pid}.tmp`;
-    await writeFile(tmpPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
-    try {
-      await rename(tmpPath, path);
-    } catch (err) {
-      // Rare on POSIX but possible (cross-filesystem move, perms change). Clean up the tmp so
-      // it doesn't sit around as orphaned half-state. Swallow the unlink failure so the caller
-      // sees the ORIGINAL rename error (the actionable one) — leaking an orphan is strictly
-      // less bad than masking the root cause.
-      try {
-        await unlink(tmpPath);
-      } catch {
-        // ignored — orphan tmp on next write attempt will overwrite this anyway (PID-suffixed)
-      }
-      throw err;
-    }
-  }
-
-  /**
-   * Cursor file path for a chain. Sanitises the name (slashes, whitespace) so a config-driven
-   * chain name can never escape the baseDir. We don't expect adversarial input — every chain
-   * name comes from our own `config/networks.ts` — but cheap to lock down anyway.
-   */
-  private pathFor(chainName: string): string {
-    const safe = chainName.toLowerCase().replace(/[^a-z0-9_-]/g, "-");
-    return join(this.baseDir, `cursor-${safe}.json`);
+    // Inner store stamps version automatically — caller supplies just the payload fields.
+    return this.inner.write(chainName, { ...data, version: CURSOR_SCHEMA_VERSION });
   }
 }
 
-function isENOENT(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    (err as { code: string }).code === "ENOENT"
-  );
-}
-
-function validate(parsed: unknown, path: string, chainName: string): CursorData {
-  if (
-    typeof parsed !== "object" ||
-    parsed === null ||
-    typeof (parsed as { lastProcessedBlock?: unknown }).lastProcessedBlock !== "number" ||
-    typeof (parsed as { updatedAt?: unknown }).updatedAt !== "number" ||
-    typeof (parsed as { version?: unknown }).version !== "number"
-  ) {
+function validate(parsed: unknown, chainName: string, path: string): CursorData {
+  const candidate = parsed as { lastProcessedBlock?: unknown; updatedAt?: unknown };
+  if (typeof candidate.lastProcessedBlock !== "number") {
     throw new Error(
-      `cursor-store: malformed cursor file for chain '${chainName}' at ${path}. Delete it to reset to lookback boot.`,
+      `cursor-store: malformed cursor file for chain '${chainName}' at ${path}. Missing or non-numeric lastProcessedBlock. Delete it to reset to lookback boot.`,
     );
   }
-  const candidate = parsed as { lastProcessedBlock: number; updatedAt: number; version: number };
+  if (typeof candidate.updatedAt !== "number") {
+    throw new Error(
+      `cursor-store: malformed cursor file for chain '${chainName}' at ${path}. Missing or non-numeric updatedAt. Delete it to reset.`,
+    );
+  }
   // Range checks. The typeof guard above accepts -Infinity, NaN, Infinity, fractional numbers —
   // none of which are valid block numbers or timestamps. Catch them here so they don't reach
   // the scanner's `Number(...)` casts and turn into silent NaN propagations downstream.
@@ -125,11 +70,6 @@ function validate(parsed: unknown, path: string, chainName: string): CursorData 
   if (!Number.isInteger(candidate.updatedAt) || candidate.updatedAt < 0) {
     throw new Error(
       `cursor-store: invalid updatedAt (${candidate.updatedAt}) for chain '${chainName}' at ${path}. Expected a non-negative integer (Unix ms). Delete to reset.`,
-    );
-  }
-  if (candidate.version !== CURSOR_SCHEMA_VERSION) {
-    throw new Error(
-      `cursor-store: cursor file for chain '${chainName}' at ${path} has unsupported version ${candidate.version} (expected ${CURSOR_SCHEMA_VERSION}). Delete it or add a migration.`,
     );
   }
   return {

--- a/relayer/lib/cursor-store.ts
+++ b/relayer/lib/cursor-store.ts
@@ -47,6 +47,9 @@ export class CursorStore {
   }
 }
 
+// JsonStateStore's validator signature uses `key`; we name it `chainName` here because the
+// cursor-store's only consumers are per-chain — the semantic name reads better in error
+// messages. Same position, same type — just contextual naming.
 function validate(parsed: unknown, chainName: string, path: string): CursorData {
   const candidate = parsed as { lastProcessedBlock?: unknown; updatedAt?: unknown };
   if (typeof candidate.lastProcessedBlock !== "number") {

--- a/relayer/lib/json-state-store.ts
+++ b/relayer/lib/json-state-store.ts
@@ -1,0 +1,133 @@
+/**
+ * ABOUTME: Generic atomic per-key JSON state store — one file per key at <baseDir>/<prefix>-<key>.json
+ * with tmpfile+rename atomic writes, schema versioning, and ENOENT-as-null reads. Cursor store and
+ * pending-message store both layer on top of this primitive.
+ * ABOUTME: WHY: extracted from the original CursorStore so the pending-message persistence (Phase
+ * 2) doesn't duplicate the atomic-write plumbing. One canonical path for "file must be either
+ * old-intact or new-fully-present, never torn" — fewer chances to get it wrong twice.
+ */
+
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+/**
+ * Options for the generic store. The schema-versioning hooks live here so consumers can evolve
+ * their payload format independently — bump `expectedVersion` + add a migrate function and old
+ * files migrate forward at read time.
+ */
+export interface JsonStateStoreOptions<T> {
+  baseDir: string;
+  /** Filename prefix, e.g. "cursor" or "pending". Final file: `<baseDir>/<prefix>-<key>.json`. */
+  filenamePrefix: string;
+  /** Schema version this consumer expects to read/write. */
+  expectedVersion: number;
+  /**
+   * Optional migrator — receives a parsed payload from disk with `payload.version < expectedVersion`,
+   * returns the migrated payload at expectedVersion. If omitted, an older version throws.
+   */
+  migrate?: (oldPayload: unknown, oldVersion: number) => T;
+  /** Validate the payload shape (post-migration). Throw with a useful message on bad input. */
+  validate: (payload: unknown, key: string, path: string) => T;
+}
+
+/**
+ * Per-key atomic JSON state store. Each `key` (typically a chain name) gets its own file —
+ * isolation between keys means a write for chain A can never block or interfere with a read for
+ * chain B. The atomic-write pattern is tmpfile + rename: a `kill -9` mid-write leaves either the
+ * old file intact or the new one fully present, never a torn file.
+ */
+export class JsonStateStore<T> {
+  constructor(private readonly opts: JsonStateStoreOptions<T>) {}
+
+  /**
+   * Read the payload for `key`. Returns null when the file does not exist (cold start case) —
+   * the caller decides whether to bootstrap from defaults or fail loudly. Throws on malformed
+   * JSON, validation failure, or unsupported version without a migrate path: don't silently
+   * use empty defaults because a manual edit corrupted the file.
+   */
+  async read(key: string): Promise<T | null> {
+    const path = this.pathFor(key);
+    try {
+      const raw = await readFile(path, "utf8");
+      const parsed = JSON.parse(raw);
+      return this.coerceVersion(parsed, key, path);
+    } catch (err) {
+      if (isENOENT(err)) return null;
+      throw err;
+    }
+  }
+
+  /**
+   * Atomically persist `payload`. Writes to `<path>.<pid>.tmp` then renames over the canonical
+   * path. On rename failure the tmp is unlinked (best effort — orphan tmp on next attempt would
+   * be PID-suffixed and overwritten anyway).
+   *
+   * The payload's `version` field is stamped from `opts.expectedVersion` — callers don't manage
+   * the version themselves.
+   */
+  async write(key: string, payload: T): Promise<void> {
+    const path = this.pathFor(key);
+    await mkdir(dirname(path), { recursive: true });
+    const versioned = { ...payload, version: this.opts.expectedVersion };
+    const tmpPath = `${path}.${process.pid}.tmp`;
+    await writeFile(tmpPath, `${JSON.stringify(versioned, null, 2)}\n`, "utf8");
+    try {
+      await rename(tmpPath, path);
+    } catch (err) {
+      try {
+        await unlink(tmpPath);
+      } catch {
+        // ignored — orphan tmp will be overwritten on next write (PID-suffixed)
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Resolve version then validate. If the payload's version matches expected, validate directly.
+   * If older AND a migrator exists, migrate then validate. Otherwise throw — refusing to load an
+   * unsupported version is the difference between "operator notices early" and "data corruption
+   * propagates silently."
+   */
+  private coerceVersion(parsed: unknown, key: string, path: string): T {
+    if (typeof parsed !== "object" || parsed === null) {
+      throw new Error(
+        `${this.opts.filenamePrefix}-store: malformed payload for key '${key}' at ${path}. Expected an object.`,
+      );
+    }
+    const version = (parsed as { version?: unknown }).version;
+    if (typeof version !== "number" || !Number.isInteger(version)) {
+      throw new Error(
+        `${this.opts.filenamePrefix}-store: missing or invalid version in payload for key '${key}' at ${path}.`,
+      );
+    }
+    if (version === this.opts.expectedVersion) {
+      return this.opts.validate(parsed, key, path);
+    }
+    if (version < this.opts.expectedVersion && this.opts.migrate) {
+      const migrated = this.opts.migrate(parsed, version);
+      return this.opts.validate(migrated, key, path);
+    }
+    throw new Error(
+      `${this.opts.filenamePrefix}-store: unsupported version ${version} for key '${key}' at ${path} (expected ${this.opts.expectedVersion}). Delete the file or add a migration.`,
+    );
+  }
+
+  /**
+   * File path for a key. Sanitises the name (slashes, whitespace, capitalisation) so a
+   * config-driven key cannot escape baseDir via path traversal.
+   */
+  private pathFor(key: string): string {
+    const safe = key.toLowerCase().replace(/[^a-z0-9_-]/g, "-");
+    return join(this.opts.baseDir, `${this.opts.filenamePrefix}-${safe}.json`);
+  }
+}
+
+function isENOENT(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: string }).code === "ENOENT"
+  );
+}

--- a/relayer/lib/pending-state-store.ts
+++ b/relayer/lib/pending-state-store.ts
@@ -1,0 +1,183 @@
+/**
+ * ABOUTME: Per-source-chain persistence for pendingMessages + processedMessages — survives
+ * restarts so we (a) don't re-relay messages already delivered (gas savings) and (b) don't
+ * lose visibility into messages waiting on Iris attestation.
+ * ABOUTME: Sibling of CursorStore using the same JsonStateStore primitive — one file per source
+ * chain at relayer/state/pending-<chain>.json. Atomic writes, schema-versioned.
+ */
+
+import { JsonStateStore } from "./json-state-store";
+
+const PENDING_SCHEMA_VERSION = 1 as const;
+
+/**
+ * Persisted shape of a pending CCTP message. Mirrors the iris-relay `PendingMessage` interface
+ * with two NEW fields for Phase 2 (`retryAttempts`, `nextRetryAt`) that support per-message
+ * retry/backoff on relayWithHook failures.
+ */
+export interface PersistedPendingMessage {
+  messageBytes: string;
+  messageHash: string;
+  sourceDomain: number;
+  destinationDomain: number;
+  nonce: string;
+  sourceTxHash: string;
+  sourceBlock: number;
+  detectedAt: number;
+  pollAttempts: number;
+  lastStatus: string;
+  /** Failed-relay retry counter; null means no relay attempted yet. Capped at MAX_RELAY_RETRIES. */
+  retryAttempts: number;
+  /** Unix ms — relay attempts before this time are blocked by the backoff scheduler. 0 = no wait. */
+  nextRetryAt: number;
+}
+
+export interface PendingStateData {
+  pending: PersistedPendingMessage[];
+  /**
+   * Set of messageHashes we've already delivered (relayWithHook returned success OR the contract
+   * said "already processed"). Used to short-circuit `enqueueMessage` when the scanner re-discovers
+   * a message after a restart. Stored as a sorted array on disk for JSON-friendliness.
+   *
+   * Note: this grows without bound at the relayer's current volume (handful of messages per hour
+   * at most). At ~70 bytes per hash, 10k entries = 700KB. Future Phase 3 polish: prune entries
+   * older than MAX_ATTESTATION_AGE_MS × 2 since they're irrelevant by then.
+   */
+  processed: string[];
+  updatedAt: number;
+  version: typeof PENDING_SCHEMA_VERSION;
+}
+
+/**
+ * Filesystem-backed per-source-chain pending state. The key is the SOURCE chain name (where
+ * MessageSent was emitted) because that's the dimension the iris-relay's `pendingMessages` Map
+ * is implicitly keyed by — each chain's state owns its own pendingMessages.
+ *
+ * Mutation pattern: load on init → mutate in memory → write the whole snapshot back on every
+ * change. Writes are cheap (single-file, atomic rename, small payload) but the caller MUST
+ * await the write before returning from the mutating operation, otherwise a crash between
+ * mutation + write would lose the change.
+ */
+export class PendingStateStore {
+  private readonly inner: JsonStateStore<PendingStateData>;
+
+  constructor(baseDir: string) {
+    this.inner = new JsonStateStore<PendingStateData>({
+      baseDir,
+      filenamePrefix: "pending",
+      expectedVersion: PENDING_SCHEMA_VERSION,
+      validate,
+    });
+  }
+
+  async read(chainName: string): Promise<PendingStateData | null> {
+    return this.inner.read(chainName);
+  }
+
+  async write(
+    chainName: string,
+    pending: PersistedPendingMessage[],
+    processed: Set<string>,
+  ): Promise<void> {
+    const sortedProcessed = Array.from(processed).sort();
+    await this.inner.write(chainName, {
+      pending,
+      processed: sortedProcessed,
+      updatedAt: Date.now(),
+      version: PENDING_SCHEMA_VERSION,
+    });
+  }
+}
+
+function validate(
+  parsed: unknown,
+  chainName: string,
+  path: string,
+): PendingStateData {
+  const candidate = parsed as { pending?: unknown; processed?: unknown; updatedAt?: unknown };
+  if (!Array.isArray(candidate.pending)) {
+    throw new Error(
+      `pending-store: invalid 'pending' field for chain '${chainName}' at ${path}. Expected an array. Delete to reset.`,
+    );
+  }
+  if (!Array.isArray(candidate.processed)) {
+    throw new Error(
+      `pending-store: invalid 'processed' field for chain '${chainName}' at ${path}. Expected an array. Delete to reset.`,
+    );
+  }
+  if (
+    typeof candidate.updatedAt !== "number" ||
+    !Number.isInteger(candidate.updatedAt) ||
+    candidate.updatedAt < 0
+  ) {
+    throw new Error(
+      `pending-store: invalid 'updatedAt' field for chain '${chainName}' at ${path}. Expected a non-negative integer (Unix ms). Delete to reset.`,
+    );
+  }
+  // Per-element shape check on pending — loud failure on a corrupted entry rather than
+  // propagating undefined fields into the relay loop. We're permissive about extra fields so
+  // a future writer that added a field can still be read by an older reader.
+  const pending = candidate.pending.map((msg, idx) =>
+    validatePending(msg, chainName, path, idx),
+  );
+  // Processed entries are just message-hash strings; light validation.
+  const processed = candidate.processed.map((s, idx) => {
+    if (typeof s !== "string") {
+      throw new Error(
+        `pending-store: processed[${idx}] for chain '${chainName}' at ${path} is not a string. Delete to reset.`,
+      );
+    }
+    return s;
+  });
+  return {
+    pending,
+    processed,
+    updatedAt: candidate.updatedAt,
+    version: PENDING_SCHEMA_VERSION,
+  };
+}
+
+function validatePending(
+  msg: unknown,
+  chainName: string,
+  path: string,
+  idx: number,
+): PersistedPendingMessage {
+  if (typeof msg !== "object" || msg === null) {
+    throw new Error(
+      `pending-store: pending[${idx}] for chain '${chainName}' at ${path} is not an object.`,
+    );
+  }
+  const m = msg as Partial<PersistedPendingMessage>;
+  const requiredStrings: (keyof PersistedPendingMessage)[] = [
+    "messageBytes",
+    "messageHash",
+    "nonce",
+    "sourceTxHash",
+    "lastStatus",
+  ];
+  for (const field of requiredStrings) {
+    if (typeof m[field] !== "string") {
+      throw new Error(
+        `pending-store: pending[${idx}].${String(field)} for chain '${chainName}' at ${path} is not a string.`,
+      );
+    }
+  }
+  const requiredNumbers: (keyof PersistedPendingMessage)[] = [
+    "sourceDomain",
+    "destinationDomain",
+    "sourceBlock",
+    "detectedAt",
+    "pollAttempts",
+    "retryAttempts",
+    "nextRetryAt",
+  ];
+  for (const field of requiredNumbers) {
+    if (typeof m[field] !== "number" || !Number.isFinite(m[field] as number)) {
+      throw new Error(
+        `pending-store: pending[${idx}].${String(field)} for chain '${chainName}' at ${path} is not a finite number.`,
+      );
+    }
+  }
+  return m as PersistedPendingMessage;
+}

--- a/relayer/lib/pending-state-store.ts
+++ b/relayer/lib/pending-state-store.ts
@@ -80,6 +80,17 @@ export class PendingStateStore {
     processed: Set<string>,
   ): Promise<void> {
     const sortedProcessed = Array.from(processed).sort();
+    // Defensive size signal — fires when the processed-hash set grows past a level that
+    // suggests either real volume scale-up or a dedup bug. At the relayer's intended POC
+    // volume (handful per hour) we expect <100 entries even after months of uptime; crossing
+    // 10k means either we should ship the Phase 3 prune logic OR something is wrong (e.g. the
+    // dedup short-circuit in enqueueMessage broke and we're re-adding hashes that should have
+    // been caught). Either way operators should investigate.
+    if (sortedProcessed.length > PROCESSED_SET_WARN_THRESHOLD) {
+      console.warn(
+        `[pending-store] ${chainName}: processed-hash set has grown to ${sortedProcessed.length} entries (warn threshold ${PROCESSED_SET_WARN_THRESHOLD}). At current volume this is unexpected — investigate or ship Phase 3 prune logic.`,
+      );
+    }
     await this.inner.write(chainName, {
       pending,
       processed: sortedProcessed,
@@ -88,6 +99,9 @@ export class PendingStateStore {
     });
   }
 }
+
+/** Loud-log threshold for the processed-set size — see comment in PendingStateStore.write. */
+const PROCESSED_SET_WARN_THRESHOLD = 10_000;
 
 function validate(
   parsed: unknown,

--- a/relayer/modules/cctp-relay.ts
+++ b/relayer/modules/cctp-relay.ts
@@ -836,11 +836,11 @@ export class CCTPRelayModule {
     });
     try {
       while (this.isRunning) {
-        // Poll all chains for new messages
-        for (const state of this.chains.values()) {
-          if (!this.isRunning) break;
-          await this.pollChain(state);
-        }
+        // Poll all chains for new messages — in PARALLEL. pollChain has its own try/catch that
+        // writes to state.lastError, so a failure on one chain doesn't reject the Promise
+        // (allSettled is belt + braces). One slow chain no longer delays others.
+        const chainStates = Array.from(this.chains.values());
+        await Promise.allSettled(chainStates.map((state) => this.pollChain(state)));
 
         if (!this.isRunning) break;
 

--- a/relayer/modules/cctp-relay.ts
+++ b/relayer/modules/cctp-relay.ts
@@ -840,7 +840,20 @@ export class CCTPRelayModule {
         // writes to state.lastError, so a failure on one chain doesn't reject the Promise
         // (allSettled is belt + braces). One slow chain no longer delays others.
         const chainStates = Array.from(this.chains.values());
-        await Promise.allSettled(chainStates.map((state) => this.pollChain(state)));
+        const pollResults = await Promise.allSettled(
+          chainStates.map((state) => this.pollChain(state)),
+        );
+        // Defensive: see iris-relay's runPollLoop for the rationale — log any rejection that
+        // somehow slipped past pollChain's inner try/catch.
+        for (let i = 0; i < pollResults.length; i++) {
+          const r = pollResults[i];
+          if (r?.status === "rejected") {
+            const chainName = chainStates[i]?.config.name ?? "unknown";
+            console.error(
+              `[cctp-relay] ${chainName}: pollChain rejected unexpectedly (bypassed inner try/catch): ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`,
+            );
+          }
+        }
 
         if (!this.isRunning) break;
 

--- a/relayer/modules/iris-relay.ts
+++ b/relayer/modules/iris-relay.ts
@@ -29,6 +29,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { CursorStore } from "../lib/cursor-store";
 import { getLogsChunked } from "../lib/get-logs-chunked";
+import { PendingStateStore, type PersistedPendingMessage } from "../lib/pending-state-store";
 import { RpcTimeoutError, withTimeout } from "../lib/rpc-utils";
 
 /** Where per-chain cursor files live. Module-relative so the relayer is location-independent. */
@@ -57,6 +58,17 @@ interface PendingMessage {
   pollAttempts: number;
   /** Last Iris status seen */
   lastStatus: string;
+  /**
+   * Number of relayWithHook attempts that FAILED (not counting "already processed" — that's
+   * success-equivalent). Capped at MAX_RELAY_RETRIES; on cap we expire the message with a
+   * loud log so the operator can manually investigate.
+   */
+  retryAttempts: number;
+  /**
+   * Unix ms — when the next relay attempt is allowed. Set to `now + backoffMs` on each failure;
+   * `processPendingMessages` skips entries with `nextRetryAt > now`. 0 = no backoff active.
+   */
+  nextRetryAt: number;
 }
 
 interface IrisMessageResponse {
@@ -83,7 +95,11 @@ interface ChainState {
    * at most one chunk of replay, never the entire scan window.
    */
   lastProcessedBlock: number;
-  /** Set of canonical message hashes we've enqueued. In-memory only — dedup across restarts comes from the contract's "already processed" check. */
+  /**
+   * Set of canonical message hashes we've enqueued + completed (relayed OR "already processed"
+   * on the destination). Restart-safe via PendingStateStore — survives so we don't burn gas
+   * re-relaying messages already delivered before the restart.
+   */
   processedMessages: Set<string>;
   /**
    * Last scan error for this chain, or null when the most recent tick succeeded. Surfaces in
@@ -93,6 +109,15 @@ interface ChainState {
   lastError: { message: string; at: number } | null;
   /** Unix ms of the last successful scan tick. Used by the future health endpoint. */
   lastScanAt: number;
+  /**
+   * Locally-tracked pending nonce for transactions THIS relayer sends to this chain. Refreshed
+   * from `eth_getTransactionCount(addr, 'pending')` on first use or after a nonce error. Without
+   * this, the production CCTP relay is vulnerable to the Sepolia load-balancer nonce drift that
+   * project memory documents: a fresh request lands on a backend that hasn't seen the prior
+   * submit's nonce yet, ethers picks a stale "pending" → "nonce too low" rejection. The
+   * mock cctp-relay has done this for a while; production iris-relay was the gap.
+   */
+  pendingNonce: number | null;
 }
 
 // ============ Constants ============
@@ -154,8 +179,31 @@ const BURN_MSG_MINT_RECIPIENT_OFFSET = 36;
 const MINT_RECIPIENT_ABSOLUTE_OFFSET = MSG_BODY_OFFSET + BURN_MSG_MINT_RECIPIENT_OFFSET;
 const MINT_RECIPIENT_LENGTH = 32;
 
-/** Max time to keep polling for an attestation before giving up (ms) */
-const MAX_ATTESTATION_AGE_MS = 30 * 60 * 1000; // 30 minutes
+/**
+ * Max time to keep polling for an attestation before giving up (ms). Default 60 min, configurable
+ * via `RELAYER_ATTESTATION_AGE_MS` env var. The previous 30-min default was thin for mainnet —
+ * Ethereum standard-finality CCTP attestations land at 15-19 min and occasionally take longer.
+ */
+const MAX_ATTESTATION_AGE_MS = (() => {
+  const raw = process.env.RELAYER_ATTESTATION_AGE_MS;
+  if (raw === undefined || raw === "") return 60 * 60 * 1000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 60_000) {
+    throw new Error(
+      `Invalid RELAYER_ATTESTATION_AGE_MS=${raw} — expected a number ≥ 60000 (1 minute floor).`,
+    );
+  }
+  return parsed;
+})();
+
+/**
+ * Per-message retry policy for failed relayWithHook submissions. Mirrors cctp-relay's
+ * RetryEntry constants. 5 attempts with exponential backoff (2s/4s/8s/16s/32s) — total ~62s
+ * before giving up, which is enough to ride out a brief destination-chain RPC blip without
+ * pinning the loop on a permanently-failing tx.
+ */
+const MAX_RELAY_RETRIES = 5;
+const RELAY_RETRY_BASE_DELAY_MS = 2_000;
 
 // ============ Helpers ============
 
@@ -270,12 +318,14 @@ export class IrisRelayModule {
   private irisClient: IrisClient;
   private pendingMessages: Map<string, PendingMessage> = new Map();
   private cursorStore: CursorStore;
+  private pendingStateStore: PendingStateStore;
 
   constructor() {
     const { iris } = armadaRelayerSettings;
     this.pollIntervalMs = armadaRelayerSettings.cctpPollIntervalMs;
     this.irisClient = new IrisClient(iris.apiUrl);
     this.cursorStore = new CursorStore(RELAYER_STATE_DIR);
+    this.pendingStateStore = new PendingStateStore(RELAYER_STATE_DIR);
   }
 
   async initialize(): Promise<boolean> {
@@ -354,6 +404,38 @@ export class IrisRelayModule {
       // MessageSent emitted before the relayer started OR during a restart window.
       const lastProcessedBlock = await this.resolveBootCursor(chainConfig, currentBlock);
 
+      // Load persisted pendingMessages + processedMessages — restart-safe. Without this, any
+      // message that was mid-attestation when the relayer stopped would have to be
+      // re-discovered by the scanner (works because cursor is persisted), but messages already
+      // successfully relayed before restart would be re-relayed and burn gas on the contract's
+      // "already processed" check.
+      const processedMessages = new Set<string>();
+      try {
+        const persisted = await this.pendingStateStore.read(chainConfig.name);
+        if (persisted) {
+          // Re-hydrate pendingMessages from disk. Keyed by messageHash in the module-level
+          // Map; entries from THIS source chain get added back so processPendingMessages can
+          // continue waiting on Iris where we left off (preserving pollAttempts / retry state).
+          let restored = 0;
+          for (const p of persisted.pending) {
+            this.pendingMessages.set(p.messageHash, p);
+            restored++;
+          }
+          for (const hash of persisted.processed) {
+            processedMessages.add(hash);
+          }
+          if (restored > 0 || persisted.processed.length > 0) {
+            console.log(
+              `  [iris-relay] ${chainConfig.name}: Restored ${restored} pending + ${persisted.processed.length} processed message(s) from disk`,
+            );
+          }
+        }
+      } catch (err: any) {
+        console.error(
+          `  [iris-relay] ${chainConfig.name}: Pending-state file unreadable (${err.message}). Starting with empty pending state — Iris will re-attest any in-flight message and the next scan will re-discover them via the cursor.`,
+        );
+      }
+
       return {
         config: chainConfig,
         provider,
@@ -363,9 +445,10 @@ export class IrisRelayModule {
         knownRecipients,
         domain: chainConfig.cctpDomain,
         lastProcessedBlock,
-        processedMessages: new Set(),
+        processedMessages,
         lastError: null,
         lastScanAt: 0,
+        pendingNonce: null,
       };
     } catch (e: any) {
       console.error(`    Connection error: ${e.message}`);
@@ -440,6 +523,36 @@ export class IrisRelayModule {
 
   private getChainByDomain(domain: number): ChainState | undefined {
     return this.chains.get(domain);
+  }
+
+  /**
+   * Snapshot this chain's pending + processed state to disk. Called from every mutation site
+   * (enqueueMessage, processPendingMessages success/failure/expiry). One write per chain per
+   * mutation batch — bounded by chain count, not by message count.
+   *
+   * Errors are logged but NOT propagated. The next mutation will retry the write; in the
+   * meantime the in-memory state is correct and the relay loop continues. Persistence is
+   * best-effort within a tick but eventually-consistent (we'd lose at most one tick's worth
+   * of state if the disk goes away entirely).
+   */
+  private async persistChain(state: ChainState): Promise<void> {
+    try {
+      const pendingForChain: PersistedPendingMessage[] = [];
+      for (const msg of this.pendingMessages.values()) {
+        if (msg.sourceDomain === state.domain) {
+          pendingForChain.push(msg);
+        }
+      }
+      await this.pendingStateStore.write(
+        state.config.name,
+        pendingForChain,
+        state.processedMessages,
+      );
+    } catch (err: any) {
+      console.error(
+        `  [iris-relay] ${state.config.name}: Failed to persist pending state (${err.message}). In-memory state is correct; next mutation will retry.`,
+      );
+    }
   }
 
   // ========== Event Scanning ==========
@@ -594,9 +707,15 @@ export class IrisRelayModule {
       detectedAt: Date.now(),
       pollAttempts: 0,
       lastStatus: "new",
+      retryAttempts: 0,
+      nextRetryAt: 0,
     };
 
     this.pendingMessages.set(messageHash, pending);
+    // Persist immediately so a crash between enqueue and the first Iris poll doesn't lose
+    // this entry — the cursor has already advanced past sourceBlock, so without persistence
+    // the scanner wouldn't re-discover it.
+    void this.persistChain(sourceState);
 
     const irisUrl = this.irisClient.getUrl(sourceDomain, log.transactionHash);
 
@@ -623,17 +742,34 @@ export class IrisRelayModule {
     if (this.pendingMessages.size === 0) return;
 
     const entries = Array.from(this.pendingMessages.entries());
+    // Track which source chains had any state mutation this tick so we persist them ONCE at
+    // the end rather than per-message — keeps disk write count linear in chains, not messages.
+    const dirtyChains = new Set<ChainState>();
+
     for (const [hash, msg] of entries) {
+      const sourceState = this.getChainByDomain(msg.sourceDomain);
+
       // Check if expired
       const age = Date.now() - msg.detectedAt;
       if (age > MAX_ATTESTATION_AGE_MS) {
-        console.log(
+        // Loud expiry log — distinct from steady-state console.log so operators monitoring for
+        // EXPIRED have an actionable signal before the message is dropped from memory + disk.
+        console.error(
           `\n[iris-relay] EXPIRED: message ${hash.slice(0, 18)}... after ${elapsed(msg.detectedAt)} ` +
-          `(${msg.pollAttempts} polls, last status: ${msg.lastStatus})`
+          `(${msg.pollAttempts} polls, ${msg.retryAttempts} relay retries, last status: ${msg.lastStatus})`
         );
-        console.log(`  Source Tx: ${msg.sourceTxHash}`);
-        console.log(`  Iris URL:  ${this.irisClient.getUrl(msg.sourceDomain, msg.sourceTxHash)}`);
+        console.error(`  Source Tx: ${msg.sourceTxHash}`);
+        console.error(`  Iris URL:  ${this.irisClient.getUrl(msg.sourceDomain, msg.sourceTxHash)}`);
+        console.error(`  Manual recovery: fetch attestation from Iris + call hookRouter.relayWithHook on destination chain.`);
         this.pendingMessages.delete(hash);
+        if (sourceState) dirtyChains.add(sourceState);
+        continue;
+      }
+
+      // Skip if we're inside a backoff window from a prior relay failure. The scanner keeps
+      // the message in pendingMessages so it's surfaced again on the next tick after the
+      // backoff expires.
+      if (msg.nextRetryAt > Date.now()) {
         continue;
       }
 
@@ -672,11 +808,34 @@ export class IrisRelayModule {
 
       const relayed = await this.relayMessage(msg, result.attestation, result.message);
       if (relayed) {
-        // Mark as processed on the source chain state
-        const sourceState = this.getChainByDomain(msg.sourceDomain);
+        // Mark as processed on the source chain state + remove from pending. Persist below.
         if (sourceState) sourceState.processedMessages.add(hash);
+        this.pendingMessages.delete(hash);
+        if (sourceState) dirtyChains.add(sourceState);
+      } else {
+        // Relay failed — schedule a retry per backoff or give up if cap reached.
+        msg.retryAttempts++;
+        if (msg.retryAttempts >= MAX_RELAY_RETRIES) {
+          console.error(
+            `[iris-relay] GAVE UP on relayMessage for ${hash.slice(0, 18)}... after ${msg.retryAttempts} attempts. Source Tx: ${msg.sourceTxHash}. Manual recovery may be required.`,
+          );
+          this.pendingMessages.delete(hash);
+          if (sourceState) dirtyChains.add(sourceState);
+        } else {
+          // Exponential backoff: 2s, 4s, 8s, 16s, 32s for attempts 1-5.
+          const backoffMs = RELAY_RETRY_BASE_DELAY_MS * Math.pow(2, msg.retryAttempts - 1);
+          msg.nextRetryAt = Date.now() + backoffMs;
+          console.log(
+            `  [iris-relay] relayMessage retry ${msg.retryAttempts}/${MAX_RELAY_RETRIES} for ${hash.slice(0, 18)}... in ${backoffMs}ms`,
+          );
+          if (sourceState) dirtyChains.add(sourceState);
+        }
       }
-      this.pendingMessages.delete(hash);
+    }
+
+    // One disk write per dirty chain at end-of-tick — bounded by chain count, not message count.
+    for (const state of dirtyChains) {
+      await this.persistChain(state);
     }
   }
 
@@ -700,6 +859,21 @@ export class IrisRelayModule {
 
       console.log(`  Source Tx: ${msg.sourceTxHash}`);
 
+      // Initialise / refresh explicit nonce tracking for this destination chain. The provider's
+      // `getTransactionCount('pending')` is the source of truth on first use; we then bump
+      // locally to avoid round-tripping for every relay. Resets to null on nonce errors so the
+      // catch block below can recover.
+      if (destState.pendingNonce === null) {
+        destState.pendingNonce = await destState.provider.getTransactionCount(
+          destState.wallet.address,
+          "pending",
+        );
+        console.log(
+          `  Initialized tx nonce for ${destState.config.name}: ${destState.pendingNonce}`,
+        );
+      }
+      const txNonce = destState.pendingNonce;
+
       // Use hookRouter.relayWithHook() to atomically call receiveMessage + hook dispatch
       let tx: ethers.ContractTransactionResponse;
       if (destState.hookRouter) {
@@ -708,19 +882,28 @@ export class IrisRelayModule {
           HOOK_ROUTER_ABI,
           destState.wallet
         );
-        console.log(`  Sending relayWithHook to ${destState.config.name} via CCTPHookRouter...`);
-        tx = await hookRouter.relayWithHook(msgToRelay, attestation);
+        console.log(
+          `  Sending relayWithHook to ${destState.config.name} via CCTPHookRouter (tx nonce: ${txNonce})...`,
+        );
+        tx = await hookRouter.relayWithHook(msgToRelay, attestation, { nonce: txNonce });
       } else {
         const messageTransmitter = new ethers.Contract(
           destState.messageTransmitter,
           REAL_MESSAGE_TRANSMITTER_ABI,
           destState.wallet
         );
-        console.log(`  Sending receiveMessage to ${destState.config.name}...`);
-        tx = await messageTransmitter.receiveMessage(msgToRelay, attestation);
+        console.log(
+          `  Sending receiveMessage to ${destState.config.name} (tx nonce: ${txNonce})...`,
+        );
+        tx = await messageTransmitter.receiveMessage(msgToRelay, attestation, { nonce: txNonce });
       }
-      console.log(`  Tx hash: ${tx.hash}`);
 
+      // Bump immediately — even if .wait() throws below, the next relay attempt should use
+      // nonce+1 (the broadcast already happened). The catch's nonce-reset only fires for
+      // errors that happen BEFORE the send returns.
+      destState.pendingNonce = txNonce + 1;
+
+      console.log(`  Tx hash: ${tx.hash}`);
       const receipt = await tx.wait();
       console.log(`  Confirmed in block ${receipt?.blockNumber}`);
       console.log(`  Relay successful`);
@@ -732,6 +915,18 @@ export class IrisRelayModule {
       ) {
         console.log(`  Already processed on-chain, marking as done`);
         return true;
+      }
+      // Nonce-class errors (Sepolia load-balancer drift, replacement underpriced, etc.) — reset
+      // the local cache so the next attempt re-reads from the provider. Don't surface as a
+      // hard failure since the underlying state may already be correct on chain.
+      if (
+        e.message?.includes("nonce") ||
+        e.message?.includes("NONCE") ||
+        e.code === "NONCE_EXPIRED" ||
+        e.code === "REPLACEMENT_UNDERPRICED"
+      ) {
+        console.log(`  Nonce error detected, refreshing on next attempt`);
+        destState.pendingNonce = null;
       }
       console.error(`  [iris-relay] Relay failed: ${e.message || e}`);
       return false;
@@ -772,12 +967,12 @@ export class IrisRelayModule {
     });
     try {
       while (this.isRunning) {
-        // 1. Scan all chains for new MessageSent events
+        // 1. Scan all chains for new MessageSent events — in PARALLEL. pollChain has its own
+        //    try/catch that writes to state.lastError, so a failure on one chain doesn't reject
+        //    the Promise (allSettled is belt + braces for the unexpected). One slow chain (e.g.
+        //    a stuck Iris attestation lookup) no longer delays every other chain's tick.
         const chainStates = Array.from(this.chains.values());
-        for (const state of chainStates) {
-          if (!this.isRunning) break;
-          await this.pollChain(state);
-        }
+        await Promise.allSettled(chainStates.map((state) => this.pollChain(state)));
 
         if (!this.isRunning) break;
 

--- a/relayer/modules/iris-relay.ts
+++ b/relayer/modules/iris-relay.ts
@@ -972,7 +972,22 @@ export class IrisRelayModule {
         //    the Promise (allSettled is belt + braces for the unexpected). One slow chain (e.g.
         //    a stuck Iris attestation lookup) no longer delays every other chain's tick.
         const chainStates = Array.from(this.chains.values());
-        await Promise.allSettled(chainStates.map((state) => this.pollChain(state)));
+        const pollResults = await Promise.allSettled(
+          chainStates.map((state) => this.pollChain(state)),
+        );
+        // Defensive: pollChain's own catch should swallow + log everything into state.lastError,
+        // so a rejection here means an unexpected throw BEFORE pollChain entered its try (impossible
+        // under normal code paths, but the test harness or a future refactor could regress this).
+        // Log loudly so the operator sees it instead of a silent allSettled swallow.
+        for (let i = 0; i < pollResults.length; i++) {
+          const r = pollResults[i];
+          if (r?.status === "rejected") {
+            const chainName = chainStates[i]?.config.name ?? "unknown";
+            console.error(
+              `[iris-relay] ${chainName}: pollChain rejected unexpectedly (bypassed inner try/catch): ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`,
+            );
+          }
+        }
 
         if (!this.isRunning) break;
 

--- a/relayer/test/lib/cursor-store.test.ts
+++ b/relayer/test/lib/cursor-store.test.ts
@@ -53,7 +53,11 @@ describe("CursorStore", function () {
       }
     });
 
-    it("throws on unexpected shape (missing required fields)", async function () {
+    it("throws on unexpected shape — missing version field caught by inner store", async function () {
+      // WHY: a payload without a version stamp fails at the JsonStateStore layer (which checks
+      // version before delegating to the cursor-specific validator). The error message includes
+      // "missing or invalid version" — more actionable than a generic "malformed" since it
+      // points at the specific field operators need to fix.
       const store = new CursorStore(dir);
       const path = join(dir, "cursor-hub.json");
       await writeFile(path, JSON.stringify({ foo: "bar" }), "utf8");
@@ -61,7 +65,22 @@ describe("CursorStore", function () {
         await store.read("hub");
         expect.fail("should have thrown");
       } catch (err) {
-        expect((err as Error).message).to.match(/malformed cursor/);
+        expect((err as Error).message).to.match(/missing or invalid version|malformed cursor/);
+      }
+    });
+
+    it("throws on cursor-specific shape errors when version IS present but other fields are missing", async function () {
+      // WHY: when version is valid but lastProcessedBlock/updatedAt are absent or wrong type,
+      // the cursor-specific validator (downstream of the version check) catches it with a
+      // message that identifies the chain by name.
+      const store = new CursorStore(dir);
+      const path = join(dir, "cursor-hub.json");
+      await writeFile(path, JSON.stringify({ version: 1, foo: "bar" }), "utf8");
+      try {
+        await store.read("hub");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.match(/malformed cursor file for chain 'hub'/);
       }
     });
 

--- a/relayer/test/lib/pending-state-store.test.ts
+++ b/relayer/test/lib/pending-state-store.test.ts
@@ -1,0 +1,182 @@
+// ABOUTME: Tests for PendingStateStore — per-source-chain persistence of pending CCTP messages + processed dedup set.
+// ABOUTME: WHY: in-memory pendingMessages was the second silent-data-loss surface after the cursor. A restart between MessageSent discovery and Iris attestation completion would forget the in-flight message entirely; with persistence the next boot re-loads exactly the same state. The validation tests pin the format invariants so a corrupted file is caught loudly rather than rehydrated as garbage.
+
+import { expect } from "chai";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  PendingStateStore,
+  type PersistedPendingMessage,
+} from "../../lib/pending-state-store";
+
+function samplePending(overrides: Partial<PersistedPendingMessage> = {}): PersistedPendingMessage {
+  return {
+    messageBytes: "0xabcd",
+    messageHash: "0xhash1",
+    sourceDomain: 6,
+    destinationDomain: 0,
+    nonce: "0xnonce",
+    sourceTxHash: "0xtx1",
+    sourceBlock: 12345,
+    detectedAt: 1_700_000_000_000,
+    pollAttempts: 2,
+    lastStatus: "pending",
+    retryAttempts: 0,
+    nextRetryAt: 0,
+    ...overrides,
+  };
+}
+
+describe("PendingStateStore", function () {
+  let dir: string;
+
+  beforeEach(async function () {
+    dir = await mkdtemp(join(tmpdir(), "pending-store-"));
+  });
+
+  afterEach(async function () {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  describe("read/write round trip", function () {
+    it("returns null when the file does not exist (cold start)", async function () {
+      // WHY: cold-start contract matches CursorStore — null signals "no prior state, bootstrap
+      // from empty pending + empty processed set."
+      const store = new PendingStateStore(dir);
+      expect(await store.read("base-sepolia")).to.equal(null);
+    });
+
+    it("round-trips an empty state (no pending messages, no processed entries)", async function () {
+      // WHY: the first write after init typically happens before any messages are enqueued.
+      // The empty state must serialize/deserialize cleanly — a writer that rejected empty
+      // arrays would block first-cycle persistence.
+      const store = new PendingStateStore(dir);
+      await store.write("hub", [], new Set());
+      const got = await store.read("hub");
+      expect(got?.pending).to.deep.equal([]);
+      expect(got?.processed).to.deep.equal([]);
+      expect(got?.updatedAt).to.be.a("number");
+    });
+
+    it("round-trips pending messages + processed hashes", async function () {
+      const store = new PendingStateStore(dir);
+      const pending = [
+        samplePending({ messageHash: "0xa", sourceTxHash: "0xtxA" }),
+        samplePending({ messageHash: "0xb", sourceTxHash: "0xtxB", pollAttempts: 5 }),
+      ];
+      const processed = new Set(["0xdone1", "0xdone2"]);
+      await store.write("hub", pending, processed);
+
+      const got = await store.read("hub");
+      expect(got?.pending).to.have.lengthOf(2);
+      expect(got?.pending[0]?.messageHash).to.equal("0xa");
+      expect(got?.pending[1]?.pollAttempts).to.equal(5);
+      expect(got?.processed).to.have.members(["0xdone1", "0xdone2"]);
+    });
+
+    it("sorts processed hashes on write — stable file content across runs", async function () {
+      // WHY: stable on-disk content means a no-op write doesn't dirty the file. Useful for
+      // operators diffing state between snapshots / for any future "did this change?" check.
+      const store = new PendingStateStore(dir);
+      await store.write("hub", [], new Set(["0xb", "0xa", "0xc"]));
+      const got = await store.read("hub");
+      expect(got?.processed).to.deep.equal(["0xa", "0xb", "0xc"]);
+    });
+  });
+
+  describe("validation", function () {
+    it("throws on a pending entry missing a required string field", async function () {
+      // WHY: a corrupted entry where messageBytes is null/missing must NOT be loaded as
+      // undefined into the relayer — the downstream relayMessage call would either crash with
+      // a confusing error or (worse) submit garbage. Loud failure at the boundary forces the
+      // operator to investigate (delete the file, restart, scanner re-discovers from chain).
+      const store = new PendingStateStore(dir);
+      const path = join(dir, "pending-hub.json");
+      // Manually construct corrupted JSON — version stamp valid but pending entry missing fields.
+      await writeFile(
+        path,
+        JSON.stringify({
+          pending: [{ messageHash: "0xa" /* missing the rest */ }],
+          processed: [],
+          updatedAt: 1,
+          version: 1,
+        }),
+        "utf8",
+      );
+      try {
+        await store.read("hub");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.match(/pending\[0\]/);
+      }
+    });
+
+    it("throws when 'pending' is not an array", async function () {
+      const store = new PendingStateStore(dir);
+      const path = join(dir, "pending-hub.json");
+      await writeFile(
+        path,
+        JSON.stringify({ pending: "oops", processed: [], updatedAt: 1, version: 1 }),
+        "utf8",
+      );
+      try {
+        await store.read("hub");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.match(/invalid 'pending'/);
+      }
+    });
+
+    it("throws when 'processed' contains a non-string", async function () {
+      // WHY: the dedup set is keyed by string hashes. A numeric or null entry would break the
+      // Set semantics and could allow re-relay of an already-processed message.
+      const store = new PendingStateStore(dir);
+      const path = join(dir, "pending-hub.json");
+      await writeFile(
+        path,
+        JSON.stringify({ pending: [], processed: ["0xa", 42], updatedAt: 1, version: 1 }),
+        "utf8",
+      );
+      try {
+        await store.read("hub");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.match(/processed\[1\].*not a string/);
+      }
+    });
+
+    it("throws on unsupported version (would need a migration)", async function () {
+      const store = new PendingStateStore(dir);
+      const path = join(dir, "pending-hub.json");
+      await writeFile(
+        path,
+        JSON.stringify({ pending: [], processed: [], updatedAt: 1, version: 99 }),
+        "utf8",
+      );
+      try {
+        await store.read("hub");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.match(/unsupported version 99/);
+      }
+    });
+  });
+
+  describe("per-chain isolation", function () {
+    it("hub and base-sepolia have independent files", async function () {
+      // WHY: scanning + retry-backoff are per-chain. A write on chain A must never overwrite
+      // chain B's state, even with simultaneous mutations.
+      const store = new PendingStateStore(dir);
+      await store.write("hub", [samplePending({ messageHash: "0xhub" })], new Set(["0xpHub"]));
+      await store.write("base-sepolia", [samplePending({ messageHash: "0xbase" })], new Set(["0xpBase"]));
+
+      const hub = await store.read("hub");
+      const base = await store.read("base-sepolia");
+      expect(hub?.pending[0]?.messageHash).to.equal("0xhub");
+      expect(base?.pending[0]?.messageHash).to.equal("0xbase");
+      expect(hub?.processed).to.deep.equal(["0xpHub"]);
+      expect(base?.processed).to.deep.equal(["0xpBase"]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the relayer hardening per [`.claude/RELAYER_HARDENING.md`](.claude/RELAYER_HARDENING.md). Closes every remaining scanner-side recoverability gap short of the bigger architectural changes deferred to Phase 2B.

## What this fixes

### 1. Persistent pendingMessages + processedMessages

- New `lib/json-state-store.ts` — generic atomic per-key JSON store extracted from CursorStore. Same tmpfile+rename atomicity, same schema versioning + migration hook. CursorStore now a thin wrapper.
- New `lib/pending-state-store.ts` — per-source-chain persistence of pending CCTP messages + processed dedup hashes. File per chain at `relayer/state/pending-<chain>.json`.
- `iris-relay` hydrates on cold start (`initChain`) and persists on every mutation (`enqueueMessage`, `processPendingMessages` success/failure/expiry).

**Eliminates two real failure modes:**
- *Re-relay of already-delivered messages* — without the persisted processed set, a restart caused the scanner to re-discover messages via the cursor and re-attempt relay, burning gas on the contract's "already processed" check.
- *Lost in-flight Iris waits* — without the persisted pending set, a restart between MessageSent discovery and Iris attestation completion meant we'd depend entirely on the scanner re-finding the message (works because cursor persists) AND Iris re-attesting (works because Iris is server-side), but we'd lose visibility into pollAttempts / retryAttempts state.

### 2. Per-message retry + exponential backoff in iris-relay

Ports the `RetryEntry` pattern from cctp-relay: **5 attempts at 2/4/8/16/32s exponential backoff**. Replaces "relayWithHook failed → hot-loop on every poll tick forever" — previously the iris-relay had no per-message backoff at all.

State persisted via `retryAttempts` + `nextRetryAt` on each `PendingMessage`. `processPendingMessages` skips entries inside their backoff window. On cap reached, message is dropped with a loud GAVE-UP log so operators can manually recover.

### 3. Explicit pendingNonce tracking in iris-relay

cctp-relay has had this for a while; iris-relay was the gap. Per-chain `pendingNonce` field initialised from `getTransactionCount('pending')` on first use, bumped locally on success, reset on nonce-class errors (`NONCE_EXPIRED`, `REPLACEMENT_UNDERPRICED`, message includes 'nonce').

**Fixes the documented Sepolia load-balancer nonce drift** (per project memory) that affected the production iris-relay.

### 4. MAX_ATTESTATION_AGE_MS configurable + loud expiry telemetry

- Default bumped 30 → 60 min. Ethereum standard-finality CCTP attestations land at 15-19 min and occasionally take longer — 30 was thin for mainnet.
- Configurable via `RELAYER_ATTESTATION_AGE_MS` env (≥ 60s floor).
- Expiry path now logs via `console.error` with `sourceTxHash` + Iris URL + manual-recovery hint, instead of disappearing into steady-state `console.log`.

### 5. Parallel pollChain in both relay modules

Replaces `for await` with `Promise.allSettled(states.map(pollChain))`. Per-chain failure independence — each `pollChain` already writes its own `state.lastError`, so a failure on one chain doesn't reject the Promise. One slow chain no longer delays others.

## What's NOT in scope (Phase 2B, separate PR)

**Non-blocking `relayMessage`** — converting the relay path from "submit + await confirmation in the same loop" to "submit + track receipt across subsequent ticks" is a real architectural change (state machine for in-flight relay txs, idempotency-via-receipt-lookup for "we submitted but lost the hash", separate processing path). Defer to Phase 2B as a separate PR after this one stabilises in production.

## Phase 3 still outstanding

- `/health` endpoint exposing per-chain `lastProcessedBlock`, `lastError`, lag, `pendingCount`
- Migrate `console.log` → `pino` structured logger
- Prometheus `/metrics`

## Test plan

- [x] `npm run test:relayer` — 58/58 passing (+11 new for PendingStateStore + updated cursor-store tests)
- [x] Typecheck clean across full relayer surface
- [ ] **Manual Sepolia validation** (after deploy):
  1. **Restart preserves pending**: start relayer, submit a cross-chain shield, kill relayer mid-Iris-wait. Inspect `relayer/state/pending-base-sepolia.json` — verify the pending message is persisted. Restart and confirm log message `Restored N pending + N processed message(s) from disk`. Iris attestation should pick up where it left off.
  2. **Restart skips already-delivered**: complete a shield successfully, restart relayer, confirm logs show the processed hash was loaded and the scanner does NOT re-enqueue it on next discovery.
  3. **Retry/backoff visible**: temporarily mis-deploy the hub HookRouter (or set wrong gas), submit a shield, observe `relayMessage retry N/5 for ... in Xms` logs with exponential delays.
  4. **Nonce drift recovery**: stress-test with rapid simultaneous shields on Sepolia — if a nonce-class error fires, confirm `Nonce error detected, refreshing on next attempt` log + subsequent attempt succeeds.
  5. **Parallel polling**: in logs, confirm both chains' "Found N messages in blocks X-Y" lines appear concurrently rather than serially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)