### PR TITLE
feat(relayer): phase 3A — /health endpoint with per-chain status + rollup

### DIFF
--- a/.claude/RELAYER_HARDENING.md
+++ b/.claude/RELAYER_HARDENING.md
@@ -15,21 +15,43 @@ Sizing: XS (<1 hr), S (<½ day), M (~1 day), L (multi-day).
 | Phase 1 | Stop the silent stalls — persistent cursor + chunked/bisected getLogs + RPC timeouts + non-silent errors + confirmation depth + async shutdown | ✅ shipped in PR #292 |
 | Phase 2 | Recoverability — persistent pending+processed, per-message retry/backoff, explicit nonce tracking, parallel polling, configurable attestation TTL | ✅ shipped in PR #293 |
 | Phase 2B | Non-blocking relay loop — fire-and-track receipts, stuck-tx detection, state-machine separation | ✅ shipped in PR #294 |
-| **Phase 3** | **Observability — health endpoint, structured logs, metrics** | **open** |
+| Phase 3A | Observability part 1 — `/health` endpoint with per-chain status + rollup | ✅ shipped in PR #295 |
+| **Phase 3B** | **Structured JSON logs (pino migration)** | **open** |
+| **Phase 3C** | **Prometheus `/metrics` endpoint** | **open** |
 
 ---
 
-## Phase 3 — open items
+## Phase 3B — Structured JSON logs (open)
 
-### Iris CCTP relay — `modules/iris-relay.ts`
+Migrate `console.log` / `console.error` across the relayer to `pino` so production logs are parseable by Loki / Datadog / etc. Today everything is free-form prefixed strings — fine for `tail -f`, fragile for any ingestion pipeline.
 
 | Item | Size | Notes |
 |---|---|---|
-| **`/health` endpoint** | S | Surface per-chain `{ lastProcessedBlock, chainHead, lagBlocks, lastScanAt, lastError, pendingCount }`. Mirror the indexer's `IndexerHealth` shape (`crowdfund-ui/packages/shared/src/lib/indexer.ts:29-48`). Status field: `healthy \| degraded \| stale \| unhealthy`. Gives operators a positive signal that the scanner is actually working — currently the only signal is logs. |
-| **Structured JSON logs** | S | Migrate `console.log`/`console.error` to `pino` (already a transitive dep via @railgun-community/wallet). Production logs are currently fragile to parse — Loki/Datadog ingestion needs structured shape. Keep the existing log content; just change the serialiser. |
-| **Prometheus `/metrics` endpoint** | M | Counters: messages-enqueued, attestations-polled, submits-successful, submits-failed, reverts, stuck-txs, expired-messages. Histograms: end-to-end delivery latency (detectedAt → confirmed), Iris attestation latency. Gauges: per-chain `lagBlocks`, `pendingCount`, `processedCount`. Existing `lastError` field is the natural place to wire counters from. |
+| **Pino setup + child loggers per module** | S | Add `pino` as a direct dep (currently transitive via `@railgun-community/wallet`). Create a root logger in `armada-relayer.ts`; pass child loggers (`logger.child({ module: 'iris-relay' })`) into each module's constructor. |
+| **Log statement migration** | S | Rewrite every `console.*` call to use the module logger. Preserve current log CONTENT — chain names, message hashes, block numbers, error stacks. Adopt log levels: `debug` for per-tick chatter (skip-stale-message decisions), `info` for state transitions (attestation ready, tx submitted, confirmation received), `warn` for retry/backoff scheduling, `error` for gave-up cases + scan failures. |
+| **Local dev pretty-printer** | XS | Local dev (CCTP_MODE=mock) should still produce human-readable output. Use `pino-pretty` as a dev dep, wire via env: `LOG_PRETTY=1 npm run armada-relayer` pipes through it. |
 
-### Privacy relay — `modules/privacy-relay.ts`
+WHY: production logs are currently fragile to parse. The hardening so far is invisible to operators unless they `tail -f` the process. Structured logs unlock dashboards, alerting on specific error codes, and queryable history.
+
+---
+
+## Phase 3C — Prometheus `/metrics` endpoint (open)
+
+Adds a `/metrics` endpoint scrapable by Prometheus / VictoriaMetrics / Grafana Agent. Complementary to `/health` (which is a point-in-time snapshot) — metrics give the time-series view that lets operators distinguish "we always have 2 pending messages" from "pending count has been growing for 30 minutes."
+
+| Item | Size | Notes |
+|---|---|---|
+| **Prometheus client setup** | XS | Add `prom-client` dep. Register the default Node.js process metrics (event loop lag, GC, heap). |
+| **Counters** | S | `relayer_messages_enqueued_total{source_chain}`, `relayer_attestations_polled_total{source_chain,outcome}`, `relayer_submits_total{dest_chain,outcome}`, `relayer_reverts_total{dest_chain}`, `relayer_stuck_txs_total{dest_chain}`, `relayer_expired_messages_total{source_chain}`. |
+| **Histograms** | S | `relayer_delivery_latency_seconds{source,dest}` — from `detectedAt` (source MessageSent) → confirmed receipt on destination. `relayer_iris_attestation_latency_seconds{source}` — from `detectedAt` → Iris returns the attestation. Buckets: tuned for Sepolia (10s, 30s, 1m, 2m, 5m, 10m, 30m, 1h). |
+| **Gauges** | S | `relayer_lag_blocks{chain}`, `relayer_pending_count{chain}`, `relayer_processed_count{chain}`, `relayer_inflight_count{chain}`. Updated each poll tick. |
+| **Route in http-api** | XS | `GET /metrics` returning `register.metrics()` with the Prometheus text content-type. |
+
+WHY: `/health` answers "is it broken right now?" Metrics answer "is it getting worse?" Both are needed — the former pages, the latter explains.
+
+---
+
+## Privacy relay — `modules/privacy-relay.ts`
 
 Out of scope for POC, tracked for production-readiness:
 
