### PR TITLE
feat(indexer): crowdfund alert evaluator implementing MONITORING.md §8 A1–A20 (#318)

### DIFF
--- a/config/secrets.env.template
+++ b/config/secrets.env.template
@@ -9,3 +9,22 @@ export DEPLOYER_PRIVATE_KEY=0xYOUR_PRIVATE_KEY_HERE
 # fate. Generate any standard 12- or 24-word BIP39 phrase (e.g. an offline generator) and
 # paste it here. Used only by relayer/modules/railgun-wallet.ts at boot.
 export RELAYER_RAILGUN_MNEMONIC="word word word word word word word word word word word word"
+
+# ----------------------------------------------------------------------------
+# Crowdfund alert evaluator — Discord webhooks (one URL per severity).
+# Created in Discord: Server Settings → Integrations → Webhooks → New Webhook.
+# Anyone with these URLs can post to the channel — treat as bearer credentials.
+# Set the same URL for all four to route everything into one channel, or split
+# P0/P1 (paged) from P2/P3 (silent log). Empty severities self-skip with a
+# stderr warning, so it's safe to leave some unset during testing.
+# ----------------------------------------------------------------------------
+export CROWDFUND_ALERT_WEBHOOK_P0=
+export CROWDFUND_ALERT_WEBHOOK_P1=
+export CROWDFUND_ALERT_WEBHOOK_P2=
+export CROWDFUND_ALERT_WEBHOOK_P3=
+
+# Optional role mention IDs prepended to messages of that severity. Use the
+# numeric role ID (right-click role → Copy ID in Discord developer mode).
+# Format: <@&ROLE_ID>. Leave blank to skip mentions entirely.
+# export CROWDFUND_ALERT_MENTION_P0="<@&123456789012345678>"
+# export CROWDFUND_ALERT_MENTION_P1="<@&123456789012345678>"

--- a/crowdfund-ui/packages/indexer/src/alerts/chainState.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/chainState.ts
@@ -1,0 +1,38 @@
+// ABOUTME: Optional contract reads used by A13 (treasury balance) and the time-based
+// ABOUTME: rules (A18/A19/A20). Wrapped behind an interface so tests can pass a fake.
+
+import { Contract, JsonRpcProvider } from 'ethers'
+import { CROWDFUND_ABI_FRAGMENTS, ERC20_ABI_FRAGMENTS } from '../../../shared/src/lib/constants.js'
+
+export interface ChainStateReader {
+  /** Unix seconds when finalize() was called; 0 if not finalized yet. */
+  readFinalizedAt(): Promise<number>
+  /** Treasury USDC balance in 6-decimal units. */
+  readTreasuryUsdcBalance(): Promise<bigint>
+}
+
+export interface ChainStateOptions {
+  rpcUrl: string
+  crowdfundAddress: string
+  usdcAddress: string
+  treasuryAddress: string
+}
+
+export function createRpcChainStateReader(options: ChainStateOptions): ChainStateReader {
+  const provider = new JsonRpcProvider(options.rpcUrl)
+  const crowdfund = new Contract(options.crowdfundAddress, CROWDFUND_ABI_FRAGMENTS, provider) as unknown as {
+    finalizedAt(): Promise<bigint>
+  }
+  const usdc = new Contract(options.usdcAddress, ERC20_ABI_FRAGMENTS, provider) as unknown as {
+    balanceOf(addr: string): Promise<bigint>
+  }
+  return {
+    async readFinalizedAt() {
+      const raw = await crowdfund.finalizedAt()
+      return Number(raw)
+    },
+    async readTreasuryUsdcBalance() {
+      return await usdc.balanceOf(options.treasuryAddress)
+    },
+  }
+}

--- a/crowdfund-ui/packages/indexer/src/alerts/evaluator.test.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/evaluator.test.ts
@@ -1,0 +1,98 @@
+// ABOUTME: Unit tests for the alert evaluator — dispatch, dedupe, state persistence.
+// ABOUTME: Uses in-memory notifier and state store; no external IO.
+
+import { describe, expect, it } from 'vitest'
+import { evaluateAndDispatch } from './evaluator.js'
+import { createInMemoryNotifier } from './notifier.js'
+import { createInMemoryAlertStateStore } from './state.js'
+import type { AlertContext, AlertEvent } from './types.js'
+
+const MINIMAL_CTX: AlertContext = {
+  now: 0,
+  params: {
+    chainId: 1, contractAddress: '0xc', treasuryAddress: '0xt',
+    openTimestamp: 0, week1Deadline: 0, commitmentDeadline: 0,
+  },
+  snapshot: {
+    metadata: {
+      schemaVersion: 1, chainId: 1, contractAddress: '0xc',
+      deployBlock: 0, verifiedBlock: 0, verifiedBlockHash: '0x',
+      snapshotHash: '0x', generatedAt: new Date(0).toISOString(),
+      reconciliation: { status: 'pending', checkedBlock: null, provider: null, checkedAt: null, mismatches: [] },
+    },
+    events: [],
+    graph: { nodes: new Map(), edges: [], summaries: new Map(), events: [] },
+  },
+  health: {
+    status: 'healthy',
+    chainHead: 0, confirmedHead: 0, ingestedCursor: 0, verifiedCursor: 0, lagBlocks: 0,
+    lastIngestedAt: null, lastVerifiedAt: null, lastReconciledAt: null,
+    hasGaps: false, gapRanges: [], gapsRequiringIntervention: [],
+    lastError: null, latestSnapshotHash: null, latestStaticSnapshotUrl: null,
+  },
+  thresholds: {
+    duplicateSlotFraction: 0.10,
+    finalizeGraceSeconds: 7200,
+    claimParticipationFloor: 0.5,
+    refundUnclaimedThreshold: 0.1,
+  },
+  treasuryUsdcBalance: null,
+  finalizedAt: null,
+}
+
+const SAMPLE_A1: AlertEvent = {
+  id: 'A1', severity: 'P3', dedupeKey: 'A1', title: 'arm', body: 'b', runbook: 'r',
+}
+const SAMPLE_A11: AlertEvent = {
+  id: 'A11', severity: 'P0', dedupeKey: 'A11', title: 'cancel', body: 'b', runbook: 'r',
+}
+
+describe('evaluateAndDispatch', () => {
+  it('delivers each alert once across runs', async () => {
+    const notifier = createInMemoryNotifier()
+    const state = createInMemoryAlertStateStore()
+    const evaluate = () => [SAMPLE_A1, SAMPLE_A11]
+
+    const first = await evaluateAndDispatch({ context: MINIMAL_CTX, notifier, stateStore: state, evaluate })
+    expect(first.delivered.map((e) => e.id)).toEqual(['A1', 'A11'])
+    expect(first.skipped).toEqual([])
+
+    const second = await evaluateAndDispatch({ context: MINIMAL_CTX, notifier, stateStore: state, evaluate })
+    expect(second.delivered).toEqual([])
+    expect(second.skipped.map((e) => e.id)).toEqual(['A1', 'A11'])
+
+    // Notifier should have received exactly two distinct sends total.
+    expect(notifier.events.map((e) => e.dedupeKey)).toEqual(['A1', 'A11'])
+  })
+
+  it('dedupe keys are per-tier — same alert, different tier, delivers separately', async () => {
+    const notifier = createInMemoryNotifier()
+    const state = createInMemoryAlertStateStore()
+    const tier80: AlertEvent = { id: 'A4', severity: 'P2', dedupeKey: 'A4:80', title: 't', body: 'b', runbook: 'r' }
+    const tier100: AlertEvent = { id: 'A4', severity: 'P1', dedupeKey: 'A4:100', title: 't', body: 'b', runbook: 'r' }
+
+    const first = await evaluateAndDispatch({
+      context: MINIMAL_CTX, notifier, stateStore: state,
+      evaluate: () => [tier80],
+    })
+    expect(first.delivered).toHaveLength(1)
+
+    const second = await evaluateAndDispatch({
+      context: MINIMAL_CTX, notifier, stateStore: state,
+      evaluate: () => [tier80, tier100],
+    })
+    expect(second.delivered).toHaveLength(1)
+    expect(second.delivered[0].dedupeKey).toBe('A4:100')
+  })
+
+  it('persists state only when delivering at least one alert', async () => {
+    const notifier = createInMemoryNotifier()
+    const writes: Array<ReadonlySet<string>> = []
+    const state = {
+      async read() { return { firedKeys: new Set<string>() } },
+      async write(next: { firedKeys: ReadonlySet<string> }) { writes.push(next.firedKeys) },
+    }
+    await evaluateAndDispatch({ context: MINIMAL_CTX, notifier, stateStore: state, evaluate: () => [] })
+    expect(writes).toEqual([])
+  })
+})

--- a/crowdfund-ui/packages/indexer/src/alerts/evaluator.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/evaluator.ts
@@ -1,0 +1,46 @@
+// ABOUTME: Orchestrator — runs all alert rules, dispatches new alerts, persists fired-key state.
+// ABOUTME: Pure of side effects other than the injected notifier and state store.
+
+import { evaluateAllRules } from './rules.js'
+import type { Notifier } from './notifier.js'
+import type { AlertStateStore } from './state.js'
+import type { AlertContext, AlertEvent } from './types.js'
+
+export interface EvaluatorResult {
+  total: number
+  delivered: AlertEvent[]
+  skipped: AlertEvent[]
+}
+
+export interface EvaluateInput {
+  context: AlertContext
+  notifier: Notifier
+  stateStore: AlertStateStore
+  /** Optional override of the rules pipeline (defaults to evaluateAllRules). */
+  evaluate?: (ctx: AlertContext) => AlertEvent[]
+}
+
+export async function evaluateAndDispatch(input: EvaluateInput): Promise<EvaluatorResult> {
+  const evaluate = input.evaluate ?? evaluateAllRules
+  const candidates = evaluate(input.context)
+  const state = await input.stateStore.read()
+  const fired = new Set(state.firedKeys)
+  const delivered: AlertEvent[] = []
+  const skipped: AlertEvent[] = []
+
+  for (const event of candidates) {
+    if (fired.has(event.dedupeKey)) {
+      skipped.push(event)
+      continue
+    }
+    await input.notifier.send(event)
+    fired.add(event.dedupeKey)
+    delivered.push(event)
+  }
+
+  if (delivered.length > 0) {
+    await input.stateStore.write({ firedKeys: fired })
+  }
+
+  return { total: candidates.length, delivered, skipped }
+}

--- a/crowdfund-ui/packages/indexer/src/alerts/notifier.test.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/notifier.test.ts
@@ -1,0 +1,59 @@
+// ABOUTME: Unit tests for the Discord webhook notifier.
+// ABOUTME: Stubs fetch to verify routing per severity and payload shape.
+
+import { describe, expect, it } from 'vitest'
+import { createDiscordNotifier } from './notifier.js'
+import type { AlertEvent } from './types.js'
+
+function buildEvent(severity: AlertEvent['severity']): AlertEvent {
+  return {
+    id: 'A11',
+    severity,
+    dedupeKey: 'A11',
+    title: 'Cancelled',
+    body: 'Crowdfund cancelled by SC',
+    runbook: 'OPERATIONS.md §7',
+    context: { something: 'detail' },
+  }
+}
+
+describe('Discord notifier', () => {
+  it('routes severity to its webhook and posts JSON', async () => {
+    const calls: Array<{ url: string; body: string }> = []
+    const fetchImpl = async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), body: String(init?.body) })
+      return new Response(null, { status: 204 })
+    }
+    const notifier = createDiscordNotifier({
+      webhooks: { P0: 'https://discord.test/p0', P3: 'https://discord.test/p3' },
+      mentions: { P0: '<@&123>' },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+
+    await notifier.send(buildEvent('P0'))
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe('https://discord.test/p0')
+    const payload = JSON.parse(calls[0].body) as { content: string }
+    expect(payload.content).toContain('<@&123>')
+    expect(payload.content).toContain('[P0 A11] Cancelled')
+    expect(payload.content).toContain('OPERATIONS.md §7')
+  })
+
+  it('skips delivery when severity has no webhook', async () => {
+    let called = false
+    const notifier = createDiscordNotifier({
+      webhooks: { P0: 'https://discord.test/p0' },
+      fetchImpl: (async () => { called = true; return new Response() }) as unknown as typeof fetch,
+    })
+    await notifier.send(buildEvent('P2'))
+    expect(called).toBe(false)
+  })
+
+  it('throws when Discord returns non-2xx', async () => {
+    const notifier = createDiscordNotifier({
+      webhooks: { P0: 'https://discord.test/p0' },
+      fetchImpl: (async () => new Response('rate limited', { status: 429 })) as unknown as typeof fetch,
+    })
+    await expect(notifier.send(buildEvent('P0'))).rejects.toThrow(/429/)
+  })
+})

