### PR TITLE
feat(relayer): phase 2B — non-blocking relay loop with receipt polling state machine

### DIFF
--- a/.claude/RELAYER_HARDENING.md
+++ b/.claude/RELAYER_HARDENING.md
@@ -1,38 +1,46 @@
 # Relayer — Hardening Backlog
 
-Items needing dedicated attention on the Armada relayer (`relayer/`) before it can run unattended in production. Most of these surfaced during cross-chain shield/unshield testing on Sepolia where messages were silently dropped.
+Items needing dedicated attention on the Armada relayer (`relayer/`) before it can run unattended in production. Most surfaced during cross-chain shield/unshield testing on Sepolia where messages were silently dropped.
 
-This is **separate** from `ARMADA_INTERFACE_POLISH.md` — those are frontend gaps; this file is server-side reliability.
+Separate from `ARMADA_INTERFACE_POLISH.md` — that's frontend gaps; this file is server-side reliability.
 
 Sizing: XS (<1 hr), S (<½ day), M (~1 day), L (multi-day).
 
 ---
 
-## Iris CCTP relay — `modules/iris-relay.ts`
+## Status
 
-### Confirmed silent-failure modes (high priority)
+| Phase | Theme | Status |
+|---|---|---|
+| Phase 1 | Stop the silent stalls — persistent cursor + chunked/bisected getLogs + RPC timeouts + non-silent errors + confirmation depth + async shutdown | ✅ shipped in PR #292 |
+| Phase 2 | Recoverability — persistent pending+processed, per-message retry/backoff, explicit nonce tracking, parallel polling, configurable attestation TTL | ✅ shipped in PR #293 |
+| Phase 2B | Non-blocking relay loop — fire-and-track receipts, stuck-tx detection, state-machine separation | ✅ shipped in PR #294 |
+| **Phase 3** | **Observability — health endpoint, structured logs, metrics** | **open** |
+
+---
+
+## Phase 3 — open items
+
+### Iris CCTP relay — `modules/iris-relay.ts`
 
 | Item | Size | Notes |
 |---|---|---|
-| **Bounded lookback on cold start** | XS | `pollChain` (lines 351-393) sets `lastProcessedBlock = currentBlock` on first tick — any `MessageSent` event in a block submitted before the relayer started is silently skipped forever. Fix: on the cold-start branch (lines 355-361), set `lastProcessedBlock = currentBlock - LOOKBACK_BLOCKS` (env-configurable, default ~2000 for Sepolia ≈ 67 min headroom). Recovers messages submitted during a restart window. |
-| **Persist `lastProcessedBlock` to disk** | S | The cursor is in-memory only — every restart resets it to "now," guaranteeing message drops during the restart window. Combine with the lookback above into a single hardening commit. Per-chain JSON file alongside existing relayer state. |
-| **Chunked `getLogs` with bounded range** | S | After any RPC blip the next `getLogs(fromBlock=lastProcessed+1, toBlock=now)` can span 1000s of blocks; most public RPCs (Alchemy 500, drpc 1024) reject "block range too large" — and because the catch on line 391 is silent, the failure repeats forever, growing worse with every tick. Fix: cap each `getLogs` at `MAX_LOG_RANGE` (e.g. 500), advance the cursor in chunks across multiple ticks if needed. |
-| **Stop swallowing scan errors silently** | XS | `pollChain` line 391-393 — `catch (e) { /* Silently ignore */ }` hides RPC errors, rate limits (429), connection drops. At minimum log; ideally back off + retry with metrics. This is the single most important fix because it's the difference between "relayer broken" and "looks healthy but processes nothing." |
+| **`/health` endpoint** | S | Surface per-chain `{ lastProcessedBlock, chainHead, lagBlocks, lastScanAt, lastError, pendingCount }`. Mirror the indexer's `IndexerHealth` shape (`crowdfund-ui/packages/shared/src/lib/indexer.ts:29-48`). Status field: `healthy \| degraded \| stale \| unhealthy`. Gives operators a positive signal that the scanner is actually working — currently the only signal is logs. |
+| **Structured JSON logs** | S | Migrate `console.log`/`console.error` to `pino` (already a transitive dep via @railgun-community/wallet). Production logs are currently fragile to parse — Loki/Datadog ingestion needs structured shape. Keep the existing log content; just change the serialiser. |
+| **Prometheus `/metrics` endpoint** | M | Counters: messages-enqueued, attestations-polled, submits-successful, submits-failed, reverts, stuck-txs, expired-messages. Histograms: end-to-end delivery latency (detectedAt → confirmed), Iris attestation latency. Gauges: per-chain `lagBlocks`, `pendingCount`, `processedCount`. Existing `lastError` field is the natural place to wire counters from. |
 
-### Confirmed real-world incident
+### Privacy relay — `modules/privacy-relay.ts`
 