@@ -83,6 +105,18 @@ Non-blocking relay loop:
 - Stuck/dropped tx detection — `STUCK_TX_THRESHOLD_MS` (10 min default, env-configurable) triggers re-submit with fresh nonce
 - Revert handling — receipt with `status=0` routes through the existing retry/backoff machinery
 - Backward-compatible schema: `submittedTxHash` + `submittedAt` are optional, v1 files from Phase 2 load cleanly
+
+### Phase 3A (PR #295)
+
+`/health` endpoint — gives operators a positive signal that the scanner is alive (previously only signal was log tailing):
+
+- `RelayerHealth` + `ChainHealth` types in `relayer/types.ts` mirror the indexer's `IndexerHealth` shape
+- Pure `classifyChainHealth()` classifier in `relayer/lib/health-classifier.ts` — multipliers tied to pollInterval (3× = stale, 10× = unhealthy) + 100-block lag threshold for degraded
+- Worst-wins `rollupStatus()` aggregator
+- `lastChainHead` field on `ChainState` (both iris-relay + cctp-relay) — captured each tick, used to compute `lagBlocks` cheaply at request time
+- `getHealth()` on `IrisRelayModule` + `CCTPRelayModule` — both implement the same contract, surfaced through `cctpRelayModule` in armada-relayer
+- `GET /health` route in http-api — HTTP 200 for healthy/degraded, 503 for stale/unhealthy so k8s/uptime-kuma can act without parsing JSON
+- 16 unit tests for the classifier pin severity ordering + boundary thresholds
 
 ---
 

--- a/relayer/armada-relayer.ts
+++ b/relayer/armada-relayer.ts
@@ -155,21 +155,6 @@ async function main() {
     armadaYieldAdapter: contracts.armadaYieldAdapter,
   });
 
-  // Initialize HTTP API — the cctpRelayModule below is constructed AFTER the api, so we pass
-  // a lazy getter rather than the snapshot. The api calls it on each /health request.
-  let healthProvider: (() => RelayerHealth) | null = null;
-  const httpApi = new HttpApi(
-    armadaRelayerSettings.port,
-    privacyRelay,
-    feeCalculator,
-    () => {
-      if (!healthProvider) {
-        throw new Error("Health provider not yet initialised");
-      }
-      return healthProvider();
-    },
-  );
-
   // Initialize CCTP relay module — select based on CCTP mode. `getHealth` is the contract
   // surfaced to http-api for the /health endpoint; both iris and cctp modules implement it.
   let cctpRelayModule: {
@@ -201,10 +186,16 @@ async function main() {
     }
     cctpRelayModule = cctpRelay;
   }
-  // Wire the health provider now that the module exists. The lambda passed to HttpApi above
-  // resolves to this on every request.
-  healthProvider = () => cctpRelayModule.getHealth();
   console.log();
+
+  // Initialize HTTP API — constructed AFTER cctpRelayModule so the /health closure can bind to
+  // it directly. No lazy-getter indirection, no init-order race window.
+  const httpApi = new HttpApi(
+    armadaRelayerSettings.port,
+    privacyRelay,
+    feeCalculator,
+    () => cctpRelayModule.getHealth(),
+  );
 
   // Start HTTP server
   await httpApi.start();

--- a/relayer/armada-relayer.ts
+++ b/relayer/armada-relayer.ts
@@ -21,7 +21,7 @@ import { PrivacyRelay } from "./modules/privacy-relay";
 import { HttpApi } from "./modules/http-api";
 import { CCTPRelayModule } from "./modules/cctp-relay";
 import { IrisRelayModule } from "./modules/iris-relay";
-import type { PrivacyPoolDeployment, CCTPDeployment } from "./types";
+import type { PrivacyPoolDeployment, CCTPDeployment, RelayerHealth } from "./types";
 import { getNetworkConfig } from "../config/networks";
 import { installBisectingGetLogs } from "./lib/rpc-bisecting";
 
@@ -155,15 +155,29 @@ async function main() {
     armadaYieldAdapter: contracts.armadaYieldAdapter,
   });
 
-  // Initialize HTTP API
+  // Initialize HTTP API — the cctpRelayModule below is constructed AFTER the api, so we pass
+  // a lazy getter rather than the snapshot. The api calls it on each /health request.
+  let healthProvider: (() => RelayerHealth) | null = null;
   const httpApi = new HttpApi(
     armadaRelayerSettings.port,
     privacyRelay,
-    feeCalculator
+    feeCalculator,
+    () => {
+      if (!healthProvider) {
+        throw new Error("Health provider not yet initialised");
+      }
+      return healthProvider();
+    },
   );
 