--- a/crowdfund-ui/packages/indexer/src/alerts/notifier.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/notifier.ts
@@ -1,0 +1,70 @@
+// ABOUTME: Notifier abstraction — receives an AlertEvent and posts it to a delivery channel.
+// ABOUTME: Discord webhook implementation; test-time fake captures sent events in-memory.
+
+import type { AlertEvent, Severity } from './types.js'
+
+export interface Notifier {
+  send(event: AlertEvent): Promise<void>
+}
+
+export interface DiscordWebhookConfig {
+  /**
+   * Severity → webhook URL. P0 and P1 should point at a paged channel; P2/P3
+   * a silent log channel. Unmapped severities are dropped (with a console warn).
+   */
+  webhooks: Partial<Record<Severity, string>>
+  /** Optional override for fetch (test seam). */
+  fetchImpl?: typeof fetch
+  /** Optional severity → role mention. */
+  mentions?: Partial<Record<Severity, string>>
+}
+
+function formatPayload(event: AlertEvent, mention: string | undefined): unknown {
+  const lines = [
+    `**[${event.severity} ${event.id}] ${event.title}**`,
+    event.body,
+    `Runbook: ${event.runbook}`,
+  ]
+  if (event.context && Object.keys(event.context).length > 0) {
+    lines.push('```json\n' + JSON.stringify(event.context, null, 2) + '\n```')
+  }
+  const content = mention ? `${mention} ${lines.join('\n')}` : lines.join('\n')
+  return { content, allowed_mentions: { parse: ['roles', 'users'] } }
+}
+
+export function createDiscordNotifier(config: DiscordWebhookConfig): Notifier {
+  const doFetch: typeof fetch = config.fetchImpl ?? fetch
+  return {
+    async send(event) {
+      const url = config.webhooks[event.severity]
+      if (!url) {
+        process.stderr.write(`[alerts] no webhook configured for severity ${event.severity}; skipping ${event.id}\n`)
+        return
+      }
+      const mention = config.mentions?.[event.severity]
+      const res = await doFetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formatPayload(event, mention)),
+      })
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`Discord webhook ${event.severity} returned ${res.status}: ${text}`)
+      }
+    },
+  }
+}
+
+export interface InMemoryNotifierLog {
+  events: AlertEvent[]
+}
+
+export function createInMemoryNotifier(): Notifier & InMemoryNotifierLog {
+  const events: AlertEvent[] = []
+  return {
+    events,
+    async send(event) {
+      events.push(event)
+    },
+  }
+}

