### PR TITLE
feat(committer,admin): Sentry frontend error reporting (#316)

### DIFF
--- a/crowdfund-ui/packages/admin/package.json
+++ b/crowdfund-ui/packages/admin/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-separator": "^1.1.4",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@sentry/react": "^8.55.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "ethers": "^6.15.0",

--- a/crowdfund-ui/packages/admin/src/lib/sentry.ts
+++ b/crowdfund-ui/packages/admin/src/lib/sentry.ts
@@ -1,0 +1,39 @@
+// ABOUTME: Sentry initialization for the crowdfund admin app.
+// ABOUTME: No-op when VITE_SENTRY_DSN is unset so local/dev runs incur no overhead.
+
+import * as Sentry from '@sentry/react'
+
+let initialized = false
+
+export function initSentry(): void {
+  if (initialized) return
+  const dsn = import.meta.env.VITE_SENTRY_DSN
+  if (!dsn) return
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.MODE ?? 'production',
+    release: import.meta.env.VITE_SENTRY_RELEASE,
+    // Error tracking only — performance/replay incur per-event cost we don't need.
+    tracesSampleRate: 0,
+    // Don't send PII (wallet addresses are sensitive in this context).
+    sendDefaultPii: false,
+  })
+  initialized = true
+}
+
+/**
+ * Capture an error originating from a privileged admin action (finalize, cancel, seed
+ * batch, sweep, etc.). Tag + structured breadcrumb separate admin failures from
+ * generic render errors in Sentry triage.
+ */
+export function captureAdminError(err: unknown, context?: Record<string, unknown>): void {
+  if (!initialized) return
+  Sentry.withScope((scope) => {
+    scope.setTag('source', 'admin')
+    if (context) scope.setContext('admin', context as Record<string, unknown>)
+    Sentry.captureException(err)
+  })
+}
+
+export const SentryErrorBoundary = Sentry.ErrorBoundary

--- a/crowdfund-ui/packages/admin/src/main.tsx
+++ b/crowdfund-ui/packages/admin/src/main.tsx
@@ -6,15 +6,20 @@ import { Provider as JotaiProvider } from 'jotai'
 import { Toaster } from 'sonner'
 import { MotionConfig } from 'framer-motion'
 import { App } from '@/App'
+import { initSentry, SentryErrorBoundary } from '@/lib/sentry'
 import './index.css'
+
+initSentry()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <JotaiProvider>
-      <MotionConfig reducedMotion="user">
-        <App />
-      </MotionConfig>
-      <Toaster richColors position="bottom-right" />
-    </JotaiProvider>
+    <SentryErrorBoundary fallback={<div className="p-6">An unexpected error occurred. The team has been notified.</div>}>
+      <JotaiProvider>
+        <MotionConfig reducedMotion="user">
+          <App />
+        </MotionConfig>
+        <Toaster richColors position="bottom-right" />
+      </JotaiProvider>
+    </SentryErrorBoundary>
   </StrictMode>,
 )

--- a/crowdfund-ui/packages/committer/package.json
+++ b/crowdfund-ui/packages/committer/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.1.8",
     "@rainbow-me/rainbowkit": "^2.2.10",
+    "@sentry/react": "^8.55.0",
     "@tanstack/react-query": "^5.96.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/crowdfund-ui/packages/committer/src/lib/sentry.ts
