### PR TITLE
feat(relayer-mediation): A2 server-side broadcaster-fee verification

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -28,7 +28,7 @@ fi
 # --- Check 3: .env file leak prevention ---
 # Only non-secret environment templates and committed public config envs are allowed.
 # All other .env files should be gitignored, but check as a safety net.
-ALLOWED_ENV_FILES="config/local.env config/sepolia.env sample.env.dev sample.env.production"
+ALLOWED_ENV_FILES="config/local.env config/sepolia.env config/secrets.env.template sample.env.dev sample.env.production"
 ENV_VIOLATIONS=""
 for f in $STAGED_FILES; do
   if [[ "$f" == *.env || "$f" == *.env.* ]]; then

--- a/apps/armada-interface/src/config/relayer.ts
+++ b/apps/armada-interface/src/config/relayer.ts
@@ -13,6 +13,10 @@ export const RELAYER_ENDPOINTS = {
 export type RelayerErrorCode =
   | 'FEE_TOO_LOW'
   | 'FEE_EXPIRED'
+  // The proof's broadcaster-fee output is missing, points at a wrong recipient/token, or pays
+  // less than the advertised rate. Surfaces only when the user's local fee-quote drifted from
+  // the relayer's after the proof was already built; UX should prompt a re-quote + rebuild.
+  | 'FEE_INSUFFICIENT'
   | 'INVALID_TARGET'
   | 'INVALID_CHAIN'
   | 'INVALID_DATA'
@@ -26,6 +30,7 @@ export type RelayerErrorCode =
 export const RELAYER_STATUS_CODES: Readonly<Record<RelayerErrorCode, number>> = {
   FEE_TOO_LOW: 402,
   FEE_EXPIRED: 402,
+  FEE_INSUFFICIENT: 402,
   INVALID_TARGET: 400,
   INVALID_CHAIN: 400,
   INVALID_DATA: 400,

--- a/config/local.env
+++ b/config/local.env
@@ -43,9 +43,16 @@ export RELAYER_PORT=3001
 export ETH_USDC_PRICE=2000
 
 # Relayer's Railgun (0zk) broadcaster address — published on /fees so clients can route
-# the broadcaster-fee output of their SNARK proofs here. Empty until Phase A2/A3 enrolls
-# a relayer Railgun wallet; the /fees response surfaces this verbatim.
+# the broadcaster-fee output of their SNARK proofs here. When unset, the relayer derives it
+# from RELAYER_RAILGUN_MNEMONIC at boot; when set, the relayer asserts that the derived
+# address matches (boot-fail otherwise) so misconfiguration is caught immediately.
 export BROADCASTER_RAILGUN_ADDRESS=
+
+# BIP39 mnemonic the relayer uses to derive its Railgun (0zk) wallet — separate from the
+# deployer key by design so contract ownership and fee collection don't share fate. The
+# wallet's viewing key decrypts broadcaster-fee commitments at request-validation time.
+# Local default: Anvil's test mnemonic (publicly known; safe for local Anvil only).
+export RELAYER_RAILGUN_MNEMONIC="test test test test test test test test test test test junk"
 
 # Treasury address (optional — defaults to deployer address if unset)
 # export TREASURY_ADDRESS=0x...

--- a/config/secrets.env.template
+++ b/config/secrets.env.template
@@ -3,3 +3,9 @@
 
 # Deployer private key (with 0x prefix)
 export DEPLOYER_PRIVATE_KEY=0xYOUR_PRIVATE_KEY_HERE
+
+# BIP39 mnemonic the relayer uses to derive its Railgun (0zk) wallet. Independent of the
+# deployer key by design so contract-owner and fee-collector responsibilities don't share
+# fate. Generate any standard 12- or 24-word BIP39 phrase (e.g. an offline generator) and
+# paste it here. Used only by relayer/modules/railgun-wallet.ts at boot.
+export RELAYER_RAILGUN_MNEMONIC="word word word word word word word word word word word word"

--- a/config/sepolia.env
+++ b/config/sepolia.env
@@ -86,9 +86,14 @@ export RELAYER_PORT=3001
 export ETH_USDC_PRICE=2000
 
 # Relayer's Railgun (0zk) broadcaster address — published on /fees so clients can route
-# the broadcaster-fee output of their SNARK proofs here. Empty until Phase A2/A3 enrolls
-# a relayer Railgun wallet; the /fees response surfaces this verbatim.
+# the broadcaster-fee output of their SNARK proofs here. When unset, the relayer derives it
+# from RELAYER_RAILGUN_MNEMONIC at boot; when set, the relayer asserts that the derived
+# address matches (boot-fail otherwise) so misconfiguration is caught immediately.
 export BROADCASTER_RAILGUN_ADDRESS=
+
+# RELAYER_RAILGUN_MNEMONIC is loaded from config/secrets.env (gitignored). Generate one with
+# `npx ts-node scripts/derive_relayer_railgun_address.ts` (or any BIP39 mnemonic tool) and
+# paste it there — never commit a real Sepolia mnemonic to the repo.
 
 # ============================================================================
 # RevenueLock Beneficiaries

--- a/lib/sdk/init.ts
+++ b/lib/sdk/init.ts
@@ -38,9 +38,10 @@ import { getArtifact } from 'railgun-circuit-test-artifacts';
 // ============ Storage Configuration ============
 
 const DATA_DIR = path.join(__dirname, '../../data');
-const DB_PATH = path.join(DATA_DIR, 'railgun-db');
+const DEFAULT_DB_PATH = path.join(DATA_DIR, 'railgun-db');
 
-// Ensure data directory exists
+// Ensure default data directory exists. Callers that pass a custom dbPath own their own
+// directory existence — see initializeEngine's `dbPath` parameter.
 if (!fs.existsSync(DATA_DIR)) {
   fs.mkdirSync(DATA_DIR, { recursive: true });
 }
@@ -218,10 +219,16 @@ const engineDebugger = {
  * Initialize the Railgun Engine for local devnet
  *
  * @param walletSource - Name for wallet source (max 16 chars, lowercase)
+ * @param dbPath - Optional override for the LevelDB path. Defaults to `<repo>/data/railgun-db`.
+ *                 Callers should pass an explicit path when they need lifecycle isolation from
+ *                 the default (e.g. the relayer keeps its DB under `relayer/state/railgun-db/`
+ *                 so test runs and a long-running relayer don't compete for the same LevelDB
+ *                 single-process lock). The caller owns creating the directory if needed.
  * @returns Initialized RailgunEngine instance
  */
 export async function initializeEngine(
-  walletSource: string = 'cctppoc'
+  walletSource: string = 'cctppoc',
+  dbPath: string = DEFAULT_DB_PATH
 ): Promise<RailgunEngine> {
   if (engine) {
     console.log('Engine already initialized');
@@ -229,11 +236,11 @@ export async function initializeEngine(
   }
 
   console.log('Initializing Railgun Engine...');
-  console.log(`  Database: ${DB_PATH}`);
+  console.log(`  Database: ${dbPath}`);
   console.log(`  Wallet source: ${walletSource}`);
 
   // Create LevelDB instance
-  const db = leveldown(DB_PATH);
+  const db = leveldown(dbPath);
 
   // Initialize engine
   engine = await RailgunEngine.initForWallet(
@@ -310,11 +317,12 @@ export async function shutdownEngine(): Promise<void> {
 }
 
 /**
- * Clear the database (for fresh start)
+ * Clear the database (for fresh start). Operates on the default path only; callers that
+ * passed a custom `dbPath` to `initializeEngine` own their own teardown.
  */
 export function clearDatabase(): void {
-  if (fs.existsSync(DB_PATH)) {
-    fs.rmSync(DB_PATH, { recursive: true, force: true });
+  if (fs.existsSync(DEFAULT_DB_PATH)) {
+    fs.rmSync(DEFAULT_DB_PATH, { recursive: true, force: true });
     console.log('Database cleared');
   }
 }

--- a/relayer/armada-relayer.ts
+++ b/relayer/armada-relayer.ts
@@ -18,6 +18,7 @@ import { armadaRelayerSettings } from "./config";
 import { WalletManager } from "./modules/wallet-manager";
 import { FeeCalculator } from "./modules/fee-calculator";
 import { PrivacyRelay } from "./modules/privacy-relay";
+import { RelayerRailgunWallet } from "./modules/railgun-wallet";
 import { HttpApi } from "./modules/http-api";
 import { CCTPRelayModule } from "./modules/cctp-relay";
 import { IrisRelayModule } from "./modules/iris-relay";
@@ -134,9 +135,21 @@ async function main() {
   await walletManager.initialize();
   console.log();
 
-  // Initialize fee calculator
+  // Initialize the relayer's Railgun (0zk) wallet — engine boot + mnemonic-derived wallet.
+  // MUST precede FeeCalculator so the derived address is published on `/fees` from the first
+  // request, and MUST precede PrivacyRelay so broadcaster-fee verification has a viewing key.
+  // Fail fast on misconfiguration (missing mnemonic, mismatching env address) — operators see
+  // a clear startup error rather than a silently-broken service.
+  console.log("[armada] Initializing relayer Railgun wallet...");
+  const railgunWallet = new RelayerRailgunWallet();
+  const { walletId: railgunWalletId, railgunAddress } = await railgunWallet.initialize();
+  console.log(`  Wallet ID: ${railgunWalletId.slice(0, 16)}...`);
+  console.log(`  Broadcaster address: ${railgunAddress}`);
+  console.log();
+
+  // Initialize fee calculator (now that we have the derived broadcaster address to publish)
   console.log("[armada] Initializing fee calculator...");
-  const feeCalculator = new FeeCalculator(walletManager);
+  const feeCalculator = new FeeCalculator(walletManager, railgunAddress);
   const initialFees = await feeCalculator.generateFeeSchedule();
   console.log("[armada] Initial fee schedule:");
   console.log(`  Transfer:           ${FeeCalculator.formatUsdcFee(initialFees.fees.transfer)}`);
@@ -148,12 +161,24 @@ async function main() {
   console.log(`  Expires:            ${new Date(initialFees.expiresAt).toISOString()}`);
   console.log();
 
-  // Initialize privacy relay
+  // Initialize privacy relay — verifier context binds the loaded Railgun wallet, hub chain ID,
+  // PrivacyPool address, and USDC address so per-request fee verification has everything it
+  // needs without re-reading config.
   console.log("[armada] Initializing privacy relay...");
-  const privacyRelay = new PrivacyRelay(walletManager, feeCalculator, {
-    privacyPool: contracts.privacyPool,
-    armadaYieldAdapter: contracts.armadaYieldAdapter,
-  });
+  const privacyRelay = new PrivacyRelay(
+    walletManager,
+    feeCalculator,
+    {
+      privacyPool: contracts.privacyPool,
+      armadaYieldAdapter: contracts.armadaYieldAdapter,
+    },
+    {
+      wallet: railgunWallet.getWallet(),
+      privacyPoolAddress: contracts.privacyPool,
+      hubChainId: netConfig.hub.chainId,
+      usdcAddress: contracts.usdc,
+    },
+  );
 
   // Initialize CCTP relay module — select based on CCTP mode. `getHealth` is the contract
   // surfaced to http-api for the /health endpoint; both iris and cctp modules implement it.
@@ -255,6 +280,13 @@ async function main() {
       httpApi.stop();
     } catch (err) {
       console.error("[armada] Error during HTTP API shutdown:", err);
+    }
+    try {
+      // Releases the LevelDB single-process lock so a subsequent boot (or test run) can open
+      // the engine without hitting "LOCK already held".
+      await railgunWallet.shutdown();
+    } catch (err) {
+      console.error("[armada] Error during Railgun engine shutdown:", err);
     }
     clearTimeout(forceExit);
     process.exit(0);

--- a/relayer/config.ts
+++ b/relayer/config.ts
@@ -230,12 +230,20 @@ export const armadaRelayerSettings = {
   cctpFinalityMode: getCCTPFinalityMode(),
   /**
    * Relayer's Railgun `0zk...` address, published verbatim on `/fees` so clients can route the
-   * broadcaster-fee output of their SNARK proof here. Empty string is allowed in Phase A1 (the
-   * /fees response is the only consumer and no handler calls submitRelay yet); Phase A2 will
-   * tighten this to a startup requirement once server-side fee verification needs to decrypt the
-   * matching commitment ciphertext.
+   * broadcaster-fee output of their SNARK proof here. When empty, the relayer derives it from
+   * `RELAYER_RAILGUN_MNEMONIC` at boot; when set, the relayer asserts the derived address
+   * matches and fails boot otherwise (cheap misconfiguration detector).
    */
   broadcasterRailgunAddress: process.env.BROADCASTER_RAILGUN_ADDRESS ?? "",
+  /**
+   * BIP39 mnemonic used to derive the relayer's Railgun (0zk) wallet. Required — relayer
+   * refuses to boot without it because broadcaster-fee verification needs the wallet's
+   * viewing key to decrypt incoming commitment ciphertexts. Local default lives in
+   * `config/local.env` (Anvil's publicly-known test mnemonic); sepolia/prod sourced from
+   * gitignored `config/secrets.env`. Loaded at boot only — never logged, never persisted to
+   * relayer state (only the engine's leveldown sees derived keys).
+   */
+  railgunWalletMnemonic: process.env.RELAYER_RAILGUN_MNEMONIC ?? "",
 };
 
 // Legacy config export for backward compatibility

--- a/relayer/modules/broadcaster-fee-verifier.ts
+++ b/relayer/modules/broadcaster-fee-verifier.ts
@@ -1,0 +1,132 @@
+/**
+ * Broadcaster Fee Verifier
+ *
+ * Server-side check that the broadcaster-fee output baked into an incoming SNARK proof actually
+ * pays the relayer at the rate it advertised. Without this, a malicious client could submit a
+ * well-formed proof with a $0 (or arbitrary-recipient) broadcaster output and the relayer would
+ * eat the gas — defeating the whole relayer-mediation model.
+ *
+ * How it works:
+ *   1. The relayer maintains its own Railgun (`0zk`) wallet (`railgun-wallet.ts`) whose viewing
+ *      key is the only key that can decrypt outputs sent to that address.
+ *   2. The frontend builds a proof with `broadcasterFeeRecipient: { tokenAddress, amount,
+ *      recipientAddress: relayer0zkAddress }`. The SDK encrypts one of the proof's commitment
+ *      ciphertexts to that recipient.
+ *   3. On `/relay`, we hand the request's calldata to the wallet's
+ *      `extractFirstNoteERC20AmountMap(...)` helper. The SDK decodes the calldata, attempts
+ *      decryption of each commitment ciphertext with our viewing key, and returns a map of
+ *      `{tokenAddress -> amount}` containing only successfully-decrypted outputs.
+ *   4. We look up the USDC entry. If missing OR its amount < advertised, we reject with
+ *      `FEE_INSUFFICIENT`.
+ *
+ * Scope (Phase A2):
+ *   - Vanilla `transact(Transaction[])` calls only. The SDK's calldata decoder is hard-coded to
+ *     the `transact` / `relay` function names, so wrapper functions (atomicCrossChainUnshield,
+ *     lendAndShield, redeemAndShield) need their own extraction path. Those land alongside the
+ *     handler PRs that need them (A4 for yield, A5 for xchain). The caller (privacy-relay) is
+ *     responsible for routing only `transact` calls here; other selectors are rejected at the
+ *     `INVALID_DATA` gate.
+ *   - Phase A2 single-token (USDC). The map check is keyed by USDC token hash; any output to
+ *     another token is ignored (treated as "no broadcaster fee paid for USDC").
+ */
+
+import { ContractTransaction } from "ethers";
+import { RailgunWallet, getTokenDataHashERC20 } from "@railgun-community/engine";
+import { ChainType, TXIDVersion } from "@railgun-community/shared-models";
+import { RelayError } from "../types";
+
+export interface VerifierContext {
+  /** The relayer's loaded Railgun wallet — supplies the viewing key used for decryption. */
+  wallet: RailgunWallet;
+  /** PrivacyPool contract address on the hub chain. SDK uses this to ABI-decode the calldata. */
+  privacyPoolAddress: string;
+  /** Hub chain ID — wrapped into the `Chain` shape the SDK helper expects. */
+  hubChainId: number;
+  /** USDC token address on the hub chain. The verifier matches the broadcaster output's token
+   *  against the Railgun-derived hash of this address; payments in any other token are ignored. */
+  usdcAddress: string;
+}
+
+export interface BroadcasterFeeVerifyRequest {
+  /** Target contract — must be the PrivacyPool for the SDK decoder to accept it. */
+  to: string;
+  /** ABI-encoded `transact(Transaction[])` calldata as it would be sent on-chain. */
+  data: string;
+}
+
+/**
+ * Verify that the incoming relay request pays at least `advertisedFee` USDC to the relayer's
+ * broadcaster address. Throws `RelayError("FEE_INSUFFICIENT", ...)` on any failure mode:
+ *   - calldata isn't a vanilla `transact(...)` call
+ *   - no commitment in the proof decrypts to our viewing key
+ *   - the decrypted commitment is for a token other than USDC
+ *   - the USDC amount is less than advertised
+ *
+ * Returns the actual amount detected on success (the caller may log it; useful in tests).
+ */
+export async function verifyBroadcasterFee(
+  ctx: VerifierContext,
+  request: BroadcasterFeeVerifyRequest,
+  advertisedFee: bigint,
+): Promise<bigint> {
+  // The SDK helper signature wants an ethers `ContractTransaction`. Only `to` + `data` are
+  // load-bearing for decoding; `value` defaults to 0 (Transaction structs don't carry ETH).
+  const transactionRequest: ContractTransaction = {
+    to: request.to,
+    data: request.data,
+  };
+
+  // EVM hub chain — relayer only processes hub-chain submits (privacy-relay's INVALID_CHAIN gate
+  // enforces that earlier). Wrap into Railgun's Chain shape for the SDK call.
+  const chain = { type: ChainType.EVM, id: ctx.hubChainId };
+
+  let amountMap: Record<string, bigint>;
+  try {
+    // V2 (Poseidon Merkle) — the only TXID version Armada's PrivacyPool supports. SDK helper
+    // returns a map of `tokenAddress -> amount` for every commitment in the proof that
+    // successfully decrypts under our viewing key. Outputs to other recipients (the user's
+    // change, the unshield-target, etc.) DON'T decrypt and don't appear.
+    //
+    // `useRelayAdapt: false` — vanilla `transact(...)`, decoded with the RailgunSmartWallet ABI.
+    // Wrapper functions need useRelayAdapt routing extensions; out of scope for A2 (see header).
+    amountMap = await ctx.wallet.extractFirstNoteERC20AmountMap(
+      TXIDVersion.V2_PoseidonMerkle,
+      chain,
+      transactionRequest,
+      false, // useRelayAdapt
+      ctx.privacyPoolAddress,
+    );
+  } catch (e: any) {
+    // SDK throws on:
+    //   - `to` mismatch with contractAddress  (caller bug — privacy-relay should have rejected)
+    //   - function name mismatch (e.g. somebody fed a wrapper-function calldata in)
+    //   - malformed Transaction encoding
+    // Any of these → the request didn't pay us a verifiable fee.
+    throw new RelayError(
+      "FEE_INSUFFICIENT",
+      `Broadcaster-fee verification failed: ${e?.message ?? "could not decode proof outputs"}.`,
+    );
+  }
+
+  // Railgun maps tokens by an internal hash (sha256(serializeTokenData(address, ERC20, 0))) not
+  // the raw 0x address. Compute the expected key from our USDC address and look it up.
+  const usdcTokenHash = getTokenDataHashERC20(ctx.usdcAddress).toLowerCase();
+
+  // The map's keys come from the SDK pre-lower-cased (token hashes are deterministic from the
+  // contract address but the case can vary across SDK paths); normalise both sides defensively.
+  const normalisedMap: Record<string, bigint> = {};
+  for (const [k, v] of Object.entries(amountMap)) {
+    normalisedMap[k.toLowerCase()] = v;
+  }
+
+  const paidUsdc = normalisedMap[usdcTokenHash] ?? 0n;
+  if (paidUsdc < advertisedFee) {
+    throw new RelayError(
+      "FEE_INSUFFICIENT",
+      `Broadcaster fee too low: paid ${paidUsdc} USDC raw, advertised ${advertisedFee} USDC raw. ` +
+        `Re-fetch the fee quote and re-build the proof with the matching broadcaster fee.`,
+    );
+  }
+
+  return paidUsdc;
+}

--- a/relayer/modules/fee-calculator.ts
+++ b/relayer/modules/fee-calculator.ts
@@ -56,24 +56,21 @@ export class FeeCalculator {
 
   private cctpFastMode: boolean;
 
-  constructor(walletManager: WalletManager) {
+  /**
+   * @param walletManager EVM hot wallet — supplies gas-price for fee computation.
+   * @param broadcasterRailgunAddress The relayer's `0zk` address, derived at boot from the
+   *        Railgun wallet (`relayer/modules/railgun-wallet.ts`). Published verbatim on `/fees`
+   *        so clients route their proof's broadcaster output here. Must be a non-empty string;
+   *        the relayer refuses to boot when the wallet derivation fails (see armada-relayer.ts).
+   */
+  constructor(walletManager: WalletManager, broadcasterRailgunAddress: string) {
     this.walletManager = walletManager;
     this.profitMarginBps = armadaRelayerSettings.profitMarginBps;
     this.ethUsdcPrice = armadaRelayerSettings.ethUsdcPrice;
     this.feeTtlSeconds = armadaRelayerSettings.feeTtlSeconds;
     this.feeVarianceBufferBps = armadaRelayerSettings.feeVarianceBufferBps;
-    this.broadcasterRailgunAddress = armadaRelayerSettings.broadcasterRailgunAddress;
+    this.broadcasterRailgunAddress = broadcasterRailgunAddress;
     this.cctpFastMode = armadaRelayerSettings.cctpFinalityMode === "fast";
-
-    if (!this.broadcasterRailgunAddress) {
-      // Loud but non-fatal in A1: /fees still responds, the field is just empty. A2 will tighten
-      // this to a startup throw because broadcaster-fee verification needs the address to know
-      // which commitment ciphertext to decrypt.
-      console.warn(
-        "[fee-calculator] BROADCASTER_RAILGUN_ADDRESS is unset — /fees will return an empty " +
-          "broadcasterRailgunAddress. Required before relayer-mediated submit is wired (Phase A2/A3)."
-      );
-    }
   }
 
   /**

--- a/relayer/modules/http-api.ts
+++ b/relayer/modules/http-api.ts
@@ -175,6 +175,7 @@ export class HttpApi {
         return 400;
       case "FEE_TOO_LOW":
       case "FEE_EXPIRED":
+      case "FEE_INSUFFICIENT":
         return 402; // Payment Required
       case "DUPLICATE_TX":
         return 409; // Conflict

--- a/relayer/modules/privacy-relay.ts
+++ b/relayer/modules/privacy-relay.ts
@@ -34,6 +34,11 @@ import { hubChain } from "../config";
 const ALLOWED_SELECTORS: Record<string, string> = {
   // PrivacyPool.transact(Transaction[]) — transfers and unshield-local
   "0xd8ae136a": "transact",
+  // Selectors temporarily off the allowlist (returning with the matching handler PRs that
+  // extend the verifier to decode their wrapper functions):
+  //   0xe484d408 atomicCrossChainUnshield → restored in A5 (unshield-xchain handler migration)
+  //   0xf2987ad1 lendAndShield            → restored in A4 (yield-deposit handler migration)
+  //   0x0793b70e redeemAndShield          → restored in A4 (yield-withdraw handler migration)
 };
 
 /**

--- a/relayer/modules/privacy-relay.ts
+++ b/relayer/modules/privacy-relay.ts
@@ -6,26 +6,61 @@
  * matches the advertised rate.
  */
 
-import { ethers } from "ethers";
 import { RelayError } from "../types";
 import type { RelayRequest, TransactionStatus } from "../types";
 import type { WalletManager } from "./wallet-manager";
 import type { FeeCalculator } from "./fee-calculator";
+import type { VerifierContext } from "./broadcaster-fee-verifier";
+import { verifyBroadcasterFee } from "./broadcaster-fee-verifier";
 import { hubChain } from "../config";
 
 // ============ Constants ============
 
-/** Known function selectors for allowed operations (from compiled contracts) */
+/**
+ * Known function selectors for allowed operations.
+ *
+ * Phase A2 scope (Option I — see `.claude/RELAYER_MEDIATION_PLAN.md`): vanilla `transact(...)`
+ * only. The broadcaster-fee verifier consumes the SDK's decoder which is hard-coded to the
+ * canonical `transact` / `relay` function names. Wrapper functions (atomicCrossChainUnshield,
+ * lendAndShield, redeemAndShield) carry an embedded Transaction struct but the SDK won't
+ * decode their outer signature — extending the verifier with extraction logic for each wrapper
+ * ships alongside the handler PR that needs it (A4 for yield, A5 for atomicCrossChainUnshield).
+ *
+ * Until then, the wrapper selectors are off the allowlist so the relayer cannot accept a
+ * request it cannot verify. This intentionally drops the legacy `usdc-v2-frontend` paths that
+ * used those selectors; the active app (armada-interface) hasn't migrated any handler to
+ * `submitRelay` yet (A3 starts that), so there's no live consumer to break.
+ */
 const ALLOWED_SELECTORS: Record<string, string> = {
-  // PrivacyPool.transact(Transaction[]) — transfers and unshields
+  // PrivacyPool.transact(Transaction[]) — transfers and unshield-local
   "0xd8ae136a": "transact",
-  // PrivacyPool.atomicCrossChainUnshield(..., uint256 maxFee) — cross-chain unshields
-  "0xe484d408": "atomicCrossChainUnshield",
-  // ArmadaYieldAdapter.lendAndShield — shielded lend
-  "0xf2987ad1": "lendAndShield",
-  // ArmadaYieldAdapter.redeemAndShield — shielded redeem
-  "0x0793b70e": "redeemAndShield",
 };
+
+/**
+ * Per-selector mapping into the FeeSchedule's per-op fee. The SDK doesn't tell us at the
+ * selector level whether a `transact()` is a transfer or an unshield — both are valid. We use
+ * MIN as the lower bound: the relayer accepts the smaller-quoted fee for either op type. In
+ * practice transfer and unshield are quoted identically today (both gas-estimated at 500k),
+ * so this is a robustness hedge, not a functional gap.
+ */
+function advertisedFeeForSelector(
+  selector: string,
+  fees: { transfer: string; unshield: string; crossContract: string; crossChainShield: string; crossChainUnshield: string },
+): bigint {
+  switch (selector) {
+    case "0xd8ae136a": {
+      const t = BigInt(fees.transfer);
+      const u = BigInt(fees.unshield);
+      return t < u ? t : u;
+    }
+    default:
+      // Defensive — the caller already gated on ALLOWED_SELECTORS, so this branch is unreachable.
+      throw new RelayError(
+        "INVALID_DATA",
+        `No advertised-fee mapping for selector ${selector}.`,
+      );
+  }
+}
 
 // ============ Privacy Relay ============
 
@@ -33,16 +68,21 @@ export class PrivacyRelay {
   private walletManager: WalletManager;
   private feeCalculator: FeeCalculator;
   private allowedTargets: Set<string>;
+  private verifierContext: VerifierContext;
 
   constructor(
     walletManager: WalletManager,
     feeCalculator: FeeCalculator,
-    allowedContracts: { privacyPool: string; armadaYieldAdapter: string }
+    allowedContracts: { privacyPool: string; armadaYieldAdapter: string },
+    verifierContext: VerifierContext,
   ) {
     this.walletManager = walletManager;
     this.feeCalculator = feeCalculator;
+    this.verifierContext = verifierContext;
 
-    // Normalize addresses to lowercase for comparison
+    // Normalize addresses to lowercase for comparison. ArmadaYieldAdapter stays in the set so
+    // legacy routing (if reactivated) can find it; A2's effective allowlist is enforced via
+    // ALLOWED_SELECTORS, which currently only accepts `transact(...)` on the PrivacyPool.
     this.allowedTargets = new Set([
       allowedContracts.privacyPool.toLowerCase(),
       allowedContracts.armadaYieldAdapter.toLowerCase(),
@@ -106,7 +146,16 @@ export class PrivacyRelay {
       );
     }
 
-    // 5. Check wallet availability
+    // 5. Verify broadcaster fee — decrypt the proof's output to our wallet, confirm it pays at
+    // least the advertised rate for this selector. This is the security-critical gate that
+    // prevents a malicious client from submitting a $0-fee proof and burning the relayer's gas.
+    // Runs BEFORE gas estimation so we don't pay an RPC call to learn the request will be
+    // rejected anyway.
+    const fees = await this.feeCalculator.getCurrentFees();
+    const advertisedFee = advertisedFeeForSelector(selector, fees.fees);
+    await verifyBroadcasterFee(this.verifierContext, { to, data }, advertisedFee);
+
+    // 6. Check wallet availability
     if (this.walletManager.isLocked()) {
       throw new RelayError(
         "RELAYER_BUSY",
@@ -114,7 +163,7 @@ export class PrivacyRelay {
       );
     }
 
-    // 6. Estimate gas to catch reverts early
+    // 7. Estimate gas to catch reverts early
     let gasEstimate: bigint;
     try {
       gasEstimate = await this.walletManager.estimateGas(to, data);
@@ -133,7 +182,7 @@ export class PrivacyRelay {
         `(gas estimate: ${gasEstimate}, limit: ${gasLimit})`
     );
 
-    // 7. Submit
+    // 8. Submit
     try {
       const result = await this.walletManager.submitTransaction(
         to,

--- a/relayer/modules/railgun-wallet.ts
+++ b/relayer/modules/railgun-wallet.ts
@@ -1,0 +1,149 @@
+/**
+ * Relayer Railgun Wallet
+ *
+ * Initialises the Railgun engine + derives the relayer's `0zk` wallet from a BIP39 mnemonic
+ * configured at deploy time. The derived wallet's viewing key is what powers broadcaster-fee
+ * verification in `broadcaster-fee-verifier.ts`: when a user POSTs a tx to `/relay`, we use the
+ * viewing key to attempt decryption of each `commitmentCiphertext[]` entry; the one that
+ * decrypts tells us the value of the broadcaster output destined for this wallet, which we
+ * then compare against the advertised fee.
+ *
+ * Boot sequence (called from `armada-relayer.ts::main`):
+ *   1. assert RELAYER_RAILGUN_MNEMONIC env is set (refuse to boot otherwise — without it,
+ *      the relayer cannot verify fees and would be exposed to free-relay attacks)
+ *   2. init engine with a relayer-specific LevelDB path (separate from test runs to avoid
+ *      the single-process LevelDB lock fight on local dev)
+ *   3. derive wallet via `engine.createWalletFromMnemonic` — deterministic from
+ *      (mnemonic, derivationIndex), so restarts re-derive instead of growing new wallet IDs
+ *   4. assert the derived 0zk address matches any operator-set `BROADCASTER_RAILGUN_ADDRESS`
+ *      (mismatch = misconfiguration → fail boot, don't ship a wrong address on `/fees`)
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { RailgunEngine, RailgunWallet } from "@railgun-community/engine";
+import { initializeEngine, shutdownEngine } from "../../lib/sdk/init";
+import { DEFAULT_ENCRYPTION_KEY } from "../../lib/sdk/wallet";
+import { armadaRelayerSettings } from "../config";
+
+/**
+ * Relayer-local LevelDB path. Kept under `relayer/state/` alongside the other relayer
+ * persistence (cursors, pending messages) so operational tools that flush state can treat
+ * one directory as authoritative. NOT shared with `<repo>/data/railgun-db/` (the default
+ * lib/sdk path) because LevelDB is single-process: a long-running relayer would prevent
+ * test runs from opening their own engine, and vice versa.
+ */
+const RELAYER_RAILGUN_DB_DIR = path.join(
+  __dirname,
+  "..",
+  "state",
+  "railgun-db",
+);
+
+/**
+ * Engine `walletSource` tag — max 16 chars, lowercase. Identifies the relayer as the
+ * originator of any merkletree scan + wallet creation calls in engine logs.
+ */
+const ENGINE_WALLET_SOURCE = "armadarelay";
+
+export interface RelayerWalletHandle {
+  /** Engine-internal wallet ID (sha256 of viewing key + derivation index — stable per mnemonic). */
+  walletId: string;
+  /** `0zk...` address. The value the relayer publishes on `/fees` as `broadcasterRailgunAddress`. */
+  railgunAddress: string;
+}
+
+export class RelayerRailgunWallet {
+  private wallet: RailgunWallet | null = null;
+  private engine: RailgunEngine | null = null;
+
+  /**
+   * Initialise the engine and derive the relayer's Railgun wallet. Throws on misconfiguration
+   * — missing mnemonic, mnemonic-derived address mismatching `BROADCASTER_RAILGUN_ADDRESS`,
+   * or engine init failure. The relayer caller is expected to `process.exit(1)` on throw so
+   * the operator sees a clear startup failure rather than a silently broken service.
+   */
+  async initialize(): Promise<RelayerWalletHandle> {
+    const mnemonic = armadaRelayerSettings.railgunWalletMnemonic.trim();
+    if (!mnemonic) {
+      throw new Error(
+        "[railgun-wallet] RELAYER_RAILGUN_MNEMONIC is required. Set it in config/local.env " +
+          "(Anvil default mnemonic) for local dev, or config/secrets.env (gitignored) for " +
+          "sepolia/prod. The relayer cannot verify broadcaster fees without it.",
+      );
+    }
+    const wordCount = mnemonic.split(/\s+/).length;
+    if (wordCount !== 12 && wordCount !== 24) {
+      throw new Error(
+        `[railgun-wallet] RELAYER_RAILGUN_MNEMONIC has ${wordCount} words; expected 12 or 24 ` +
+          `(standard BIP39). Generate one with any BIP39 tool or via npm run derive:relayer-railgun.`,
+      );
+    }
+
+    // Ensure the relayer-local LevelDB directory exists before the engine tries to open it.
+    if (!fs.existsSync(RELAYER_RAILGUN_DB_DIR)) {
+      fs.mkdirSync(RELAYER_RAILGUN_DB_DIR, { recursive: true });
+    }
+
+    this.engine = await initializeEngine(
+      ENGINE_WALLET_SOURCE,
+      RELAYER_RAILGUN_DB_DIR,
+    );
+
+    // Deterministic: same (mnemonic, derivationIndex) always produces the same wallet ID and
+    // re-uses the engine-side state. Restarts pick up where the previous boot left off — no
+    // growing wallet-id sprawl, no rescan-from-zero penalty.
+    this.wallet = (await this.engine.createWalletFromMnemonic(
+      DEFAULT_ENCRYPTION_KEY,
+      mnemonic,
+      0, // derivationIndex — fixed; A2 doesn't support multi-key rotation. See notes in PLAN.
+      undefined, // creationBlockNumbers — relayer doesn't scan history (no UTXOs to find)
+    )) as RailgunWallet;
+
+    const railgunAddress = this.wallet.getAddress();
+
+    // Cross-check the operator-published address (if any) against the derived one. A mismatch
+    // means either (a) the mnemonic was rotated without updating the env, or (b) the env was
+    // hand-edited with a wrong value. Either way: fail boot before /fees serves a wrong address
+    // to clients. Future SNARK proofs built against the published address would silently land
+    // in some OTHER wallet's outbox, gas paid + no recovery.
+    const advertised = armadaRelayerSettings.broadcasterRailgunAddress.trim();
+    if (advertised && advertised !== railgunAddress) {
+      throw new Error(
+        `[railgun-wallet] BROADCASTER_RAILGUN_ADDRESS (${advertised}) does not match the ` +
+          `address derived from RELAYER_RAILGUN_MNEMONIC (${railgunAddress}). Either unset the ` +
+          `env (the relayer will use the derived address) or fix the mnemonic / env entry.`,
+      );
+    }
+
+    return { walletId: this.wallet.id, railgunAddress };
+  }
+
+  /**
+   * Get the underlying RailgunWallet instance. `BroadcasterFeeVerifier` calls
+   * `wallet.extractFirstNoteERC20AmountMap(...)` on this for per-request decryption.
+   * Throws if init hasn't run — guards against a wiring bug where the verifier is constructed
+   * before the wallet is loaded.
+   */
+  getWallet(): RailgunWallet {
+    if (!this.wallet) {
+      throw new Error(
+        "[railgun-wallet] getWallet() before initialize() — boot order bug",
+      );
+    }
+    return this.wallet;
+  }
+
+  /**
+   * Graceful shutdown — releases the LevelDB single-process lock so a subsequent boot (or a
+   * concurrent test run) doesn't see "LOCK already held" errors. Called from armada-relayer's
+   * SIGINT/SIGTERM handler.
+   */
+  async shutdown(): Promise<void> {
+    if (this.engine) {
+      await shutdownEngine();
+      this.engine = null;
+      this.wallet = null;
+    }
+  }
+}

--- a/relayer/modules/railgun-wallet.ts
+++ b/relayer/modules/railgun-wallet.ts
@@ -8,6 +8,12 @@
  * decrypts tells us the value of the broadcaster output destined for this wallet, which we
  * then compare against the advertised fee.
  *
+ * Secret-handling invariant: the mnemonic is NEVER logged, returned in error messages, or
+ * persisted to disk anywhere outside the engine's own encrypted LevelDB state. Console output
+ * here is limited to the derived `walletId` (sha256 of the viewing key) and the derived
+ * `0zk` address — both publicly derivable from the mnemonic but neither leaks it. If you add
+ * console output below, keep it to these two safe-to-log primitives.
+ *
  * Boot sequence (called from `armada-relayer.ts::main`):
  *   1. assert RELAYER_RAILGUN_MNEMONIC env is set (refuse to boot otherwise — without it,
  *      the relayer cannot verify fees and would be exposed to free-relay attacks)
@@ -108,12 +114,23 @@ export class RelayerRailgunWallet {
     // to clients. Future SNARK proofs built against the published address would silently land
     // in some OTHER wallet's outbox, gas paid + no recovery.
     const advertised = armadaRelayerSettings.broadcasterRailgunAddress.trim();
-    if (advertised && advertised !== railgunAddress) {
-      throw new Error(
-        `[railgun-wallet] BROADCASTER_RAILGUN_ADDRESS (${advertised}) does not match the ` +
-          `address derived from RELAYER_RAILGUN_MNEMONIC (${railgunAddress}). Either unset the ` +
-          `env (the relayer will use the derived address) or fix the mnemonic / env entry.`,
-      );
+    if (advertised) {
+      // Format-check before the equality check so a typo (e.g. an 0x address pasted in) surfaces
+      // as "you put the wrong kind of address in this env" rather than a confusing mismatch.
+      if (!advertised.startsWith("0zk")) {
+        throw new Error(
+          `[railgun-wallet] BROADCASTER_RAILGUN_ADDRESS must be a Railgun address (0zk...), ` +
+            `got something starting with "${advertised.slice(0, 4)}". Either unset the env or ` +
+            `paste the relayer's derived 0zk address.`,
+        );
+      }
+      if (advertised !== railgunAddress) {
+        throw new Error(
+          `[railgun-wallet] BROADCASTER_RAILGUN_ADDRESS (${advertised}) does not match the ` +
+            `address derived from RELAYER_RAILGUN_MNEMONIC (${railgunAddress}). Either unset ` +
+            `the env (the relayer will use the derived address) or fix the mnemonic / env entry.`,
+        );
+      }
     }
 
     return { walletId: this.wallet.id, railgunAddress };

--- a/relayer/test/modules/broadcaster-fee-verifier.test.ts
+++ b/relayer/test/modules/broadcaster-fee-verifier.test.ts
@@ -1,0 +1,181 @@
+// ABOUTME: Unit tests for verifyBroadcasterFee — the security gate that rejects /relay requests
+// ABOUTME: whose embedded SNARK proof doesn't pay the relayer at the advertised rate.
+
+import { expect } from "chai";
+import { RailgunWallet, getTokenDataHashERC20 } from "@railgun-community/engine";
+import {
+  verifyBroadcasterFee,
+  type VerifierContext,
+} from "../../modules/broadcaster-fee-verifier";
+import { RelayError } from "../../types";
+
+// Fixed test addresses — no on-chain deployment, just shapes the verifier accepts.
+const USDC_ADDRESS = "0x1111111111111111111111111111111111111111";
+const OTHER_TOKEN_ADDRESS = "0x2222222222222222222222222222222222222222";
+const PRIVACY_POOL_ADDRESS = "0x3333333333333333333333333333333333333333";
+const HUB_CHAIN_ID = 31337;
+
+// Realistic-shaped calldata — the verifier never decodes it itself, but it gets handed verbatim
+// to the (stubbed) SDK helper.  A `0xd8ae136a` selector + filler bytes is enough for the
+// privacy-relay caller's gate to be plausible.
+const FAKE_TRANSACT_DATA = "0xd8ae136a" + "00".repeat(32);
+
+const ADVERTISED_FEE = 50_000n; // 0.05 USDC raw
+
+/**
+ * Build a stub RailgunWallet whose only loaded method is the one verify() actually calls.
+ * `as unknown as RailgunWallet` is the deliberate cast — we want the stub to satisfy the
+ * structural type that the verifier consumes, not the full SDK surface.
+ */
+function stubWallet(returnMap: Record<string, bigint>): RailgunWallet {
+  return {
+    extractFirstNoteERC20AmountMap: async () => returnMap,
+  } as unknown as RailgunWallet;
+}
+
+function stubWalletThrowing(err: Error): RailgunWallet {
+  return {
+    extractFirstNoteERC20AmountMap: async () => {
+      throw err;
+    },
+  } as unknown as RailgunWallet;
+}
+
+function ctxFor(wallet: RailgunWallet): VerifierContext {
+  return {
+    wallet,
+    privacyPoolAddress: PRIVACY_POOL_ADDRESS,
+    hubChainId: HUB_CHAIN_ID,
+    usdcAddress: USDC_ADDRESS,
+  };
+}
+
+describe("verifyBroadcasterFee", () => {
+  // Token hashes are derived once and pinned at the suite level so every test agrees on which
+  // map keys mean USDC vs other tokens — a regression that swapped the hash function would
+  // surface as cross-test divergence rather than per-test failures.
+  const USDC_TOKEN_HASH = getTokenDataHashERC20(USDC_ADDRESS).toLowerCase();
+  const OTHER_TOKEN_HASH = getTokenDataHashERC20(OTHER_TOKEN_ADDRESS).toLowerCase();
+
+  describe("accept path", () => {
+    it("returns the paid amount when USDC entry is present and >= advertised", async () => {
+      // WHY: the happy path is the most common branch — proves the verifier doesn't
+      // throw spuriously when the SDK returns a properly-formed map. Also pins the return
+      // value (the actual paid amount) so loggers/metrics can record it.
+      const wallet = stubWallet({ [USDC_TOKEN_HASH]: ADVERTISED_FEE * 2n });
+      const paid = await verifyBroadcasterFee(
+        ctxFor(wallet),
+        { to: PRIVACY_POOL_ADDRESS, data: FAKE_TRANSACT_DATA },
+        ADVERTISED_FEE,
+      );
+      expect(paid).to.equal(ADVERTISED_FEE * 2n);
+    });
+
+    it("accepts at the exact advertised-amount boundary (paid == advertised)", async () => {
+      // WHY: pin the comparator. A regression that flipped `<` to `<=` would silently reject
+      // every request that paid the EXACTLY-advertised amount — the most common path once
+      // clients optimize their broadcaster fees to the displayed minimum.
+      const wallet = stubWallet({ [USDC_TOKEN_HASH]: ADVERTISED_FEE });
+      const paid = await verifyBroadcasterFee(
+        ctxFor(wallet),
+        { to: PRIVACY_POOL_ADDRESS, data: FAKE_TRANSACT_DATA },
+        ADVERTISED_FEE,
+      );
+      expect(paid).to.equal(ADVERTISED_FEE);
+    });
+  });
+
+  describe("reject path — FEE_INSUFFICIENT", () => {
+    it("rejects when the returned map has no USDC entry (only other tokens)", async () => {
+      // WHY: a malicious or buggy client could put a broadcaster output for an unrelated token
+      // (say, ETH) into their proof — the SDK would decrypt it (we own the recipient key) but
+      // it doesn't pay our gas reimbursement. Must reject. Defends against the "pay me in
+      // shitcoins" exploit class.
+      const wallet = stubWallet({ [OTHER_TOKEN_HASH]: ADVERTISED_FEE * 10n });
+      await expectRejectedAs(
+        verifyBroadcasterFee(
+          ctxFor(wallet),
+          { to: PRIVACY_POOL_ADDRESS, data: FAKE_TRANSACT_DATA },
+          ADVERTISED_FEE,
+        ),
+        "FEE_INSUFFICIENT",
+        /paid 0 USDC raw/,
+      );
+    });
+
+    it("rejects when the returned map is empty (no decryptable outputs to relayer)", async () => {
+      // WHY: catches the "no broadcaster output at all" attack — a tampered proof where the
+      // adversary stripped the broadcaster output before submission, hoping the relayer
+      // would forward the tx without checking.
+      const wallet = stubWallet({});
+      await expectRejectedAs(
+        verifyBroadcasterFee(
+          ctxFor(wallet),
+          { to: PRIVACY_POOL_ADDRESS, data: FAKE_TRANSACT_DATA },
+          ADVERTISED_FEE,
+        ),
+        "FEE_INSUFFICIENT",
+        /paid 0 USDC raw/,
+      );
+    });
+
+    it("rejects when the USDC amount is less than advertised (off-by-one below)", async () => {
+      // WHY: pin the lower-bound comparator. A client that quoted a fee 30 minutes ago and
+      // built a proof against that quote would see the relayer's advertised fee drift upward.
+      // The verifier MUST catch the shortfall; otherwise drift = free relays.
+      const wallet = stubWallet({ [USDC_TOKEN_HASH]: ADVERTISED_FEE - 1n });
+      await expectRejectedAs(
+        verifyBroadcasterFee(
+          ctxFor(wallet),
+          { to: PRIVACY_POOL_ADDRESS, data: FAKE_TRANSACT_DATA },
+          ADVERTISED_FEE,
+        ),
+        "FEE_INSUFFICIENT",
+        new RegExp(`paid ${ADVERTISED_FEE - 1n} USDC raw, advertised ${ADVERTISED_FEE}`),
+      );
+    });
+
+    it("rejects with FEE_INSUFFICIENT when the SDK helper throws (e.g. malformed calldata)", async () => {
+      // WHY: the SDK throws on `to`/contract address mismatch, function-name mismatch (a
+      // wrapper-function calldata fed in), or unparseable Transaction encoding. All three are
+      // attack-shaped — a benign client never produces them. Mapping them to FEE_INSUFFICIENT
+      // (vs INVALID_DATA) keeps the security framing: "we couldn't verify the fee, so we
+      // don't relay" — regardless of whether the failure was at the decoder or the value
+      // check.
+      const wallet = stubWalletThrowing(
+        new Error("Contract method atomicCrossChainUnshield invalid: expected transact"),
+      );
+      await expectRejectedAs(
+        verifyBroadcasterFee(
+          ctxFor(wallet),
+          { to: PRIVACY_POOL_ADDRESS, data: FAKE_TRANSACT_DATA },
+          ADVERTISED_FEE,
+        ),
+        "FEE_INSUFFICIENT",
+        /could not decode proof outputs|invalid: expected transact/,
+      );
+    });
+  });
+});
+
+/**
+ * Helper: assert a promise rejects with a RelayError of a specific code + matching message.
+ * Using a single helper keeps the assertion shape consistent across tests — if a future
+ * refactor changes how RelayError surfaces (e.g. nested cause), there's one place to update.
+ */
+async function expectRejectedAs(
+  promise: Promise<unknown>,
+  expectedCode: string,
+  messagePattern: RegExp,
+): Promise<void> {
+  let caught: unknown = null;
+  try {
+    await promise;
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught, "expected promise to reject").to.be.instanceOf(RelayError);
+  const err = caught as RelayError;
+  expect(err.code).to.equal(expectedCode);
+  expect(err.message).to.match(messagePattern);
+}

--- a/relayer/test/modules/railgun-wallet.test.ts
+++ b/relayer/test/modules/railgun-wallet.test.ts
@@ -1,0 +1,69 @@
+// ABOUTME: Integration-smoke test for RelayerRailgunWallet — proves the engine init + wallet derivation
+// ABOUTME: pipeline is wired against the real SDK (no mocks), and that the derivation is deterministic.
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { expect } from "chai";
+import { initializeEngine, shutdownEngine } from "../../../lib/sdk/init";
+import { DEFAULT_ENCRYPTION_KEY } from "../../../lib/sdk/wallet";
+import { RailgunWallet } from "@railgun-community/engine";
+
+// Anvil's publicly-known test mnemonic. Producing the same 0zk address from it twice in a row
+// is what proves the wallet-derivation pipeline is deterministic — the load-bearing property
+// for `restarts re-derive instead of growing new wallet IDs` (railgun-wallet.ts header).
+const ANVIL_MNEMONIC = "test test test test test test test test test test test junk";
+
+/**
+ * Init + create + tear down a wallet against a freshly-created LevelDB. Returns the derived
+ * 0zk address. The temp dir is removed via the test's after hook.
+ *
+ * WHY a helper: the integration test runs the same sequence twice (proving determinism). We
+ * want the second run to use a SEPARATE DB so it can't satisfy the assertion by reading
+ * already-derived state from the first run's DB — the property we're proving is the SDK's
+ * deterministic key derivation from the mnemonic, not its persistence layer.
+ */
+async function deriveAddressInTempDb(): Promise<string> {
+  const dbPath = fs.mkdtempSync(path.join(os.tmpdir(), "armada-relayer-engine-"));
+  try {
+    const engine = await initializeEngine("armadarlytst", dbPath);
+    const wallet = (await engine.createWalletFromMnemonic(
+      DEFAULT_ENCRYPTION_KEY,
+      ANVIL_MNEMONIC,
+      0,
+      undefined,
+    )) as RailgunWallet;
+    return wallet.getAddress();
+  } finally {
+    await shutdownEngine();
+    // Tear down the temp dir — leaving it would leak ~few-MB LevelDB files per test run on dev
+    // machines. `force: true` swallows the rare race where engine.unload's lockfile cleanup
+    // hadn't fully completed.
+    fs.rmSync(dbPath, { recursive: true, force: true });
+  }
+}
+
+describe("RelayerRailgunWallet — engine + derivation integration", function () {
+  // The engine boots a substantial amount of SDK machinery (leveldown, artifact getter, debugger
+  // wiring); the first init in a process is the slowest. 30s gives generous headroom for cold
+  // CI sandboxes.
+  this.timeout(30_000);
+
+  it("derives the same 0zk address for the same mnemonic across separate engine boots", async () => {
+    // WHY: pins the production invariant that a relayer restart re-derives the SAME wallet
+    // identity. Without this, restarts would grow a fresh wallet ID + fresh on-chain
+    // address — operators would see /fees serve a new broadcaster address, and any prior fee
+    // outputs would be stranded in a wallet the relayer no longer owns.
+    const addr1 = await deriveAddressInTempDb();
+    const addr2 = await deriveAddressInTempDb();
+    expect(addr1).to.equal(addr2);
+  });
+
+  it("produces an address with the 0zk-prefixed bech32 shape the protocol expects", async () => {
+    // WHY: catches drift in the SDK's address-encoding scheme. A future SDK update that
+    // switched to e.g. `0xRailgun:` prefix would silently break the frontend's
+    // recipientAddress validation in shielded transfer modals; this test fails first.
+    const addr = await deriveAddressInTempDb();
+    expect(addr).to.match(/^0zk[0-9a-z]+$/);
+  });
+});

--- a/relayer/types.ts
+++ b/relayer/types.ts
@@ -55,6 +55,11 @@ export interface TransactionStatus {
 export type RelayErrorCode =
   | "FEE_TOO_LOW"
   | "FEE_EXPIRED"
+  // The proof's broadcaster-fee output is missing, points at a different recipient/token, or
+  // pays less than the advertised fee. Distinct from FEE_TOO_LOW (which historically meant
+  // "the request body's declared fee is too low" — not used today since the fee comes from the
+  // cached schedule); FEE_INSUFFICIENT means "the SNARK itself doesn't pay us enough."
+  | "FEE_INSUFFICIENT"
   | "INVALID_TARGET"
   | "INVALID_CHAIN"
   | "INVALID_DATA"

--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -18,6 +18,8 @@ ALLOWED_FILES=(
   "apps/armada-interface/vite.config.ts"  # Anvil deployer key for local dev /api/fund-gas endpoint
   "apps/armada-interface/src/lib/relayer.test.ts"  # Fake 0xdeadbeef-padded tx hash fixture for mocked /relay responses
   "apps/armada-interface/src/lib/tx/poller.test.ts"  # Fake 0xaaaa... tx hash fixture for mocked /status polling
+  "config/secrets.env.template"  # Placeholder mnemonic ("word word word..."); real secret lives in gitignored secrets.env
+  "relayer/test/modules/railgun-wallet.test.ts"  # Anvil's publicly-known test mnemonic — required to prove deterministic derivation
 )
 
 # Patterns that indicate secrets. Each entry: "LABEL:::REGEX"


### PR DESCRIPTION
## Summary

[Phase A2](../blob/main/.claude/RELAYER_MEDIATION_PLAN.md#phase-a--6-prs-55-days) of the relayer-mediation plan. Closes the free-relay attack surface: every incoming `/relay` request now has its embedded SNARK proof decrypted server-side against the relayer's Railgun viewing key, and the broadcaster-fee output is checked against the advertised rate.

**Scope decision (Option I, agreed before code):** vanilla `transact(Transaction[])` only. The SDK's calldata decoder is hard-coded to `transact` / `relay` function names, so wrapper functions (`atomicCrossChainUnshield`, `lendAndShield`, `redeemAndShield`) are temporarily off the allowlist — they return with their respective handler-migration PRs (A4 for yield, A5 for atomicCrossChainUnshield). The legacy `usdc-v2-frontend` is the only consumer that loses those paths; armada-interface hasn't migrated any handler to `submitRelay` yet (A3 starts that).

## What changed

- **`relayer/modules/railgun-wallet.ts`** (new) — boot-time Railgun engine init + mnemonic-derived wallet. Refuses to boot without `RELAYER_RAILGUN_MNEMONIC`. Cross-checks any operator-set `BROADCASTER_RAILGUN_ADDRESS` against the derived address; mismatch → fail boot.
- **`relayer/modules/broadcaster-fee-verifier.ts`** (new) — wraps the SDK's `extractFirstNoteERC20AmountMap` helper. Returns the paid amount on accept; throws `RelayError(FEE_INSUFFICIENT)` on every failure mode (no output to relayer, wrong token, wrong amount, malformed calldata).
- **`relayer/modules/privacy-relay.ts`** — narrows `ALLOWED_SELECTORS` to `transact(...)` only; inserts verifier call between selector validation and gas estimation; per-selector `advertisedFeeForSelector` mapping picks `MIN(transfer, unshield)` as the lower bound for `transact` calls.
- **`relayer/armada-relayer.ts`** — boot order: engine + wallet → FeeCalculator (now receives derived address by constructor) → PrivacyRelay (with VerifierContext binding). Shutdown handler releases the LevelDB lock.
- **`lib/sdk/init.ts`** — `initializeEngine()` gains an optional `dbPath` so the relayer's engine lives at `relayer/state/railgun-db/` separate from test/script DBs (avoids LevelDB single-process lock fights).
- **`FEE_INSUFFICIENT` error code** — added to both relayer types and frontend `RelayerErrorCode`, mapped to HTTP 402.
- **`RELAYER_RAILGUN_MNEMONIC` env** — local default = Anvil test mnemonic; Sepolia/prod = required, gitignored in `config/secrets.env`. Independent of the deployer key by design (key-separation between contract-owner and fee-collector roles).

## Test plan

- [x] `npm run test:relayer` — 87/87 pass (was 79; +8 new: 6 unit tests for the verifier + 2 integration smoke tests for engine boot + deterministic derivation)
- [x] `npm run typecheck --workspace=@armada/interface` — clean
- [x] `npm run test --workspace=@armada/interface -- --run` — 583/583 pass (frontend mirror of `FEE_INSUFFICIENT` doesn't break existing tests)
- [x] Pre-commit secret scan green (test fixtures with Anvil's public mnemonic + `secrets.env.template` allowlisted)
- [ ] Manual end-to-end validation deferred to A3 — when `unshield-local` handler migrates to `submitRelay`, the live path will exercise the full verifier with a real proof. A2's integration tests cover the engine+wallet boot but not the full real-proof round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)