-User reported a `crossChainShield` from Base Sepolia → Ethereum Sepolia (~3 USDC) that confirmed on source, deducted balance, never delivered to the shielded pool. Source tx `0x8617f73…51f65b49`. Relayer running as systemd, no log entries for the message. Most likely cause: chronic "stuck on too-large `getLogs` range" — any single past RPC blip wedges scanning forever. Manual recovery via `hookRouter.relayWithHook(message, attestation)` from Iris is the workaround until the lookback + chunking lands.
-
-### Additional reliability gaps
+Out of scope for POC, tracked for production-readiness:
 
 | Item | Size | Notes |
 |---|---|---|
-| **Silent `mintRecipient` filter drop** | XS | `enqueueMessage` lines 422-425 — when a message's `mintRecipient` doesn't match `destState.knownRecipients`, return silently with NO log. The neighboring `destinationCaller` filter at line 432 DOES log. Symmetric logging would surface "we're seeing messages we don't recognise" issues. |
-| **Iris API failures only warn, never escalate** | XS | `checkAttestation` logs API errors as `console.warn` (line 212) and `catch (e)` block logs `[iris] Poll error` as warn (line 234). Use `console.error` for non-404 failures so they surface above default log thresholds. |
-| **No retry/backoff on `relayWithHook` revert** | S | `relayMessage` (line 537-589) handles "Nonce already used" as success but other reverts (gas issues, hub-side contract checks) return false and the message stays in `pendingMessages` forever, retrying every poll. Add an exponential-backoff retry counter with a max-attempts ceiling. |
-| **No health endpoint** | XS | Today there's no `/health` / `/status` to confirm the relayer is actually scanning chains (vs. running but wedged). Add one returning `{ chains: { name: { lastProcessedBlock, lastScanAt } } }` so monitoring can alert on stale cursors. |
+| **No idempotency on `/relay`** | S | Anyone with the calldata + a live `feesCacheId` can re-submit. For production: bind requests to a user-supplied nonce or signature. |
+| **No rate limiting** | S | A single client can flood. Express middleware (`express-rate-limit`) keyed by IP or signature. |
 
-### What's NOT a relayer problem (frontend handles)
+---
+
+## What's NOT a relayer problem (frontend handles)
 
 For completeness so future investigators don't go hunting in the wrong place:
 
@@ -40,35 +48,46 @@ For completeness so future investigators don't go hunting in the wrong place:
 
 ---
 
+## Resolved — historical reference
+
+### Phase 1 (PR #292)
+
+Closed the silent-stall failure class that dropped a real Sepolia shield (`0x8617f73…`):
+
+- Cold-start lookback (bootstrap from `currentBlock - bootLookbackBlocks` when no cursor exists)
+- Persistent `lastProcessedBlock` per chain in `relayer/state/cursor-{chain}.json`
+- Chunked `getLogs` (cursor-checkpoint cadence)
+- Bisecting `eth_getLogs` patch (adapts to Alchemy 10-block cap automatically)
+- RPC timeouts via `withTimeout` — no more wedged-socket loop pinning
+- Non-silent error handling with `lastError` per chain
+- Confirmation depth — won't scan reorg-vulnerable tip blocks
+- Async shutdown that awaits in-flight scan + flushes cursors before `process.exit`
+
+### Phase 2 (PR #293)
+
+Closed the remaining scanner-side recoverability gaps:
+
+- Persistent `pendingMessages` + `processedMessages` per chain (restart-safe dedup)
+- Per-message retry + exponential backoff for failed `relayWithHook` (ported `RetryEntry` from cctp-relay)
+- Explicit `pendingNonce` tracking in iris-relay (Sepolia load-balancer drift fix)
+- `MAX_ATTESTATION_AGE_MS` configurable via env, default bumped 30 → 60 min, expiry telemetry loud
+- Parallel `pollChain` via `Promise.allSettled` — one slow chain no longer delays others
+
+### Phase 2B (PR #294)
+
+Non-blocking relay loop:
+
+- `relayMessage` → `submitRelay` — broadcasts and returns immediately without `await tx.wait()`. Per-message confirmation latency (~12s on Sepolia) no longer serialises the loop.
+- New `processInflightRelays(state)` — receipt polling phase, runs after `processPendingMessages` in each tick
+- State machine via `submittedTxHash` field: absent → awaiting Iris; set → awaiting receipt
+- Stuck/dropped tx detection — `STUCK_TX_THRESHOLD_MS` (10 min default, env-configurable) triggers re-submit with fresh nonce
+- Revert handling — receipt with `status=0` routes through the existing retry/backoff machinery
+- Backward-compatible schema: `submittedTxHash` + `submittedAt` are optional, v1 files from Phase 2 load cleanly
+
+---
+
 ## Mock CCTP relay — `modules/cctp-relay.ts`
 
 | Item | Size | Notes |
 |---|---|---|
