### PR TITLE
fix(relayer): dedup CCTP messages by (sourceTxHash, logIndex) — fixes silent skip on identical-amount unshields

### DIFF
--- a/relayer/lib/pending-state-store.ts
+++ b/relayer/lib/pending-state-store.ts
@@ -8,7 +8,7 @@
 
 import { JsonStateStore } from "./json-state-store";
 
-const PENDING_SCHEMA_VERSION = 1 as const;
+const PENDING_SCHEMA_VERSION = 2 as const;
 
 /**
  * Persisted shape of a pending CCTP message. Mirrors the iris-relay `PendingMessage` interface
@@ -21,10 +21,24 @@ const PENDING_SCHEMA_VERSION = 1 as const;
  *
  * Both Phase 2B fields are OPTIONAL — a v1 file written by the prior version (which had
  * neither) loads cleanly. The state machine treats absent fields as "awaiting Iris."
+ *
+ * v2 added `dedupKey` — `${sourceTxHash}:${logIndex}`. The previous v1 dedup used
+ * `messageHash` (keccak256 of the source-side messageBytes), but CCTP V2 leaves the source
+ * nonce slot at bytes32(0) and our burn body has no per-tx-unique field, so two unshields
+ * with the same {amount, maxFee, finalRecipient} produce byte-identical messageBytes and
+ * collide on hash. `(sourceTxHash, logIndex)` is the canonical EVM identifier for a log and
+ * cannot collide between two distinct burns.
  */
 export interface PersistedPendingMessage {
   messageBytes: string;
   messageHash: string;
+  /**
+   * Globally-unique-per-log dedup key, format `${sourceTxHash}:${logIndex}`. Used as the key
+   * in the in-memory pendingMessages Map and the per-chain processedMessages Set. Distinct
+   * from `messageHash` (which is keccak256(messageBytes) — used for Iris attestation lookup,
+   * not dedup, because identical burns produce identical hashes in CCTP V2).
+   */
+  dedupKey: string;
   sourceDomain: number;
   destinationDomain: number;
   nonce: string;
@@ -54,12 +68,13 @@ export interface PersistedPendingMessage {
 export interface PendingStateData {
   pending: PersistedPendingMessage[];
   /**
-   * Set of messageHashes we've already delivered (relayWithHook returned success OR the contract
-   * said "already processed"). Used to short-circuit `enqueueMessage` when the scanner re-discovers
+   * Set of `dedupKey`s (format `${sourceTxHash}:${logIndex}`) for messages we've already
+   * delivered (relayWithHook returned success OR the destination contract said
+   * "already processed"). Used to short-circuit `enqueueMessage` when the scanner re-discovers
    * a message after a restart. Stored as a sorted array on disk for JSON-friendliness.
    *
    * Note: this grows without bound at the relayer's current volume (handful of messages per hour
-   * at most). At ~70 bytes per hash, 10k entries = 700KB. Future Phase 3 polish: prune entries
+   * at most). At ~80 bytes per entry, 10k entries = 800KB. Future Phase 3 polish: prune entries
    * older than MAX_ATTESTATION_AGE_MS × 2 since they're irrelevant by then.
    */
   processed: string[];
@@ -86,6 +101,7 @@ export class PendingStateStore {
       filenamePrefix: "pending",
       expectedVersion: PENDING_SCHEMA_VERSION,
       validate,
+      migrate: migrateV1ToV2,
     });
   }
 
@@ -121,6 +137,65 @@ export class PendingStateStore {
 
 /** Loud-log threshold for the processed-set size — see comment in PendingStateStore.write. */
 const PROCESSED_SET_WARN_THRESHOLD = 10_000;
+
+/**
+ * Migrate a v1 payload (pre-dedupKey, processed-keyed-by-messageHash) to v2.
+ *
+ * v1 `processed[]` entries are keccak256(messageBytes) — incompatible with v2's dedupKey
+ * (`${sourceTxHash}:${logIndex}`). There's no way to recover the dedupKey from a bare hash, so
+ * we drop the v1 processed[] entirely. Pending messages also get back-filled with a synthetic
+ * dedupKey derived from their `sourceTxHash`; logIndex is unrecoverable from the persisted
+ * payload, so we use `0` as a placeholder. The pending-message dedupKey is only used for
+ * Map keying + future dedup; the brief window where two un-confirmed messages from the same
+ * source tx could collide is acceptable — `atomicCrossChainUnshield` and `crossChainShield`
+ * each emit exactly one MessageSent per tx, so `:0` is correct in practice today.
+ *
+ * The cost of dropping v1 processed[] is one possible re-relay per previously-delivered
+ * message that the scanner re-discovers — the destination contract's "already processed"
+ * check is the safety net (submitRelay returns 'already-processed', the message is then
+ * marked processed under v2). One wasted RPC call per stale message, not a real issue.
+ */
+function migrateV1ToV2(oldPayload: unknown, oldVersion: number): PendingStateData {
+  if (oldVersion !== 1) {
+    throw new Error(
+      `pending-store: cannot migrate from version ${oldVersion} — no migrator defined for that path.`,
+    );
+  }
+  const candidate = oldPayload as {
+    pending?: unknown;
+    processed?: unknown;
+    updatedAt?: unknown;
+  };
+  if (!Array.isArray(candidate.pending)) {
+    throw new Error(`pending-store: v1 migration failed — 'pending' is not an array.`);
+  }
+  if (typeof candidate.updatedAt !== "number") {
+    throw new Error(`pending-store: v1 migration failed — 'updatedAt' is missing or non-numeric.`);
+  }
+  const migratedPending = candidate.pending.map((raw, idx) => {
+    if (typeof raw !== "object" || raw === null) {
+      throw new Error(`pending-store: v1 migration failed — pending[${idx}] is not an object.`);
+    }
+    const r = raw as Partial<PersistedPendingMessage> & { sourceTxHash?: string };
+    if (typeof r.sourceTxHash !== "string") {
+      throw new Error(
+        `pending-store: v1 migration failed — pending[${idx}].sourceTxHash missing or non-string; cannot synthesize dedupKey.`,
+      );
+    }
+    return { ...r, dedupKey: `${r.sourceTxHash}:0` } as PersistedPendingMessage;
+  });
+  console.warn(
+    `[pending-store] Migrating v1 → v2: dropping ${
+      Array.isArray(candidate.processed) ? candidate.processed.length : 0
+    } legacy processed-hash entries; back-filled dedupKey on ${migratedPending.length} pending message(s). Any previously-relayed messages re-discovered by the scanner will get a one-shot 'already processed' bounce on first re-submit.`,
+  );
+  return {
+    pending: migratedPending,
+    processed: [], // legacy keccak256(messageBytes) entries are not convertible — drop them.
+    updatedAt: candidate.updatedAt,
+    version: PENDING_SCHEMA_VERSION,
+  };
+}
 
 function validate(
   parsed: unknown,
@@ -185,6 +260,7 @@ function validatePending(
   const requiredStrings: (keyof PersistedPendingMessage)[] = [
     "messageBytes",
     "messageHash",
+    "dedupKey",
     "nonce",
     "sourceTxHash",
     "lastStatus",

--- a/relayer/lib/pending-state-store.ts
+++ b/relayer/lib/pending-state-store.ts
@@ -8,6 +8,19 @@
 
 import { JsonStateStore } from "./json-state-store";
 
+/**
+ * Schema version of the persisted pending-state file. Bumped 1 → 2 when dedupKey was added
+ * alongside the (sourceTxHash, logIndex)-based dedup; see `migrateV1ToV2` below for the
+ * forward path.
+ *
+ * ROLLBACK STRATEGY: there is no automatic v2 → v1 downgrade. A v2 file rejected by an older
+ * relayer would simply throw on startup. If you must roll back, delete the per-chain
+ * `relayer/state/pending-<chain>.json` files first — the scanner will re-discover any
+ * in-flight messages from chain history via its persisted cursor (the lookback covers the
+ * recent past, so no events are lost). The cost is one repeated relay attempt per
+ * previously-delivered message; the destination contract's "already processed" check is
+ * the safety net.
+ */
 const PENDING_SCHEMA_VERSION = 2 as const;
 
 /**

--- a/relayer/modules/iris-relay.ts
+++ b/relayer/modules/iris-relay.ts
@@ -720,7 +720,16 @@ export class IrisRelayModule {
   private enqueueMessage(log: ethers.Log, sourceState: ChainState): void {
     const iface = new ethers.Interface(REAL_MESSAGE_SENT_ABI);
     const parsed = iface.parseLog({ topics: log.topics as string[], data: log.data });
-    if (!parsed) return;
+    if (!parsed) {
+      // Topic matched MessageSent but the ABI decoder couldn't parse the payload — almost
+      // certainly an ABI mismatch (event signature drift on chain, or non-CCTP contract reusing
+      // the same topic on the same address). Loud-log so operators can investigate; without
+      // this the scanner would silently swallow valid-looking messages.
+      console.warn(
+        `[iris-relay] ${sourceState.config.name}: MessageSent ABI parse failed for tx ${log.transactionHash} log index ${log.index}. Skipping.`,
+      );
+      return;
+    }
 
     const messageBytes: string = parsed.args[0];
     const messageHash = ethers.keccak256(messageBytes);
@@ -732,9 +741,24 @@ export class IrisRelayModule {
     // canonical EVM identifier for a log emission and cannot collide between distinct burns.
     const dedupKey = `${log.transactionHash}:${log.index}`;
 
-    // Already processed or already queued
-    if (sourceState.processedMessages.has(dedupKey)) return;
-    if (this.pendingMessages.has(dedupKey)) return;
+    // Already processed (delivered + persisted) — short-circuit to avoid re-relay. Logged so
+    // a re-discovery (cursor rewind, restart with stale state) is visible to operators rather
+    // than disappearing silently. Steady-state scanning shouldn't re-discover the same log
+    // because the cursor advances past it.
+    if (sourceState.processedMessages.has(dedupKey)) {
+      console.log(
+        `  [iris-relay] ${sourceState.config.name}: skip ${dedupKey} — already in processedMessages (previously delivered).`,
+      );
+      return;
+    }
+    // Already queued in this process — re-discovery of an in-flight message (also non-steady
+    // state). Same diagnostic value as the processed-set check.
+    if (this.pendingMessages.has(dedupKey)) {
+      console.log(
+        `  [iris-relay] ${sourceState.config.name}: skip ${dedupKey} — already in pendingMessages (in-flight).`,
+      );
+      return;
+    }
 
     const { sourceDomain, destinationDomain, nonce, mintRecipient, destinationCaller } = parseMessageFields(messageBytes);
 
@@ -748,7 +772,14 @@ export class IrisRelayModule {
     // On real CCTP V2, the MessageV2.recipient is always the dest TokenMessenger (shared),
     // so we check mintRecipient (the actual contract that receives minted tokens).
     if (destState.knownRecipients.size > 0 && mintRecipient && !destState.knownRecipients.has(mintRecipient)) {
-      // Not our message — someone else's CCTP transfer on the shared MessageTransmitter
+      // Not our message — someone else's CCTP transfer on the shared MessageTransmitter. Log
+      // it so a misconfigured knownRecipients set (stale deployment file, address typo) doesn't
+      // present as "the relayer silently dropped my message." Includes both the rejected
+      // mintRecipient and the expected set so operators can diff them.
+      console.log(
+        `  [iris-relay] ${sourceState.config.name}: skip ${dedupKey} — mintRecipient ${mintRecipient} not in ${destState.config.name}'s knownRecipients ` +
+          `[${Array.from(destState.knownRecipients).join(", ")}]. Either a foreign CCTP transfer on the shared MessageTransmitter OR a deployment-address drift.`,
+      );
       return;
     }
 

--- a/relayer/modules/iris-relay.ts
+++ b/relayer/modules/iris-relay.ts
@@ -370,6 +370,18 @@ export class IrisRelayModule {
   private isRunning: boolean = false;
   private pollIntervalMs: number;
   private irisClient: IrisClient;
+  /**
+   * In-flight messages keyed by dedupKey (`${sourceTxHash}:${logIndex}`). Globally scoped
+   * across all source chains because messageHash → dedupKey routing carries the sourceDomain
+   * on each entry.
+   *
+   * CONCURRENCY: this Map is touched only from inside the single Node.js event loop. The
+   * relayer is a single-process service; `pollChain` runs sequentially per chain (no two
+   * concurrent enqueues for the same chain) and the cross-chain `Promise.allSettled` in
+   * `runPollLoop` parallelises across chains but never interleaves microtasks mid-tick within
+   * one chain's scan. JS single-threaded execution guarantees the `has(dedupKey) → set(...)`
+   * pair in `enqueueMessage` cannot be torn by another writer. No lock is required.
+   */
   private pendingMessages: Map<string, PendingMessage> = new Map();
   private cursorStore: CursorStore;
   private pendingStateStore: PendingStateStore;

--- a/relayer/modules/iris-relay.ts
+++ b/relayer/modules/iris-relay.ts
@@ -42,8 +42,20 @@ const RELAYER_STATE_DIR = path.join(__dirname, "..", "state");
 interface PendingMessage {
   /** Raw message bytes from MessageSent event */
   messageBytes: string;
-  /** keccak256 hash of the message bytes */
+  /**
+   * keccak256(messageBytes) — used as the Iris attestation lookup key. NOT used for dedup:
+   * CCTP V2's source-side messageBytes have no per-tx-unique field (nonce slot is bytes32(0)),
+   * so two identical-amount/recipient burns produce the SAME messageHash. Use `dedupKey` for
+   * Map keying + processed-set membership.
+   */
   messageHash: string;
+  /**
+   * Globally-unique-per-log dedup key, format `${sourceTxHash}:${logIndex}`. The canonical EVM
+   * identifier for a log emission — guaranteed unique within a chain, immune to message-bytes
+   * collisions between two byte-identical burns. Used as the Map key in `pendingMessages` and
+   * the entry in `ChainState.processedMessages`.
+   */
+  dedupKey: string;
   /** Source chain CCTP domain */
   sourceDomain: number;
   /** Destination chain CCTP domain */
@@ -455,12 +467,12 @@ export class IrisRelayModule {
       try {
         const persisted = await this.pendingStateStore.read(chainConfig.name);
         if (persisted) {
-          // Re-hydrate pendingMessages from disk. Keyed by messageHash in the module-level
-          // Map; entries from THIS source chain get added back so processPendingMessages can
-          // continue waiting on Iris where we left off (preserving pollAttempts / retry state).
+          // Re-hydrate pendingMessages from disk. Keyed by dedupKey in the module-level Map;
+          // entries from THIS source chain get added back so processPendingMessages can continue
+          // waiting on Iris where we left off (preserving pollAttempts / retry state).
           let restored = 0;
           for (const p of persisted.pending) {
-            this.pendingMessages.set(p.messageHash, p);
+            this.pendingMessages.set(p.dedupKey, p);
             restored++;
           }
           for (const hash of persisted.processed) {
@@ -713,9 +725,16 @@ export class IrisRelayModule {
     const messageBytes: string = parsed.args[0];
     const messageHash = ethers.keccak256(messageBytes);
 
+    // Dedup key — `${sourceTxHash}:${logIndex}`. We deliberately do NOT dedup on messageHash:
+    // CCTP V2 leaves the source nonce slot at bytes32(0) and our burn body has no per-tx-unique
+    // field, so two unshields with the same {amount, maxFee, finalRecipient} produce
+    // byte-identical messageBytes (and thus identical hashes). (sourceTxHash, logIndex) is the
+    // canonical EVM identifier for a log emission and cannot collide between distinct burns.
+    const dedupKey = `${log.transactionHash}:${log.index}`;
+
     // Already processed or already queued
-    if (sourceState.processedMessages.has(messageHash)) return;
-    if (this.pendingMessages.has(messageHash)) return;
+    if (sourceState.processedMessages.has(dedupKey)) return;
+    if (this.pendingMessages.has(dedupKey)) return;
 
     const { sourceDomain, destinationDomain, nonce, mintRecipient, destinationCaller } = parseMessageFields(messageBytes);
 
@@ -746,6 +765,7 @@ export class IrisRelayModule {
     const pending: PendingMessage = {
       messageBytes,
       messageHash,
+      dedupKey,
       sourceDomain,
       destinationDomain,
       nonce,
@@ -758,7 +778,7 @@ export class IrisRelayModule {
       nextRetryAt: 0,
     };
 
-    this.pendingMessages.set(messageHash, pending);
+    this.pendingMessages.set(dedupKey, pending);
     // Persist immediately so a crash between enqueue and the first Iris poll doesn't lose
     // this entry — the cursor has already advanced past sourceBlock, so without persistence
     // the scanner wouldn't re-discover it.
@@ -983,7 +1003,7 @@ export class IrisRelayModule {
         // AND the destination chain (no state mutation but conceptually relevant). We only
         // mark the source dirty here; the destination's pending state for this message
         // already ran through the source's persistChain since pendingMessages is keyed by
-        // messageHash globally.
+        // dedupKey globally.
         if (sourceState) await this.persistChain(sourceState);
         mutated = true;
       } else {
@@ -1026,9 +1046,9 @@ export class IrisRelayModule {
     msg.retryAttempts++;
     if (msg.retryAttempts >= MAX_RELAY_RETRIES) {
       console.error(
-        `[iris-relay] ${chainLabel}: GAVE UP on ${msg.messageHash.slice(0, 18)}... after ${msg.retryAttempts} attempts. Source Tx: ${msg.sourceTxHash}. Manual recovery may be required.`,
+        `[iris-relay] ${chainLabel}: GAVE UP on ${msg.dedupKey} (hash ${msg.messageHash.slice(0, 18)}...) after ${msg.retryAttempts} attempts. Source Tx: ${msg.sourceTxHash}. Manual recovery may be required.`,
       );
-      this.pendingMessages.delete(msg.messageHash);
+      this.pendingMessages.delete(msg.dedupKey);
     } else {
       const backoffMs = RELAY_RETRY_BASE_DELAY_MS * Math.pow(2, msg.retryAttempts - 1);
       msg.nextRetryAt = Date.now() + backoffMs;

--- a/relayer/test/lib/pending-state-store.test.ts
+++ b/relayer/test/lib/pending-state-store.test.ts
@@ -14,6 +14,7 @@ function samplePending(overrides: Partial<PersistedPendingMessage> = {}): Persis
   return {
     messageBytes: "0xabcd",
     messageHash: "0xhash1",
+    dedupKey: "0xtx1:0",
     sourceDomain: 6,
     destinationDomain: 0,
     nonce: "0xnonce",
@@ -93,14 +94,14 @@ describe("PendingStateStore", function () {
       // operator to investigate (delete the file, restart, scanner re-discovers from chain).
       const store = new PendingStateStore(dir);
       const path = join(dir, "pending-hub.json");
-      // Manually construct corrupted JSON — version stamp valid but pending entry missing fields.
+      // Manually construct corrupted JSON — v2 version stamp, but pending entry missing fields.
       await writeFile(
         path,
         JSON.stringify({
           pending: [{ messageHash: "0xa" /* missing the rest */ }],
           processed: [],
           updatedAt: 1,
-          version: 1,
+          version: 2,
         }),
         "utf8",
       );
@@ -117,7 +118,7 @@ describe("PendingStateStore", function () {
       const path = join(dir, "pending-hub.json");
       await writeFile(
         path,
-        JSON.stringify({ pending: "oops", processed: [], updatedAt: 1, version: 1 }),
+        JSON.stringify({ pending: "oops", processed: [], updatedAt: 1, version: 2 }),
         "utf8",
       );
       try {
@@ -129,13 +130,13 @@ describe("PendingStateStore", function () {
     });
 
     it("throws when 'processed' contains a non-string", async function () {
-      // WHY: the dedup set is keyed by string hashes. A numeric or null entry would break the
-      // Set semantics and could allow re-relay of an already-processed message.
+      // WHY: the dedup set is keyed by string dedupKeys. A numeric or null entry would break
+      // the Set semantics and could allow re-relay of an already-processed message.
       const store = new PendingStateStore(dir);
       const path = join(dir, "pending-hub.json");
       await writeFile(
         path,
-        JSON.stringify({ pending: [], processed: ["0xa", 42], updatedAt: 1, version: 1 }),
+        JSON.stringify({ pending: [], processed: ["0xtx:0", 42], updatedAt: 1, version: 2 }),
         "utf8",
       );
       try {
@@ -143,6 +144,43 @@ describe("PendingStateStore", function () {
         expect.fail("should have thrown");
       } catch (err) {
         expect((err as Error).message).to.match(/processed\[1\].*not a string/);
+      }
+    });
+
+    it("throws when a v2 pending entry is missing dedupKey", async function () {
+      // WHY: dedupKey is the v2 dedup contract — switching from messageHash fixed a silent
+      // collision where two identical-amount/recipient unshields produced byte-identical
+      // messageBytes (CCTP V2 source nonce is bytes32(0)) and the second one was silently
+      // skipped forever. A v2 file missing dedupKey on a pending entry would re-introduce
+      // that collision; rejecting at the boundary forces the operator to either delete the
+      // file (scanner re-discovers from chain, computes a fresh dedupKey) or fix the writer.
+      const store = new PendingStateStore(dir);
+      const path = join(dir, "pending-hub.json");
+      const noDedupKey = {
+        messageBytes: "0xabcd",
+        messageHash: "0xa",
+        // dedupKey absent
+        sourceDomain: 6,
+        destinationDomain: 0,
+        nonce: "0xn",
+        sourceTxHash: "0xtx",
+        sourceBlock: 1,
+        detectedAt: 1,
+        pollAttempts: 0,
+        lastStatus: "new",
+        retryAttempts: 0,
+        nextRetryAt: 0,
+      };
+      await writeFile(
+        path,
+        JSON.stringify({ pending: [noDedupKey], processed: [], updatedAt: 1, version: 2 }),
+        "utf8",
+      );
+      try {
+        await store.read("hub");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect((err as Error).message).to.match(/dedupKey/);
       }
     });
 
@@ -182,44 +220,6 @@ describe("PendingStateStore", function () {
       expect(got?.pending[0]?.submittedAt).to.equal(1_700_000_500_000);
     });
 
-    it("a v1 file written before Phase 2B (no submittedTxHash) loads cleanly", async function () {
-      // WHY: backward-compat invariant. Phase 2 deployments wrote v1 files without the new
-      // fields; the Phase 2B reader MUST accept them as "awaiting Iris" (no submittedTxHash).
-      // Without this, the first restart after the Phase 2B upgrade would fail to load any
-      // existing pending state — losing every in-flight message in the wild.
-      const store = new PendingStateStore(dir);
-      const path = join(dir, "pending-hub.json");
-      const legacyPending = {
-        messageBytes: "0xabcd",
-        messageHash: "0xa",
-        sourceDomain: 6,
-        destinationDomain: 0,
-        nonce: "0xn",
-        sourceTxHash: "0xtx",
-        sourceBlock: 1,
-        detectedAt: 1,
-        pollAttempts: 0,
-        lastStatus: "new",
-        retryAttempts: 0,
-        nextRetryAt: 0,
-        // submittedTxHash + submittedAt absent — pre-Phase-2B file
-      };
-      await writeFile(
-        path,
-        JSON.stringify({
-          pending: [legacyPending],
-          processed: [],
-          updatedAt: 1,
-          version: 1,
-        }),
-        "utf8",
-      );
-      const got = await store.read("hub");
-      expect(got?.pending).to.have.lengthOf(1);
-      expect(got?.pending[0]?.submittedTxHash).to.equal(undefined);
-      expect(got?.pending[0]?.submittedAt).to.equal(undefined);
-    });
-
     it("rejects a half-populated submittedTxHash/submittedAt pair (corruption)", async function () {
       // WHY: the two fields MUST be set together. submittedTxHash without submittedAt would
       // skip processInflightRelays's stuck-tx detection (no timestamp to compare against);
@@ -230,6 +230,7 @@ describe("PendingStateStore", function () {
       const halfPopulated = {
         messageBytes: "0xabcd",
         messageHash: "0xa",
+        dedupKey: "0xtx:0",
         sourceDomain: 6,
         destinationDomain: 0,
         nonce: "0xn",
@@ -245,7 +246,7 @@ describe("PendingStateStore", function () {
       };
       await writeFile(
         path,
-        JSON.stringify({ pending: [halfPopulated], processed: [], updatedAt: 1, version: 1 }),
+        JSON.stringify({ pending: [halfPopulated], processed: [], updatedAt: 1, version: 2 }),
         "utf8",
       );
       try {
@@ -254,6 +255,95 @@ describe("PendingStateStore", function () {
       } catch (err) {
         expect((err as Error).message).to.match(/submittedAt/);
       }
+    });
+  });
+
+  describe("v1 → v2 migration", function () {
+    // WHY THIS SUITE EXISTS: v2 switched dedup from keccak256(messageBytes) to
+    // `${sourceTxHash}:${logIndex}`. The change was driven by a real silent-data-loss bug:
+    // CCTP V2 leaves the source nonce slot at bytes32(0) and our burn body has no per-tx-unique
+    // field, so two unshields with the same {amount, maxFee, finalRecipient} produced byte-
+    // identical messageBytes → identical messageHash → the second was silently skipped forever
+    // (after Phase 2 made processedMessages persistent). The migrator drops legacy processed[]
+    // entries (they're hashes incompatible with the new key shape) and back-fills dedupKey on
+    // any in-flight pending messages. These tests pin the migrator's contract so a future
+    // change can't regress the persistence path.
+
+    it("migrates a v1 file by back-filling dedupKey on pending messages and dropping legacy processed[]", async function () {
+      const store = new PendingStateStore(dir);
+      const path = join(dir, "pending-hub.json");
+      // Legacy pending — no dedupKey field (v1 didn't have it). Has the rest of the v1 shape
+      // including the pre-Phase-2B optional submittedTxHash absence.
+      const legacyPending = {
+        messageBytes: "0xabcd",
+        messageHash: "0xlegacyhash",
+        sourceDomain: 6,
+        destinationDomain: 0,
+        nonce: "0xn",
+        sourceTxHash: "0xlegacytx",
+        sourceBlock: 1,
+        detectedAt: 1,
+        pollAttempts: 0,
+        lastStatus: "new",
+        retryAttempts: 0,
+        nextRetryAt: 0,
+      };
+      await writeFile(
+        path,
+        JSON.stringify({
+          pending: [legacyPending],
+          // Two legacy processed-hash entries — both must be dropped on migration. The cost of
+          // dropping is one possible re-relay each (caught by the destination contract's
+          // "already processed" check — submitRelay returns 'already-processed' and the message
+          // is then marked processed under the v2 dedupKey scheme).
+          processed: ["0xprev_hash_a", "0xprev_hash_b"],
+          updatedAt: 1,
+          version: 1,
+        }),
+        "utf8",
+      );
+      const got = await store.read("hub");
+      expect(got?.pending).to.have.lengthOf(1);
+      // dedupKey back-filled as `${sourceTxHash}:0`. logIndex is unrecoverable from the
+      // persisted v1 payload, but our two xchain entry points each emit exactly one MessageSent
+      // per tx, so `:0` is correct in practice for migrated entries today.
+      expect(got?.pending[0]?.dedupKey).to.equal("0xlegacytx:0");
+      // Original v1 fields preserved.
+      expect(got?.pending[0]?.messageHash).to.equal("0xlegacyhash");
+      expect(got?.pending[0]?.submittedTxHash).to.equal(undefined);
+      // Legacy processed entries DROPPED — they're keyed by messageHash, incompatible with
+      // the new dedupKey shape. Re-discovered messages will get a one-shot "already processed"
+      // bounce on first re-submit.
+      expect(got?.processed).to.deep.equal([]);
+    });
+
+    it("after migration, the migrated file persists at v2 — a second read does not re-trigger the migrator", async function () {
+      // WHY: subtle contract. After a successful read+migrate, the NEXT write must stamp v2
+      // so future reads short-circuit through the v2 validator (not the v1 migrator). Without
+      // this, the migrator could be invoked repeatedly on the same file, and any non-idempotent
+      // migration logic would corrupt state.
+      const store = new PendingStateStore(dir);
+      const path = join(dir, "pending-hub.json");
+      await writeFile(
+        path,
+        JSON.stringify({
+          pending: [],
+          processed: ["0xprev_hash"],
+          updatedAt: 1,
+          version: 1,
+        }),
+        "utf8",
+      );
+      // First read: triggers migrator.
+      const firstRead = await store.read("hub");
+      expect(firstRead?.version).to.equal(2);
+      // Persist back to disk under v2.
+      await store.write("hub", firstRead!.pending, new Set(firstRead!.processed));
+      // Second read: must NOT migrate (the v1 migrator would throw on a payload without
+      // version:1, so a regression that re-triggers the migrator would surface here).
+      const secondRead = await store.read("hub");
+      expect(secondRead?.version).to.equal(2);
+      expect(secondRead?.processed).to.deep.equal([]);
     });
   });
 


### PR DESCRIPTION
## Summary

The relayer silently dropped cross-chain unshields whose `messageBytes` matched a previously-delivered message — most commonly when the user retried with the same {amount, maxFee, finalRecipient}. CCTP V2 leaves the source nonce slot at \`bytes32(0)\` and our burn body has no per-tx-unique field, so identical user actions produce byte-identical \`messageBytes\` and thus identical \`keccak256(messageBytes)\`. The relayer's dedup keyed on that hash, so the second one hit the processed-set check (Phase 2 made it persistent) and was silently skipped forever.

User confirmed: a 5 USDC unshield that worked the first time silently failed on retry; 5.1 USDC succeeded immediately.

## Root cause

\`iris-relay.ts::enqueueMessage\` used \`keccak256(messageBytes)\` for both:
1. The Iris attestation lookup key (correct — Iris IS keyed by message hash)
2. The Map key in \`pendingMessages\` + the entry in \`ChainState.processedMessages\` (WRONG — collides for identical burns)

\`PersistedPendingMessage.messageHash\` was the persisted dedup field.

## Fix

Add a separate \`dedupKey\` field with format \`\${sourceTxHash}:\${logIndex}\` — the canonical EVM identifier for a log emission. Both fields exist in scope at \`enqueueMessage\` via the ethers \`Log\`. \`messageHash\` is preserved for Iris lookups; \`dedupKey\` drives Map keying and processed-set membership.

Changes:
- \`PersistedPendingMessage\` gains \`dedupKey: string\` (required)
- Schema bumped v1 → v2 in \`PendingStateStore\`
- Migrator \`migrateV1ToV2\` back-fills \`dedupKey\` on in-flight pending entries as \`\${sourceTxHash}:0\` (logIndex unrecoverable from the persisted payload; our two xchain entry points each emit exactly one MessageSent per tx, so \`:0\` is correct in practice today). Legacy \`processed[]\` entries are dropped — they're keccak256 hashes incompatible with the new key shape. The destination contract's \"already processed\" check is the safety net (one-shot wasted RPC call per re-discovered stale message)
- \`iris-relay.ts\` Map operations switch to \`dedupKey\`: \`pendingMessages.set/get/has/delete\`, \`processedMessages.has/add\`. Hydration loop and \`scheduleResubmit\` updated; iteration variables that flow into deletes are already typed correctly (they're whatever the Map is keyed by)
- \`messageHash\` still computed + persisted — required for Iris attestation polling

## Tests

\`relayer/test/lib/pending-state-store.test.ts\` — 79/79 passing:
- All validation tests updated to v2 schema
- New: \`throws when a v2 pending entry is missing dedupKey\` — pins the new schema invariant; documents the bug-fix's intent
- New describe block \`v1 → v2 migration\`:
  - \`migrates a v1 file by back-filling dedupKey on pending messages and dropping legacy processed[]\` — pins the migrator's full contract
  - \`after migration, the migrated file persists at v2 — a second read does not re-trigger the migrator\` — pins idempotency

## Operator notes (rollout)

- On first start after deploy, the relayer will read any existing \`pending-*.json\` v1 file, migrate it to v2, and log a warning summarising what was dropped/back-filled
- Any messages that were previously-relayed-and-marked-processed will get re-discovered by the scanner once. Each gets a one-shot \`submitRelay\` attempt, the destination contract returns \"already processed\", and submitRelay returns \`'already-processed'\` — no double-spend risk. One small gas cost per stale entry, bounded by the number of entries in the old \`processed[]\` array
- No env vars added; nothing operator-facing to change

## Test plan

- [x] \`npm run test:relayer\` — 79/79 passing
- [x] typecheck clean
- [ ] Manual Sepolia: send the failing 5 USDC cross-chain unshield (same amount as a prior successful one) — confirm it's queued + delivered
- [ ] Manual Sepolia: cross-chain shield still works (symmetric flow, same code path)
- [ ] Inspect \`pending-Hub.json\` post-restart: \`processed: []\`, in-flight entries have \`dedupKey\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)