### PR TITLE
fix(privacy-pool): remove unshield fee per spec (#153)

### DIFF
--- a/contracts/governance/ArmadaGovernor.sol
+++ b/contracts/governance/ArmadaGovernor.sol
@@ -401,7 +401,6 @@ contract ArmadaGovernor is Initializable, ReentrancyGuardUpgradeable, UUPSUpgrad
         extendedSelectors[bytes4(keccak256("upgradeToAndCall(address,bytes)"))] = true;
         // Fee parameters (on privacy pool and yield vault)
         extendedSelectors[bytes4(keccak256("setShieldFee(uint120)"))] = true;
-        extendedSelectors[bytes4(keccak256("setUnshieldFee(uint120)"))] = true;
         extendedSelectors[bytes4(keccak256("setYieldFeeBps(uint256)"))] = true;
         // Steward election (on TreasurySteward) — removal is Standard (defensive/emergency action)
         extendedSelectors[bytes4(keccak256("electSteward(address)"))] = true;

--- a/contracts/privacy-pool/PrivacyPool.sol
+++ b/contracts/privacy-pool/PrivacyPool.sol
@@ -283,16 +283,6 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
     }
 
     /**
-     * @notice Set the unshield fee in basis points
-     * @param _feeBps Fee in basis points (50 = 0.50%)
-     */
-    function setUnshieldFee(uint120 _feeBps) external override {
-        require(msg.sender == owner, "PrivacyPool: Only owner");
-        require(_feeBps <= 10000, "PrivacyPool: Fee too high");
-        unshieldFee = _feeBps;
-    }
-
-    /**
      * @notice Enable or disable testing mode
      * @dev POC ONLY - bypasses SNARK verification
      * @param _enabled Whether to enable testing mode

--- a/contracts/privacy-pool/interfaces/IPrivacyPool.sol
+++ b/contracts/privacy-pool/interfaces/IPrivacyPool.sol
@@ -124,12 +124,6 @@ interface IPrivacyPool is IMessageHandlerV2 {
     function setShieldFee(uint120 feeBps) external;
 
     /**
-     * @notice Set the unshield fee in basis points
-     * @param feeBps Fee in basis points (50 = 0.50%)
-     */
-    function setUnshieldFee(uint120 feeBps) external;
-
-    /**
      * @notice Enable or disable testing mode
      * @dev POC ONLY - bypasses SNARK verification
      * @param enabled Whether to enable testing mode

--- a/contracts/privacy-pool/modules/TransactModule.sol
+++ b/contracts/privacy-pool/modules/TransactModule.sol
@@ -27,9 +27,6 @@ import "../../governance/IShieldPauseController.sol";
 contract TransactModule is PrivacyPoolStorage, ITransactModule {
     using SafeERC20 for IERC20;
 
-    /// @notice Basis points denominator (100% = 10000)
-    uint120 private constant BASIS_POINTS = 10000;
-
     /**
      * @notice Execute private transactions (transfers and/or local unshields)
      * @dev Validates proofs, nullifies inputs, creates new commitments.
@@ -192,17 +189,14 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
         bytes32 destinationCaller,
         uint256 maxFee
     ) internal returns (uint64 nonce) {
-        // Calculate unshield amount (after fees)
-        uint120 unshieldAmount = _transaction.unshieldPreimage.value;
-        (uint120 base, uint120 fee) = _getFee(uint136(unshieldAmount), true, unshieldFee);
+        // Unshield is free per spec — the full preimage value is bridged.
+        // `fee` is retained at zero solely so the Unshield event below keeps its 4-field
+        // shape for downstream log parsers.
+        uint120 base = _transaction.unshieldPreimage.value;
+        uint120 fee = 0;
 
-        // Validate maxFee does not exceed base amount after protocol fee
+        // Validate maxFee does not exceed the bridged amount
         require(maxFee <= base, "TransactModule: maxFee exceeds base");
-
-        // Transfer fee to treasury
-        if (fee > 0 && treasury != address(0)) {
-            IERC20(usdc).safeTransfer(treasury, fee);
-        }
 
         // Encode CCTP payload
         bytes memory hookData = CCTPPayloadLib.encodeUnshield(
@@ -360,26 +354,10 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
         // Get recipient from npk (address encoded as bytes32)
         address recipient = address(uint160(uint256(_note.npk)));
 
-        // Privileged recipients (e.g. yield adapter) bypass unshield fee
-        uint120 base;
-        uint120 fee;
-        if (privilegedShieldCallers[recipient]) {
-            base = _note.value;
-            fee = 0;
-        } else {
-            (base, fee) = _getFee(_note.value, true, unshieldFee);
-        }
-
-        // Transfer to recipient
-        token.safeTransfer(recipient, base);
-
-        // Transfer fee to treasury
-        if (fee > 0 && treasury != address(0)) {
-            token.safeTransfer(treasury, fee);
-        }
-
-        // Emit unshield event
-        emit Unshield(recipient, _note.token, base, fee);
+        // Unshield is free per spec — the full preimage value is paid out. The trailing
+        // 0 in the Unshield event preserves the 4-field shape for downstream log parsers.
+        token.safeTransfer(recipient, _note.value);
+        emit Unshield(recipient, _note.token, _note.value, 0);
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -395,27 +373,6 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
             total += _transactions[i].boundParams.commitmentCiphertext.length;
         }
         return total;
-    }
-
-    /**
-     * @notice Calculate base and fee amounts
-     */
-    function _getFee(
-        uint136 _amount,
-        bool _isInclusive,
-        uint120 _feeBP
-    ) internal pure returns (uint120 base, uint120 fee) {
-        if (_feeBP == 0) {
-            return (uint120(_amount), 0);
-        }
-
-        if (_isInclusive) {
-            base = uint120(_amount - (_amount * _feeBP) / BASIS_POINTS);
-            fee = uint120(_amount) - base;
-        } else {
-            base = uint120(_amount);
-            fee = uint120((BASIS_POINTS * _amount) / (BASIS_POINTS - _feeBP) - _amount);
-        }
     }
 
     /**

--- a/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
+++ b/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
@@ -80,7 +80,9 @@ abstract contract PrivacyPoolStorage {
     /// @notice Shield fee in basis points (100 = 1%), default 0 for POC
     uint120 public shieldFee;
 
-    /// @notice Unshield fee in basis points (100 = 1%), default 0 for POC
+    /// @notice DEPRECATED — unshield is free per spec.
+    /// @dev Slot retained for storage layout compatibility with the delegatecall modules
+    ///      (removing it would shift `nftFee` and every subsequent slot). Always 0.
     uint120 public unshieldFee;
 
     /// @notice NFT fee in basis points, default 0 for POC (required for SDK compatibility)

--- a/test/privacy_pool_adversarial.ts
+++ b/test/privacy_pool_adversarial.ts
@@ -376,21 +376,22 @@ describe("Privacy Pool Adversarial", function () {
       expect(poolAfter - poolBefore).to.equal(amount - expectedFee);
     });
 
-    it("privileged unshield recipient bypasses unshield fee", async function () {
-      await privacyPool.setUnshieldFee(50);
-      const ShieldForwarder = await ethers.getContractFactory("ShieldForwarder");
-      const forwarder = await ShieldForwarder.deploy(privacyPoolAddress);
-      await privacyPool.setPrivilegedShieldCaller(await forwarder.getAddress(), true);
-
+    it("unshield is always free — no fee transferred to treasury, full amount to recipient", async function () {
+      // WHY: Per FEE_STRUCTURE.md, unshield is free. There is no setter to raise the
+      //      unshield fee any more — pin that an ordinary (non-privileged) recipient
+      //      receives the full preimage value and the treasury sees zero inflow on the
+      //      unshield path. If a future change reintroduces an unshield fee, this fails.
       const amount = ethers.parseUnits("100", 6);
       const root = await shieldAndGetRoot(amount);
       const usdcAddr = await hubUsdc.getAddress();
-      const recipientAddr = await forwarder.getAddress();
+
+      // Plain EOA recipient — explicitly NOT a privileged shield caller.
+      const recipientAddr = await alice.getAddress();
       const npkBigInt = BigInt(recipientAddr);
       const tokenId = BigInt(usdcAddr);
       const unshieldAmount = ethers.parseUnits("50", 6);
       const commitHash = computeCommitmentHash(npkBigInt, tokenId, unshieldAmount);
-      const nullifier = ethers.keccak256(ethers.toUtf8Bytes("priv-unshield-null"));
+      const nullifier = ethers.keccak256(ethers.toUtf8Bytes("free-unshield-null"));
 
       const tx = makeTransaction({
         merkleRoot: root,
@@ -409,13 +410,8 @@ describe("Privacy Pool Adversarial", function () {
 
       await privacyPool.transact([tx]);
 
-      const treasuryAfter = await hubUsdc.balanceOf(deployerAddress);
-      const recipientAfter = await hubUsdc.balanceOf(recipientAddr);
-
-      expect(treasuryAfter - treasuryBefore).to.equal(0n);
-      expect(recipientAfter - recipientBefore).to.equal(unshieldAmount);
-
-      await privacyPool.setUnshieldFee(0);
+      expect((await hubUsdc.balanceOf(deployerAddress)) - treasuryBefore).to.equal(0n);
+      expect((await hubUsdc.balanceOf(recipientAddr)) - recipientBefore).to.equal(unshieldAmount);
     });
   });
 


### PR DESCRIPTION
Closes #153.

## Summary

`FEE_STRUCTURE.md` specifies unshield (withdraw) is free. This rips out the residual unshield-fee surface inherited from the POC era — setter, governor extended-selector registration, fee math in both local and cross-chain unshield flows, and the now-dead `_getFee` / `BASIS_POINTS` in `TransactModule`.

## Changes

### Contracts

- **`PrivacyPoolStorage.unshieldFee`** — marked `DEPRECATED` in-place. Slot retained for delegatecall storage-layout compatibility (removing it would shift `nftFee` and every subsequent slot in the modules' storage view). Always zero from here on.
- **`PrivacyPool.setUnshieldFee` + `IPrivacyPool.setUnshieldFee`** — removed.
- **`ArmadaGovernor`** — dropped the `setUnshieldFee(uint120)` extended-selector registration. `setShieldFee` and `setYieldFeeBps` remain as-is.
- **`TransactModule._executeCCTPBurn`** (cross-chain unshield) — no fee calculation; full preimage value is bridged. Treasury transfer removed.
- **`TransactModule._transferTokenOut`** (local unshield) — no fee calculation, and the privileged-bypass conditional is gone (universally free, so the special case is no longer meaningful). Treasury transfer removed.
- **`TransactModule._getFee` + `BASIS_POINTS`** — dead after the above. Removed. `ShieldModule` has its own copies for the shield path.

### Event compatibility

The `Unshield(address, TokenData, uint256 base, uint256 fee)` event keeps its 4-field shape (trailing `fee` always `0`). Indexers, subgraphs, and the UI parse this — changing the signature would force a coordinated downstream update for what is essentially a cosmetic gain. Same precedent as the recent `Withdraw(... uint256 yieldFee)` in `ArmadaYieldVault` (PR #275).

### Tests

`test/privacy_pool_adversarial.ts` — replaced "privileged unshield recipient bypasses unshield fee" with "unshield is always free, regardless of caller". Pins the spec: a non-privileged EOA receives the full preimage value, treasury sees zero inflow. If a future change reintroduces an unshield fee, this fails.

## Storage-slot note

The vault and pool modules use the delegatecall architecture documented in `CLAUDE.md`. The `unshieldFee` storage slot at `PrivacyPoolStorage.sol` is therefore preserved (marked DEPRECATED). A future migration that overhauls the storage layout could reclaim the slot then; doing it in this PR would require either a storage gap or a coordinated module-side rewrite, both out of scope for what spec #153 calls a removal of fee semantics.

## Test plan

- [x] `npx hardhat compile` — clean (116 contracts).
- [x] `forge test --offline` — 674 / 674 pass.
- [x] `npm run test:all` (local Anvil + fresh `npm run setup`) — 824 passing, 1 pending, 0 failing.