-| _(none flagged — used only for local Anvil; correctness has been validated end-to-end)_ | — | If `iris-relay.ts` issues are fixed, consider whether to keep two parallel impls or unify with mode-flag branching. |
-
----
-
-## Privacy relay — `modules/privacy-relay.ts`
-
-| Item | Size | Notes |
-|---|---|---|
-| **No idempotency on `/relay`** | S | Anyone with the calldata + a live `feesCacheId` can re-submit the same tx. Acceptable for POC; for production: bind requests to a user-supplied nonce or signature. |
-| **No rate limiting** | S | A single client can flood the relayer with `/relay` requests. Express middleware (`express-rate-limit`) keyed by IP or signature. |
-
----
-
-## Cross-cutting
-
-| Item | Size | Notes |
-|---|---|---|
-| **Structured JSON logs** | S | Today: `console.log` with ad-hoc formatting. Migrate to a structured logger (pino, which is already a transitive dep via @railgun-community/wallet) so production logs can be parsed by Loki/Datadog/etc. |
-| **Telemetry/metrics surface** | M | Counters for messages-enqueued, attestation-polls, relays-successful/failed; histogram for end-to-end delivery latency. Even basic Prometheus `/metrics` endpoint would dramatically improve operability. |
-
----
-
-## Suggested order of attack
-
-1. **Item 1-4 above** (the four "silent failure mode" items) as one focused PR — lookback + persisted cursor + chunked getLogs + non-silent error handling. This eliminates the class of "relayer running but quietly broken" failures.
-2. **Health endpoint** as a small follow-up — gives operators a positive signal that scanning is happening.
-3. Retry/backoff + structured logging + metrics as a separate hardening pass once #1 has stabilised behavior.
-4. Idempotency + rate limiting come last (production-readiness, not POC blockers).
+| _(none flagged for Phase 3 — used only for local Anvil; the non-blocking refactor was explicitly skipped here since `tx.wait()` against Anvil is instant and the added complexity has zero benefit)_ | — | If iris-relay ever needs to share code with cctp-relay beyond the existing `lib/` primitives, consider a base class. Not needed yet. |