--- a/crowdfund-ui/packages/indexer/src/alerts/rules.test.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/rules.test.ts
@@ -1,0 +1,451 @@
+// ABOUTME: Unit tests for crowdfund alert rule evaluators (MONITORING.md §8 A1–A20).
+// ABOUTME: Each rule is exercised in isolation with a synthetic AlertContext.
+
+import { describe, expect, it } from 'vitest'
+import {
+  ruleA1, ruleA2, ruleA3, ruleA4, ruleA5, ruleA6, ruleA7, ruleA8,
+  ruleA9a, ruleA9b, ruleA10, ruleA11, ruleA12, ruleA13, ruleA17, ruleA18, ruleA19, ruleA20,
+  evaluateAllRules,
+} from './rules.js'
+import { ALERT_THRESHOLD_DEFAULTS } from './thresholds.js'
+import type { AlertContext, CrowdfundParams } from './types.js'
+import type { CrowdfundEvent } from '../../../shared/src/lib/events.js'
+import type { AddressSummary, CrowdfundGraph, GraphEdge, GraphNode } from '../../../shared/src/lib/graph.js'
+
+const HOP0_CAP = 15_000n * 10n ** 6n
+const HOP1_CAP = 4_000n * 10n ** 6n
+
+const OPEN_TS = 1_700_000_000
+const WEEK1_TS = OPEN_TS + 7 * 24 * 60 * 60
+const COMMIT_TS = OPEN_TS + 21 * 24 * 60 * 60
+
+const PARAMS: CrowdfundParams = {
+  chainId: 11155111,
+  contractAddress: '0xcccc',
+  treasuryAddress: '0xt',
+  openTimestamp: OPEN_TS,
+  week1Deadline: WEEK1_TS,
+  commitmentDeadline: COMMIT_TS,
+}
+
+function emptyGraph(): CrowdfundGraph {
+  return { nodes: new Map(), edges: [], summaries: new Map(), events: [] }
+}
+
+function makeNode(address: string, hop: number, committed: bigint, invitesReceived = 1): GraphNode {
+  return {
+    address,
+    hop,
+    invitesReceived,
+    committed,
+    rawDeposited: committed,
+    invitedBy: [],
+    invitesUsed: 0,
+    invitesAvailable: 0,
+    allocatedArm: null,
+    acceptedUsdc: null,
+  }
+}
+
+function makeEdge(fromAddress: string, fromHop: number, toAddress: string, toHop: number): GraphEdge {
+  return { fromAddress, fromHop, toAddress, toHop }
+}
+
+function makeEvent(
+  type: CrowdfundEvent['type'],
+  args: Record<string, unknown> = {},
+  blockNumber = 1,
+  logIndex = 0,
+): CrowdfundEvent {
+  return {
+    type,
+    blockNumber,
+    transactionHash: `0xtx${blockNumber}${logIndex}`,
+    logIndex,
+    args,
+  }
+}
+
+function makeContext(overrides: Partial<AlertContext> = {}): AlertContext {
+  const graph = overrides.snapshot?.graph ?? emptyGraph()
+  const events = overrides.snapshot?.events ?? []
+  return {
+    now: OPEN_TS - 1,
+    params: PARAMS,
+    snapshot: {
+      metadata: {
+        schemaVersion: 1,
+        chainId: PARAMS.chainId,
+        contractAddress: PARAMS.contractAddress,
+        deployBlock: 0,
+        verifiedBlock: 100,
+        verifiedBlockHash: '0xb',
+        snapshotHash: '0xs',
+        generatedAt: new Date(0).toISOString(),
+        reconciliation: { status: 'pending', checkedBlock: null, provider: null, checkedAt: null, mismatches: [] },
+      },
+      events,
+      graph,
+    },
+    health: {
+      status: 'healthy',
+      chainHead: 0, confirmedHead: 0, ingestedCursor: 0, verifiedCursor: 0, lagBlocks: 0,
+      lastIngestedAt: null, lastVerifiedAt: null, lastReconciledAt: null,
+      hasGaps: false, gapRanges: [], gapsRequiringIntervention: [],
+      lastError: null, latestSnapshotHash: null, latestStaticSnapshotUrl: null,
+    },
+    thresholds: ALERT_THRESHOLD_DEFAULTS,
+    treasuryUsdcBalance: null,
+    finalizedAt: null,
+    ...overrides,
+  }
+}
+
+// ============ A1 ============
+describe('ruleA1 — ARM loaded', () => {
+  it('fires P3 once when ArmLoaded is present', () => {
+    const ctx = makeContext({
+      snapshot: { ...makeContext().snapshot, events: [makeEvent('ArmLoaded', {})] } as never,
+    })
+    const out = ruleA1(ctx)
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({ id: 'A1', severity: 'P3', dedupeKey: 'A1' })
+  })
+  it('does not fire when ArmLoaded absent', () => {
+    expect(ruleA1(makeContext())).toEqual([])
+  })
+})
+
+// ============ A2 ============
+describe('ruleA2 — sale open, not armed', () => {
+  it('fires P1 when now ≥ openTimestamp and no ArmLoaded', () => {
+    const ctx = makeContext({ now: OPEN_TS + 1 })
+    const out = ruleA2(ctx)
+    expect(out[0]).toMatchObject({ id: 'A2', severity: 'P1' })
+  })
+  it('does not fire when armed', () => {
+    const ctx = makeContext({
+      now: OPEN_TS + 1,
+      snapshot: { ...makeContext().snapshot, events: [makeEvent('ArmLoaded')] } as never,
+    })
+    expect(ruleA2(ctx)).toEqual([])
+  })
+  it('does not fire before openTimestamp', () => {
+    expect(ruleA2(makeContext({ now: OPEN_TS - 1 }))).toEqual([])
+  })
+})
+
+// ============ A3 ============
+describe('ruleA3 — week-1 action after week1Deadline', () => {
+  it('no-ops without event timestamps (current indexer state)', () => {
+    const ctx = makeContext({
+      now: WEEK1_TS + 100,
+      snapshot: {
+        ...makeContext().snapshot,
+        events: [makeEvent('SeedAdded', { seed: '0xs' })],
+      } as never,
+    })
+    expect(ruleA3(ctx)).toEqual([])
+  })
+  it('fires P0 when an event carries a _timestamp beyond week1Deadline', () => {
+    const ctx = makeContext({
+      snapshot: {
+        ...makeContext().snapshot,
+        events: [makeEvent('SeedAdded', { seed: '0xs', _timestamp: WEEK1_TS + 1 })],
+      } as never,
+    })
+    const out = ruleA3(ctx)
+    expect(out[0]).toMatchObject({ id: 'A3', severity: 'P0' })
+  })
+})
+
+// ============ A4 ============
+describe('ruleA4 — seed budget', () => {
+  it('fires P2 at 80%', () => {
+    const events = Array.from({ length: 128 }, (_, i) =>
+      makeEvent('SeedAdded', { seed: `0x${i}` }, i + 1, 0),
+    )
+    const out = ruleA4(makeContext({ snapshot: { ...makeContext().snapshot, events } as never }))
+    expect(out[0]).toMatchObject({ id: 'A4', severity: 'P2', dedupeKey: 'A4:80' })
+  })
+  it('fires P1 at 100%', () => {
+    const events = Array.from({ length: 160 }, (_, i) =>
+      makeEvent('SeedAdded', { seed: `0x${i}` }, i + 1, 0),
+    )
+    const out = ruleA4(makeContext({ snapshot: { ...makeContext().snapshot, events } as never }))
+    expect(out[0]).toMatchObject({ id: 'A4', severity: 'P1', dedupeKey: 'A4:100' })
+  })
+  it('does not fire below 80%', () => {
+    const events = Array.from({ length: 50 }, (_, i) =>
+      makeEvent('SeedAdded', { seed: `0x${i}` }, i + 1, 0),
+    )
+    expect(ruleA4(makeContext({ snapshot: { ...makeContext().snapshot, events } as never }))).toEqual([])
+  })
+})
+
+// ============ A5 ============
+describe('ruleA5 — launch-team placements', () => {
+  it('fires separately for hop-1 and hop-2 budgets', () => {
+    const events = [
+      ...Array.from({ length: 60 }, (_, i) => makeEvent('LaunchTeamInvited', { invitee: `0xa${i}`, hop: 1 }, i + 1, 0)),
+      ...Array.from({ length: 48 }, (_, i) => makeEvent('LaunchTeamInvited', { invitee: `0xb${i}`, hop: 2 }, i + 200, 0)),
+    ]
+    const out = ruleA5(makeContext({ snapshot: { ...makeContext().snapshot, events } as never }))
+    const ids = out.map((e) => e.dedupeKey).sort()
+    expect(ids).toContain('A5:hop1:100')
+    expect(ids).toContain('A5:hop2:80')
+  })
+})
+
+// ============ A6 ============
+describe('ruleA6 — duplicate same-hop slots', () => {
+  it('fires P2 when duplicate ratio exceeds threshold', () => {
+    const nodes = new Map<string, GraphNode>()
+    for (let i = 0; i < 10; i++) {
+      nodes.set(`a${i}-1`, makeNode(`0xa${i}`, 1, HOP1_CAP, i < 3 ? 2 : 1))
+    }
+    const graph: CrowdfundGraph = { ...emptyGraph(), nodes }
+    const out = ruleA6(makeContext({ snapshot: { ...makeContext().snapshot, graph } as never }))
+    expect(out[0]).toMatchObject({ id: 'A6', severity: 'P2' })
+  })
+  it('does not fire below threshold', () => {
+    const nodes = new Map<string, GraphNode>()
+    for (let i = 0; i < 100; i++) {
+      nodes.set(`a${i}-1`, makeNode(`0xa${i}`, 1, HOP1_CAP, i < 2 ? 2 : 1))
+    }
+    const graph: CrowdfundGraph = { ...emptyGraph(), nodes }
+    expect(ruleA6(makeContext({ snapshot: { ...makeContext().snapshot, graph } as never }))).toEqual([])
+  })
+})
+
+// ============ A7 ============
+describe('ruleA7 — expansion threshold', () => {
+  it('fires at 80% of ELASTIC_TRIGGER', () => {
+    const nodes = new Map<string, GraphNode>()
+    // 80 seeds × $15k = $1.2M; ELASTIC_TRIGGER = $1.5M → 80%
+    for (let i = 0; i < 80; i++) nodes.set(`a${i}-0`, makeNode(`0xa${i}`, 0, HOP0_CAP))
+    const graph: CrowdfundGraph = { ...emptyGraph(), nodes }
+    const out = ruleA7(makeContext({ snapshot: { ...makeContext().snapshot, graph } as never }))
+    expect(out[0]).toMatchObject({ id: 'A7', dedupeKey: 'A7:80' })
+  })
+  it('fires at 100% with the highest crossed tier', () => {
+    const nodes = new Map<string, GraphNode>()
+    for (let i = 0; i < 100; i++) nodes.set(`a${i}-0`, makeNode(`0xa${i}`, 0, HOP0_CAP))
+    const graph: CrowdfundGraph = { ...emptyGraph(), nodes }
+    const out = ruleA7(makeContext({ snapshot: { ...makeContext().snapshot, graph } as never }))
+    expect(out[0].dedupeKey).toBe('A7:100')
+  })
+})
+
+// ============ A8 ============
+describe('ruleA8 — minimum at risk late', () => {
+  it('fires when sub-minimum with ≤72h left', () => {
+    const nodes = new Map<string, GraphNode>()
+    nodes.set('a-0', makeNode('0xa', 0, HOP0_CAP)) // $15k — far below MIN_SALE
+    const graph: CrowdfundGraph = { ...emptyGraph(), nodes }
+    const ctx = makeContext({
+      now: COMMIT_TS - 60 * 60 * 24 * 2, // 48h before deadline
+      snapshot: { ...makeContext().snapshot, graph } as never,
+    })
+    const out = ruleA8(ctx)
+    expect(out[0]).toMatchObject({ id: 'A8', dedupeKey: 'A8:72h' })
+  })
+  it('does not fire after deadline', () => {
+    const ctx = makeContext({ now: COMMIT_TS + 1 })
+    expect(ruleA8(ctx)).toEqual([])
+  })
+})
+
+// ============ A9a / A9b ============
+describe('ruleA9a — deadline passed, qualified', () => {
+  it('fires P1 within grace, P0 beyond it', () => {
+    const nodes = new Map<string, GraphNode>()
+    for (let i = 0; i < 100; i++) nodes.set(`a${i}-0`, makeNode(`0xa${i}`, 0, HOP0_CAP))
+    const graph: CrowdfundGraph = { ...emptyGraph(), nodes }
+    const ctx = makeContext({
+      now: COMMIT_TS + 60 * 60, // 1h past, within 2h grace
+      snapshot: { ...makeContext().snapshot, graph } as never,
+    })
+    expect(ruleA9a(ctx)[0]).toMatchObject({ id: 'A9a', severity: 'P1', dedupeKey: 'A9a:P1' })
+    const ctx2 = makeContext({
+      now: COMMIT_TS + 60 * 60 * 3, // past grace
+      snapshot: { ...makeContext().snapshot, graph } as never,
+    })
+    expect(ruleA9a(ctx2)[0]).toMatchObject({ severity: 'P0', dedupeKey: 'A9a:P0' })
+  })
+  it('does not fire after Finalized or Cancelled', () => {
+    const nodes = new Map<string, GraphNode>()
+    for (let i = 0; i < 100; i++) nodes.set(`a${i}-0`, makeNode(`0xa${i}`, 0, HOP0_CAP))
+    const graph: CrowdfundGraph = { ...emptyGraph(), nodes }
+    const ctx = makeContext({
+      now: COMMIT_TS + 60 * 60,
+      snapshot: {
+        ...makeContext().snapshot,
+        graph,
+        events: [makeEvent('Finalized', { refundMode: false, saleSize: 0n, netProceeds: 0n }, 200)],
+      } as never,
+    })
+    expect(ruleA9a(ctx)).toEqual([])
+  })
+})
+
+describe('ruleA9b — deadline passed, sub-minimum', () => {
+  it('fires P1', () => {
+    const ctx = makeContext({ now: COMMIT_TS + 60 })
+    expect(ruleA9b(ctx)[0]).toMatchObject({ id: 'A9b', severity: 'P1' })
+  })
+})
+
+// ============ A10/A11/A12 ============
+describe('finalization alerts', () => {
+  it('A10 fires on refundMode=true', () => {
+    const ctx = makeContext({
+      snapshot: {
+        ...makeContext().snapshot,
+        events: [makeEvent('Finalized', { refundMode: true, saleSize: 0n, netProceeds: 0n }, 50)],
+      } as never,
+    })
+    expect(ruleA10(ctx)[0]).toMatchObject({ id: 'A10', severity: 'P1' })
+  })
+  it('A11 fires on Cancelled', () => {
+    const ctx = makeContext({
+      snapshot: {
+        ...makeContext().snapshot,
+        events: [makeEvent('Cancelled', {}, 75)],
+      } as never,
+    })
+    expect(ruleA11(ctx)[0]).toMatchObject({ id: 'A11', severity: 'P0' })
+  })
+  it('A12 fires on Finalized success', () => {
+    const ctx = makeContext({
+      snapshot: {
+        ...makeContext().snapshot,
+        events: [makeEvent('Finalized', { refundMode: false, saleSize: 1_800_000_000_000n, netProceeds: 1_000_000_000_000n }, 100)],
+      } as never,
+    })
+    expect(ruleA12(ctx)[0]).toMatchObject({ id: 'A12', severity: 'P3' })
+  })
+})
+
+// ============ A13 ============
+describe('ruleA13 — treasury proceeds mismatch', () => {
+  it('does not fire when balance matches netProceeds within rounding buffer', () => {
+    const nodes = new Map<string, GraphNode>()
+    for (let i = 0; i < 100; i++) nodes.set(`n${i}-0`, makeNode(`0xa${i}`, 0, 0n))
+    const graph: CrowdfundGraph = { ...emptyGraph(), nodes }
+    const ctx = makeContext({
+      treasuryUsdcBalance: 1_000_000n,
+      snapshot: {
+        ...makeContext().snapshot,
+        graph,
+        events: [makeEvent('Finalized', { refundMode: false, netProceeds: 1_000_050n }, 100)],
+      } as never,
+    })
+    // diff = 50, buffer = 100 (participantNodes count)
+    expect(ruleA13(ctx)).toEqual([])
+  })
+  it('fires P0 when diff exceeds rounding buffer', () => {
+    const nodes = new Map<string, GraphNode>()
+    for (let i = 0; i < 10; i++) nodes.set(`n${i}-0`, makeNode(`0xa${i}`, 0, 0n))
+    const graph: CrowdfundGraph = { ...emptyGraph(), nodes }
+    const ctx = makeContext({
+      treasuryUsdcBalance: 1_000_000n,
+      snapshot: {
+        ...makeContext().snapshot,
+        graph,
+        events: [makeEvent('Finalized', { refundMode: false, netProceeds: 999_500n }, 100)],
+      } as never,
+    })
+    // diff = 500, buffer = 10 → fires
+    expect(ruleA13(ctx)[0]).toMatchObject({ id: 'A13', severity: 'P0' })
+  })
+})
+
+// ============ A17 ============
+describe('ruleA17 — settlement after refundMode/cancel', () => {
+  it('fires P0 when Allocated appears after refundMode', () => {
+    const ctx = makeContext({
+      snapshot: {
+        ...makeContext().snapshot,
+        events: [
+          makeEvent('Finalized', { refundMode: true, saleSize: 0n, netProceeds: 0n }, 100),
+          makeEvent('Allocated', { participant: '0xa', armTransferred: 1n, refundUsdc: 0n, delegate: '0xd' }, 101),
+        ],
+      } as never,
+    })
+    const out = ruleA17(ctx)
+    expect(out[0]).toMatchObject({ id: 'A17', severity: 'P0' })
+  })
+})
+
+// ============ A18 / A19 / A20 (time-gated) ============
+describe('time-gated rules', () => {
+  it('A18 fires when claim ratio under threshold after 14 days', () => {
+    const events = [
+      makeEvent('Finalized', { refundMode: false, saleSize: 0n, netProceeds: 0n }, 100),
+      ...Array.from({ length: 10 }, (_, i) => makeEvent('Committed', { participant: `0xa${i}`, hop: 0, amount: HOP0_CAP }, 101 + i)),
+      ...Array.from({ length: 2 }, (_, i) => makeEvent('Allocated', { participant: `0xa${i}`, armTransferred: 0n, refundUsdc: 0n, delegate: '0xd' }, 200 + i)),
+    ]
+    const ctx = makeContext({
+      finalizedAt: OPEN_TS,
+      now: OPEN_TS + 15 * 24 * 60 * 60,
+      snapshot: { ...makeContext().snapshot, events } as never,
+    })
+    expect(ruleA18(ctx)[0]).toMatchObject({ id: 'A18' })
+  })
+  it('A19 fires when refund-claim shortfall exceeds threshold after 30 days', () => {
+    const summaries = new Map<string, AddressSummary>()
+    summaries.set('0xa', {
+      address: '0xa',
+      hops: [0],
+      totalCommitted: HOP0_CAP,
+      perHop: new Map(),
+      displayInviter: 'armada',
+      allocatedArm: null,
+      refundUsdc: 1_000_000n, // refundable
+      allocatedPerHop: new Map(),
+      armClaimed: false,
+      refundClaimed: false,
+      delegate: null,
+    })
+    const graph: CrowdfundGraph = { ...emptyGraph(), summaries }
+    const events = [
+      makeEvent('Finalized', { refundMode: false, saleSize: 0n, netProceeds: 0n }, 100),
+      // 80k of 1M claimed = 8% claimed, 92% unclaimed → above 10% threshold
+      makeEvent('RefundClaimed', { participant: '0xa', usdcAmount: 80_000n }, 200),
+    ]
+    const ctx = makeContext({
+      finalizedAt: OPEN_TS,
+      now: OPEN_TS + 31 * 24 * 60 * 60,
+      snapshot: { ...makeContext().snapshot, graph, events } as never,
+    })
+    expect(ruleA19(ctx)[0]).toMatchObject({ id: 'A19' })
+  })
+  it('A20 fires past 3-year window after success', () => {
+    const ctx = makeContext({
+      finalizedAt: OPEN_TS,
+      now: OPEN_TS + 1095 * 24 * 60 * 60 + 1,
+      snapshot: {
+        ...makeContext().snapshot,
+        events: [makeEvent('Finalized', { refundMode: false, saleSize: 0n, netProceeds: 0n }, 100)],
+      } as never,
+    })
+    expect(ruleA20(ctx)[0]).toMatchObject({ id: 'A20' })
+  })
+})
+
+// ============ evaluateAllRules ============
+describe('evaluateAllRules', () => {
+  it('aggregates across all rules', () => {
+    const ctx = makeContext({
+      now: OPEN_TS + 1,
+      snapshot: { ...makeContext().snapshot, events: [] } as never,
+    })
+    const out = evaluateAllRules(ctx)
+    // A2 should fire (open, not armed); A9b only fires after deadline.
+    expect(out.map((e) => e.id)).toContain('A2')
+  })
+})
+
+// Reference imports to keep linter happy if rules are re-exported elsewhere.
+void makeEdge