+++ b/crowdfund-ui/packages/committer/src/lib/sentry.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Sentry initialization for the crowdfund committer app.
+// ABOUTME: No-op when VITE_SENTRY_DSN is unset so local/dev runs incur no overhead.
+
+import * as Sentry from '@sentry/react'
+
+let initialized = false
+
+export function initSentry(): void {
+  if (initialized) return
+  const dsn = import.meta.env.VITE_SENTRY_DSN
+  if (!dsn) return
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.MODE ?? 'production',
+    release: import.meta.env.VITE_SENTRY_RELEASE,
+    // Error tracking only — performance/replay incur per-event cost we don't need.
+    tracesSampleRate: 0,
+    // Don't send PII (wallet addresses are sensitive in this context).
+    sendDefaultPii: false,
+  })
+  initialized = true
+}
+
+/**
+ * Capture an error originating from a wallet interaction (RainbowKit/wagmi, signature
+ * rejection, chain mismatch, etc.) with a `wallet` tag and structured breadcrumb so
+ * Sentry filters and the issue triage flow can split wallet errors from contract errors.
+ */
+export function captureWalletError(err: unknown, context?: Record<string, unknown>): void {
+  if (!initialized) return
+  Sentry.withScope((scope) => {
+    scope.setTag('source', 'wallet')
+    if (context) scope.setContext('wallet', context as Record<string, unknown>)
+    Sentry.captureException(err)
+  })
+}
+
+/**
+ * Capture an error originating from a contract write (revert, gas estimation failure,
+ * receipt mismatch, etc.). Tag + breadcrumb mirror the wallet path so triage stays simple.
+ */
+export function captureContractError(err: unknown, context?: Record<string, unknown>): void {
+  if (!initialized) return
+  Sentry.withScope((scope) => {
+    scope.setTag('source', 'contract')
+    if (context) scope.setContext('contract', context as Record<string, unknown>)
+    Sentry.captureException(err)
+  })
+}
+
+export const SentryErrorBoundary = Sentry.ErrorBoundary

--- a/crowdfund-ui/packages/committer/src/main.tsx
+++ b/crowdfund-ui/packages/committer/src/main.tsx
@@ -12,29 +12,34 @@ import { MotionConfig } from 'framer-motion'
 import { wagmiConfig } from '@/config/wagmi'
 import { App } from '@/App'
 import { InviteLinkRedemption } from '@/components/InviteLinkRedemption'
+import { initSentry, SentryErrorBoundary } from '@/lib/sentry'
 import '@rainbow-me/rainbowkit/styles.css'
 import './index.css'
+
+initSentry()
 
 const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <WagmiProvider config={wagmiConfig}>
-      <QueryClientProvider client={queryClient}>
-        <RainbowKitProvider theme={darkTheme()}>
-          <JotaiProvider>
-            <BrowserRouter>
-              <MotionConfig reducedMotion="user">
-                <Routes>
-                  <Route path="/" element={<App />} />
-                  <Route path="/invite" element={<InviteLinkRedemption />} />
-                </Routes>
-              </MotionConfig>
-            </BrowserRouter>
-            <CrowdfundToaster />
-          </JotaiProvider>
-        </RainbowKitProvider>
-      </QueryClientProvider>
-    </WagmiProvider>
+    <SentryErrorBoundary fallback={<div className="p-6">An unexpected error occurred. The team has been notified.</div>}>
+      <WagmiProvider config={wagmiConfig}>
+        <QueryClientProvider client={queryClient}>
+          <RainbowKitProvider theme={darkTheme()}>
+            <JotaiProvider>
+              <BrowserRouter>
+                <MotionConfig reducedMotion="user">
+                  <Routes>
+                    <Route path="/" element={<App />} />
+                    <Route path="/invite" element={<InviteLinkRedemption />} />
+                  </Routes>
+                </MotionConfig>
+              </BrowserRouter>
+              <CrowdfundToaster />
+            </JotaiProvider>
+          </RainbowKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>
+    </SentryErrorBoundary>
   </StrictMode>,
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,7 @@
         "@radix-ui/react-separator": "^1.1.4",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.1.8",
+        "@sentry/react": "^8.55.0",
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -175,6 +176,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.1.8",
         "@rainbow-me/rainbowkit": "^2.2.10",
+        "@sentry/react": "^8.55.0",
         "@tanstack/react-query": "^5.96.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -8643,6 +8645,117 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.55.2.tgz",