--- a/relayer/lib/pending-state-store.ts
+++ b/relayer/lib/pending-state-store.ts
@@ -13,7 +13,14 @@ const PENDING_SCHEMA_VERSION = 1 as const;
 /**
  * Persisted shape of a pending CCTP message. Mirrors the iris-relay `PendingMessage` interface
  * with two NEW fields for Phase 2 (`retryAttempts`, `nextRetryAt`) that support per-message
- * retry/backoff on relayWithHook failures.
+ * retry/backoff on relayWithHook failures, plus two NEW fields for Phase 2B
+ * (`submittedTxHash`, `submittedAt`) that turn the relay loop into a state machine — the
+ * presence of `submittedTxHash` means "broadcast happened, waiting for destination receipt"
+ * (handled by `processInflightRelays`); absence means "still waiting on Iris attestation"
+ * (handled by `processPendingMessages`).
+ *
+ * Both Phase 2B fields are OPTIONAL — a v1 file written by the prior version (which had
+ * neither) loads cleanly. The state machine treats absent fields as "awaiting Iris."
  */
 export interface PersistedPendingMessage {
   messageBytes: string;
@@ -30,6 +37,18 @@ export interface PersistedPendingMessage {
   retryAttempts: number;
   /** Unix ms — relay attempts before this time are blocked by the backoff scheduler. 0 = no wait. */
   nextRetryAt: number;
+  /**
+   * Destination-chain tx hash once we've broadcast `hookRouter.relayWithHook(...)`. Presence
+   * is the state-machine flag: set → awaiting receipt confirmation (processInflightRelays);
+   * absent → still awaiting Iris attestation (processPendingMessages).
+   */
+  submittedTxHash?: string;
+  /**
+   * Unix ms of the broadcast. Used by processInflightRelays to detect stuck/dropped txs —
+   * if the receipt hasn't arrived within `STUCK_TX_THRESHOLD_MS` of this timestamp, the
+   * message is force-re-submitted with a fresh nonce.
+   */
+  submittedAt?: number;
 }
 
 export interface PendingStateData {
@@ -190,6 +209,20 @@ function validatePending(
     if (typeof m[field] !== "number" || !Number.isFinite(m[field] as number)) {
       throw new Error(
         `pending-store: pending[${idx}].${String(field)} for chain '${chainName}' at ${path} is not a finite number.`,
+      );
+    }
+  }
+  // Optional fields — validate ONLY if present. submittedTxHash + submittedAt MUST be present
+  // together; one without the other indicates corruption that downstream logic would mishandle.
+  if (m.submittedTxHash !== undefined || m.submittedAt !== undefined) {
+    if (typeof m.submittedTxHash !== "string") {
+      throw new Error(
+        `pending-store: pending[${idx}].submittedTxHash for chain '${chainName}' at ${path} is set but not a string.`,
+      );
+    }
+    if (typeof m.submittedAt !== "number" || !Number.isFinite(m.submittedAt)) {
+      throw new Error(
+        `pending-store: pending[${idx}].submittedAt for chain '${chainName}' at ${path} is set but not a finite number.`,
       );
     }
   }

--- a/relayer/modules/iris-relay.ts
+++ b/relayer/modules/iris-relay.ts
@@ -69,6 +69,18 @@ interface PendingMessage {
    * `processPendingMessages` skips entries with `nextRetryAt > now`. 0 = no backoff active.
    */
   nextRetryAt: number;
+  /**
+   * Destination-chain tx hash once `hookRouter.relayWithHook` has broadcast successfully.
+   * Presence drives the state machine: set → awaiting confirmation (handled by
+   * processInflightRelays); absent → still awaiting Iris attestation (handled by
+   * processPendingMessages). The two phases are mutually exclusive per message per tick.
+   */
+  submittedTxHash?: string;
+  /**
+   * Unix ms of the broadcast. processInflightRelays uses (now - submittedAt) to detect
+   * stuck/dropped txs — past STUCK_TX_THRESHOLD_MS we force a re-submit with a fresh nonce.
+   */
+  submittedAt?: number;
 }
 
 interface IrisMessageResponse {
@@ -204,6 +216,28 @@ const MAX_ATTESTATION_AGE_MS = (() => {
  */
 const MAX_RELAY_RETRIES = 5;
 const RELAY_RETRY_BASE_DELAY_MS = 2_000;
+
+/**
+ * How long an in-flight broadcast can sit without a receipt before we treat it as stuck/dropped
+ * and re-submit with a fresh nonce. Default 10 min — Ethereum L1 finality is ~12s under normal
+ * conditions, so 50× headroom for genuinely-dropped txs (mempool eviction, replacement-fee
+ * loss, etc.). Configurable via `RELAYER_STUCK_TX_THRESHOLD_MS` env var.
+ *
+ * Re-submit goes through the normal retry/backoff machinery — the message gets
+ * `submittedTxHash` cleared so it re-enters processPendingMessages → submitRelay with
+ * `retryAttempts` bumped.
+ */
+const STUCK_TX_THRESHOLD_MS = (() => {
+  const raw = process.env.RELAYER_STUCK_TX_THRESHOLD_MS;
+  if (raw === undefined || raw === "") return 10 * 60 * 1000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 60_000) {
+    throw new Error(
+      `Invalid RELAYER_STUCK_TX_THRESHOLD_MS=${raw} — expected a number ≥ 60000 (1 minute floor).`,
+    );
+  }
+  return parsed;
+})();
 
 // ============ Helpers ============
 
@@ -766,6 +800,13 @@ export class IrisRelayModule {
         continue;
       }
 
+      // Skip if this message has already been broadcast and is waiting for receipt
+      // confirmation — that's processInflightRelays's domain, not ours. The state-machine
+      // marker is `submittedTxHash`.
+      if (msg.submittedTxHash) {
+        continue;
+      }
+
       // Skip if we're inside a backoff window from a prior relay failure. The scanner keeps
       // the message in pendingMessages so it's surfaced again on the next tick after the
       // backoff expires.
@@ -801,23 +842,30 @@ export class IrisRelayModule {
         continue;
       }
 
-      // Attestation ready — relay it
+      // Attestation ready — submit to destination chain (non-blocking — receipt polled later).
       console.log(
         `\n[iris-relay] ATTESTATION READY for ${hash.slice(0, 18)}... after ${elapsed(msg.detectedAt)} (${msg.pollAttempts} polls)`
       );
 
-      const relayed = await this.relayMessage(msg, result.attestation, result.message);
-      if (relayed) {
-        // Mark as processed on the source chain state + remove from pending. Persist below.
+      const outcome = await this.submitRelay(msg, result.attestation, result.message);
+      if (outcome === "submitted") {
+        // submitRelay set msg.submittedTxHash + msg.submittedAt. Keep the message in pending —
+        // processInflightRelays will pick it up next tick to confirm. Mark the source chain
+        // dirty so the persist below captures the new submittedTxHash.
+        if (sourceState) dirtyChains.add(sourceState);
+      } else if (outcome === "already-processed") {
+        // The destination contract reports we (or someone) already delivered this. Treat as
+        // success — mark processed and remove from pending. Common after a crash mid-submit.
         if (sourceState) sourceState.processedMessages.add(hash);
         this.pendingMessages.delete(hash);
         if (sourceState) dirtyChains.add(sourceState);
       } else {
-        // Relay failed — schedule a retry per backoff or give up if cap reached.
+        // outcome === "failed" — broadcast rejected (revert, RPC error, nonce drift). Bump
+        // retry counter and schedule backoff, or give up at cap.
         msg.retryAttempts++;
         if (msg.retryAttempts >= MAX_RELAY_RETRIES) {
           console.error(
-            `[iris-relay] GAVE UP on relayMessage for ${hash.slice(0, 18)}... after ${msg.retryAttempts} attempts. Source Tx: ${msg.sourceTxHash}. Manual recovery may be required.`,
+            `[iris-relay] GAVE UP on submitRelay for ${hash.slice(0, 18)}... after ${msg.retryAttempts} attempts. Source Tx: ${msg.sourceTxHash}. Manual recovery may be required.`,
           );
           this.pendingMessages.delete(hash);
           if (sourceState) dirtyChains.add(sourceState);
@@ -826,7 +874,7 @@ export class IrisRelayModule {
           const backoffMs = RELAY_RETRY_BASE_DELAY_MS * Math.pow(2, msg.retryAttempts - 1);
           msg.nextRetryAt = Date.now() + backoffMs;
           console.log(
-            `  [iris-relay] relayMessage retry ${msg.retryAttempts}/${MAX_RELAY_RETRIES} for ${hash.slice(0, 18)}... in ${backoffMs}ms`,
+            `  [iris-relay] submitRelay retry ${msg.retryAttempts}/${MAX_RELAY_RETRIES} for ${hash.slice(0, 18)}... in ${backoffMs}ms`,
           );
           if (sourceState) dirtyChains.add(sourceState);
         }
@@ -840,17 +888,174 @@ export class IrisRelayModule {
   }
 
   /**
-   * Submit receiveMessage on the destination chain.
+   * Phase 2B: receipt polling for in-flight relays. Runs once per poll tick per chain — checks
+   * each pending message whose `submittedTxHash` is set (broadcast happened, awaiting receipt).
+   *
+   * Three outcomes per message:
+   *  1. Receipt arrived, status=success → mark processed, remove from pending. Done.
+   *  2. Receipt arrived, status=reverted → bump retryAttempts, clear submittedTxHash so the
+   *     message re-enters submitRelay next cycle. Existing backoff applies.
+   *  3. No receipt yet AND time since submit > STUCK_TX_THRESHOLD_MS → assume mempool eviction
+   *     or dropped tx, force re-submit (same path as revert above).
+   *
+   * Otherwise (no receipt, within threshold) just continue waiting.
+   *
+   * Receipts are fetched in parallel via Promise.allSettled — a single chain's RPC can
+   * typically handle a handful of getTransactionReceipt calls in flight.
    */
-  private async relayMessage(
+  private async processInflightRelays(state: ChainState): Promise<void> {
+    // Collect in-flight messages for THIS chain. We use the message's destinationDomain since
+    // submittedTxHash is on the destination chain — that's where we poll for receipts.
+    const inflight: Array<{ hash: string; msg: PendingMessage }> = [];
+    for (const [hash, msg] of this.pendingMessages.entries()) {
+      if (msg.submittedTxHash && msg.destinationDomain === state.domain) {
+        inflight.push({ hash, msg });
+      }
+    }
+    if (inflight.length === 0) return;
+
+    const { rpcTimeoutMs } = state.config.scanner;
+    const now = Date.now();
+
+    // Fetch receipts in parallel. Each lookup wraps in withTimeout — a stuck RPC on one tx
+    // can't pin the whole loop.
+    const receipts = await Promise.allSettled(
+      inflight.map(({ msg }) =>
+        withTimeout(
+          state.provider.getTransactionReceipt(msg.submittedTxHash!),
+          rpcTimeoutMs,
+          `getTransactionReceipt ${state.config.name} ${msg.submittedTxHash!.slice(0, 12)}`,
+        ),
+      ),
+    );
+
+    let mutated = false;
+    for (let i = 0; i < inflight.length; i++) {
+      const { hash, msg } = inflight[i]!;
+      const result = receipts[i]!;
+
+      if (result.status === "rejected") {
+        // RPC error / timeout while checking. Don't mutate state — next tick retries the same
+        // receipt lookup. Log once per N attempts to avoid spamming for persistent issues.
+        const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+        console.warn(
+          `  [iris-relay] ${state.config.name}: getTransactionReceipt ${msg.submittedTxHash!.slice(0, 18)}... failed (${reason}). Will retry next tick.`,
+        );
+        continue;
+      }
+
+      const receipt = result.value;
+      if (receipt === null) {
+        // Still pending. Check stuck threshold.
+        const sinceSubmit = now - (msg.submittedAt ?? now);
+        if (sinceSubmit > STUCK_TX_THRESHOLD_MS) {
+          console.error(
+            `[iris-relay] STUCK TX: ${msg.submittedTxHash!.slice(0, 18)}... has no receipt after ${Math.round(sinceSubmit / 1000)}s (>${Math.round(STUCK_TX_THRESHOLD_MS / 1000)}s threshold). Re-submitting with fresh nonce on next cycle.`,
+          );
+          this.scheduleResubmit(msg, state.config.name);
+          mutated = true;
+        }
+        continue;
+      }
+
+      if (receipt.status === 1) {
+        // Success — mark processed and remove from pending.
+        const sourceState = this.getChainByDomain(msg.sourceDomain);
+        if (sourceState) sourceState.processedMessages.add(hash);
+        this.pendingMessages.delete(hash);
+        console.log(
+          `[iris-relay] ${state.config.name}: confirmed ${msg.submittedTxHash!.slice(0, 18)}... in block ${receipt.blockNumber} (${msg.retryAttempts} retries, ${Math.round((now - (msg.submittedAt ?? now)) / 1000)}s submit→confirm)`,
+        );
+        // Persist BOTH chains: the source chain (for processedMessages add + pending delete)
+        // AND the destination chain (no state mutation but conceptually relevant). We only
+        // mark the source dirty here; the destination's pending state for this message
+        // already ran through the source's persistChain since pendingMessages is keyed by
+        // messageHash globally.
+        if (sourceState) await this.persistChain(sourceState);
+        mutated = true;
+      } else {
+        // Reverted on chain — re-submit through the retry/backoff path. The nonce was consumed
+        // by the reverted tx, so we don't reset destState.pendingNonce — the next submit gets
+        // the next nonce.
+        console.error(
+          `[iris-relay] REVERTED on chain: ${msg.submittedTxHash!.slice(0, 18)}... (tx mined but receipt.status=0). Will re-submit through retry/backoff.`,
+        );
+        this.scheduleResubmit(msg, state.config.name);
+        mutated = true;
+      }
+    }
+
+    // Persist any source chain whose state changed (stuck/revert clears submittedTxHash, success
+    // already persisted inline above to minimise the crash-recovery window).
+    if (mutated) {
+      const dirtySourceChains = new Set<ChainState>();
+      for (const { msg } of inflight) {
+        const sourceState = this.getChainByDomain(msg.sourceDomain);
+        if (sourceState) dirtySourceChains.add(sourceState);
+      }
+      for (const dirtyState of dirtySourceChains) {
+        await this.persistChain(dirtyState);
+      }
+    }
+  }
+
+  /**
+   * Move a message from "awaiting confirmation" back into "needs submit" — clears
+   * submittedTxHash + submittedAt, bumps retryAttempts + schedules backoff. The next
+   * processPendingMessages tick will re-submit with a fresh nonce (since destState.pendingNonce
+   * already advanced past the failed/stuck tx's nonce).
+   *
+   * Shared between revert + stuck-tx paths since both want the same outcome.
+   */
+  private scheduleResubmit(msg: PendingMessage, chainLabel: string): void {
+    msg.submittedTxHash = undefined;
+    msg.submittedAt = undefined;
+    msg.retryAttempts++;
+    if (msg.retryAttempts >= MAX_RELAY_RETRIES) {
+      console.error(
+        `[iris-relay] ${chainLabel}: GAVE UP on ${msg.messageHash.slice(0, 18)}... after ${msg.retryAttempts} attempts. Source Tx: ${msg.sourceTxHash}. Manual recovery may be required.`,
+      );
+      this.pendingMessages.delete(msg.messageHash);
+    } else {
+      const backoffMs = RELAY_RETRY_BASE_DELAY_MS * Math.pow(2, msg.retryAttempts - 1);
+      msg.nextRetryAt = Date.now() + backoffMs;
+      console.log(
+        `  [iris-relay] ${chainLabel}: re-submit retry ${msg.retryAttempts}/${MAX_RELAY_RETRIES} for ${msg.messageHash.slice(0, 18)}... in ${backoffMs}ms`,
+      );
+    }
+  }
+
+  /**
+   * Submit `receiveMessage` / `relayWithHook` on the destination chain — broadcast only.
+   *
+   * NON-BLOCKING by design (Phase 2B). The function returns as soon as the broadcast resolves
+   * (typically <1s), NOT after on-chain confirmation. The destination receipt is checked
+   * later by `processInflightRelays` on subsequent poll ticks. This frees the relay loop
+   * from per-message ~12s confirmation latency that previously serialised everything.
+   *
+   * On `'submitted'`: the caller MUST persist `msg.submittedTxHash` + `msg.submittedAt`
+   * before yielding to the event loop, otherwise a crash between broadcast and persist
+   * loses the txHash and the message would be re-submitted on restart (recovered via the
+   * destination contract's "already processed" check, but at gas cost).
+   *
+   * Returns:
+   *  - `'submitted'`  — tx broadcast, hash captured in `msg.submittedTxHash`. Caller keeps the
+   *                     message in pending state for receipt polling.
+   *  - `'already-processed'` — destination contract reports this message was already delivered
+   *                     (likely by a prior submit-then-crash that we lost track of). Caller
+   *                     marks as processed and removes from pending.
+   *  - `'failed'`     — broadcast rejected (revert, RPC error, nonce drift). Caller bumps
+   *                     retryAttempts and schedules backoff via the existing Phase 2 machinery.
+   */
+  private async submitRelay(
     msg: PendingMessage,
     attestation: string,
-    irisMessage: string
-  ): Promise<boolean> {
+    irisMessage: string,
+  ): Promise<"submitted" | "already-processed" | "failed"> {
     const destState = this.getChainByDomain(msg.destinationDomain);
     if (!destState) {
       console.error(`  [iris-relay] No chain for destination domain ${msg.destinationDomain}`);
-      return false;
+      return "failed";
     }
 
     try {
@@ -898,23 +1103,23 @@ export class IrisRelayModule {
         tx = await messageTransmitter.receiveMessage(msgToRelay, attestation, { nonce: txNonce });
       }
 
-      // Bump immediately — even if .wait() throws below, the next relay attempt should use
-      // nonce+1 (the broadcast already happened). The catch's nonce-reset only fires for
-      // errors that happen BEFORE the send returns.
+      // Bump the nonce now — broadcast happened, the chain's mempool has reserved this nonce.
+      // Even if the message later reverts on receipt, the nonce is consumed.
       destState.pendingNonce = txNonce + 1;
 
-      console.log(`  Tx hash: ${tx.hash}`);
-      const receipt = await tx.wait();
-      console.log(`  Confirmed in block ${receipt?.blockNumber}`);
-      console.log(`  Relay successful`);
-      return true;
+      // Mutate the message so the caller can persist + transition to "awaiting receipt" state.
+      msg.submittedTxHash = tx.hash;
+      msg.submittedAt = Date.now();
+
+      console.log(`  Tx submitted: ${tx.hash} (awaiting confirmation, non-blocking)`);
+      return "submitted";
     } catch (e: any) {
       if (
         e.message?.includes("already processed") ||
         e.message?.includes("Nonce already used")
       ) {
         console.log(`  Already processed on-chain, marking as done`);
-        return true;
+        return "already-processed";
       }
       // Nonce-class errors (Sepolia load-balancer drift, replacement underpriced, etc.) — reset
       // the local cache so the next attempt re-reads from the provider. Don't surface as a
@@ -928,8 +1133,8 @@ export class IrisRelayModule {
         console.log(`  Nonce error detected, refreshing on next attempt`);
         destState.pendingNonce = null;
       }
-      console.error(`  [iris-relay] Relay failed: ${e.message || e}`);
-      return false;
+      console.error(`  [iris-relay] Submit failed: ${e.message || e}`);
+      return "failed";
     }
   }
 
@@ -991,12 +1196,31 @@ export class IrisRelayModule {
 
         if (!this.isRunning) break;
 
-        // 2. Check pending messages for attestations and relay
+        // 2. Check pending messages for attestations and submit relays (non-blocking — the
+        //    submit returns after broadcast, NOT after destination-chain confirmation).
         await this.processPendingMessages();
 
         if (!this.isRunning) break;
 
-        // 3. Sleep before next cycle — abort early if stop() fires.
+        // 3. Phase 2B: poll destination chains for receipts of in-flight submitted relays.
+        //    Per-chain parallel — one slow chain doesn't delay others. Same defensive-logging
+        //    pattern as pollChain (Promise.allSettled + per-rejection error log).
+        const inflightResults = await Promise.allSettled(
+          chainStates.map((state) => this.processInflightRelays(state)),
+        );
+        for (let i = 0; i < inflightResults.length; i++) {
+          const r = inflightResults[i];
+          if (r?.status === "rejected") {
+            const chainName = chainStates[i]?.config.name ?? "unknown";
+            console.error(
+              `[iris-relay] ${chainName}: processInflightRelays rejected unexpectedly: ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`,
+            );
+          }
+        }
+
+        if (!this.isRunning) break;
+
+        // 4. Sleep before next cycle — abort early if stop() fires.
         await this.sleepCancellable(this.pollIntervalMs);
       }
     } finally {

--- a/relayer/test/lib/pending-state-store.test.ts
+++ b/relayer/test/lib/pending-state-store.test.ts
@@ -161,6 +161,100 @@ describe("PendingStateStore", function () {
         expect((err as Error).message).to.match(/unsupported version 99/);
       }
     });
+
+    it("accepts Phase 2B submittedTxHash + submittedAt optional fields", async function () {
+      // WHY: the v1 schema added two optional fields for the non-blocking state machine. A
+      // round-trip with them set must preserve both. Without this test a serialiser bug that
+      // dropped optional fields could silently lose the "awaiting receipt" marker — the
+      // message would re-submit on next tick (gas waste) instead of being recognised as
+      // already in-flight.
+      const store = new PendingStateStore(dir);
+      const pending = [
+        samplePending({
+          messageHash: "0xinflight",
+          submittedTxHash: "0xdesttx123",
+          submittedAt: 1_700_000_500_000,
+        }),
+      ];
+      await store.write("hub", pending, new Set());
+      const got = await store.read("hub");
+      expect(got?.pending[0]?.submittedTxHash).to.equal("0xdesttx123");
+      expect(got?.pending[0]?.submittedAt).to.equal(1_700_000_500_000);
+    });
+
+    it("a v1 file written before Phase 2B (no submittedTxHash) loads cleanly", async function () {
+      // WHY: backward-compat invariant. Phase 2 deployments wrote v1 files without the new
+      // fields; the Phase 2B reader MUST accept them as "awaiting Iris" (no submittedTxHash).
+      // Without this, the first restart after the Phase 2B upgrade would fail to load any
+      // existing pending state — losing every in-flight message in the wild.
+      const store = new PendingStateStore(dir);
+      const path = join(dir, "pending-hub.json");
+      const legacyPending = {
+        messageBytes: "0xabcd",
+        messageHash: "0xa",
+        sourceDomain: 6,
+        destinationDomain: 0,
+        nonce: "0xn",
+        sourceTxHash: "0xtx",
+        sourceBlock: 1,
+        detectedAt: 1,
+        pollAttempts: 0,
+        lastStatus: "new",
+        retryAttempts: 0,
+        nextRetryAt: 0,
+        // submittedTxHash + submittedAt absent — pre-Phase-2B file
+      };
+      await writeFile(
+        path,
+        JSON.stringify({
+          pending: [legacyPending],
+          processed: [],
+          updatedAt: 1,
+          version: 1,
+        }),
+        "utf8",
+      );
+      const got = await store.read("hub");
+      expect(got?.pending).to.have.lengthOf(1);
+      expect(got?.pending[0]?.submittedTxHash).to.equal(undefined);
+      expect(got?.pending[0]?.submittedAt).to.equal(undefined);
+    });
+
+    it("rejects a half-populated submittedTxHash/submittedAt pair (corruption)", async function () {
+      // WHY: the two fields MUST be set together. submittedTxHash without submittedAt would
+      // skip processInflightRelays's stuck-tx detection (no timestamp to compare against);
+      // submittedAt without submittedTxHash would have no hash to look up. Both indicate
+      // corruption; loud failure forces operator investigation.
+      const store = new PendingStateStore(dir);
+      const path = join(dir, "pending-hub.json");
+      const halfPopulated = {
+        messageBytes: "0xabcd",
+        messageHash: "0xa",
+        sourceDomain: 6,
+        destinationDomain: 0,
+        nonce: "0xn",
+        sourceTxHash: "0xtx",
+        sourceBlock: 1,
+        detectedAt: 1,
+        pollAttempts: 0,
+        lastStatus: "new",
+        retryAttempts: 0,
+        nextRetryAt: 0,
+        submittedTxHash: "0xhash",
+        // submittedAt missing — corruption
+      };
+      await writeFile(
+        path,
+        JSON.stringify({ pending: [halfPopulated], processed: [], updatedAt: 1, version: 1 }),
+        "utf8",
+      );
+      try {
+        await store.read("hub");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.match(/submittedAt/);
+      }
+    });
   });
 
   describe("per-chain isolation", function () {


### PR DESCRIPTION
## Summary

Phase 2B of the relayer hardening sequence — closes the last serialisation bottleneck in the iris-relay tick loop. Previously `relayMessage` awaited `tx.wait()` per message (~12s on Sepolia), so a queue of N pending attestation-ready messages took N × 12s to drain. This PR turns the relay path into a state machine: broadcast and return, poll receipts on a later tick.

Phase 1 (#292) and Phase 2 (#293) closed silent stalls and recoverability gaps; Phase 2B closes the throughput gap.

## Design

State machine driven by the presence of `submittedTxHash` on a `PendingMessage`:

- **absent** → still awaiting Iris attestation (handled by `processPendingMessages`)
- **set** → broadcast happened, awaiting destination receipt (handled by new `processInflightRelays`)

`submitRelay` (renamed from `relayMessage`) now returns one of three outcomes:

- `'submitted'` — tx broadcast, hash captured. Caller keeps message in pending for receipt polling.
- `'already-processed'` — destination contract reports prior delivery (recovers crash-mid-submit cases).
- `'failed'` — broadcast rejected. Caller bumps `retryAttempts` and schedules backoff via existing Phase 2 machinery.

New `processInflightRelays(state)` runs once per tick per chain in parallel via `Promise.allSettled`:

- Receipt status=1 → mark processed, remove from pending, persist source chain inline.
- Receipt status=0 (reverted) → re-submit through retry/backoff path. Nonce was consumed, so no `pendingNonce` reset.
- Receipt absent and `(now - submittedAt) > STUCK_TX_THRESHOLD_MS` → assume dropped/evicted, force re-submit with fresh nonce.

Configurable via `RELAYER_STUCK_TX_THRESHOLD_MS` env (default 10 min, floor 1 min).

## Schema

`PersistedPendingMessage` gains two **optional** fields: `submittedTxHash` + `submittedAt`. Schema version stays at v1 — Phase 2 files written before this PR load cleanly with both fields absent (= awaiting Iris). Validator enforces the pair must be set together (half-populated = corruption).

## Out of scope

`cctp-relay.ts` is unchanged. It runs only against local Anvil where `tx.wait()` is instant, so the added state-machine complexity has zero benefit there.

## Test plan

- [x] `npm run test:relayer` — 61/61 passing (added 3 tests for the new schema fields)
- [x] typecheck clean
- [ ] Manual Sepolia: restart relayer with an in-flight submitted tx in `pending-*.json`; expect `processInflightRelays` to pick it up and confirm without re-submitting
- [ ] Manual Sepolia: induce a revert (e.g. malformed message) and watch the retry/backoff loop re-submit
- [ ] Manual Sepolia: leave a tx in mempool past `STUCK_TX_THRESHOLD_MS` (or set threshold to 60s) and confirm force-re-submit fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)