### PR TITLE
feat(fees): augment ShieldFeeRecorded with asset, take bps, integrator volume

### DIFF
--- a/contracts/fees/ArmadaFeeModule.sol
+++ b/contracts/fees/ArmadaFeeModule.sol
@@ -146,6 +146,7 @@ contract ArmadaFeeModule is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
 
     /// @inheritdoc IArmadaFeeModule
     function recordShieldFee(
+        address asset,
         address integrator,
         uint256 amount,
         uint256 armadaTakePaid,
@@ -153,15 +154,30 @@ contract ArmadaFeeModule is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     ) external override {
         require(msg.sender == privacyPool, "ArmadaFeeModule: only privacy pool");
 
+        // Capture the effective Armada-take rate BEFORE bumping volume — otherwise the
+        // emitted bps would reflect the tier this shield just unlocked, not the tier
+        // that priced it.
+        uint256 armadaTakeBps = _getEffectiveArmadaTake(integrator);
+
         cumulativeArmadaFees += armadaTakePaid;
 
+        uint256 cumulativeVolumeAfter = 0;
         if (integrator != address(0) && _integrators[integrator].registered) {
             _integrators[integrator].cumulativeVolume += amount;
             _integrators[integrator].cumulativeEarnings += integratorFeePaid;
             cumulativeIntegratorFees += integratorFeePaid;
+            cumulativeVolumeAfter = _integrators[integrator].cumulativeVolume;
         }
 
-        emit ShieldFeeRecorded(integrator, amount, armadaTakePaid, integratorFeePaid);
+        emit ShieldFeeRecorded(
+            asset,
+            integrator,
+            amount,
+            armadaTakeBps,
+            armadaTakePaid,
+            integratorFeePaid,
+            cumulativeVolumeAfter
+        );
     }
 
     /// @inheritdoc IArmadaFeeModule

