### PR TITLE
feat(contracts): register full unshield/transfer vkey set against live PrivacyPool

### DIFF
--- a/lib/artifacts.ts
+++ b/lib/artifacts.ts
@@ -46,15 +46,58 @@ export interface SolidityVerifyingKey {
 }
 
 /**
- * Testing subset of circuit configurations
- * These cover the most common use cases for shield/transfer/unshield
+ * Circuit configurations the deployment script registers on PrivacyPool.
+ *
+ * Railgun's `transact()` proof shape is `(nullifiers, commitments)` — how many input notes
+ * the proof spends, and how many output commitments it produces. The contract stores one
+ * verification key per (N, M) pair (see VerifierModule); a proof with a shape that isn't
+ * registered reverts with `"PrivacyPool: Verification key not set"`.
+ *
+ * What's needed in practice:
+ *  - SHIELD always emits `(1, 2)` — preimage + dummy padding.
+ *  - LEND/REDEEM (cross-contract) emits `(1, 1)` — one nullifier, one change.
+ *  - TRANSFER with change emits `(N, 2)` — N spent + recipient + change.
+ *  - UNSHIELD WITH CONSOLIDATION emits `(N, 1)` — N spent + change (no zero-output shapes
+ *    exist in Railgun's circuit set, even when the unshield consumes the exact amount).
+ *  - MULTI-RECIPIENT transfer emits `(N, 3)` — uncommon today, cheap insurance to register.
+ *
+ * The grouping comments below mirror the operation each pair enables. If a user op generates
+ * a shape that isn't here, they'll hit `"Verification key not set"` and the op can't proceed
+ * without a redeploy or a one-shot register-against-the-live-contract pass (see
+ * `scripts/register_missing_vkeys.ts`).
  */
 export const TESTING_ARTIFACT_CONFIGS: ArtifactConfig[] = [
+  // Original baseline set — used by the first POC deployments.
   { nullifiers: 1, commitments: 1 },  // Cross-contract: lend/redeem (1 unshield -> 1 shield)
   { nullifiers: 1, commitments: 2 },  // Shield: 1 input -> 2 outputs
   { nullifiers: 2, commitments: 2 },  // Simple transfer
   { nullifiers: 2, commitments: 3 },  // Transfer with change
   { nullifiers: 8, commitments: 4 },  // Medium consolidation
+
+  // Consolidation unshields — (N notes spent, 1 change). Triggered whenever the SDK has to
+  // combine multiple smaller notes to satisfy a withdrawal/transfer amount. Without these,
+  // users with fragmented UTXO sets (which happens fast in normal use — every change output
+  // counts) hit "Verification key not set" the moment their largest single note can't cover
+  // the requested amount alone.
+  { nullifiers: 2, commitments: 1 },
+  { nullifiers: 3, commitments: 1 },
+  { nullifiers: 4, commitments: 1 },
+  { nullifiers: 5, commitments: 1 },
+  { nullifiers: 6, commitments: 1 },
+  { nullifiers: 7, commitments: 1 },
+  { nullifiers: 8, commitments: 1 },
+
+  // Transfer with change variants — (N notes spent, 1 recipient + 1 change).
+  { nullifiers: 3, commitments: 2 },
+  { nullifiers: 4, commitments: 2 },
+  { nullifiers: 5, commitments: 2 },
+  { nullifiers: 6, commitments: 2 },
+
+  // Fan-out / multi-recipient cases — (N, 3). Less common but trivially cheap to register
+  // alongside the rest; saves a future redeploy if the SDK ever emits one of these.
+  { nullifiers: 1, commitments: 3 },
+  { nullifiers: 3, commitments: 3 },
+  { nullifiers: 4, commitments: 3 },
 ];
 
 /**

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "deploy:faucets": "hardhat run scripts/deploy_faucet.ts",
     "link": "hardhat run scripts/link_privacy_pool.ts --network hub",
     "load:vk-1x1": "hardhat run scripts/load_verification_key_1x1.ts --network hub",
+    "vkeys:register": "hardhat run scripts/register_missing_vkeys.ts --network hub",
+    "vkeys:register:sepolia": "hardhat run scripts/register_missing_vkeys.ts --network sepoliaHub",
     "derive:relayer-railgun": "npx ts-node scripts/derive_relayer_railgun_address.ts",
     "relayer": "npx ts-node relayer/armada-relayer.ts",
     "armada-relayer": "npx ts-node relayer/armada-relayer.ts",

--- a/scripts/register_missing_vkeys.ts
+++ b/scripts/register_missing_vkeys.ts
@@ -1,0 +1,108 @@
+// ABOUTME: One-shot script — registers every (nullifiers, commitments) verification key in
+// ABOUTME: TESTING_ARTIFACT_CONFIGS against a live PrivacyPool deployment, skipping any pair
+// ABOUTME: already on-chain. Idempotent: safe to re-run, no redeploy required.
+//
+// Problem this exists for: `PrivacyPool: Verification key not set` reverts when a user
+// transact() proof has a (N, M) shape the deployer never registered. Adding new pairs at
+// runtime is owner-only but otherwise plumbing-free — VerifierModule.setVerificationKey
+// goes through the proxy's delegatecall surface, mutating the proxy's storage.
+//
+// Usage:
+//   VITE_NETWORK=local|sepolia npm run vkeys:register
+// (Or via the dedicated env-bound npm scripts; see package.json.)
+
+import { ethers } from "hardhat";
+import {
+  formatVKeyForSolidity,
+  getVKey,
+  TESTING_ARTIFACT_CONFIGS,
+  type ArtifactConfig,
+} from "../lib/artifacts";
+import {
+  createNonceManager,
+  loadDeployment,
+} from "./deploy-utils";
+import {
+  getDeployEnv,
+  getPrivacyPoolDeploymentFile,
+  isLocal,
+} from "../config/networks";
+
+async function main(): Promise<void> {
+  const env = getDeployEnv();
+  const filename = getPrivacyPoolDeploymentFile("hub");
+  const manifest = loadDeployment(filename);
+  if (!manifest) {
+    throw new Error(
+      `No PrivacyPool hub deployment found at deployments/${filename}. Run the hub deploy first.`,
+    );
+  }
+  const privacyPoolAddr = manifest.contracts?.privacyPool;
+  if (!privacyPoolAddr) {
+    throw new Error(`${filename} missing contracts.privacyPool`);
+  }
+
+  console.log("=".repeat(60));
+  console.log("  VerifyingKey Registrar");
+  console.log(`  Environment: ${env}${isLocal() ? " (local Anvil)" : ""}`);
+  console.log(`  PrivacyPool: ${privacyPoolAddr}`);
+  console.log("=".repeat(60));
+
+  const [signer] = await ethers.getSigners();
+  console.log(`  Signer:      ${signer.address}`);
+
+  // Attach to the PrivacyPool proxy. The pool exposes both `getVerificationKey` and
+  // `setVerificationKey` as forwarders to VerifierModule (delegatecall), so the PrivacyPool
+  // ABI is the right typing here — same pattern as `load_verification_key_1x1.ts`.
+  const pool = await ethers.getContractAt("PrivacyPool", privacyPoolAddr, signer);
+
+  // Pre-scan: which pairs already have a vkey? `alpha1.x === 0` is the same sentinel the
+  // contract's `require` uses for "not set". Use a fresh provider call per pair (cheap) so
+  // a partially-applied state from a prior run is detected accurately.
+  const toRegister: ArtifactConfig[] = [];
+  console.log("\n[1/2] Checking current on-chain state...");
+  for (const cfg of TESTING_ARTIFACT_CONFIGS) {
+    const existing = await pool.getVerificationKey(cfg.nullifiers, cfg.commitments);
+    if (existing.alpha1.x === 0n) {
+      toRegister.push(cfg);
+      console.log(`  (${cfg.nullifiers}x${cfg.commitments}) — NOT registered, will set`);
+    } else {
+      console.log(`  (${cfg.nullifiers}x${cfg.commitments}) — already on chain, skip`);
+    }
+  }
+
+  if (toRegister.length === 0) {
+    console.log("\nNothing to do. All configured verification keys are on chain.");
+    return;
+  }
+
+  console.log(`\n[2/2] Registering ${toRegister.length} verification key(s)...`);
+  // Nonce manager: explicit on testnet (Sepolia load-balanced RPCs drop stale-pending on
+  // backend drift), no-op on local Anvil. Mirrors the pattern in deploy_privacy_pool.ts.
+  const nm = await createNonceManager(signer);
+
+  for (let i = 0; i < toRegister.length; i++) {
+    const cfg = toRegister[i];
+    const vkey = getVKey(cfg.nullifiers, cfg.commitments);
+    const solidityVKey = formatVKeyForSolidity(vkey, cfg.nullifiers, cfg.commitments);
+
+    console.log(
+      `  [${i + 1}/${toRegister.length}] setVerificationKey(${cfg.nullifiers}, ${cfg.commitments})...`,
+    );
+    const tx = await pool.setVerificationKey(
+      cfg.nullifiers,
+      cfg.commitments,
+      solidityVKey,
+      nm.override(),
+    );
+    const receipt = await tx.wait();
+    console.log(`     tx ${receipt?.hash} mined in block ${receipt?.blockNumber}`);
+  }
+
+  console.log("\nDone.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Direct unshield was failing with \`PrivacyPool: Verification key not set\` whenever the user's withdraw amount required consolidating more than one shielded note. Root cause: \`TESTING_ARTIFACT_CONFIGS\` registered only 5 proof shapes at deploy time, and the SDK's note-selection algorithm generates shapes like \`(2, 1)\`, \`(3, 1)\`, \`(4, 1)\` etc. whenever it has to combine notes — none of which were registered.

This PR extends the registered set to cover every realistic shape an unshield, transfer, or yield op could produce, and adds a one-shot script to register the new pairs against the **live** PrivacyPool (no redeploy needed — \`setVerificationKey\` is owner-gated and we hold the deployer key).

## What changed

**\`lib/artifacts.ts\`** — extends \`TESTING_ARTIFACT_CONFIGS\` from 5 to 19 entries. The new shapes cover:
- Consolidation unshields \`(N, 1)\` for \`N ∈ [2..8]\` — the user's bug class
- Transfer-with-change \`(N, 2)\` for \`N ∈ [3..6]\`
- Multi-recipient \`(N, 3)\` for \`N ∈ {1, 3, 4}\` — cheap defensive coverage

Note: there are no \`(N, 0)\` circuits in Railgun's set. Even an unshield that consumes the exact amount emits at least one \`(N, 1)\` commitment. So the smallest unshield shape we need to register is \`(N, 1)\`, not \`(N, 0)\`.

**\`scripts/register_missing_vkeys.ts\`** — idempotent registrar. Walks \`TESTING_ARTIFACT_CONFIGS\`, checks each shape's current on-chain vkey via \`getVerificationKey\` (uses \`alpha1.x === 0\` as the "not set" sentinel — same check the contract uses in its require), and calls \`setVerificationKey\` only for missing shapes. Uses \`createNonceManager\` from the existing deploy helpers so Sepolia's load-balanced RPCs don't drift the nonce. Re-running is safe — already-registered shapes log "skip" and don't burn a tx.

**\`package.json\`** — two new scripts:
- \`npm run vkeys:register\` — registers against the local Anvil hub
- \`npm run vkeys:register:sepolia\` — registers against the Sepolia hub

Mirrors the existing \`load:vk-1x1\` pattern verbatim (same \`getContractAt("PrivacyPool", ...)\` typing, same \`setVerificationKey\` call shape).

## Why we can do this against the live contract

\`VerifierModule.setVerificationKey\` is \`onlyDelegatecall\` + \`require(msg.sender == owner)\`. The owner is the deployer EOA (\`config/secrets.env\`'s deployer key). The PrivacyPool proxy forwards \`setVerificationKey\` via delegatecall, so the storage mutation lands in the proxy's slot. All existing state (merkle tree, deposits, lends, history) preserved.

## Cost estimate

14 new shapes × ~150k gas ≈ 2M gas total. At Sepolia's typical ~1 gwei, ≈ 0.002 ETH (a few cents).

## Test plan

- [x] \`npx tsc -p .\` clean for the new files (existing errors in \`usdc-v2-frontend/\` are unchanged legacy noise)
- [ ] Local: \`npm run chains\` + \`npm run setup\` + \`npm run vkeys:register\` — should report all-already-registered (since setup now uses the extended config)
- [ ] Sepolia: \`npm run vkeys:register:sepolia\` — should register the 14 missing pairs. Re-run to confirm idempotency (logs "skip" for all)
- [ ] After Sepolia run: retry the failing unshield amount in armada-interface; should pass the pre-flight simulate (no more "Verification key not set")

🤖 Generated with [Claude Code](https://claude.com/claude-code)