-  // Initialize CCTP relay module — select based on CCTP mode
-  let cctpRelayModule: { start: () => void; stop: () => void; chainCount: number };
+  // Initialize CCTP relay module — select based on CCTP mode. `getHealth` is the contract
+  // surfaced to http-api for the /health endpoint; both iris and cctp modules implement it.
+  let cctpRelayModule: {
+    start: () => void;
+    stop: () => void;
+    chainCount: number;
+    getHealth: () => RelayerHealth;
+  };
 
   if (armadaRelayerSettings.cctpReal) {
     console.log("[armada] Initializing REAL CCTP relay (Iris attestation)...");
@@ -187,6 +201,9 @@ async function main() {
     }
     cctpRelayModule = cctpRelay;
   }
+  // Wire the health provider now that the module exists. The lambda passed to HttpApi above
+  // resolves to this on every request.
+  healthProvider = () => cctpRelayModule.getHealth();
   console.log();
 
   // Start HTTP server

--- a/relayer/lib/health-classifier.ts
+++ b/relayer/lib/health-classifier.ts
@@ -1,0 +1,81 @@
+// ABOUTME: Pure classifier — folds (lastError, lastScanAt, pollIntervalMs, lagBlocks) into one of
+// ABOUTME: four status buckets used by the /health endpoint. Kept dependency-free + side-effect-free so
+// ABOUTME: it's unit-testable without spinning up an iris-relay / cctp-relay module.
+
+import type { ChainHealthStatus } from "../types";
+
+/**
+ * Threshold multipliers expressed relative to the chain's configured pollIntervalMs.
+ *
+ * Why relative to pollInterval rather than absolute ms? Different chains run different poll
+ * cadences (mainnet vs L2 testnet, mock-anvil vs real-Sepolia). A fixed 30s "stale" threshold
+ * would either be too sensitive on a 60s poller or too forgiving on a 5s poller. Tying the
+ * thresholds to N×interval keeps the classifier well-tuned regardless of operator config.
+ *
+ * Tuning rationale:
+ *  - `stale` at 3× allows one missed tick + buffer for the next tick to start — anything
+ *    longer than that and the scanner is genuinely stuck (not just slow).
+ *  - `unhealthy` at 10× corresponds to ~5 minutes at a 30s poll cadence, the same ballpark
+ *    operators expect for "page someone now." Bump if you find this too noisy.
+ *
+ * `LAG_BLOCKS_DEGRADED` is absolute (not relative) because block production is roughly fixed
+ * on each chain — 100 blocks behind on Sepolia (~20 min) is the same operational concern
+ * regardless of how often we're polling. Set conservatively; the scanner's chunked getLogs
+ * means it WILL catch up, but until it does, anything depending on cursor freshness is lagging.
+ */
+const STALE_MULTIPLIER = 3;
+const UNHEALTHY_MULTIPLIER = 10;
+const LAG_BLOCKS_DEGRADED = 100;
+
+export interface ChainHealthInput {
+  lastError: { message: string; at: number } | null;
+  lastScanAt: number;
+  pollIntervalMs: number;
+  lagBlocks: number;
+  /** Current time in unix ms. Parameterised so tests can be deterministic. */
+  now: number;
+}
+
+/**
+ * Classify a chain's scanner state. Order of checks matters — unhealthy must win over stale must
+ * win over degraded, because they're worsening severities and we report the highest one.
+ *
+ *  1. Never scanned successfully (`lastScanAt === 0`) → `unhealthy`. Cold start that's failed to
+ *     produce a single good tick is operationally indistinguishable from a wedge.
+ *  2. Time since last good tick > UNHEALTHY_MULTIPLIER × pollInterval → `unhealthy`.
+ *  3. Time since last good tick > STALE_MULTIPLIER × pollInterval → `stale`.
+ *  4. Most recent tick errored OR lagBlocks > threshold → `degraded`.
+ *  5. Otherwise → `healthy`.
+ */
+export function classifyChainHealth(input: ChainHealthInput): ChainHealthStatus {
+  const { lastError, lastScanAt, pollIntervalMs, lagBlocks, now } = input;
+
+  if (lastScanAt === 0) return "unhealthy";
+
+  const sinceLastScan = now - lastScanAt;
+  if (sinceLastScan > UNHEALTHY_MULTIPLIER * pollIntervalMs) return "unhealthy";
+  if (sinceLastScan > STALE_MULTIPLIER * pollIntervalMs) return "stale";
+
+  if (lastError !== null) return "degraded";
+  if (lagBlocks > LAG_BLOCKS_DEGRADED) return "degraded";
+
+  return "healthy";
+}
+
+/**
+ * Roll up multiple per-chain statuses into a single overall status. "Worst wins" — if any chain
+ * is unhealthy the overall is unhealthy, etc. Empty input array returns `unhealthy` because a
+ * relayer with zero chains has nothing useful to report; treating it as healthy would be
+ * misleading. (In practice this can't happen — the relayer requires at least one chain to start —
+ * but the classifier shouldn't silently mask the empty case.)
+ */
+export function rollupStatus(statuses: ChainHealthStatus[]): ChainHealthStatus {
+  if (statuses.length === 0) return "unhealthy";
+  // Severity order (worst → best). Find the worst.
+  const severity: ChainHealthStatus[] = ["unhealthy", "stale", "degraded", "healthy"];
+  for (const level of severity) {
+    if (statuses.includes(level)) return level;
+  }
+  // Unreachable — `statuses` is always a subset of severity values — but TS doesn't know that.
+  return "healthy";
+}