--- a/crowdfund-ui/packages/indexer/src/alerts/rules.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/rules.ts
@@ -1,0 +1,483 @@
+// ABOUTME: Pure alert-rule evaluators for MONITORING.md §8 A1–A20.
+// ABOUTME: Each rule returns 0..n AlertEvent occurrences given the current context.
+
+import { CROWDFUND_CONSTANTS } from '../../../shared/src/lib/constants.js'
+import type { CrowdfundEvent } from '../../../shared/src/lib/events.js'
+import type { CrowdfundGraph } from '../../../shared/src/lib/graph.js'
+import type { AlertContext, AlertEvent, AlertRule } from './types.js'
+
+const TIER_LEVELS = [80, 90, 100] as const
+const EXPANSION_TIERS = [80, 90, 95, 100] as const
+
+// ============ Generic helpers ============
+
+function eventsOfType(events: readonly CrowdfundEvent[], type: CrowdfundEvent['type']): readonly CrowdfundEvent[] {
+  return events.filter((e) => e.type === type)
+}
+
+function cappedDemandTotal(graph: CrowdfundGraph): bigint {
+  let total = 0n
+  for (const node of graph.nodes.values()) total += node.committed
+  return total
+}
+
+function duplicateSlotNodeCount(graph: CrowdfundGraph): number {
+  let count = 0
+  for (const node of graph.nodes.values()) {
+    if (node.hop >= 1 && node.invitesReceived > 1) count++
+  }
+  return count
+}
+
+function occupiedHop12Count(graph: CrowdfundGraph): number {
+  let count = 0
+  for (const node of graph.nodes.values()) if (node.hop === 1 || node.hop === 2) count++
+  return count
+}
+
+function uniqueCommittedAddressCount(events: readonly CrowdfundEvent[]): number {
+  const set = new Set<string>()
+  for (const e of events) {
+    if (e.type === 'Committed') set.add(String(e.args.participant).toLowerCase())
+  }
+  return set.size
+}
+
+function countLaunchTeamPlacementsAtHop(events: readonly CrowdfundEvent[], hop: number): number {
+  return events.filter((e) => e.type === 'LaunchTeamInvited' && Number(e.args.hop) === hop).length
+}
+
+function nearestCrossedTier(value: number, target: number, tiers: readonly number[]): number | null {
+  if (target <= 0) return null
+  let crossed: number | null = null
+  for (const t of tiers) {
+    if ((value * 100) / target >= t) crossed = t
+  }
+  return crossed
+}
+
+function findLatestEvent(
+  events: readonly CrowdfundEvent[],
+  type: CrowdfundEvent['type'],
+): CrowdfundEvent | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i].type === type) return events[i]
+  }
+  return null
+}
+
+function severityForBudget(crossedTier: number): 'P1' | 'P2' {
+  return crossedTier >= 100 ? 'P1' : 'P2'
+}
+
+// ============ Rule implementations ============
+
+// A1 — ARM loaded (P3, once)
+export const ruleA1: AlertRule = (ctx) => {
+  const event = findLatestEvent(ctx.snapshot.events, 'ArmLoaded')
+  if (!event) return []
+  return [{
+    id: 'A1',
+    severity: 'P3',
+    dedupeKey: 'A1',
+    title: 'ARM loaded',
+    body: `ArmLoaded emitted at block ${event.blockNumber}. Commitment window opens at openTimestamp.`,
+    runbook: 'OPERATIONS.md §3 Steps 5–8',
+  }]
+}
+
+// A2 — Sale should be open but not yet armed (P1)
+export const ruleA2: AlertRule = (ctx) => {
+  if (ctx.now < ctx.params.openTimestamp) return []
+  const armed = eventsOfType(ctx.snapshot.events, 'ArmLoaded').length > 0
+  if (armed) return []
+  return [{
+    id: 'A2',
+    severity: 'P1',
+    dedupeKey: 'A2',
+    title: 'Sale open window reached but ARM not loaded',
+    body: `openTimestamp=${ctx.params.openTimestamp} has passed but no ArmLoaded event has been seen.`,
+    runbook: 'OPERATIONS.md §3 Steps 4–5',
+  }]
+}
+
+// A3 — Week-1 action outside week-1 window (P0)
+export const ruleA3: AlertRule = (ctx) => {
+  const out: AlertEvent[] = []
+  for (const e of ctx.snapshot.events) {
+    if (e.type !== 'SeedAdded' && e.type !== 'LaunchTeamInvited') continue
+    // The graph keeps events ordered by block; we cannot trivially derive timestamp
+    // from the event itself, but the indexer guarantees no event past the contract's
+    // own week-1 guard. A week-1 violation would mean a contract or RPC failure.
+    // Use blockNumber as the dedupe seed so each offending event fires once.
+    if (e.blockNumber === 0) continue
+    // Coarse-grained timestamp comparison would require block-timestamp lookups;
+    // the contract's _requireArmLoadedAndPreInviteEnd already enforces this. If a
+    // week-1 event ever appears past week1Deadline, the indexer + chain are
+    // inconsistent — surface it.
+    // For now, A3 is wired but only fires when an indexer extension supplies
+    // event timestamps. Skip when timestamp is unknown.
+    const timestamp = Number((e.args as { _timestamp?: number })._timestamp ?? 0)
+    if (timestamp === 0) continue
+    if (timestamp <= ctx.params.week1Deadline) continue
+    out.push({
+      id: 'A3',
+      severity: 'P0',
+      dedupeKey: `A3:${e.type}:${e.transactionHash}:${e.logIndex}`,
+      title: 'Week-1 action emitted after week-1 deadline',
+      body: `${e.type} emitted at block ${e.blockNumber} after week1Deadline. Investigate immediately.`,
+      runbook: 'OPERATIONS.md §9 failure investigation',
+    })
+  }
+  return out
+}
+
+// A4 — Seed budget thresholds (P2 → P1)
+export const ruleA4: AlertRule = (ctx) => {
+  const seedCount = eventsOfType(ctx.snapshot.events, 'SeedAdded').length
+  const crossed = nearestCrossedTier(seedCount, CROWDFUND_CONSTANTS.MAX_SEEDS, TIER_LEVELS)
+  if (crossed === null) return []
+  return [{
+    id: 'A4',
+    severity: severityForBudget(crossed),
+    dedupeKey: `A4:${crossed}`,
+    title: `Seed budget at ${crossed}% (${seedCount}/${CROWDFUND_CONSTANTS.MAX_SEEDS})`,
+    body: `Hop-0 SeedAdded count reached ${crossed}% of the configured MAX_SEEDS (${CROWDFUND_CONSTANTS.MAX_SEEDS}).`,
+    runbook: 'OPERATIONS.md §4 Week-1 go/no-go; §10 decision log',
+    context: { seedCount, crossedTier: crossed },
+  }]
+}
+
+// A5 — Launch-team placement budget thresholds (P2 → P1)
+export const ruleA5: AlertRule = (ctx) => {
+  const hop1 = countLaunchTeamPlacementsAtHop(ctx.snapshot.events, 1)
+  const hop2 = countLaunchTeamPlacementsAtHop(ctx.snapshot.events, 2)
+  const out: AlertEvent[] = []
+
+  const crossed1 = nearestCrossedTier(hop1, CROWDFUND_CONSTANTS.LAUNCH_TEAM_HOP1_BUDGET, TIER_LEVELS)
+  if (crossed1 !== null) {
+    out.push({
+      id: 'A5',
+      severity: severityForBudget(crossed1),
+      dedupeKey: `A5:hop1:${crossed1}`,
+      title: `Launch-team hop-1 placements at ${crossed1}%`,
+      body: `Hop-1 placements: ${hop1}/${CROWDFUND_CONSTANTS.LAUNCH_TEAM_HOP1_BUDGET}.`,
+      runbook: 'OPERATIONS.md §4 Week-1 operations; §10 decision log',
+      context: { hop: 1, count: hop1, crossedTier: crossed1 },
+    })
+  }
+  const crossed2 = nearestCrossedTier(hop2, CROWDFUND_CONSTANTS.LAUNCH_TEAM_HOP2_BUDGET, TIER_LEVELS)
+  if (crossed2 !== null) {
+    out.push({
+      id: 'A5',
+      severity: severityForBudget(crossed2),
+      dedupeKey: `A5:hop2:${crossed2}`,
+      title: `Launch-team hop-2 placements at ${crossed2}%`,
+      body: `Hop-2 placements: ${hop2}/${CROWDFUND_CONSTANTS.LAUNCH_TEAM_HOP2_BUDGET}.`,
+      runbook: 'OPERATIONS.md §4 Week-1 operations; §10 decision log',
+      context: { hop: 2, count: hop2, crossedTier: crossed2 },
+    })
+  }
+  return out
+}
+
+// A6 — Duplicate same-hop slot growth (P2, awareness only)
+export const ruleA6: AlertRule = (ctx) => {
+  const occupied = occupiedHop12Count(ctx.snapshot.graph)
+  if (occupied === 0) return []
+  const duplicates = duplicateSlotNodeCount(ctx.snapshot.graph)
+  const ratio = duplicates / occupied
+  if (ratio < ctx.thresholds.duplicateSlotFraction) return []
+  return [{
+    id: 'A6',
+    severity: 'P2',
+    dedupeKey: `A6:${Math.round(ratio * 100)}`,
+    title: `Duplicate same-hop slot ratio ${(ratio * 100).toFixed(1)}%`,
+    body: `${duplicates}/${occupied} hop-1+hop-2 nodes have multiple slots. Intentional under the design; this is an awareness alert (see MONITORING.md §9.1).`,
+    runbook: 'OPERATIONS.md §4/§5 monitoring; no automatic intervention',
+    context: { duplicates, occupied, ratio },
+  }]
+}
+
+// A7 — Expansion threshold approaching (P2)
+export const ruleA7: AlertRule = (ctx) => {
+  const capped = cappedDemandTotal(ctx.snapshot.graph)
+  if (capped === 0n) return []
+  const ratioPct = Number((capped * 100n) / CROWDFUND_CONSTANTS.ELASTIC_TRIGGER)
+  let crossed: number | null = null
+  for (const t of EXPANSION_TIERS) if (ratioPct >= t) crossed = t
+  if (crossed === null) return []
+  return [{
+    id: 'A7',
+    severity: 'P2',
+    dedupeKey: `A7:${crossed}`,
+    title: `cappedDemand at ${crossed}% of ELASTIC_TRIGGER`,
+    body: `cappedDemand=${capped.toString()} (${ratioPct}% of ELASTIC_TRIGGER ${CROWDFUND_CONSTANTS.ELASTIC_TRIGGER.toString()}).`,
+    runbook: 'OPERATIONS.md §5 pre-finalization checkpoint',
+    context: { cappedDemand: capped.toString(), crossedTier: crossed },
+  }]
+}
+
+// A8 — Minimum raise at risk late in sale (P2)
+export const ruleA8: AlertRule = (ctx) => {
+  const capped = cappedDemandTotal(ctx.snapshot.graph)
+  if (capped >= CROWDFUND_CONSTANTS.MIN_SALE) return []
+  const remaining = ctx.params.commitmentDeadline - ctx.now
+  if (remaining <= 0) return []
+  const TWENTY_FOUR_H = 24 * 60 * 60
+  const SEVENTY_TWO_H = 72 * 60 * 60
+  let band: '72h' | '24h' | null = null
+  if (remaining <= TWENTY_FOUR_H) band = '24h'
+  else if (remaining <= SEVENTY_TWO_H) band = '72h'
+  if (!band) return []
+  return [{
+    id: 'A8',
+    severity: 'P2',
+    dedupeKey: `A8:${band}`,
+    title: `Minimum raise at risk with ${band} remaining`,
+    body: `cappedDemand=${capped.toString()} below MIN_SALE=${CROWDFUND_CONSTANTS.MIN_SALE.toString()} with ${band} until commitmentDeadline.`,
+    runbook: 'OPERATIONS.md §5 Weeks 2–3 cadence; §11 Checkpoint 3',
+    context: { cappedDemand: capped.toString(), band },
+  }]
+}
+
+// A9a — Deadline passed, qualified, finalization needed (P1 → P0 after grace)
+export const ruleA9a: AlertRule = (ctx) => {
+  if (ctx.now <= ctx.params.commitmentDeadline) return []
+  const finalized = eventsOfType(ctx.snapshot.events, 'Finalized').length > 0
+  const cancelled = eventsOfType(ctx.snapshot.events, 'Cancelled').length > 0
+  if (finalized || cancelled) return []
+  const capped = cappedDemandTotal(ctx.snapshot.graph)
+  if (capped < CROWDFUND_CONSTANTS.MIN_SALE) return []
+  const past = ctx.now - ctx.params.commitmentDeadline
+  const severity: 'P1' | 'P0' = past >= ctx.thresholds.finalizeGraceSeconds ? 'P0' : 'P1'
+  return [{
+    id: 'A9a',
+    severity,
+    dedupeKey: `A9a:${severity}`,
+    title: `Deadline passed; finalize() required`,
+    body: `commitmentDeadline ${past}s ago; cappedDemand=${capped.toString()} ≥ MIN_SALE. Call finalize().`,
+    runbook: 'OPERATIONS.md §11 Checkpoint 3; §6 Finalization procedure',
+    context: { cappedDemand: capped.toString(), past, severity },
+  }]
+}
+
+// A9b — Deadline passed, sub-minimum demand (P1)
+export const ruleA9b: AlertRule = (ctx) => {
+  if (ctx.now <= ctx.params.commitmentDeadline) return []
+  const finalized = eventsOfType(ctx.snapshot.events, 'Finalized').length > 0
+  const cancelled = eventsOfType(ctx.snapshot.events, 'Cancelled').length > 0
+  if (finalized || cancelled) return []
+  const capped = cappedDemandTotal(ctx.snapshot.graph)
+  if (capped >= CROWDFUND_CONSTANTS.MIN_SALE) return []
+  return [{
+    id: 'A9b',
+    severity: 'P1',
+    dedupeKey: 'A9b',
+    title: 'Deadline passed; sub-minimum demand',
+    body: `cappedDemand=${capped.toString()} below MIN_SALE. Permissionless finalize() will activate refundMode.`,
+    runbook: 'OPERATIONS.md §5 pre-finalization checkpoint (sub-minimum branch)',
+    context: { cappedDemand: capped.toString() },
+  }]
+}
+
+// A10 — RefundMode triggered (P1)
+export const ruleA10: AlertRule = (ctx) => {
+  const f = findLatestEvent(ctx.snapshot.events, 'Finalized')
+  if (!f) return []
+  if (f.args.refundMode !== true) return []
+  return [{
+    id: 'A10',
+    severity: 'P1',
+    dedupeKey: 'A10',
+    title: 'refundMode triggered at finalization',
+    body: `Finalized(refundMode=true) at block ${f.blockNumber}. Participants can claim full refunds. Not an exploit (see MONITORING.md §9.2).`,
+    runbook: 'OPERATIONS.md §6 Path C (refundMode); §9.7',
+  }]
+}
+
+// A11 — Cancel triggered (P0)
+export const ruleA11: AlertRule = (ctx) => {
+  const c = findLatestEvent(ctx.snapshot.events, 'Cancelled')
+  if (!c) return []
+  return [{
+    id: 'A11',
+    severity: 'P0',
+    dedupeKey: 'A11',
+    title: 'Crowdfund cancelled',
+    body: `Cancelled emitted at block ${c.blockNumber}. Security Council action.`,
+    runbook: 'OPERATIONS.md §7 cancel procedure',
+  }]
+}
+
+// A12 — Successful finalization (P3)
+export const ruleA12: AlertRule = (ctx) => {
+  const f = findLatestEvent(ctx.snapshot.events, 'Finalized')
+  if (!f) return []
+  if (f.args.refundMode === true) return []
+  return [{
+    id: 'A12',
+    severity: 'P3',
+    dedupeKey: 'A12',
+    title: 'Crowdfund finalized successfully',
+    body: `Finalized(refundMode=false) at block ${f.blockNumber}. saleSize=${String(f.args.saleSize)}, netProceeds=${String(f.args.netProceeds)}.`,
+    runbook: 'OPERATIONS.md §6 post-finalization verification; §8',
+  }]
+}
+
+// A13 — Treasury proceeds mismatch (P0)
+//
+// The contract reduces the proceeds transfer by a rounding buffer equal to
+// participantNodes.length (NOT × NUM_HOPS as the spec text claims — see contract
+// line 511). Treasury balance increase must equal netProceeds within that
+// buffer; anything more is a real mismatch.
+export const ruleA13: AlertRule = (ctx) => {
+  const f = findLatestEvent(ctx.snapshot.events, 'Finalized')
+  if (!f) return []
+  if (f.args.refundMode === true) return []
+  if (ctx.treasuryUsdcBalance === null) return []
+  const netProceeds = BigInt(String(f.args.netProceeds))
+  const participantNodes = BigInt(ctx.snapshot.graph.nodes.size)
+  const diff = netProceeds > ctx.treasuryUsdcBalance
+    ? netProceeds - ctx.treasuryUsdcBalance
+    : ctx.treasuryUsdcBalance - netProceeds
+  if (diff <= participantNodes) return []
+  return [{
+    id: 'A13',
+    severity: 'P0',
+    dedupeKey: 'A13',
+    title: 'Treasury proceeds mismatch',
+    body: `Treasury USDC balance=${ctx.treasuryUsdcBalance.toString()} vs Finalized.netProceeds=${netProceeds.toString()}; diff=${diff.toString()} exceeds rounding buffer ${participantNodes.toString()}.`,
+    runbook: 'OPERATIONS.md §8 proceeds verification',
+    context: {
+      treasuryUsdcBalance: ctx.treasuryUsdcBalance.toString(),
+      netProceeds: netProceeds.toString(),
+      diff: diff.toString(),
+      roundingBuffer: participantNodes.toString(),
+    },
+  }]
+}
+
+// A17 — Unexpected settlement events after refundMode or cancel (P0)
+export const ruleA17: AlertRule = (ctx) => {
+  const finalized = findLatestEvent(ctx.snapshot.events, 'Finalized')
+  const cancelled = findLatestEvent(ctx.snapshot.events, 'Cancelled')
+  const refundModeBlock = finalized && finalized.args.refundMode === true ? finalized.blockNumber : null
+  const cancelledBlock = cancelled ? cancelled.blockNumber : null
+  const watermarks = [refundModeBlock, cancelledBlock].filter((b): b is number => typeof b === 'number')
+  if (watermarks.length === 0) return []
+  const earliest = Math.min(...watermarks)
+  const offenders = ctx.snapshot.events.filter(
+    (e) => (e.type === 'Allocated' || e.type === 'AllocatedHop') && e.blockNumber >= earliest,
+  )
+  if (offenders.length === 0) return []
+  return offenders.map((e) => ({
+    id: 'A17' as const,
+    severity: 'P0' as const,
+    dedupeKey: `A17:${e.transactionHash}:${e.logIndex}`,
+    title: 'Settlement event after refundMode/cancel',
+    body: `${e.type} emitted at block ${e.blockNumber} after refundMode/cancel watermark (block ${earliest}). Must not occur.`,
+    runbook: 'Immediate investigation — implementation bug',
+  }))
+}
+
+// A18 — ARM claims participation lag (P2)
+export const ruleA18: AlertRule = (ctx) => {
+  const f = findLatestEvent(ctx.snapshot.events, 'Finalized')
+  if (!f || f.args.refundMode === true) return []
+  if (ctx.finalizedAt === null) return []
+  const fourteenDays = 14 * 24 * 60 * 60
+  if (ctx.now - ctx.finalizedAt < fourteenDays) return []
+  const expected = uniqueCommittedAddressCount(ctx.snapshot.events)
+  if (expected === 0) return []
+  const claimed = eventsOfType(ctx.snapshot.events, 'Allocated').length
+  const ratio = claimed / expected
+  if (ratio >= ctx.thresholds.claimParticipationFloor) return []
+  return [{
+    id: 'A18',
+    severity: 'P2',
+    dedupeKey: 'A18',
+    title: `ARM claim participation below ${Math.round(ctx.thresholds.claimParticipationFloor * 100)}%`,
+    body: `${claimed}/${expected} (${(ratio * 100).toFixed(1)}%) participants have claimed ARM 14d+ after finalization.`,
+    runbook: 'OPERATIONS.md §8 claims monitoring',
+    context: { claimed, expected, ratio },
+  }]
+}
+
+// A19 — Refund participation lag (P2)
+export const ruleA19: AlertRule = (ctx) => {
+  const f = findLatestEvent(ctx.snapshot.events, 'Finalized')
+  if (!f) return []
+  if (ctx.finalizedAt === null) return []
+  const thirtyDays = 30 * 24 * 60 * 60
+  if (ctx.now - ctx.finalizedAt < thirtyDays) return []
+  let refundable = 0n
+  for (const s of ctx.snapshot.graph.summaries.values()) {
+    if (s.refundUsdc !== null) refundable += s.refundUsdc
+  }
+  if (refundable === 0n) return []
+  let claimed = 0n
+  for (const e of ctx.snapshot.events) {
+    if (e.type === 'RefundClaimed') claimed += BigInt(String(e.args.usdcAmount))
+  }
+  const unclaimed = refundable > claimed ? refundable - claimed : 0n
+  if (unclaimed === 0n) return []
+  const unclaimedFraction = Number((unclaimed * 10_000n) / refundable) / 10_000
+  if (unclaimedFraction < ctx.thresholds.refundUnclaimedThreshold) return []
+  return [{
+    id: 'A19',
+    severity: 'P2',
+    dedupeKey: 'A19',
+    title: `Refund unclaimed > ${Math.round(ctx.thresholds.refundUnclaimedThreshold * 100)}%`,
+    body: `${unclaimed.toString()} USDC unclaimed of ${refundable.toString()} total refundable 30d+ after finalization.`,
+    runbook: 'OPERATIONS.md §8 claims monitoring',
+    context: {
+      unclaimed: unclaimed.toString(),
+      refundable: refundable.toString(),
+      unclaimedFraction,
+    },
+  }]
+}
+
+// A20 — 3-year sweep window reached (P2)
+export const ruleA20: AlertRule = (ctx) => {
+  const f = findLatestEvent(ctx.snapshot.events, 'Finalized')
+  if (!f || f.args.refundMode === true) return []
+  if (ctx.finalizedAt === null) return []
+  if (ctx.now <= ctx.finalizedAt + CROWDFUND_CONSTANTS.CLAIM_DEADLINE_DURATION) return []
+  return [{
+    id: 'A20',
+    severity: 'P2',
+    dedupeKey: 'A20',
+    title: '3-year sweep window reached',
+    body: 'Unclaimed ARM is now sweepable via withdrawUnallocatedArm().',
+    runbook: 'OPERATIONS.md §8 3-year deadline sweep',
+  }]
+}
+
+export const ALL_RULES: ReadonlyArray<{ id: string; rule: AlertRule }> = [
+  { id: 'A1', rule: ruleA1 },
+  { id: 'A2', rule: ruleA2 },
+  { id: 'A3', rule: ruleA3 },
+  { id: 'A4', rule: ruleA4 },
+  { id: 'A5', rule: ruleA5 },
+  { id: 'A6', rule: ruleA6 },
+  { id: 'A7', rule: ruleA7 },
+  { id: 'A8', rule: ruleA8 },
+  { id: 'A9a', rule: ruleA9a },
+  { id: 'A9b', rule: ruleA9b },
+  { id: 'A10', rule: ruleA10 },
+  { id: 'A11', rule: ruleA11 },
+  { id: 'A12', rule: ruleA12 },
+  { id: 'A13', rule: ruleA13 },
+  { id: 'A17', rule: ruleA17 },
+  { id: 'A18', rule: ruleA18 },
+  { id: 'A19', rule: ruleA19 },
+  { id: 'A20', rule: ruleA20 },
+]
+
+export function evaluateAllRules(ctx: AlertContext): AlertEvent[] {
+  const out: AlertEvent[] = []
+  for (const { rule } of ALL_RULES) out.push(...rule(ctx))
+  return out
+}