+      "integrity": "sha512-GnKod+gL/Y+1FUM/RGV8q6le1CoyiGbT40MitEK7eVwWe+bfTRq1gN7ioupyHFMUg1RlQkDQ4/sENmio/uow5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/core": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.2.tgz",
+      "integrity": "sha512-YlEBwybUcOQ/KjMHDmof1vwweVnBtBxYlQp7DE3fOdtW4pqqdHWTnTntQs4VgYfxzjJYgtkd9LHlGtg8qy+JVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.55.2.tgz",
+      "integrity": "sha512-XQy//NWbL0mLLM5w8wNDWMNpXz39VUyW2397dUrH8++kR63WhUVAvTOtL0o0GMVadSAzl1b08oHP9zSUNFQwcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/core": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.2.tgz",
+      "integrity": "sha512-YlEBwybUcOQ/KjMHDmof1vwweVnBtBxYlQp7DE3fOdtW4pqqdHWTnTntQs4VgYfxzjJYgtkd9LHlGtg8qy+JVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.55.2.tgz",
+      "integrity": "sha512-+W43Z697EVe/OgpGW07B773sa8xO1UbpnW0Cr+E+3FMDb6ZbXlaBUoagPTUkkQPdwBe35SDh6r8y2M3EOPGbxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.55.2",
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.55.2.tgz",
+      "integrity": "sha512-P/jGiuR7dRLG9IzD/463fLgiibyYceauav/9prRG0ZxJm1AtuO02OKball2Fs3bbzdzwHCTlcsUuL2ivDF4b5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "8.55.2",
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/core": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.2.tgz",
+      "integrity": "sha512-YlEBwybUcOQ/KjMHDmof1vwweVnBtBxYlQp7DE3fOdtW4pqqdHWTnTntQs4VgYfxzjJYgtkd9LHlGtg8qy+JVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay/node_modules/@sentry/core": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.2.tgz",
+      "integrity": "sha512-YlEBwybUcOQ/KjMHDmof1vwweVnBtBxYlQp7DE3fOdtW4pqqdHWTnTntQs4VgYfxzjJYgtkd9LHlGtg8qy+JVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.55.2.tgz",
+      "integrity": "sha512-xHuPIEKhx9zw5quWvv4YgZprnwoVMCfxIhmOIf6KJ9iizyUHeUDcKpLS59xERroqwX4RpvK+l/27AZu4zfZlzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.55.2",
+        "@sentry-internal/feedback": "8.55.2",
+        "@sentry-internal/replay": "8.55.2",
+        "@sentry-internal/replay-canvas": "8.55.2",
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/@sentry/core": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.2.tgz",
+      "integrity": "sha512-YlEBwybUcOQ/KjMHDmof1vwweVnBtBxYlQp7DE3fOdtW4pqqdHWTnTntQs4VgYfxzjJYgtkd9LHlGtg8qy+JVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/@sentry/core": {
       "version": "5.30.0",
       "dev": true,
@@ -8722,6 +8835,32 @@
       "version": "1.14.1",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/@sentry/react": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.55.2.tgz",
+      "integrity": "sha512-1TPfKZYkJal2Dyt2W0tf1roOZmu7sqr6/dTqjdsuu2WgGTilMEreK26YqB8ROOYdMjkVJpNCcIKXQHyMp2eCwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "8.55.2",
+        "@sentry/core": "8.55.2",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/react/node_modules/@sentry/core": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.2.tgz",
+      "integrity": "sha512-YlEBwybUcOQ/KjMHDmof1vwweVnBtBxYlQp7DE3fOdtW4pqqdHWTnTntQs4VgYfxzjJYgtkd9LHlGtg8qy+JVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
     },
     "node_modules/@sentry/tracing": {
       "version": "5.30.0",
@@ -17325,6 +17464,21 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/hono": {
       "version": "4.12.5",

--- a/specs/CROWDFUND_INDEXER_RUNBOOK.md
+++ b/specs/CROWDFUND_INDEXER_RUNBOOK.md
@@ -164,6 +164,9 @@ Frontend variables:
 | `VITE_SEPOLIA_RPC_FALLBACK` | unset | Optional browser RPC fallback. |
 | `VITE_CROWDFUND_INDEXER_URL` | unset | Indexer API base URL used for snapshot/health loading. |
 | `VITE_WALLETCONNECT_PROJECT_ID` | dev fallback | WalletConnect project ID for wallet connections. Set explicitly outside local dev. |
+| `VITE_SENTRY_DSN` | unset | Sentry DSN for `committer` and `admin` apps. When unset, Sentry init is a no-op (local/dev). |
+| `VITE_SENTRY_ENVIRONMENT` | `MODE` | Environment tag attached to Sentry events (e.g. `production`, `staging`). Falls back to Vite's `MODE`. |
+| `VITE_SENTRY_RELEASE` | unset | Release identifier attached to Sentry events. Typically the git SHA injected at build time. |
 
 ---
 


### PR DESCRIPTION
## Summary

Wires `@sentry/react` into the committer and admin React apps so unhandled rejections, render errors, and explicit wallet/contract/admin failures surface in Sentry with severity-tagged breadcrumb context. Issue #316, part of the #321 launch-readiness umbrella.

No contract changes — `contracts/crowdfund/` is audited and frozen.

Closes #316.

## What's in the box

| File | Role |
|---|---|
| `committer/src/lib/sentry.ts` | `initSentry`; `captureWalletError` (RainbowKit / wagmi); `captureContractError` (revert / receipt); `SentryErrorBoundary` re-export. |
| `admin/src/lib/sentry.ts` | `initSentry`; `captureAdminError` (finalize / cancel / sweep); `SentryErrorBoundary` re-export. |
| `committer/src/main.tsx` | Calls `initSentry()` before render; `<SentryErrorBoundary>` wraps the entire app tree (wagmi/RainbowKit/Routes). |
| `admin/src/main.tsx` | Same pattern wrapping JotaiProvider/App. |
| `package.json` (both) | Adds `@sentry/react ^8.55.0`. |
| `specs/CROWDFUND_INDEXER_RUNBOOK.md` | Frontend variables table gets `VITE_SENTRY_DSN`, `VITE_SENTRY_ENVIRONMENT`, `VITE_SENTRY_RELEASE`. |

## Defaults

- `tracesSampleRate: 0` — error tracking only; no performance/replay overhead at our scale (the issue calls out "minimum-viable reliability").
- `sendDefaultPii: false` — wallet addresses are sensitive in this context.
- DSN missing → `initSentry()` is a no-op. Local/dev runs stay overhead-free; production switches on via env var only.

## Capture helpers — why three?

The issue calls for "unhandled rejections + wallet/contract errors with breadcrumb context." Each helper sets a `source` Sentry tag (`wallet` / `contract` / `admin`) plus a structured context block so the eventual Sentry triage queue can split errors by origin. Call sites that already catch+toast errors can add one line:

```ts
captureWalletError(err, { action: 'commit', hop, amount })
```

without refactoring the existing user-facing error handling. Wiring those call sites is an incremental task — this PR establishes the infrastructure; specific call site instrumentation can land per-feature.

## Indexer logging (out of band)

The #316 task list mentions indexer log shipping. The indexer already emits one structured line per event via `process.stdout.write` / `process.stderr.write`, which is sufficient for VPS logrotate (the deployment path #317 plans). I did not add `pino` plumbing — would be churn without a delivery target. Re-open this in #316 if the hosting decision in #317 lands on a log aggregator instead of `logrotate`.

The indexer `/health` endpoint already exists at `crowdfund-ui/packages/indexer/src/api/health.ts` and is reachable on the configured port — nothing to wire here; #317 owns exposing it through the reverse proxy.

## Test plan

- [x] Committer: 69/69 vitest pass; `npx tsc --noEmit` clean; `npm run build` clean (1.9 MB → 600 kB gzip — no regression vs pre-Sentry baseline).
- [x] Admin: 78/78 vitest pass; `npx tsc --noEmit` clean; `npm run build` clean (828 KB → 270 kB gzip).
- [ ] Reviewer: with a real `VITE_SENTRY_DSN` set, throw a synthetic error in each app and confirm it lands in Sentry with the expected `source` tag.