--- a/relayer/modules/cctp-relay.ts
+++ b/relayer/modules/cctp-relay.ts
@@ -20,6 +20,8 @@ import * as path from "path";
 import { CursorStore } from "../lib/cursor-store";
 import { getLogsChunked } from "../lib/get-logs-chunked";
 import { RpcTimeoutError, withTimeout } from "../lib/rpc-utils";
+import { classifyChainHealth, rollupStatus } from "../lib/health-classifier";
+import type { ChainHealth, RelayerHealth } from "../types";
 
 /** Where per-chain cursor files live — shared with iris-relay. Module-relative. */
 const RELAYER_STATE_DIR = path.join(__dirname, "..", "state");
@@ -65,8 +67,14 @@ interface ChainState {
   pendingNonce: number | null;
   /** Last scan error, or null when most recent tick succeeded. Replaces the silent catch. */
   lastError: { message: string; at: number } | null;
-  /** Unix ms of the last successful scan tick (for the future health endpoint). */
+  /** Unix ms of the last successful scan tick. Used by the /health endpoint. */
   lastScanAt: number;
+  /**
+   * Chain head observed during the most recent successful tick. Captured here (rather than
+   * fetched fresh on each /health request) so the endpoint is cheap and rate-limit-safe.
+   * `chainHead - lastProcessedBlock` is the cursor lag operators care about. 0 = never scanned.
+   */
+  lastChainHead: number;
 }
 
 /** Retry queue entry for failed CCTP relay attempts */
@@ -368,6 +376,7 @@ export class CCTPRelayModule {
         pendingNonce: null,
         lastError: null,
         lastScanAt: 0,
+        lastChainHead: 0,
       };
     } catch (e: any) {
       console.error(`    Connection error: ${e.message}`);
@@ -731,6 +740,9 @@ export class CCTPRelayModule {
         ),
       );
 
+      // Capture the freshly-observed head for /health (raw tip, NOT confirmation-adjusted).
+      state.lastChainHead = currentBlock;
+
       // Apply confirmation depth — on Anvil this is 0 so behaviour matches the old code; on
       // any real chain we won't scan reorg-vulnerable tip blocks.
       const effectiveHead = currentBlock - confirmationDepth;
@@ -900,5 +912,51 @@ export class CCTPRelayModule {
    */
   get chainCount(): number {
     return this.chains.size;
+  }
+
+  /**
+   * Snapshot per-chain scanner state for the /health endpoint. Same shape as IrisRelayModule
+   * so the http-api consumer is mode-agnostic. `pendingCount` here reflects the retry queue
+   * (failed relays awaiting backoff) — the cctp-relay's only "in-flight" state, since
+   * successful relays complete inline within the poll tick.
+   */
+  getHealth(): RelayerHealth {
+    const now = Date.now();
+
+    const pendingBySource = new Map<number, number>();
+    for (const entry of this.retryQueue) {
+      const domain = entry.sourceState.domain;
+      pendingBySource.set(domain, (pendingBySource.get(domain) ?? 0) + 1);
+    }
+
+    const chains: ChainHealth[] = [];
+    for (const state of this.chains.values()) {
+      const lagBlocks =
+        state.lastChainHead > 0 ? state.lastChainHead - state.lastProcessedBlock : 0;
+      const status = classifyChainHealth({
+        lastError: state.lastError,
+        lastScanAt: state.lastScanAt,
+        pollIntervalMs: this.pollIntervalMs,
+        lagBlocks,
+        now,
+      });
+      chains.push({
+        chainName: state.config.name,
+        domain: state.domain,
+        status,
+        lastProcessedBlock: state.lastProcessedBlock,
+        chainHead: state.lastChainHead,
+        lagBlocks,
+        lastScanAt: state.lastScanAt,
+        lastError: state.lastError,
+        pendingCount: pendingBySource.get(state.domain) ?? 0,
+      });
+    }
+
+    return {
+      status: rollupStatus(chains.map((c) => c.status)),
+      chains,
+      generatedAt: now,
+    };
   }
 }

--- a/relayer/modules/http-api.ts
+++ b/relayer/modules/http-api.ts
@@ -10,7 +10,7 @@
 import express from "express";
 import cors from "cors";
 import { RelayError } from "../types";
-import type { RelayRequest } from "../types";
+import type { RelayRequest, RelayerHealth } from "../types";
 import type { PrivacyRelay } from "./privacy-relay";
 import type { FeeCalculator } from "./fee-calculator";
 