--- a/crowdfund-ui/packages/indexer/src/alerts/runner.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/runner.ts
@@ -1,0 +1,89 @@
+// ABOUTME: Top-level "run once" entry: assemble AlertContext from store + RPC, dispatch.
+// ABOUTME: Used by the `evaluate-alerts` CLI subcommand (and a future scheduled cron).
+
+import { buildHealth } from '../api/health.js'
+import { buildSnapshot } from '../snapshots/build.js'
+import { getExhaustedRepairRanges } from '../ingest/reconcile.js'
+import { getRepairRanges } from '../ingest/ranges.js'
+import type { IndexerStore } from '../db/store.js'
+import type { ChainStateReader } from './chainState.js'
+import { evaluateAndDispatch, type EvaluatorResult } from './evaluator.js'
+import { createDiscordNotifier, type Notifier } from './notifier.js'
+import type { AlertStateStore } from './state.js'
+import { readThresholdsFromEnv } from './thresholds.js'
+import type { AlertContext, CrowdfundParams, Severity } from './types.js'
+
+export interface RunAlertsOnceInput {
+  store: IndexerStore
+  stateStore: AlertStateStore
+  params: CrowdfundParams
+  repairMaxAttempts: number
+  /** Used to read finalizedAt and treasury USDC balance. Optional — null when offline. */
+  chainState: ChainStateReader | null
+  notifier: Notifier
+  /** Test seam — defaults to `() => Math.floor(Date.now() / 1000)`. */
+  nowSeconds?: () => number
+}
+
+export async function runAlertsOnce(input: RunAlertsOnceInput): Promise<EvaluatorResult> {
+  const data = await input.store.read()
+  const now = input.nowSeconds ? input.nowSeconds() : Math.floor(Date.now() / 1000)
+
+  const snapshot = buildSnapshot({
+    data,
+    chainId: input.params.chainId,
+    contractAddress: input.params.contractAddress,
+  })
+
+  const health = buildHealth({
+    cursor: data.cursor,
+    gapRanges: getRepairRanges(data.ranges),
+    gapsRequiringIntervention: getExhaustedRepairRanges(data.ranges, input.repairMaxAttempts),
+    lastIngestedAt: data.lastIngestedAt,
+    lastVerifiedAt: data.lastVerifiedAt,
+    lastReconciledAt: data.lastReconciledAt,
+    lastError: data.lastError,
+    latestSnapshotHash: data.latestSnapshotHash,
+    latestStaticSnapshotUrl: data.latestStaticSnapshotUrl,
+  })
+
+  let finalizedAt: number | null = null
+  let treasuryUsdcBalance: bigint | null = null
+  if (input.chainState) {
+    const [finalizedRaw, balance] = await Promise.all([
+      input.chainState.readFinalizedAt(),
+      input.chainState.readTreasuryUsdcBalance(),
+    ])
+    finalizedAt = finalizedRaw > 0 ? finalizedRaw : null
+    treasuryUsdcBalance = balance
+  }
+
+  const context: AlertContext = {
+    now,
+    params: input.params,
+    snapshot,
+    health,
+    thresholds: readThresholdsFromEnv(),
+    treasuryUsdcBalance,
+    finalizedAt,
+  }
+
+  return await evaluateAndDispatch({
+    context,
+    notifier: input.notifier,
+    stateStore: input.stateStore,
+  })
+}
+
+/** Build a Discord notifier from environment variables (one webhook per severity). */
+export function createDiscordNotifierFromEnv(): Notifier {
+  const webhooks: Partial<Record<Severity, string>> = {}
+  const mentions: Partial<Record<Severity, string>> = {}
+  for (const sev of ['P0', 'P1', 'P2', 'P3'] as const) {
+    const url = process.env[`CROWDFUND_ALERT_WEBHOOK_${sev}`]
+    if (url) webhooks[sev] = url
+    const mention = process.env[`CROWDFUND_ALERT_MENTION_${sev}`]
+    if (mention) mentions[sev] = mention
+  }
+  return createDiscordNotifier({ webhooks, mentions })
+}