--- a/contracts/fees/IArmadaFeeModule.sol
+++ b/contracts/fees/IArmadaFeeModule.sol
@@ -41,7 +41,23 @@ interface IArmadaFeeModule is IFeeCollector {
     // ══════════════════════════════════════════════════════════════════════════
 
     event IntegratorRegistered(address indexed integrator, uint256 baseFee);
-    event ShieldFeeRecorded(address indexed integrator, uint256 amount, uint256 armadaTake, uint256 integratorFee);
+    /// @notice Emitted when a shield's fee is recorded.
+    /// @param asset The token shielded (e.g. USDC).
+    /// @param integrator The integrator addressed credited for the shield, or zero for direct shields.
+    /// @param amount Gross shield amount (before fees).
+    /// @param armadaTakeBps The effective Armada take rate (in bps) that applied to this shield.
+    /// @param armadaTakePaid Absolute Armada take transferred to the treasury.
+    /// @param integratorFeePaid Absolute integrator fee transferred to the integrator.
+    /// @param integratorCumulativeVolume Integrator's cumulative volume INCLUDING this shield. Zero for direct shields.
+    event ShieldFeeRecorded(
+        address indexed asset,
+        address indexed integrator,
+        uint256 amount,
+        uint256 armadaTakeBps,
+        uint256 armadaTakePaid,
+        uint256 integratorFeePaid,
+        uint256 integratorCumulativeVolume
+    );
     event YieldFeeRecorded(uint256 amount);
     event BaseArmadaTakeUpdated(uint256 oldBps, uint256 newBps);
     event TierAdded(uint256 index, uint256 volumeThreshold, uint256 armadaTakeBps);
@@ -81,11 +97,17 @@ interface IArmadaFeeModule is IFeeCollector {
     // ══════════════════════════════════════════════════════════════════════════
 
     /// @notice Record a shield fee after payment. Called by PrivacyPool only.
-    /// @param integrator Integrator address (address(0) for no integrator)
-    /// @param amount Gross shield amount
-    /// @param armadaTakePaid Armada protocol fee actually paid
-    /// @param integratorFeePaid Integrator fee actually paid
+    /// @dev Looks up the effective Armada-take rate that applied to this shield
+    ///      BEFORE updating the integrator's cumulative volume (so the rate emitted
+    ///      reflects the tier that actually priced this shield, not the tier the
+    ///      shield may have just unlocked).
+    /// @param asset The token shielded.
+    /// @param integrator Integrator address (address(0) for no integrator).
+    /// @param amount Gross shield amount.
+    /// @param armadaTakePaid Armada protocol fee actually paid.
+    /// @param integratorFeePaid Integrator fee actually paid.
     function recordShieldFee(
+        address asset,
         address integrator,
         uint256 amount,
         uint256 armadaTakePaid,

--- a/contracts/privacy-pool/modules/ShieldModule.sol
+++ b/contracts/privacy-pool/modules/ShieldModule.sol
@@ -156,7 +156,13 @@ contract ShieldModule is PrivacyPoolStorage, IShieldModule {
                 }
 
                 // Record fee in fee module
-                IArmadaFeeModule(feeModule).recordShieldFee(integrator, amount, armadaTake, integratorFee);
+                IArmadaFeeModule(feeModule).recordShieldFee(
+                    _request.preimage.token.tokenAddress,
+                    integrator,
+                    amount,
+                    armadaTake,
+                    integratorFee
+                );
             } else if (shieldFee > 0) {
                 // Flat fee fallback path (used when feeModule == address(0))
                 (uint120 base, uint120 feeAmount) = _getFee(_request.preimage.value, true, shieldFee);
@@ -289,7 +295,13 @@ contract ShieldModule is PrivacyPoolStorage, IShieldModule {
             }
 
             // Record fee in fee module
-            IArmadaFeeModule(feeModule).recordShieldFee(integrator, amount, armadaTake, integratorFee);
+            IArmadaFeeModule(feeModule).recordShieldFee(
+                _note.token.tokenAddress,
+                integrator,
+                amount,
+                armadaTake,
+                integratorFee
+            );
         } else {
             // Flat fee fallback path (used when feeModule == address(0))
             (uint120 base, uint120 feeAmount) = _getFee(_note.value, true, shieldFee);

--- a/test-foundry/ArmadaFeeModule.t.sol
+++ b/test-foundry/ArmadaFeeModule.t.sol
@@ -21,10 +21,20 @@ contract ArmadaFeeModuleTest is Test {
     address public integrator1 = address(0x1111);
     address public integrator2 = address(0x2222);
     address public nonOwner = address(0xBAD);
+    /// @dev Placeholder asset address — these unit tests don't deploy a real ERC20.
+    address public asset = address(0xA55E7);
 
     // Events (for expectEmit)
     event IntegratorRegistered(address indexed integrator, uint256 baseFee);
-    event ShieldFeeRecorded(address indexed integrator, uint256 amount, uint256 armadaTake, uint256 integratorFee);
+    event ShieldFeeRecorded(
+        address indexed asset,
+        address indexed integrator,
+        uint256 amount,
+        uint256 armadaTakeBps,
+        uint256 armadaTakePaid,
+        uint256 integratorFeePaid,
+        uint256 integratorCumulativeVolume
+    );
     event YieldFeeRecorded(uint256 amount);
     event BaseArmadaTakeUpdated(uint256 oldBps, uint256 newBps);
     event TierAdded(uint256 index, uint256 volumeThreshold, uint256 armadaTakeBps);
@@ -136,7 +146,7 @@ contract ArmadaFeeModuleTest is Test {
 
         // Push integrator volume above $250k tier
         vm.prank(privacyPool);
-        feeModule.recordShieldFee(integrator1, 300_000e6, 150e6, 90e6);
+        feeModule.recordShieldFee(asset, integrator1, 300_000e6, 150e6, 90e6);
 
         (uint256 armadaTake, uint256 integratorFee, uint256 totalFee) =
             feeModule.calculateShieldFee(integrator1, 10_000e6);
@@ -187,14 +197,14 @@ contract ArmadaFeeModuleTest is Test {
 
         // Push volume above $250k
         vm.prank(privacyPool);
-        feeModule.recordShieldFee(integrator1, 300_000e6, 0, 0);
+        feeModule.recordShieldFee(asset, integrator1, 300_000e6, 0, 0);
 
         (uint256 take2, , ) = feeModule.calculateShieldFee(integrator1, 1000e6);
         assertEq(take2, (1000e6 * 40) / 10000); // tier 1: 40 bps
 
         // Push volume above $1M
         vm.prank(privacyPool);
-        feeModule.recordShieldFee(integrator1, 800_000e6, 0, 0);
+        feeModule.recordShieldFee(asset, integrator1, 800_000e6, 0, 0);
 
         (uint256 take3, , ) = feeModule.calculateShieldFee(integrator1, 1000e6);
         assertEq(take3, (1000e6 * 30) / 10000); // tier 2: 30 bps
@@ -206,7 +216,7 @@ contract ArmadaFeeModuleTest is Test {
 
         // Volume exactly at threshold
         vm.prank(privacyPool);
-        feeModule.recordShieldFee(integrator1, 250_000e6, 0, 0);
+        feeModule.recordShieldFee(asset, integrator1, 250_000e6, 0, 0);
 
         uint256 take = feeModule.getArmadaTake(integrator1);
         assertEq(take, 40); // Should match tier 1
@@ -247,13 +257,95 @@ contract ArmadaFeeModuleTest is Test {
         feeModule.setIntegratorFee(30);
 
         vm.startPrank(privacyPool);
-        feeModule.recordShieldFee(integrator1, 100_000e6, 50e6, 30e6);
-        feeModule.recordShieldFee(integrator1, 200_000e6, 100e6, 60e6);
+        feeModule.recordShieldFee(asset, integrator1, 100_000e6, 50e6, 30e6);
+        feeModule.recordShieldFee(asset, integrator1, 200_000e6, 100e6, 60e6);
         vm.stopPrank();
 
         IArmadaFeeModule.IntegratorInfo memory info = feeModule.getIntegratorInfo(integrator1);
         assertEq(info.cumulativeVolume, 300_000e6);
         assertEq(info.cumulativeEarnings, 90e6);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // ShieldFeeRecorded event payload (#158)
+    // ══════════════════════════════════════════════════════════════════════
+
+    /// WHY: Pin every field of the augmented event so the spec fields (asset,
+    ///      armadaTakeBps, integratorCumulativeVolume) can't silently regress.
+    ///      Uses an integrator at base-tier (no custom terms) so armadaTakeBps
+    ///      resolves to baseArmadaTakeBps = 50.
+    function test_recordShieldFee_emitsFullPayload_directShield() public {
+        // Direct shield (no integrator) — base rate applies, cumulative volume stays 0.
+        vm.expectEmit(true, true, false, true);
+        emit ShieldFeeRecorded(
+            asset,
+            address(0),
+            10_000e6,       // amount
+            50,             // armadaTakeBps (baseArmadaTakeBps default)
+            5e6,            // armadaTakePaid
+            0,              // integratorFeePaid (no integrator)
+            0               // integratorCumulativeVolume (no integrator)
+        );
+
+        vm.prank(privacyPool);
+        feeModule.recordShieldFee(asset, address(0), 10_000e6, 5e6, 0);
+    }
+
+    /// WHY: With a registered integrator, integratorCumulativeVolume must be the
+    ///      POST-update value (i.e. including this shield), and armadaTakeBps must
+    ///      reflect the tier that priced this shield, NOT the tier this shield may
+    ///      have just unlocked. Concretely: the integrator is below the 250k tier
+    ///      threshold before this 100k shield, so they're still at base rate (50).
+    function test_recordShieldFee_emitsFullPayload_belowTier() public {
+        vm.prank(integrator1);
+        feeModule.setIntegratorFee(30);
+
+        vm.expectEmit(true, true, false, true);
+        emit ShieldFeeRecorded(
+            asset,
+            integrator1,
+            100_000e6,      // amount
+            50,             // armadaTakeBps (still base — below 250k threshold)
+            500e6,          // armadaTakePaid (5 bps of 100k = 50e6, but caller passed 500e6 — pin whatever caller passes)
+            300e6,          // integratorFeePaid (matches caller arg)
+            100_000e6       // integratorCumulativeVolume AFTER this shield
+        );
+
+        vm.prank(privacyPool);
+        feeModule.recordShieldFee(asset, integrator1, 100_000e6, 500e6, 300e6);
+    }
+
+    /// WHY: Verify the "rate at time of shield" snapshot is taken BEFORE the volume
+    ///      bump. Integrator is at 200k cumulative volume; this 100k shield will push
+    ///      them to 300k (over the 250k tier threshold → 40 bps). The emitted bps
+    ///      should still be the PRE-bump rate (50, base), not 40.
+    function test_recordShieldFee_armadaTakeBps_snapshotsPreVolumeUpdate() public {
+        vm.prank(integrator1);
+        feeModule.setIntegratorFee(30);
+
+        // Bring integrator volume to 200k (still below 250k tier threshold).
+        vm.prank(privacyPool);
+        feeModule.recordShieldFee(asset, integrator1, 200_000e6, 0, 0);
+
+        // Now a 100k shield. PRE-bump volume = 200k → base tier (50 bps).
+        // POST-bump volume = 300k → over threshold (40 bps).
+        // The event must report 50 (the rate that actually priced THIS shield).
+        vm.expectEmit(true, true, false, true);
+        emit ShieldFeeRecorded(
+            asset,
+            integrator1,
+            100_000e6,
+            50,             // PRE-bump rate
+            500e6,
+            300e6,
+            300_000e6       // POST-bump cumulative
+        );
+
+        vm.prank(privacyPool);
+        feeModule.recordShieldFee(asset, integrator1, 100_000e6, 500e6, 300e6);
+
+        // Sanity: subsequent shields should now see the new (lower) tier.
+        assertEq(feeModule.getArmadaTake(integrator1), 40);
     }
 
     // ══════════════════════════════════════════════════════════════════════
@@ -352,7 +444,7 @@ contract ArmadaFeeModuleTest is Test {
         assertEq(feeModule.cumulativeFeesCollected(), 0);
 
         vm.prank(privacyPool);
-        feeModule.recordShieldFee(address(0), 10_000e6, 5e6, 0);
+        feeModule.recordShieldFee(asset, address(0), 10_000e6, 5e6, 0);
         assertEq(feeModule.cumulativeFeesCollected(), 5e6);
 
         vm.prank(yieldVault);
@@ -365,7 +457,7 @@ contract ArmadaFeeModuleTest is Test {
         feeModule.setIntegratorFee(30);
 
         vm.prank(privacyPool);
-        feeModule.recordShieldFee(integrator1, 10_000e6, 5e6, 3e6);
+        feeModule.recordShieldFee(asset, integrator1, 10_000e6, 5e6, 3e6);
 
         // Only armada take (5e6) is protocol revenue
         assertEq(feeModule.cumulativeFeesCollected(), 5e6);
@@ -380,7 +472,7 @@ contract ArmadaFeeModuleTest is Test {
     function test_recordShieldFee_onlyPrivacyPool() public {
         vm.prank(alice);
         vm.expectRevert("ArmadaFeeModule: only privacy pool");
-        feeModule.recordShieldFee(address(0), 10_000e6, 5e6, 0);
+        feeModule.recordShieldFee(asset, address(0), 10_000e6, 5e6, 0);
     }
 
     function test_recordYieldFee_onlyYieldVault() public {
@@ -449,7 +541,7 @@ contract ArmadaFeeModuleTest is Test {
 
         // Push above tier
         vm.prank(privacyPool);
-        feeModule.recordShieldFee(integrator1, 300_000e6, 0, 0);
+        feeModule.recordShieldFee(asset, integrator1, 300_000e6, 0, 0);
 
         // Bonus = 50 (base) - 40 (tier 1) = 10
         assertEq(feeModule.getIntegratorBonus(integrator1), 10);

--- a/test-foundry/ArmadaFeeModuleInvariant.t.sol
+++ b/test-foundry/ArmadaFeeModuleInvariant.t.sol
@@ -17,6 +17,8 @@ contract ArmadaFeeModuleHandler is Test {
     address public privacyPool;
     address public yieldVault;
     address public integrator;
+    /// @dev Placeholder asset address — invariant tests don't deploy a real ERC20.
+    address public constant ASSET = address(0xA55E7);
 
     uint256 public ghost_totalArmadaFees;
     uint256 public ghost_totalIntegratorVolume;
@@ -35,7 +37,7 @@ contract ArmadaFeeModuleHandler is Test {
         uint256 integratorFee = bound(amount / 100, 0, amount - armadaTake);
 
         vm.prank(privacyPool);
-        feeModule.recordShieldFee(integrator, amount, armadaTake, integratorFee);
+        feeModule.recordShieldFee(ASSET, integrator, amount, armadaTake, integratorFee);
 
         ghost_totalArmadaFees += armadaTake;
         ghost_totalIntegratorVolume += amount;


### PR DESCRIPTION
## Summary

- Augments `ShieldFeeRecorded` to cover the spec fields it was missing: `asset` (indexed), `armadaTakeBps` (tier rate at shield time), and `integratorCumulativeVolume` (post-update snapshot).
- Adds `address asset` as the leading param of `IArmadaFeeModule.recordShieldFee`; both call sites in `ShieldModule` forward the note/preimage token address.
- Snapshots `armadaTakeBps` via `_getEffectiveArmadaTake(integrator)` *before* the cumulative-volume bump so a shield that crosses a tier threshold emits the rate that priced it, not the one it just unlocked.

Closes #158.

## Spec alignment

Per `specs/FEE_STRUCTURE.md` lines 149-157 the Shield event is specified as:

```
event Shield(asset, amount, integrator, integratorCumulativeVolume, armadaTakeBps, integratorFeeEarned)
```

This PR keeps the existing name `ShieldFeeRecorded` (renaming to bare `Shield` would collide with the Railgun-inherited `IShieldModule.Shield` event — same name, different signature, indexer-hostile). Final shape:

```solidity
event ShieldFeeRecorded(
    address indexed asset,
    address indexed integrator,
    uint256 amount,
    uint256 armadaTakeBps,
    uint256 armadaTakePaid,
    uint256 integratorFeePaid,
    uint256 integratorCumulativeVolume
);
```

Differences vs spec, intentional:
- Field order re-grouped so the two indexed topics come first.
- Keeps `armadaTakePaid` (absolute) alongside the new `armadaTakeBps` (rate). The absolute is the authoritative amount transferred (rounding-safe); the rate is informational tier-at-shield-time. Cost is ~32 bytes of log data per shield.

## Compatibility

**Hard ABI break.** No dual-emit, no compat shim. POC stage, no production indexers — off-chain consumers must update. Documented here so reviewers can flag if any downstream tooling needs touching.

## Test plan

- [x] `forge test --offline` — 677/677 pass (3 new tests: full-payload direct shield, full-payload below tier, pre-volume bps snapshot)
- [x] `npm run test:all` — 824 pass / 1 pending pre-existing
- [x] `npx hardhat compile` — clean
- [ ] Reviewer: confirm no off-chain consumer of `ShieldFeeRecorded` needs an update bundled with this change