@@ -21,16 +21,19 @@ export class HttpApi {
   private port: number;
   private privacyRelay: PrivacyRelay;
   private feeCalculator: FeeCalculator;
+  private getHealth: () => RelayerHealth;
   private server: ReturnType<express.Application["listen"]> | null = null;
 
   constructor(
     port: number,
     privacyRelay: PrivacyRelay,
-    feeCalculator: FeeCalculator
+    feeCalculator: FeeCalculator,
+    getHealth: () => RelayerHealth,
   ) {
     this.port = port;
     this.privacyRelay = privacyRelay;
     this.feeCalculator = feeCalculator;
+    this.getHealth = getHealth;
 
     this.app = express();
     this.app.use(cors());
@@ -113,13 +116,46 @@ export class HttpApi {
       }
     });
 
-    // GET / — Health check
+    // GET / — Service banner. Intentionally distinct from /health; this is the cheap
+    // "is the process alive" check, /health is the "is the scanner working" check.
     this.app.get("/", (_req, res) => {
       res.json({
         service: "armada-relayer",
         status: "running",
-        endpoints: ["GET /fees", "POST /relay", "GET /status/:txHash"],
+        endpoints: [
+          "GET /fees",
+          "POST /relay",
+          "GET /status/:txHash",
+          "GET /health",
+        ],
       });
+    });
+
+    // GET /health — Per-chain scanner state. Mirrors the indexer's IndexerHealth shape
+    // (`crowdfund-ui/packages/shared/src/lib/indexer.ts`) so a future operator dashboard can
+    // share status-pill UX.
+    //
+    // HTTP status reflects the rollup status so load balancers / monitoring (k8s liveness
+    // probes, uptime-kuma, etc.) can act on it without parsing JSON:
+    //   healthy   → 200
+    //   degraded  → 200 (still alive, surfacing transient issues in the body)
+    //   stale     → 503 (scanner wedged but process up; restart needed)
+    //   unhealthy → 503 (init failure or long-stale)
+    this.app.get("/health", (_req, res) => {
+      try {
+        const health = this.getHealth();
+        const code =
+          health.status === "healthy" || health.status === "degraded" ? 200 : 503;
+        res.status(code).json(health);
+      } catch (e: any) {
+        // getHealth itself throwing means a wiring bug (e.g. health provider not yet
+        // initialised). Log loudly and return 503 — operators should never see this in steady
+        // state, but the alternative (silent 500 with no body) is worse.
+        console.error("[http-api] /health threw:", e);
+        res
+          .status(503)
+          .json({ status: "unhealthy", error: e?.message ?? "unknown", chains: [] });
+      }
     });
   }
 
@@ -159,6 +195,7 @@ export class HttpApi {
         console.log(`  GET  http://localhost:${this.port}/fees`);
         console.log(`  POST http://localhost:${this.port}/relay`);
         console.log(`  GET  http://localhost:${this.port}/status/:txHash`);
+        console.log(`  GET  http://localhost:${this.port}/health`);
         resolve();
       });
     });

--- a/relayer/modules/http-api.ts
+++ b/relayer/modules/http-api.ts
@@ -149,12 +149,17 @@ export class HttpApi {
         res.status(code).json(health);
       } catch (e: any) {
         // getHealth itself throwing means a wiring bug (e.g. health provider not yet
-        // initialised). Log loudly and return 503 — operators should never see this in steady
-        // state, but the alternative (silent 500 with no body) is worse.
+        // initialised) — operators should never see this in steady state. Log server-side
+        // with the error detail; respond with a properly-shaped RelayerHealth so consumers
+        // parse one schema regardless of failure mode (a 503 with an ad-hoc body would
+        // break monitoring that decodes the response as RelayerHealth).
         console.error("[http-api] /health threw:", e);
-        res
-          .status(503)
-          .json({ status: "unhealthy", error: e?.message ?? "unknown", chains: [] });
+        const errorResponse: RelayerHealth = {
+          status: "unhealthy",
+          chains: [],
+          generatedAt: Date.now(),
+        };
+        res.status(503).json(errorResponse);
       }
     });
   }

--- a/relayer/modules/iris-relay.ts
+++ b/relayer/modules/iris-relay.ts
@@ -31,6 +31,8 @@ import { CursorStore } from "../lib/cursor-store";
 import { getLogsChunked } from "../lib/get-logs-chunked";
 import { PendingStateStore, type PersistedPendingMessage } from "../lib/pending-state-store";
 import { RpcTimeoutError, withTimeout } from "../lib/rpc-utils";
+import { classifyChainHealth, rollupStatus } from "../lib/health-classifier";
+import type { ChainHealth, RelayerHealth } from "../types";
 
 /** Where per-chain cursor files live. Module-relative so the relayer is location-independent. */
 const RELAYER_STATE_DIR = path.join(__dirname, "..", "state");