--- a/crowdfund-ui/packages/indexer/src/alerts/state.test.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/state.test.ts
@@ -1,0 +1,36 @@
+// ABOUTME: Unit tests for alert-state persistence — file roundtrip + missing-file behavior.
+// ABOUTME: Uses a tmp directory; cleans up between tests.
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createFileAlertStateStore, createInMemoryAlertStateStore } from './state.js'
+
+describe('createInMemoryAlertStateStore', () => {
+  it('roundtrips a Set of dedupe keys', async () => {
+    const store = createInMemoryAlertStateStore(['A1'])
+    expect((await store.read()).firedKeys.has('A1')).toBe(true)
+    await store.write({ firedKeys: new Set(['A1', 'A11']) })
+    expect(Array.from((await store.read()).firedKeys).sort()).toEqual(['A1', 'A11'])
+  })
+})
+
+describe('createFileAlertStateStore', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'alert-state-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('returns empty state when file does not exist', async () => {
+    const store = createFileAlertStateStore(join(dir, 'state.json'))
+    const state = await store.read()
+    expect(state.firedKeys.size).toBe(0)
+  })
+
+  it('writes and reads back a sorted, persistent state', async () => {
+    const store = createFileAlertStateStore(join(dir, 'state.json'))
+    await store.write({ firedKeys: new Set(['A11', 'A1', 'A4:80']) })
+    const reread = await store.read()
+    expect(Array.from(reread.firedKeys).sort()).toEqual(['A1', 'A11', 'A4:80'])
+  })
+})

--- a/crowdfund-ui/packages/indexer/src/alerts/state.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/state.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Persisted "already fired" alert dedupe state, stored as JSON next to the indexer store.
+// ABOUTME: Keeps a Set of dedupeKey strings; missing file is treated as empty.
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+export interface AlertState {
+  firedKeys: ReadonlySet<string>
+}
+
+export interface AlertStateStore {
+  read(): Promise<AlertState>
+  write(state: AlertState): Promise<void>
+}
+
+interface PersistedShape {
+  firedKeys: string[]
+}
+
+export function createFileAlertStateStore(filePath: string): AlertStateStore {
+  return {
+    async read() {
+      try {
+        const raw = await readFile(filePath, 'utf8')
+        const parsed = JSON.parse(raw) as PersistedShape
+        if (!Array.isArray(parsed.firedKeys)) return { firedKeys: new Set() }
+        return { firedKeys: new Set(parsed.firedKeys.filter((k): k is string => typeof k === 'string')) }
+      } catch (err) {
+        const e = err as NodeJS.ErrnoException
+        if (e.code === 'ENOENT') return { firedKeys: new Set() }
+        throw err
+      }
+    },
+    async write(state) {
+      const persisted: PersistedShape = { firedKeys: Array.from(state.firedKeys).sort() }
+      await mkdir(dirname(filePath), { recursive: true })
+      await writeFile(filePath, JSON.stringify(persisted, null, 2) + '\n', 'utf8')
+    },
+  }
+}
+
+export function createInMemoryAlertStateStore(initial?: Iterable<string>): AlertStateStore {
+  let state: AlertState = { firedKeys: new Set(initial ?? []) }
+  return {
+    async read() {
+      return state
+    },
+    async write(next) {
+      state = { firedKeys: new Set(next.firedKeys) }
+    },
+  }
+}

