### PR TITLE
fix(armada-interface): route xchain destination scan through ethers — restores bisecting eth_getLogs on free-tier RPCs

### DIFF
--- a/apps/armada-interface/src/features/shield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/shield-xchain/handler.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Cross-chain shield handler — user signs PrivacyPoolClient.crossChainShield on the source client chain, which burns USDC via CCTP and carries the shield payload as hook data.
 // ABOUTME: Mirrors unshield-xchain but flipped direction: burn on CLIENT → mint on HUB. The relayer (or hookRouter) delivers the message on the hub, atomically minting USDC and calling PrivacyPool.shield.
 
-import { encodeFunctionData, pad, parseAbiItem } from 'viem'
+import { encodeFunctionData, pad } from 'viem'
 import {
   getPublicClient,
   readContract,
@@ -13,7 +13,8 @@ import { erc20Abi, maxUint256 } from 'viem'
 import { ethers } from 'ethers'
 import { wagmiConfig } from '@/config/wagmi'
 import { loadDeployments } from '@/config/deployments'
-import { getNetworkConfig } from '@/config/network'
+import { getChainById, getNetworkConfig } from '@/config/network'
+import { createProvider } from '@/lib/rpc'
 import {
   getRailgunAddress as kmGetRailgunAddress,
   getWalletId as kmGetWalletId,
@@ -25,7 +26,7 @@ import {
   deriveShieldPrivateKey,
   SHIELD_SIGNATURE_MESSAGE,
 } from '@/lib/railgun/shield'
-import { extractCctpMessageFromReceipt } from '@/lib/cctp'
+import { extractCctpMessageFromReceipt, messageReceivedTopic } from '@/lib/cctp'
 import { cctpMaxFeeForKind } from '@/lib/relayer'
 import { ensureChain } from '@/lib/network-switch'
 import { advance, markFailed, markWaiting, patchArtifacts } from '@/lib/tx/reducer'
@@ -38,11 +39,21 @@ import { scanCctpDeliveryWindow } from '../unshield-xchain/scan'
 import type { StageHandler } from '@/lib/tx/executor'
 import type { TxRecord } from '@/lib/tx/types'
 
-// Same event signature the unshield-xchain handler uses for delivery detection on the destination.
-// For shield-xchain the "destination" is the HUB (where the USDC mints) — symmetric setup.
-const MESSAGE_RECEIVED_EVENT = parseAbiItem(
+// MessageReceived ABI for ethers.Interface.parseLog. We route the destination scan through
+// ethers (rather than viem) so the app-wide bisecting JsonRpcProvider patch
+// (lib/rpc-bisecting.ts) takes effect on free-tier RPCs that cap getLogs at 10 blocks
+// (Alchemy free). Viem's HTTP transport is not covered by that patch.
+const MESSAGE_RECEIVED_IFACE = new ethers.Interface([
   'event MessageReceived(address indexed caller, uint32 sourceDomain, bytes32 indexed nonce, bytes32 sender, uint32 indexed finalityThresholdExecuted, bytes messageBody)',
-)
+])
+
+// Explicit log shape we hand scanCctpDeliveryWindow so the predicate sees `topics` + `data`.
+// Mirrors ethers' Log surface (string-typed hashes, readonly topics array).
+type EthersScanLog = {
+  transactionHash?: string | null
+  topics: readonly string[]
+  data: string
+}
 
 /**
  * PrivacyPoolClient.crossChainShield ABI — the client-side entry point. Pulls USDC from the user,
@@ -326,10 +337,16 @@ async function runWaitForDelivery(
     throw new Error('Missing shieldRequest.encryptedBundle artifact — cannot identify destination delivery.')
   }
   const uniqueMarker = shieldRequest.encryptedBundle[0].slice(2).toLowerCase()
-  const hubClient = getPublicClient(wagmiConfig, { chainId: hubChainId })
-  if (!hubClient) {
-    throw new Error('No wagmi public client for hub chain')
+  // Build an ethers JsonRpcProvider for the hub chain. We deliberately bypass viem here so the
+  // app-wide bisecting `eth_getLogs` patch (lib/rpc-bisecting.ts, installed in main.tsx) applies
+  // — free-tier RPCs (Alchemy = 10-block cap) reject the configured 5_000-block window outright,
+  // and only the bisector recovers automatically.
+  const hubChain = getChainById(hubChainId)
+  if (!hubChain) {
+    throw new Error(`No chain config for hub chain ${hubChainId}`)
   }
+  const hubProvider = createProvider(hubChain.rpcUrls)
+  const hubMessageReceivedTopic = messageReceivedTopic()
 
   let cursor = markWaiting(record)
   await ctx.upsert(cursor)
@@ -357,17 +374,30 @@ async function runWaitForDelivery(
   const result = await poll<`0x${string}`>(
     async (signal) => {
       if (signal.aborted) return null
-      const outcome = await scanCctpDeliveryWindow({
-        getBlockNumber: () => hubClient.getBlockNumber(),
-        getLogsForRange: (fromBlock, toBlock) => hubClient.getLogs({
+      const outcome = await scanCctpDeliveryWindow<EthersScanLog>({
+        getBlockNumber: async () => BigInt(await hubProvider.getBlockNumber()),
+        // Filter on the MessageReceived topic only — V2 puts an Iris-assigned `eventNonce` in
+        // the indexed `nonce` topic that we can't predict source-side. The matchPredicate below
+        // narrows by hookData content (uniqueMarker = encryptedBundle[0]).
+        getLogsForRange: (fromBlock, toBlock) => hubProvider.getLogs({
           address: hubMessageTransmitter,
-          event: MESSAGE_RECEIVED_EVENT,
+          topics: [hubMessageReceivedTopic],
           fromBlock,
           toBlock,
         }),
         matchPredicate: (log) => {
-          const body = log.args.messageBody
-          return typeof body === 'string' && body.toLowerCase().includes(uniqueMarker)
+          try {
+            const parsed = MESSAGE_RECEIVED_IFACE.parseLog({
+              topics: Array.from(log.topics),
+              data: log.data,
+            })
+            const body = parsed?.args.messageBody as string | undefined
+            return typeof body === 'string' && body.toLowerCase().includes(uniqueMarker)
+          } catch {
+            // Foreign log on the same address (different ABI / unindexed topic mismatch) — skip
+            // rather than fail the whole tick. The scanner continues to the next log.
+            return false
+          }
         },
         scanFromBlock,
         maxLogRange,

--- a/apps/armada-interface/src/features/unshield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/handler.ts
@@ -2,18 +2,16 @@
 // ABOUTME: Same handler covers Withdraw modal (destination ≠ hub) and Send-External tab (destination ≠ hub) — same contract path, different UI entry.
 
 import { ethers } from 'ethers'
-import { encodeFunctionData, pad, parseAbiItem } from 'viem'
-import { getPublicClient } from 'wagmi/actions'
-import {
-  sendTransaction,
-} from 'wagmi/actions'
+import { encodeFunctionData, pad } from 'viem'
+import { getPublicClient, sendTransaction } from 'wagmi/actions'
 import { asTxError, waitForReceiptOrFail } from '@/lib/tx/receipt'
 import { classifyHandlerError } from '@/lib/tx/errors'
 import { lifecycleFor } from '@/lib/tx/lifecycles'
 import { track } from '@/lib/telemetry'
 import { wagmiConfig } from '@/config/wagmi'
 import { loadDeployments } from '@/config/deployments'
-import { getNetworkConfig } from '@/config/network'
+import { getChainById, getNetworkConfig } from '@/config/network'
+import { createProvider } from '@/lib/rpc'
 import {
   getSdkEncryptionKey as kmGetSdkEncryptionKey,
   getWalletId as kmGetWalletId,
@@ -26,15 +24,26 @@ import {
 } from '@/lib/railgun/unshield'
 import {
   extractCctpMessageFromReceipt,
+  messageReceivedTopic,
 } from '@/lib/cctp'
 import { cctpMaxFeeForKind } from '@/lib/relayer'
 import { ensureChain } from '@/lib/network-switch'
 
-// MessageReceived event signature parsed for viem's typed log filter — accepts indexed-arg
-// filters via `args.nonce`. Mirrors the on-chain event verbatim (see contracts/cctp/MockCCTPV2.sol).
-const MESSAGE_RECEIVED_EVENT = parseAbiItem(
+// MessageReceived ABI — used by ethers.Interface.parseLog to decode `messageBody` from a raw log.
+// We route the destination scan through ethers (rather than viem) so the app-wide bisecting
+// JsonRpcProvider patch (lib/rpc-bisecting.ts) takes effect on free-tier RPCs that cap getLogs
+// at 10 blocks (Alchemy free). Viem's HTTP transport is not covered by that patch.
+const MESSAGE_RECEIVED_IFACE = new ethers.Interface([
   'event MessageReceived(address indexed caller, uint32 sourceDomain, bytes32 indexed nonce, bytes32 sender, uint32 indexed finalityThresholdExecuted, bytes messageBody)',
-)
+])
+
+// Explicit log shape we hand scanCctpDeliveryWindow so the predicate sees `topics` + `data`.
+// Mirrors ethers' Log surface (string-typed hashes, readonly topics array).
+type EthersScanLog = {
+  transactionHash?: string | null
+  topics: readonly string[]
+  data: string
+}
 import { advance, markFailed, markWaiting, patchArtifacts } from '@/lib/tx/reducer'
 import { poll } from '@/lib/tx/poller'
 import { scanCctpDeliveryWindow } from './scan'
@@ -305,10 +314,16 @@ async function runWaitForDelivery(
   // ultimately resolve as the second delivery lands).
   const recipientBytes32 = pad(record.meta.recipient as `0x${string}`, { size: 32 })
   const uniqueMarker = recipientBytes32.slice(2).toLowerCase()
-  const destClient = getPublicClient(wagmiConfig, { chainId: record.meta.toChainId })
-  if (!destClient) {
-    throw new Error(`No wagmi public client for destination chain ${record.meta.toChainId}`)
+  // Build an ethers JsonRpcProvider for the destination chain. We deliberately bypass viem here
+  // so the app-wide bisecting `eth_getLogs` patch (lib/rpc-bisecting.ts, installed in main.tsx)
+  // applies — free-tier RPCs (Alchemy = 10-block cap) reject the configured 5_000-block window
+  // outright, and only the bisector recovers automatically.
+  const destChain = getChainById(record.meta.toChainId)
+  if (!destChain) {
+    throw new Error(`No chain config for destination chain ${record.meta.toChainId}`)
   }
+  const destProvider = createProvider(destChain.rpcUrls)
+  const destMessageReceivedTopic = messageReceivedTopic()
 
   // Park the record in 'waiting' so the stepper renders the "Waiting for cross-chain confirmation"
   // copy. The handler doesn't return here — poll() continues; the 'waiting' state is purely a
@@ -351,17 +366,30 @@ async function runWaitForDelivery(
       // Bounded per-tick scan — never queries more than maxLogRange blocks in a single getLogs
       // call. Across many ticks the cursor marches forward chunk-by-chunk; once caught up to head,
       // ticks short-circuit on `no-new-blocks` until the next block lands.
-      const outcome = await scanCctpDeliveryWindow({
-        getBlockNumber: () => destClient.getBlockNumber(),
-        getLogsForRange: (fromBlock, toBlock) => destClient.getLogs({
+      const outcome = await scanCctpDeliveryWindow<EthersScanLog>({
+        getBlockNumber: async () => BigInt(await destProvider.getBlockNumber()),
+        // Filter on the MessageReceived topic only — V2 puts an Iris-assigned `eventNonce` in
+        // the indexed `nonce` topic that we can't predict source-side. The matchPredicate below
+        // narrows by hookData content (uniqueMarker = pad32(recipient)).
+        getLogsForRange: (fromBlock, toBlock) => destProvider.getLogs({
           address: destMessageTransmitter,
-          event: MESSAGE_RECEIVED_EVENT,
+          topics: [destMessageReceivedTopic],
           fromBlock,
           toBlock,
         }),
         matchPredicate: (log) => {
-          const body = log.args.messageBody
-          return typeof body === 'string' && body.toLowerCase().includes(uniqueMarker)
+          try {
+            const parsed = MESSAGE_RECEIVED_IFACE.parseLog({
+              topics: Array.from(log.topics),
+              data: log.data,
+            })
+            const body = parsed?.args.messageBody as string | undefined
+            return typeof body === 'string' && body.toLowerCase().includes(uniqueMarker)
+          } catch {
+            // Foreign log on the same address (different ABI / unindexed topic mismatch) — skip
+            // rather than fail the whole tick. The scanner continues to the next log.
+            return false
+          }
         },
         scanFromBlock,
         maxLogRange,

--- a/apps/armada-interface/src/features/unshield-xchain/scan.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/scan.ts
@@ -1,8 +1,13 @@
 // ABOUTME: Pure per-tick scan helper used by the xchain unshield handler — caps the eth_getLogs window to maxLogRange blocks and advances a cursor between ticks.
 // ABOUTME: Lifted out of handler.ts so the cursor/window math is unit-testable without dragging in wagmi, ethers, or the railgun SDK.
 
-/** Minimal log shape we need: a (possibly absent) transaction hash for the match outcome. Callers pass concrete viem-typed logs which structurally satisfy this. */
-export type ScanLog = { transactionHash?: `0x${string}` | null }
+/**
+ * Minimal log shape we need: a (possibly absent) transaction hash for the match outcome. Typed
+ * as plain `string` so both viem (`\`0x${string}\``) and ethers (`string`) Log shapes
+ * structurally satisfy it. The outcome's `txHash` re-narrows to the hex brand at the boundary
+ * since on-chain logs always carry hex-string tx hashes.
+ */
+export type ScanLog = { transactionHash?: string | null }
 
 /** Caller-supplied range query. Lets the handler keep viem's typed event filter without leaking it into this helper's signature. */
 export type GetLogsForRange<TLog extends ScanLog = ScanLog> = (
@@ -63,7 +68,10 @@ export async function scanCctpDeliveryWindow<TLog extends ScanLog>(
 
   const matched = input.matchPredicate ? logs.find(input.matchPredicate) : logs[0]
   if (matched?.transactionHash) {
-    return { kind: 'match', txHash: matched.transactionHash }
+    // Re-narrow to the hex-string brand. On-chain logs always carry a 0x-prefixed hex tx hash;
+    // the type widening on ScanLog is purely to bridge viem's branded literal and ethers' plain
+    // `string`. The cast restores the brand for callers.
+    return { kind: 'match', txHash: matched.transactionHash as `0x${string}` }
   }
 
   return { kind: 'no-match', nextScanFromBlock: toBlock + 1n, scannedTo: toBlock }


### PR DESCRIPTION
## Summary

The xchain destination scan (both shield-xchain and unshield-xchain) was calling \`getLogs\` through viem's HTTP transport, bypassing the app-wide bisecting \`eth_getLogs\` patch installed in \`main.tsx\`. On free-tier RPCs (Alchemy = 10-block cap) the scanner's 5,000-block requests were instantly rejected and tracking never observed the destination delivery — the user's tx succeeded on chain but the UI stayed stuck waiting.

## Root cause

PR #280 installed \`installBisectingGetLogs()\` at the ethers \`JsonRpcProvider.prototype.send\` level — covering the Railgun SDK's internal scanning. The xchain destination scan used \`getPublicClient(wagmiConfig, { chainId })\` which returns a viem client. viem's transport is on a different stack and was never patched. The 10-block range error returned by Alchemy free was therefore propagated up, killing the poll tick.

## Fix

Switch both xchain handlers' destination scan to construct an ethers \`JsonRpcProvider\` via \`createProvider(chain.rpcUrls)\`. The existing prototype patch then bisects automatically on the well-known range errors. Identical change in both handlers; symmetric with how the relayer + Railgun SDK do scanning.

Additional bits:
- \`MessageReceived\` decoding switches from viem's typed \`parseAbiItem\` to \`ethers.Interface.parseLog\` (5 lines per handler). Match predicate semantics unchanged.
- \`messageReceivedTopic()\` reused from \`lib/cctp.ts\` for the topic filter.
- \`scan.ts::ScanLog.transactionHash\` widened from \`\\\`0x\${string}\\\` | null\` to \`string | null | undefined\` so both viem and ethers Log shapes satisfy it. The outcome's \`txHash\` re-narrows to the hex brand at the boundary (on-chain logs always carry hex tx hashes).
- Each handler defines a local \`EthersScanLog\` type that adds \`topics\` + \`data\` so the predicate can call \`parseLog\`.

The \`getBlockNumber\` snapshot calls in \`runSubmitAndBurn\` (lines 273 / 297 in their respective handlers) stay on viem — they're not getLogs and the snapshot only happens once per tx submission.

## Test plan

- [x] \`npm run typecheck --workspace=@armada/interface\` — clean
- [x] \`npm run test --workspace=@armada/interface\` — 559/559 passing
- [ ] Manual Sepolia: cross-chain unshield with Alchemy free tier client RPCs — tracking observes destination delivery
- [ ] Manual Sepolia: cross-chain shield — symmetric (scan polls hub for MessageReceived)
- [ ] Manual: check network tab logs — confirm bisection kicks in on range-too-large responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)