@@ -119,8 +121,14 @@ interface ChainState {
    * the silent catch that hid the original Sepolia incident.
    */
   lastError: { message: string; at: number } | null;
-  /** Unix ms of the last successful scan tick. Used by the future health endpoint. */
+  /** Unix ms of the last successful scan tick. Used by the /health endpoint. */
   lastScanAt: number;
+  /**
+   * Chain head observed during the most recent successful tick. Captured here (rather than
+   * fetched fresh on each /health request) so the endpoint is cheap and rate-limit-safe.
+   * `chainHead - lastProcessedBlock` is the cursor lag operators care about. 0 = never scanned.
+   */
+  lastChainHead: number;
   /**
    * Locally-tracked pending nonce for transactions THIS relayer sends to this chain. Refreshed
    * from `eth_getTransactionCount(addr, 'pending')` on first use or after a nonce error. Without
@@ -482,6 +490,7 @@ export class IrisRelayModule {
         processedMessages,
         lastError: null,
         lastScanAt: 0,
+        lastChainHead: 0,
         pendingNonce: null,
       };
     } catch (e: any) {
@@ -628,6 +637,10 @@ export class IrisRelayModule {
           `getBlockNumber ${config.name}`,
         ),
       );
+
+      // Capture the freshly-observed head BEFORE applying confirmationDepth so /health reports
+      // raw chain head (operators want "where's the tip" not "what's the last finalised block").
+      state.lastChainHead = currentBlock;
 
       // Apply confirmation depth — don't scan tip-of-chain blocks that might be reorg'd out.
       const effectiveHead = currentBlock - confirmationDepth;
@@ -1263,5 +1276,51 @@ export class IrisRelayModule {
 
   get chainCount(): number {
     return this.chains.size;
+  }
+
+  /**
+   * Snapshot per-chain scanner state for the /health endpoint. Pure data extraction — no RPC
+   * calls, no mutation. Counts pending messages by SOURCE chain since that's how
+   * PendingStateStore keys state and how operators reason about "messages stuck originating
+   * from chain X."
+   */
+  getHealth(): RelayerHealth {
+    const now = Date.now();
+
+    // Pre-bucket pending counts by source domain to avoid an O(chains × pending) loop below.
+    const pendingBySource = new Map<number, number>();
+    for (const msg of this.pendingMessages.values()) {
+      pendingBySource.set(msg.sourceDomain, (pendingBySource.get(msg.sourceDomain) ?? 0) + 1);
+    }
+
+    const chains: ChainHealth[] = [];
+    for (const state of this.chains.values()) {
+      const lagBlocks =
+        state.lastChainHead > 0 ? state.lastChainHead - state.lastProcessedBlock : 0;
+      const status = classifyChainHealth({
+        lastError: state.lastError,
+        lastScanAt: state.lastScanAt,
+        pollIntervalMs: this.pollIntervalMs,
+        lagBlocks,
+        now,
+      });
+      chains.push({
+        chainName: state.config.name,
+        domain: state.domain,
+        status,
+        lastProcessedBlock: state.lastProcessedBlock,
+        chainHead: state.lastChainHead,
+        lagBlocks,
+        lastScanAt: state.lastScanAt,
+        lastError: state.lastError,
+        pendingCount: pendingBySource.get(state.domain) ?? 0,
+      });
+    }
+
+    return {
+      status: rollupStatus(chains.map((c) => c.status)),
+      chains,
+      generatedAt: now,
+    };
   }
 }