--- a/crowdfund-ui/packages/indexer/src/alerts/thresholds.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/thresholds.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Threshold defaults from MONITORING.md §13, with environment-variable overrides.
+// ABOUTME: Pure helpers — no side effects beyond reading process.env.
+
+import type { AlertThresholds } from './types.js'
+
+const DEFAULTS: AlertThresholds = {
+  duplicateSlotFraction: 0.10,
+  finalizeGraceSeconds: 2 * 60 * 60,
+  claimParticipationFloor: 0.50,
+  refundUnclaimedThreshold: 0.10,
+}
+
+function readNumber(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (raw === undefined || raw.length === 0) return fallback
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid numeric environment variable: ${name}`)
+  }
+  return parsed
+}
+
+export function readThresholdsFromEnv(): AlertThresholds {
+  return {
+    duplicateSlotFraction: readNumber(
+      'CROWDFUND_ALERT_DUPLICATE_SLOT_FRACTION',
+      DEFAULTS.duplicateSlotFraction,
+    ),
+    finalizeGraceSeconds: readNumber(
+      'CROWDFUND_ALERT_FINALIZE_GRACE_SECONDS',
+      DEFAULTS.finalizeGraceSeconds,
+    ),
+    claimParticipationFloor: readNumber(
+      'CROWDFUND_ALERT_CLAIM_PARTICIPATION_FLOOR',
+      DEFAULTS.claimParticipationFloor,
+    ),
+    refundUnclaimedThreshold: readNumber(
+      'CROWDFUND_ALERT_REFUND_UNCLAIMED_THRESHOLD',
+      DEFAULTS.refundUnclaimedThreshold,
+    ),
+  }
+}
+
+export const ALERT_THRESHOLD_DEFAULTS = DEFAULTS

--- a/crowdfund-ui/packages/indexer/src/alerts/types.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/types.ts
@@ -1,0 +1,74 @@
+// ABOUTME: Type definitions for the crowdfund alert evaluator.
+// ABOUTME: Mirrors MONITORING.md alert ids, severity classes, and rule input shape.
+
+import type { CrowdfundSnapshot, IndexerHealth } from '../types.js'
+
+/** Alert identifier matching MONITORING.md §8 (A1–A20). */
+export type AlertId =
+  | 'A1' | 'A2' | 'A3' | 'A4' | 'A5' | 'A6' | 'A7' | 'A8'
+  | 'A9a' | 'A9b' | 'A10' | 'A11' | 'A12' | 'A13' | 'A17' | 'A18' | 'A19' | 'A20'
+
+/** Severity class per MONITORING.md §4. */
+export type Severity = 'P0' | 'P1' | 'P2' | 'P3'
+
+/**
+ * A single alert occurrence. `dedupeKey` distinguishes repeatable threshold tiers
+ * within the same alert id — e.g. A4 fires once at 80%, again at 90%, again at
+ * 100%; each uses a different dedupeKey so the evaluator does not re-fire a tier
+ * it has already announced.
+ */
+export interface AlertEvent {
+  id: AlertId
+  severity: Severity
+  /** Stable string identifying this specific firing. e.g. "A4:80". */
+  dedupeKey: string
+  title: string
+  /** Human-readable details for the delivery channel. */
+  body: string
+  /** Reference into OPERATIONS.md (or another runbook). */
+  runbook: string
+  /** Optional structured payload for downstream consumers. */
+  context?: Record<string, string | number | boolean>
+}
+
+/** Parameters from the crowdfund deploy (timing + addresses). */
+export interface CrowdfundParams {
+  chainId: number
+  contractAddress: string
+  treasuryAddress: string
+  /** Unix seconds; matches contract windowStart. */
+  openTimestamp: number
+  /** Unix seconds; openTimestamp + 7 days. */
+  week1Deadline: number
+  /** Unix seconds; openTimestamp + 21 days. */
+  commitmentDeadline: number
+}
+
+/** Numeric thresholds — see MONITORING.md §13. Overridable per env var. */
+export interface AlertThresholds {
+  /** A6 — duplicate-slot watch threshold as a fraction of occupied hop-1/2 nodes (default 0.10). */
+  duplicateSlotFraction: number
+  /** A9a — grace window in seconds after commitmentDeadline before P1 escalates to P0. */
+  finalizeGraceSeconds: number
+  /** A18 — fraction of allocated participants whose claim is considered "expected" within 14 days. */
+  claimParticipationFloor: number
+  /** A19 — fraction of refundable USDC considered "unclaimed-lag" after 30 days. */
+  refundUnclaimedThreshold: number
+}
+
+/** Inputs a rule may consult. Constructed once per evaluator tick. */
+export interface AlertContext {
+  /** Current unix seconds (test seam — default Date.now()/1000). */
+  now: number
+  params: CrowdfundParams
+  snapshot: CrowdfundSnapshot
+  health: IndexerHealth
+  thresholds: AlertThresholds
+  /** Treasury USDC balance (read at evaluator startup; null when unavailable). */
+  treasuryUsdcBalance: bigint | null
+  /** Unix seconds when finalize() was called; null pre-finalization or when unread. */
+  finalizedAt: number | null
+}
+
+/** Pure rule signature — returns 0..n alert events given current context. */
+export type AlertRule = (ctx: AlertContext) => AlertEvent[]

--- a/crowdfund-ui/packages/indexer/src/cli/commands.test.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/commands.test.ts
@@ -100,4 +100,12 @@ describe('CLI commands', () => {
       toBlock: 'latest',
     })
   })
+
+  it('parses evaluate-alerts (dispatched in cli/index.ts)', () => {
+    expect(parseCliArgs(['evaluate-alerts'])).toEqual({
+      command: 'evaluate-alerts',
+      fromBlock: null,
+      toBlock: null,
+    })
+  })
 })

--- a/crowdfund-ui/packages/indexer/src/cli/commands.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/commands.ts
@@ -12,6 +12,7 @@ export type CliCommand =
   | 'backfill'
   | 'rebuild-snapshot'
   | 'publish-snapshot'
+  | 'evaluate-alerts'
 
 export interface ParsedCliArgs {
   command: CliCommand
@@ -31,6 +32,7 @@ const COMMANDS = new Set<CliCommand>([
   'backfill',
   'rebuild-snapshot',
   'publish-snapshot',
+  'evaluate-alerts',
 ])
 
 function parseBlockValue(raw: string, name: string): number | 'latest' {

--- a/crowdfund-ui/packages/indexer/src/cli/index.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/index.ts
@@ -5,6 +5,10 @@ import { join } from 'node:path'
 import { JsonRpcProvider } from 'ethers'
 import { createIndexerStore } from '../db/createStore.js'
 import { parseCliArgs, runReadOnlyCommand } from './commands.js'
+import { createRpcChainStateReader } from '../alerts/chainState.js'
+import { createFileAlertStateStore } from '../alerts/state.js'
+import { createDiscordNotifierFromEnv, runAlertsOnce } from '../alerts/runner.js'
+import type { CrowdfundParams } from '../alerts/types.js'
 import { backfillVerifiedRanges } from '../ingest/backfill.js'
 import { createJsonRpcRangeProvider, repairRanges, verifyRange } from '../ingest/rpc.js'
 import { createReadableCrowdfundContract, reconcileSnapshot } from '../reconcile/contract.js'
@@ -212,6 +216,44 @@ async function main(): Promise<void> {
       lastError: null,
     }))
     process.stdout.write(`published ${result.snapshotFileName}\nlatest ${result.latestUrl ?? result.latestPath}\n`)
+    return
+  }
+
+  if (args.command === 'evaluate-alerts') {
+    const params: CrowdfundParams = {
+      chainId: readNumberEnv('CROWDFUND_CHAIN_ID', 11155111),
+      contractAddress: readRequiredEnv('CROWDFUND_CONTRACT_ADDRESS'),
+      treasuryAddress: readRequiredEnv('CROWDFUND_TREASURY_ADDRESS'),
+      openTimestamp: readNumberEnv('CROWDFUND_OPEN_TIMESTAMP', 0),
+      week1Deadline: readNumberEnv('CROWDFUND_WEEK1_DEADLINE', 0),
+      commitmentDeadline: readNumberEnv('CROWDFUND_COMMITMENT_DEADLINE', 0),
+    }
+    const rpcUrl = process.env.CROWDFUND_PRIMARY_RPC_URL
+    const usdcAddress = process.env.CROWDFUND_USDC_ADDRESS
+    const chainState = rpcUrl && usdcAddress
+      ? createRpcChainStateReader({
+          rpcUrl,
+          crowdfundAddress: params.contractAddress,
+          usdcAddress,
+          treasuryAddress: params.treasuryAddress,
+        })
+      : null
+    const stateFile = process.env.CROWDFUND_ALERT_STATE_FILE
+      ?? join(process.cwd(), 'data/crowdfund-indexer/alerts.json')
+    const result = await runAlertsOnce({
+      store,
+      stateStore: createFileAlertStateStore(stateFile),
+      params,
+      repairMaxAttempts: readNumberEnv('CROWDFUND_REPAIR_MAX_ATTEMPTS', 6),
+      chainState,
+      notifier: createDiscordNotifierFromEnv(),
+    })
+    process.stdout.write(
+      `evaluated ${result.total} candidates; delivered ${result.delivered.length}; skipped ${result.skipped.length}\n`,
+    )
+    for (const e of result.delivered) {
+      process.stdout.write(`  [${e.severity} ${e.id}] ${e.title} (key=${e.dedupeKey})\n`)
+    }
     return
   }
 

--- a/crowdfund-ui/packages/shared/src/lib/constants.ts
+++ b/crowdfund-ui/packages/shared/src/lib/constants.ts
@@ -35,13 +35,13 @@ export const HOP_CONFIGS: readonly [HopConfig, HopConfig, HopConfig] = [
 
 /** ABI fragments for event parsing and contract reads */
 export const CROWDFUND_ABI_FRAGMENTS = [
-  'event ArmLoaded()',
+  'event ArmLoaded(address indexed caller, uint256 balance, uint256 required)',
   'event SeedAdded(address indexed seed)',
-  'event Invited(address indexed inviter, address indexed invitee, uint8 hop, uint256 nonce)',
+  'event Invited(address indexed inviter, address indexed invitee, uint8 indexed hop, uint256 nonce)',
   'event LaunchTeamInvited(address indexed invitee, uint8 hop)',
-  'event Committed(address indexed participant, uint8 hop, uint256 amount)',
-  'event Finalized(uint256 saleSize, uint256 allocatedArm, uint256 netProceeds, bool refundMode)',
-  'event Cancelled()',
+  'event Committed(address indexed participant, uint8 indexed hop, uint256 amount)',
+  'event Finalized(uint256 saleSize, uint256 allocatedArm, uint256 netProceeds, bool refundMode, uint256 cappedDemand, uint256 totalCommitted)',
+  'event Cancelled(address indexed caller, uint256 timestamp)',
   'event Allocated(address indexed participant, uint256 armTransferred, uint256 refundUsdc, address delegate)',
   'event AllocatedHop(address indexed participant, uint8 indexed hop, uint256 acceptedUsdc)',
   'event RefundClaimed(address indexed participant, uint256 usdcAmount)',

--- a/crowdfund-ui/packages/shared/src/lib/events.test.ts
+++ b/crowdfund-ui/packages/shared/src/lib/events.test.ts
@@ -28,12 +28,17 @@ function encodeLog(
 
 describe('parseCrowdfundEvent', () => {
   it('parses ArmLoaded event', () => {
-    const log = encodeLog('ArmLoaded', [])
+    const caller = '0x' + 'aa'.repeat(20)
+    const balance = 1_800_000n * 10n ** 18n
+    const required = 1_800_000n * 10n ** 18n
+    const log = encodeLog('ArmLoaded', [caller, balance, required])
     const result = parseCrowdfundEvent(log)
     expect(result).not.toBeNull()
     expect(result!.type).toBe('ArmLoaded')
     expect(result!.blockNumber).toBe(100)
-    expect(result!.args).toEqual({})
+    expect(result!.args.caller).toBe(caller.toLowerCase())
+    expect(result!.args.balance).toBe(balance)
+    expect(result!.args.required).toBe(required)
   })
 
   it('parses SeedAdded event', () => {
@@ -84,7 +89,9 @@ describe('parseCrowdfundEvent', () => {
     const saleSize = 1_200_000n * 10n ** 6n
     const allocatedArm = 1_200_000n * 10n ** 18n
     const netProceeds = 1_100_000n * 10n ** 6n
-    const log = encodeLog('Finalized', [saleSize, allocatedArm, netProceeds, false])
+    const cappedDemand = 1_150_000n * 10n ** 6n
+    const totalCommitted = 1_300_000n * 10n ** 6n
+    const log = encodeLog('Finalized', [saleSize, allocatedArm, netProceeds, false, cappedDemand, totalCommitted])
     const result = parseCrowdfundEvent(log)
     expect(result).not.toBeNull()
     expect(result!.type).toBe('Finalized')
@@ -92,14 +99,19 @@ describe('parseCrowdfundEvent', () => {
     expect(result!.args.allocatedArm).toBe(allocatedArm)
     expect(result!.args.netProceeds).toBe(netProceeds)
     expect(result!.args.refundMode).toBe(false)
+    expect(result!.args.cappedDemand).toBe(cappedDemand)
+    expect(result!.args.totalCommitted).toBe(totalCommitted)
   })
 
   it('parses Cancelled event', () => {
-    const log = encodeLog('Cancelled', [])
+    const caller = '0x' + 'bb'.repeat(20)
+    const timestamp = 1_780_000_000n
+    const log = encodeLog('Cancelled', [caller, timestamp])
     const result = parseCrowdfundEvent(log)
     expect(result).not.toBeNull()
     expect(result!.type).toBe('Cancelled')
-    expect(result!.args).toEqual({})
+    expect(result!.args.caller).toBe(caller.toLowerCase())
+    expect(result!.args.timestamp).toBe(timestamp)
   })
 
   it('parses Allocated event', () => {
@@ -173,7 +185,7 @@ describe('parseCrowdfundEvent', () => {
   })
 
   it('preserves block number and transaction hash', () => {
-    const log = encodeLog('ArmLoaded', [], {
+    const log = encodeLog('ArmLoaded', ['0x' + 'aa'.repeat(20), 1n, 1n], {
       blockNumber: 42,
       transactionHash: '0x' + 'cd'.repeat(32),
     })
@@ -183,7 +195,7 @@ describe('parseCrowdfundEvent', () => {
   })
 
   it('preserves logIndex', () => {
-    const log = encodeLog('ArmLoaded', [], { logIndex: 5 })
+    const log = encodeLog('ArmLoaded', ['0x' + 'aa'.repeat(20), 1n, 1n], { logIndex: 5 })
     const result = parseCrowdfundEvent(log)
     expect(result!.logIndex).toBe(5)
   })
@@ -192,7 +204,7 @@ describe('parseCrowdfundEvent', () => {
 describe('parseCrowdfundEvents', () => {
   it('parses multiple logs and filters out unrecognized', () => {
     const logs = [
-      encodeLog('ArmLoaded', [], { blockNumber: 1 }),
+      encodeLog('ArmLoaded', ['0x' + 'aa'.repeat(20), 1n, 1n], { blockNumber: 1 }),
       { blockNumber: 2, transactionHash: '0x00', logIndex: 0, topics: ['0xdead'], data: '0x' },
       encodeLog('SeedAdded', ['0x' + '11'.repeat(20)], { blockNumber: 3 }),
     ]

--- a/sample.env.production
+++ b/sample.env.production
@@ -3,10 +3,13 @@
 
 # ============================================================================
 # Crowdfund Sepolia deployment
+# Values mirror deployments/crowdfund-hub-sepolia.json — keep them in sync.
 # ============================================================================
 CROWDFUND_CHAIN_ID=11155111
-CROWDFUND_CONTRACT_ADDRESS=0xF681A7c700420e5CA93f77c8988d3eED02767035
-CROWDFUND_DEPLOY_BLOCK=10743481
+CROWDFUND_CONTRACT_ADDRESS=0x24b63d7C35b6Da98FbE38AE969Be790E7E396D0b
+CROWDFUND_TREASURY_ADDRESS=0x91cFA0c37Df43661DE90A3aa7CBE89ae7920871C
+CROWDFUND_USDC_ADDRESS=0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238
+CROWDFUND_DEPLOY_BLOCK=10892713
 
 # Use separate providers for primary ingestion and audit verification.
 CROWDFUND_PRIMARY_RPC_URL=https://<primary-sepolia-rpc>
@@ -64,6 +67,39 @@ CROWDFUND_SNAPSHOT_FORCE_PATH_STYLE=false
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=<region>
+
+# ============================================================================
+# Alert evaluator (see specs/MONITORING.md §8 + CROWDFUND_INDEXER_RUNBOOK.md).
+# Window timestamps come from the deployed contract (windowStart, windowEnd,
+# launchTeamInviteEnd). Read them once with cast and pin here, or wire a small
+# helper that pulls them at startup.
+# ============================================================================
+CROWDFUND_OPEN_TIMESTAMP=1779381672
+CROWDFUND_WEEK1_DEADLINE=1779986472
+CROWDFUND_COMMITMENT_DEADLINE=1781196072
+
+# One webhook URL per severity. P0/P1 should page on-call; P2/P3 can be a
+# silent log channel. Provide the same URL for all four if you only need
+# one channel. Real webhook URLs are secrets — keep them out of source
+# control; set via secret manager / hosting platform env.
+CROWDFUND_ALERT_WEBHOOK_P0=https://discord.com/api/webhooks/<id>/<token>
+CROWDFUND_ALERT_WEBHOOK_P1=https://discord.com/api/webhooks/<id>/<token>
+CROWDFUND_ALERT_WEBHOOK_P2=https://discord.com/api/webhooks/<id>/<token>
+CROWDFUND_ALERT_WEBHOOK_P3=https://discord.com/api/webhooks/<id>/<token>
+
+# Optional role mentions per severity (e.g. <@&123…> for a role ping).
+# CROWDFUND_ALERT_MENTION_P0=<@&on-call-role-id>
+# CROWDFUND_ALERT_MENTION_P1=<@&on-call-role-id>
+
+# Persisted dedupe state — already-delivered alert keys. Use per-env paths
+# so local-Anvil dedupe state doesn't suppress Sepolia alerts.
+CROWDFUND_ALERT_STATE_FILE=data/crowdfund-indexer/alerts-sepolia.json
+
+# Threshold overrides — defaults from MONITORING.md §13 apply if unset.
+# CROWDFUND_ALERT_DUPLICATE_SLOT_FRACTION=0.10
+# CROWDFUND_ALERT_FINALIZE_GRACE_SECONDS=7200
+# CROWDFUND_ALERT_CLAIM_PARTICIPATION_FLOOR=0.50
+# CROWDFUND_ALERT_REFUND_UNCLAIMED_THRESHOLD=0.10
 
 # ============================================================================
 # Crowdfund committer / observer Vite apps

--- a/specs/CROWDFUND_INDEXER_RUNBOOK.md
+++ b/specs/CROWDFUND_INDEXER_RUNBOOK.md
@@ -367,16 +367,30 @@ Each `evaluate-alerts` invocation is a single pass — it reads current indexer 
 
 If you need tighter latency than one minute, drop the timer to 30s — the evaluator is cheap (single store read + a few RPC calls when `chainState` is configured). Sub-30s is overkill at this scale and risks Discord rate limits.
 
+### Where webhook URLs live
+
+Webhook URLs are bearer credentials — anyone holding the URL can post to that channel — so they are **never** committed to git. The canonical home for them depends on environment:
+
+| Environment | Location | Set by |
+|---|---|---|
+| **Local dev / testing** | `config/secrets.env` (gitignored; template at `config/secrets.env.template`) | Operator copies template, fills in values, `source`s the file before running the indexer or CLI. |
+| **Production VPS** | systemd `EnvironmentFile=` pointing at a root-owned file under `/etc/crowdfund-alerts/` (mode `0640`, group-readable by the alerts service user) | Deploy script writes the file from your secret manager during host provisioning. Never check the file into the repo. |
+| **Container / PaaS** | Platform secret manager (Render, Fly, Vercel, AWS Secrets Manager, GCP Secret Manager, …) injected at process start | Set via the platform's UI or `infra-as-code`; rotate via the same channel. |
+
+`sample.env.production` keeps placeholder values (`https://discord.com/api/webhooks/<id>/<token>`) so the full env-var inventory is visible without leaking credentials. `config/secrets.env.template` carries the same env-var names with empty values, ready for `cp config/secrets.env.template config/secrets.env` then editing in place.
+
+`.gitignore` already covers `config/secrets.env` — verify with `git check-ignore -v config/secrets.env` before pasting a real URL.
+
 ### Rotating or changing the Discord channel
 
 The webhook URLs are env-var-driven (`CROWDFUND_ALERT_WEBHOOK_P0/P1/P2/P3`), so swapping channels is a config change, not a code redeploy:
 
 1. Create the new webhook in Discord (Server Settings → Integrations → Webhooks → New Webhook).
-2. Update the env var(s) on the host running the cron — secret manager, systemd EnvironmentFile, `.env`, etc.
+2. Update the env var(s) in whichever store applies to your environment (see table above).
 3. Reload the cron unit (`systemctl daemon-reload && systemctl restart crowdfund-alerts.timer`, or equivalent on your platform).
 4. Optionally revoke the old webhook in Discord to prevent stale tokens from posting.
 
-You can route different severities to different channels — e.g. P0/P1 to a paged channel with an `@on-call` role mention (`CROWDFUND_ALERT_MENTION_P0=<@&ROLE_ID>`), P2/P3 to a silent log channel. Or point all four at one channel for simplicity. Webhook URLs are secrets — set them via the platform's secret store, not by committing them.
+You can route different severities to different channels — e.g. P0/P1 to a paged channel with an `@on-call` role mention (`CROWDFUND_ALERT_MENTION_P0=<@&ROLE_ID>`), P2/P3 to a silent log channel. Or point all four at one channel for simplicity.
 
 ---
 

--- a/specs/CROWDFUND_INDEXER_RUNBOOK.md
+++ b/specs/CROWDFUND_INDEXER_RUNBOOK.md
@@ -361,6 +361,23 @@ Pair with a one-shot service that runs `npm run crowdfund:indexer:cli -- evaluat
 
 To force a re-fire after operator intervention (e.g. you want a P0 to re-page after a Discord channel outage), remove the relevant `dedupeKey` entries from `data/crowdfund-indexer/alerts.json` or delete the file entirely.
 
+### Delivery cadence
+
+Each `evaluate-alerts` invocation is a single pass — it reads current indexer state, evaluates every rule, dispatches newly-fired alerts, and exits. **Worst-case alert latency is your cron interval.** Multiple alerts that become true between two ticks all deliver in the same tick, so you may see two or three messages arrive together; that's expected, not a bug.
+
+If you need tighter latency than one minute, drop the timer to 30s — the evaluator is cheap (single store read + a few RPC calls when `chainState` is configured). Sub-30s is overkill at this scale and risks Discord rate limits.
+
+### Rotating or changing the Discord channel
+
+The webhook URLs are env-var-driven (`CROWDFUND_ALERT_WEBHOOK_P0/P1/P2/P3`), so swapping channels is a config change, not a code redeploy:
+
+1. Create the new webhook in Discord (Server Settings → Integrations → Webhooks → New Webhook).
+2. Update the env var(s) on the host running the cron — secret manager, systemd EnvironmentFile, `.env`, etc.
+3. Reload the cron unit (`systemctl daemon-reload && systemctl restart crowdfund-alerts.timer`, or equivalent on your platform).
+4. Optionally revoke the old webhook in Discord to prevent stale tokens from posting.
+
+You can route different severities to different channels — e.g. P0/P1 to a paged channel with an `@on-call` role mention (`CROWDFUND_ALERT_MENTION_P0=<@&ROLE_ID>`), P2/P3 to a silent log channel. Or point all four at one channel for simplicity. Webhook URLs are secrets — set them via the platform's secret store, not by committing them.
+
 ---
 
 ## Normal Operating Loop

--- a/specs/CROWDFUND_INDEXER_RUNBOOK.md
+++ b/specs/CROWDFUND_INDEXER_RUNBOOK.md
@@ -155,6 +155,29 @@ Snapshot publication variables:
 | `CROWDFUND_SNAPSHOT_PUBLIC_BASE_URL` | unset | Public root URL used in health metadata for `latest.json`. Prefix is appended automatically. |
 | `CROWDFUND_SNAPSHOT_FORCE_PATH_STYLE` | `false` | Enables path-style S3 requests for compatible providers that need it. |
 
+Alert evaluator variables (used by `evaluate-alerts`; see [`MONITORING.md`](MONITORING.md)):
+
+| Variable | Default | Behavior |
+|----------|---------|----------|
+| `CROWDFUND_TREASURY_ADDRESS` | required | Treasury address — used to read USDC balance for A13 mismatch detection. |
+| `CROWDFUND_USDC_ADDRESS` | optional | USDC contract — required for A13 (treasury balance). Omit to skip A13. |
+| `CROWDFUND_OPEN_TIMESTAMP` | `0` | Unix seconds when the commitment window opens. Drives A2/A8/A9. |
+| `CROWDFUND_WEEK1_DEADLINE` | `0` | Unix seconds when week-1 ends (openTimestamp + 7 days). Drives A3. |
+| `CROWDFUND_COMMITMENT_DEADLINE` | `0` | Unix seconds when the 3-week window closes (openTimestamp + 21 days). Drives A8/A9. |
+| `CROWDFUND_ALERT_WEBHOOK_P0` | unset | Discord webhook URL for P0 (immediate) alerts. |
+| `CROWDFUND_ALERT_WEBHOOK_P1` | unset | Discord webhook URL for P1 (same-day) alerts. |
+| `CROWDFUND_ALERT_WEBHOOK_P2` | unset | Discord webhook URL for P2 (attention) alerts. |
+| `CROWDFUND_ALERT_WEBHOOK_P3` | unset | Discord webhook URL for P3 (informational) alerts. |
+| `CROWDFUND_ALERT_MENTION_P0` | unset | Mention prepended to P0 messages (e.g. `<@&ROLE_ID>` to ping the on-call role). |
+| `CROWDFUND_ALERT_MENTION_P1` | unset | Mention prepended to P1 messages. |
+| `CROWDFUND_ALERT_MENTION_P2` | unset | Mention prepended to P2 messages. |
+| `CROWDFUND_ALERT_MENTION_P3` | unset | Mention prepended to P3 messages. |
+| `CROWDFUND_ALERT_STATE_FILE` | `data/crowdfund-indexer/alerts.json` | JSON file persisting already-delivered dedupe keys (so cron ticks don't re-fire). |
+| `CROWDFUND_ALERT_DUPLICATE_SLOT_FRACTION` | `0.10` | A6 — duplicate-slot watch threshold (fraction of occupied hop-1/2 nodes). MONITORING.md §13. |
+| `CROWDFUND_ALERT_FINALIZE_GRACE_SECONDS` | `7200` | A9a — grace window after `commitmentDeadline` before P1 escalates to P0. MONITORING.md §13. |
+| `CROWDFUND_ALERT_CLAIM_PARTICIPATION_FLOOR` | `0.50` | A18 — minimum fraction of claimers expected 14d after success finalization. |
+| `CROWDFUND_ALERT_REFUND_UNCLAIMED_THRESHOLD` | `0.10` | A19 — maximum fraction of refundable USDC left unclaimed 30d after refundMode. |
+
 Frontend variables:
 
 | Variable | Default | Behavior |
@@ -308,6 +331,35 @@ npm run crowdfund:indexer:cli -- publish-snapshot
 ```
 
 Publishing refuses failed contract-read reconciliation when `CROWDFUND_PRIMARY_RPC_URL` is configured.
+
+Evaluate alert rules (implements [`MONITORING.md`](MONITORING.md) §8 A1–A20) and dispatch any newly-fired alerts to Discord:
+
+```bash
+npm run crowdfund:indexer:cli -- evaluate-alerts
+```
+
+The command is a single pass — it reads the indexer store, optionally consults the chain for `finalizedAt` and treasury USDC balance, runs every rule, posts new alerts to the configured webhooks, persists which dedupe keys it has already delivered, and exits. Schedule it as a recurring job (cron, systemd timer, or external scheduler) at whatever cadence matches your runbook — once per minute is fine; the cost is dominated by RPC reads.
+
+Required env: `CROWDFUND_CONTRACT_ADDRESS`, `CROWDFUND_TREASURY_ADDRESS`, the three timestamp vars (`CROWDFUND_OPEN_TIMESTAMP`, `CROWDFUND_WEEK1_DEADLINE`, `CROWDFUND_COMMITMENT_DEADLINE`), and at least one webhook URL. Without `CROWDFUND_PRIMARY_RPC_URL` + `CROWDFUND_USDC_ADDRESS`, A13 (treasury proceeds mismatch) and the time-gated rules that need `finalizedAt` (A18/A19/A20) self-skip rather than producing false positives. Alerts whose severity has no configured webhook are logged to stderr and skipped.
+
+Example systemd timer (drop into `/etc/systemd/system/crowdfund-alerts.timer`):
+
+```ini
+[Unit]
+Description=Run crowdfund alert evaluator every minute
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+Unit=crowdfund-alerts.service
+
+[Install]
+WantedBy=timers.target
+```
+
+Pair with a one-shot service that runs `npm run crowdfund:indexer:cli -- evaluate-alerts` in the indexer working directory with the env vars above.
+
+To force a re-fire after operator intervention (e.g. you want a P0 to re-page after a Discord channel outage), remove the relevant `dedupeKey` entries from `data/crowdfund-indexer/alerts.json` or delete the file entirely.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the indexer-side alert evaluator that MONITORING.md §8 already specifies, so a cron (systemd timer, GitHub Actions, etc.) can detect threshold breaches, lifecycle transitions, and implementation-bug signals from indexer state and post them to Discord. Issue #318, part of the #321 launch-readiness umbrella.

No contract changes — `contracts/crowdfund/` is audited and frozen.

Closes #318.

## What's in the box

A new `crowdfund-ui/packages/indexer/src/alerts/` module:

| File | Role |
|---|---|
| `types.ts` | `AlertId`, `Severity`, `AlertEvent`, `AlertContext`, `CrowdfundParams`. |
| `rules.ts` | Pure evaluator per rule (A1–A20). Each returns 0..n events with a stable `dedupeKey` so threshold tiers fire individually (`A4:80 → A4:90 → A4:100`). |
| `thresholds.ts` | MONITORING.md §13 defaults, env-overridable. |
| `state.ts` | File + in-memory persisted "already-fired" dedupeKey store; missing file = empty. |
| `notifier.ts` | Notifier abstraction + Discord webhook impl (per-severity URL, optional role mention, throws on non-2xx). |
| `evaluator.ts` | Orchestrator: read state, run rules, dispatch, persist. |
| `chainState.ts` | Optional RPC reads for treasury USDC balance (A13) and `finalizedAt` (A18/A19/A20). |
| `runner.ts` | `runAlertsOnce` — assembles `AlertContext` from indexer store + chain reader; entry point for the CLI. |

CLI: `npm run crowdfund:indexer:cli -- evaluate-alerts`. One-shot — perfect for systemd timer or cron.

Runbook (`specs/CROWDFUND_INDEXER_RUNBOOK.md`) gets a new "Alert evaluator variables" env table and a section documenting the cron pattern, dedupe behavior, and how to force a re-fire after operator intervention.

## A13 note

The contract's actual rounding buffer at `ArmadaCrowdfund.sol:511` is `participantNodes.length` — not `participantNodes.length × NUM_HOPS` as MONITORING.md §5 / A13 currently state. The rule matches the contract (canonical) and flags the divergence in a code comment so a separate doc PR can reconcile the spec text. Contracts remain untouched.

## Coverage

| Rule | Severity | Trigger |
|---|---|---|
| A1 | P3 | `ArmLoaded` |
| A2 | P1 | `now ≥ openTimestamp && !armed` |
| A3 | P0 | Week-1 event past `week1Deadline` (gated on event-timestamp metadata; no-ops today, ready for indexer extension) |
| A4 | P2→P1 | Seed budget 80/90/100% of MAX_SEEDS |
| A5 | P2→P1 | Hop-1 + hop-2 launch-team placements 80/90/100% |
| A6 | P2 | Duplicate same-hop slot ratio above threshold (default 10%) |
| A7 | P2 | cappedDemand 80/90/95/100% of ELASTIC_TRIGGER |
| A8 | P2 | cappedDemand < MIN_SALE with ≤72h / ≤24h left |
| A9a | P1→P0 | Deadline passed, qualified, no finalize (P0 after 2h grace) |
| A9b | P1 | Deadline passed, sub-minimum demand |
| A10 | P1 | `Finalized(refundMode=true)` |
| A11 | P0 | `Cancelled` |
| A12 | P3 | `Finalized(refundMode=false)` |
| A13 | P0 | Treasury USDC balance diff vs `Finalized.netProceeds` exceeds rounding buffer |
| A17 | P0 | `Allocated`/`AllocatedHop` after refundMode/cancel |
| A18 | P2 | <50% claimed 14d+ after success |
| A19 | P2 | >10% refundable USDC unclaimed 30d+ after finalization |
| A20 | P2 | 3-year sweep window reached |

## Tests

- `rules.test.ts` — 30 tests, one+ per rule, covering fire/no-fire, severity tier mapping, threshold edges
- `evaluator.test.ts` — 3 tests: dedupe across runs, per-tier dedupe keys, state-write skipped when nothing delivered
- `notifier.test.ts` — 3 tests: webhook routing, missing-severity skip, non-2xx throw
- `state.test.ts` — 3 tests: file roundtrip + missing-file empty state
- `commands.test.ts` — +1: parses `evaluate-alerts`

**Indexer suite: 103/103 pass; typecheck clean.**

## Test plan

- [x] `npm test --workspace=@armada/crowdfund-indexer` — 103/103
- [x] `npm run typecheck --workspace=@armada/crowdfund-indexer` — clean
- [ ] Reviewer: dry-run `evaluate-alerts` against the current Sepolia indexer (when deployed under #317) and confirm A10/A11/A12 fire end-to-end into a test Discord channel.