--- a/relayer/test/lib/health-classifier.test.ts
+++ b/relayer/test/lib/health-classifier.test.ts
@@ -1,0 +1,150 @@
+// ABOUTME: Tests for the pure /health classifier. Pins the severity ordering, the multipliers, and
+// ABOUTME: the rollup "worst-wins" behaviour. WHY: the classifier is the only thing standing between
+// ABOUTME: "scanner ticked 10 minutes ago" and an operator paging — a wrong threshold or a missing
+// ABOUTME: severity rung silently masks real failures, which is exactly the silent-stall class that
+// ABOUTME: Phase 1–2B closed for everything BUT operator visibility. These tests are the operator's
+// ABOUTME: contract that "unhealthy" means unhealthy.
+
+import { expect } from "chai";
+import { classifyChainHealth, rollupStatus } from "../../lib/health-classifier";
+
+const POLL = 30_000; // 30s — typical iris-relay cadence
+const NOW = 1_700_000_000_000;
+
+function input(overrides: Partial<Parameters<typeof classifyChainHealth>[0]> = {}) {
+  return {
+    lastError: null,
+    lastScanAt: NOW - 5_000,
+    pollIntervalMs: POLL,
+    lagBlocks: 0,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe("classifyChainHealth", function () {
+  describe("healthy baseline", function () {
+    it("returns 'healthy' when scan recent, no error, no lag", function () {
+      expect(classifyChainHealth(input())).to.equal("healthy");
+    });
+
+    it("returns 'healthy' at the stale boundary (sinceLastScan = 3× pollInterval - 1ms)", function () {
+      // WHY: pin the exact threshold. A regression that flipped the comparator to `>=`
+      // would degrade a perfectly healthy scanner that's poll-bound right at the edge.
+      expect(
+        classifyChainHealth(input({ lastScanAt: NOW - (3 * POLL - 1) })),
+      ).to.equal("healthy");
+    });
+  });
+
+  describe("unhealthy — never scanned", function () {
+    it("returns 'unhealthy' when lastScanAt === 0 (cold start that's never produced a good tick)", function () {
+      // WHY: a relayer that boots, fails to scan, and gives no positive signal is operationally
+      // worse than one that ticked once and stalled — at least the latter has a known last-good
+      // state. The classifier MUST escalate this case past 'stale' to 'unhealthy' so monitoring
+      // pages immediately rather than waiting for the stale-threshold window to elapse.
+      expect(classifyChainHealth(input({ lastScanAt: 0 }))).to.equal("unhealthy");
+    });
+
+    it("returns 'unhealthy' even if lastError is null when never scanned", function () {
+      // Defensive: the cold-start case should not be masked by error-presence checks downstream
+      // of it. Order-of-checks regression guard.
+      expect(
+        classifyChainHealth(input({ lastScanAt: 0, lastError: null })),
+      ).to.equal("unhealthy");
+    });
+  });
+
+  describe("unhealthy — long-stale", function () {
+    it("returns 'unhealthy' when sinceLastScan > 10× pollInterval", function () {
+      expect(
+        classifyChainHealth(input({ lastScanAt: NOW - (10 * POLL + 1) })),
+      ).to.equal("unhealthy");
+    });
+
+    it("unhealthy wins over 'degraded' from lastError when both apply", function () {
+      // WHY: severity ordering invariant. A long-dead scanner that ALSO has an error in its
+      // last attempt is unhealthy, not degraded — operators need the strongest signal.
+      expect(
+        classifyChainHealth(
+          input({
+            lastScanAt: NOW - (10 * POLL + 1),
+            lastError: { message: "boom", at: NOW - (10 * POLL + 1) },
+          }),
+        ),
+      ).to.equal("unhealthy");
+    });
+  });
+
+  describe("stale", function () {
+    it("returns 'stale' at sinceLastScan = 3× pollInterval + 1ms", function () {
+      expect(
+        classifyChainHealth(input({ lastScanAt: NOW - (3 * POLL + 1) })),
+      ).to.equal("stale");
+    });
+
+    it("returns 'stale' anywhere in (3×, 10×] pollInterval window", function () {
+      expect(
+        classifyChainHealth(input({ lastScanAt: NOW - 5 * POLL })),
+      ).to.equal("stale");
+    });
+
+    it("stale wins over degraded from lastError", function () {
+      // Same severity-ordering invariant as the unhealthy case — stale > degraded.
+      expect(
+        classifyChainHealth(
+          input({
+            lastScanAt: NOW - 5 * POLL,
+            lastError: { message: "boom", at: NOW - 5 * POLL },
+          }),
+        ),
+      ).to.equal("stale");
+    });
+  });
+
+  describe("degraded", function () {
+    it("returns 'degraded' when lastError is set and scan recent", function () {
+      // WHY: a recent tick that failed is the canonical degraded case — scanner alive,
+      // last attempt errored, will retry. Operator-visible but not paged.
+      expect(
+        classifyChainHealth(input({ lastError: { message: "RPC 500", at: NOW - 1_000 } })),
+      ).to.equal("degraded");
+    });
+
+    it("returns 'degraded' when lagBlocks > 100", function () {
+      // WHY: cursor is falling behind chain head — the bisecting getLogs WILL catch up,
+      // but until then anything depending on cursor freshness (UIs polling for events) is
+      // showing stale data. Operators want to know.
+      expect(classifyChainHealth(input({ lagBlocks: 101 }))).to.equal("degraded");
+    });
+
+    it("does NOT flag degraded at lagBlocks = 100 (boundary)", function () {
+      expect(classifyChainHealth(input({ lagBlocks: 100 }))).to.equal("healthy");
+    });
+  });
+});
+
+describe("rollupStatus", function () {
+  it("returns 'healthy' when all chains are healthy", function () {
+    expect(rollupStatus(["healthy", "healthy", "healthy"])).to.equal("healthy");
+  });
+
+  it("returns 'unhealthy' on an empty list (no chains == nothing useful to report)", function () {
+    // WHY: silently returning 'healthy' for an empty input would mask configuration bugs
+    // (e.g. CHAINS env var typo wiping the chain list). Loud 'unhealthy' surfaces it.
+    expect(rollupStatus([])).to.equal("unhealthy");
+  });
+
+  it("worst-wins: 'unhealthy' beats 'degraded' beats 'healthy'", function () {
+    expect(rollupStatus(["healthy", "degraded", "unhealthy"])).to.equal("unhealthy");
+    expect(rollupStatus(["healthy", "degraded"])).to.equal("degraded");
+    expect(rollupStatus(["healthy", "stale"])).to.equal("stale");
+  });
+
+  it("severity ordering: unhealthy > stale > degraded > healthy", function () {
+    // Exhaustive: every adjacent-severity pair to lock the ordering invariant.
+    expect(rollupStatus(["unhealthy", "stale"])).to.equal("unhealthy");
+    expect(rollupStatus(["stale", "degraded"])).to.equal("stale");
+    expect(rollupStatus(["degraded", "healthy"])).to.equal("degraded");
+  });
+});

--- a/relayer/types.ts
+++ b/relayer/types.ts
@@ -90,6 +90,52 @@ export interface ArmadaRelayerConfig {
   };
 }
 
+// ============ Health Types ============
+
+/**
+ * Operational status of a single chain's scanner. Mirrors the indexer's status semantics
+ * (`crowdfund-ui/packages/shared/src/lib/indexer.ts::IndexerHealthStatus`) so frontends can
+ * adopt the same status-pill UX once a relayer dashboard exists.
+ *
+ *  - `healthy`   — scanner ticked recently AND no error from the most recent tick.
+ *  - `degraded`  — recent tick failed (lastError set) OR lagBlocks above the configured ceiling.
+ *                  Scanner still alive; investigate but no immediate action required.
+ *  - `stale`     — no successful scan tick for >3× pollInterval. Scanner likely wedged.
+ *  - `unhealthy` — never scanned successfully (init failure) OR no tick for >10× pollInterval.
+ *                  Operator action required.
+ */
+export type ChainHealthStatus = "healthy" | "degraded" | "stale" | "unhealthy";
+
+/** Per-chain health snapshot. Surfaced by `GET /health` so operators have a positive signal that the scanner is alive. */
+export interface ChainHealth {
+  /** Chain name (matches the deployments and CCTP_NETWORKS config). */
+  chainName: string;
+  /** CCTP domain ID of this chain. */
+  domain: number;
+  status: ChainHealthStatus;
+  /** Highest block fully scanned (inclusive). Loaded from cursor on cold start. */
+  lastProcessedBlock: number;
+  /** Chain head observed during the most recent tick. May be stale — see `lastScanAt`. 0 if never scanned. */
+  chainHead: number;
+  /** `chainHead - lastProcessedBlock`. Negative would mean the cursor is ahead of head — shouldn't happen, surfaced if it does. */
+  lagBlocks: number;
+  /** Unix ms of the last successful scan tick. 0 if never scanned. */
+  lastScanAt: number;
+  /** Last scan error, or null when the most recent tick succeeded. */
+  lastError: { message: string; at: number } | null;
+  /** Number of in-flight messages awaiting Iris attestation OR destination confirmation (iris-relay only; cctp-relay reports 0). */
+  pendingCount: number;
+}
+
+export interface RelayerHealth {
+  /** Worst-status across all chains — overall green/yellow/red signal for monitoring. */
+  status: ChainHealthStatus;
+  /** Per-chain breakdown. */
+  chains: ChainHealth[];
+  /** Unix ms when this health snapshot was generated (server side, not cached). */
+  generatedAt: number;
+}
+
 // ============ Deployment Types ============
 
 export interface PrivacyPoolDeployment {


### PR DESCRIPTION
## Summary

First slice of Phase 3 observability — adds a `GET /health` endpoint to the relayer so operators have a positive signal that the scanner is alive. Until now the only signal was log tailing.

Mirrors the indexer's `IndexerHealth` shape (`crowdfund-ui/packages/shared/src/lib/indexer.ts`) so a future operator dashboard can share status-pill UX.

Phase 3B (pino structured logs) and Phase 3C (Prometheus \`/metrics\`) tracked as follow-ups in \`.claude/RELAYER_HARDENING.md\`.

## Shape

\`\`\`json
{
  \"status\": \"healthy\" | \"degraded\" | \"stale\" | \"unhealthy\",
  \"chains\": [
    {
      \"chainName\": \"base-sepolia\",
      \"domain\": 6,
      \"status\": \"healthy\",
      \"lastProcessedBlock\": 12345678,
      \"chainHead\": 12345680,
      \"lagBlocks\": 2,
      \"lastScanAt\": 1748073600000,
      \"lastError\": null,
      \"pendingCount\": 0
    }
  ],
  \"generatedAt\": 1748073601234
}
\`\`\`

HTTP status reflects the rollup so k8s liveness probes / uptime-kuma can act without parsing the body:
- 200 — healthy or degraded (process up, surfacing issues in body)
- 503 — stale or unhealthy (scanner wedged or never ticked)

## Status thresholds

Pure classifier in \`relayer/lib/health-classifier.ts\`, tied to each chain's configured \`pollIntervalMs\` so the same code works at any cadence:

- **unhealthy** — never scanned successfully OR no tick for >10× pollInterval
- **stale** — no tick for >3× pollInterval
- **degraded** — last tick errored OR lagBlocks > 100
- **healthy** — otherwise

Worst-status wins for the overall rollup. Empty chain list returns \`unhealthy\` so a config bug (chain list typoed away) is loud rather than masked.

## Implementation notes

- \`lastChainHead\` tracked on \`ChainState\` in both iris-relay + cctp-relay — captured during the existing per-tick \`getBlockNumber()\` call, so \`/health\` does zero RPC work.
- Both iris-relay and cctp-relay implement the same \`getHealth()\` contract. armada-relayer surfaces it through the shared \`cctpRelayModule\` interface so http-api is mode-agnostic.
- \`pendingCount\` for iris-relay = messages awaiting attestation or destination receipt, bucketed by source chain. For cctp-relay = retry-queue depth (the module's only in-flight state).

## Test plan

- [x] \`npm run test:relayer\` — 77/77 passing (added 16 classifier tests pinning severity ordering + boundary thresholds)
- [x] typecheck clean
- [ ] Manual: hit \`http://localhost:3001/health\` against a running relayer; verify shape + status
- [ ] Manual Sepolia: kill the chain RPC briefly, observe \`lastError\` populate + status flip to degraded, then recover

🤖 Generated with [Claude Code](https://claude.com/claude-code)