### PR TITLE
test(crowdfund): analysis and tests for adding OZ Multicall mixin to ArmadaCrowdfund

### DIFF
--- a/contracts/crowdfund/ArmadaCrowdfund.sol
+++ b/contracts/crowdfund/ArmadaCrowdfund.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import "@openzeppelin/contracts/utils/Multicall.sol";
 import "./IArmadaCrowdfund.sol";
 
 /// @notice Minimal ArmadaToken interface for atomic delegation on claim.
@@ -21,7 +22,7 @@ interface IArmadaTokenCrowdfund {
 /// @notice Implements the full crowdfund lifecycle: seed management, invitation chains,
 ///         USDC commitment escrow, deterministic allocation with pro-rata scaling and rollover,
 ///         elastic expansion, and refund mechanism.
-contract ArmadaCrowdfund is ReentrancyGuard, EIP712 {
+contract ArmadaCrowdfund is ReentrancyGuard, EIP712, Multicall {
     using SafeERC20 for IERC20;
 
     // ============ Constants ============

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "deploy:revenue-lock-cohort": "hardhat run scripts/deploy_revenue_lock_cohort.ts --network hub",
     "test": "hardhat test test/privacy_pool_integration.ts",
     "test:governance": "hardhat test test/governance_integration.ts test/governance_adversarial.ts test/governance_veto.ts",
-    "test:crowdfund": "hardhat test test/crowdfund_integration.ts test/crowdfund_adversarial.ts",
+    "test:crowdfund": "hardhat test test/crowdfund_integration.ts test/crowdfund_adversarial.ts test/crowdfund_multicall.ts",
     "test:all": "hardhat test",
     "test:mcp": "npx mocha --require ts-node/register mcp-server/test/unit.test.ts",
     "test:mcp:integration": "npx mocha --require ts-node/register mcp-server/test/integration.test.ts",

--- a/reports/multicall/modifier-matrix.md
+++ b/reports/multicall/modifier-matrix.md
@@ -1,0 +1,61 @@
+# ArmadaCrowdfund — External State-Changing Function Modifier Matrix
+
+Purpose: §5.1 check #6 — verify every externally-callable state-changing function on `ArmadaCrowdfund` retains its access-control and reentrancy guarantees when invoked via OZ `Multicall`'s `delegatecall`-to-self pattern.
+
+OZ `Multicall.multicall(bytes[])` performs `Address.functionDelegateCall(address(this), data[i])`, which uses the `DELEGATECALL` opcode. Under DELEGATECALL:
+- `msg.sender` is preserved (still the original EOA caller of `multicall`)
+- `msg.value` is preserved (zero — no payable functions)
+- All storage SLOADs/SSTOREs apply to `ArmadaCrowdfund`'s storage (same context)
+- `address(this)` resolves to `ArmadaCrowdfund` itself
+
+Therefore every modifier and inline `require` keyed on `msg.sender` or contract state continues to enforce its invariant identically. The matrix below confirms this case-by-case.
+
+| # | Function | Modifier(s) | Inline access / state guards | Preserved under multicall? | Notes |
+|---|---|---|---|---|---|
+| 1 | `addSeeds(address[])` (l. 200) | `onlyLaunchTeam` | — | ✅ | `msg.sender == launchTeam` check is in the modifier; preserved |
+| 2 | `addSeed(address)` (l. 208) | `onlyLaunchTeam` | — | ✅ | same as above |
+| 3 | `loadArm()` (l. 235) | — | `!armLoaded`, balance ≥ required | ✅ | idempotent gate via storage flag |
+| 4 | `invite(address, uint8)` (l. 253) | — | `phase == Active`, `armLoaded`, `block.timestamp ≤ windowEnd`, `msg.sender != launchTeam`, `inviter.isWhitelisted`, budget cap | ✅ | every gate is storage- or timestamp-keyed |
+| 5 | `launchTeamInvite(address, uint8)` (l. 283) | — | `msg.sender == launchTeam`, window-1, fromHop gate, budget gate | ✅ | sender check still binds via DELEGATECALL |
+| 6 | `commit(uint8, uint256)` (l. 316) | **`nonReentrant`** | `_requireActiveCommitWindow`, whitelist, MIN_COMMIT | ✅ | guard sets/clears `_status` per call; siblings in a bundle are independent ENTER/EXIT cycles |
+| 7 | `commitWithInvite(...)` (l. 345) | **`nonReentrant`** | nonce/deadline/signature, whitelist, MIN_COMMIT | ✅ | EIP-712 digest binds to `inviter` not `msg.sender`; signature still validates |
+| 8 | `revokeInviteNonce(uint256)` (l. 402) | — | nonce > 0, not used | ✅ | `usedNonces[msg.sender][nonce]` — sender-keyed mapping; preserved |
+| 9 | `cancel()` (l. 413) | — | `msg.sender == securityCouncil`, phase gate | ✅ | sender check still binds |
+| 10 | `finalize()` (l. 424) | **`nonReentrant`** | `block.timestamp > windowEnd`, phase gate | ✅ | permissionless; timestamp/phase still enforced |
+| 11 | `claim(address)` (l. 529) | **`nonReentrant`** | phase finalized, not refundMode, `!claimed[msg.sender]`, has commitment | ✅ | sender-keyed `claimed` flag; `transferAndDelegate` audited SAFE (no reentry path) |
+| 12 | `claimRefund()` (l. 576) | **`nonReentrant`** | refundMode \|\| Canceled, `!claimed[msg.sender]`, has commitment | ✅ | same `claimed` flag; `usdc.safeTransfer` is vanilla ERC20 |
+| 13 | `withdrawUnallocatedArm()` (l. 605) | **`nonReentrant`** | phase ∈ {Finalized, Canceled}, sweepable > 0 | ✅ | permissionless; treasury-only recipient |
+
+## Critical clarification — bundling `nonReentrant` siblings
+
+`Multicall.multicall` itself is **not** `nonReentrant`. Each delegatecalled function executes its own guard cycle:
+1. delegatecall to `data[i]` begins
+2. `nonReentrantBefore`: assert `_status == NOT_ENTERED`, set `_status = ENTERED`
+3. body executes
+4. `nonReentrantAfter`: set `_status = NOT_ENTERED`
+5. delegatecall returns
+6. delegatecall to `data[i+1]` begins — `_status` is again `NOT_ENTERED`
+
+Consequently a bundle like `multicall([commit(0, X), commit(1, Y), claim(d)])` **succeeds** — each `nonReentrant` sibling runs to completion before the next begins. The guard only blocks *nested* reentry within a single invocation (e.g. an external callee re-entering during step 3), which is unchanged by multicall.
+
+**Test plan correction.** An originally-proposed test `test_Multicall_DoubleNonReentrant_Reverts` was wrong. The actual test is `test_Multicall_BundledNonReentrantSiblings_Succeed` — asserts state mutations from both calls land. This locks in the intended composition semantics so a future refactor (e.g. accidentally wrapping multicall in `nonReentrant`) is caught.
+
+## True reentrancy surface — unchanged by Multicall
+
+Reentrancy requires an external CALL whose target eventually re-enters `ArmadaCrowdfund` within the same outer invocation. The only contracts called from `ArmadaCrowdfund` state-changing functions are:
+
+- `usdc.safeTransfer{,From}(...)` — vanilla ERC20, no hooks
+- `armToken.balanceOf(...)` — view, no callbacks
+- `armToken.safeTransfer(treasury, ...)` (in `withdrawUnallocatedArm`) — treasury is a trusted address, ArmadaToken has no transfer hooks (`_beforeTokenTransfer` does SLOADs only — see `.context/multicall-checks/transferAndDelegate-audit.md`)
+- `armToken.transferAndDelegate(...)` (in `claim`) — audited SAFE in the companion memo
+
+No call-target inside any bundleable function reaches an attacker-controllable address. Adding `Multicall` introduces zero new external call sites.
+
+## Functions explicitly NOT bundleable
+
+These are `internal`/`private`/`view` and not directly callable via multicall:
+
+- All `_*` helpers (`_initParticipant`, `_addSeed`, `_escrowCommit`, `_registerOrStackInvite`, `_effectiveCap`, `_requireActiveCommitWindow`, etc.)
+- All view functions (`armStillOwed`, `getHopStats`, `getSaleStats`, `getEstimatedCappedDemand`, `isWhitelisted`, `getCommitment`, `getInvitesRemaining`, `getInviteEdge`, `computeAllocation`, `computeAllocationAtHop`, `getEffectiveCap`, `getInvitesReceived`, `getLaunchTeamBudgetRemaining`, `getParticipantCount`)
+
+Views are still callable via multicall (and will return decoded data) but cannot mutate state. No risk surface.

--- a/reports/multicall/transferAndDelegate-audit.md
+++ b/reports/multicall/transferAndDelegate-audit.md
@@ -1,0 +1,97 @@
+# `ArmadaToken.transferAndDelegate` — Reentrancy & External-Call Audit
+
+**Verdict: SAFE.** No path from `transferAndDelegate` reaches any user-controllable external address. Bundling `ArmadaCrowdfund.claim` inside an OZ `Multicall` introduces no new reentrancy surface.
+
+---
+
+## Call graph
+
+Every function transitively reached from `transferAndDelegate`. All OZ references are to v4.9.3 (per `CLAUDE.md`).
+
+```
+ArmadaToken.transferAndDelegate(to, amount, delegatee)
+  contracts/governance/ArmadaToken.sol:196
+  |
+  +-- authorizedDelegator[msg.sender]              (SLOAD, mapping read; line 197)
+  |
+  +-- ERC20._transfer(msg.sender, to, amount)     (line 198)
+  |     OZ ERC20.sol::_transfer
+  |     |
+  |     +-- ArmadaToken._beforeTokenTransfer(from, to, amount)   (override; ArmadaToken.sol:217)
+  |     |     +-- ERC20Votes._beforeTokenTransfer (super)   [no-op in 4.9.3 for non-supply-cap path]
+  |     |     |     +-- ERC20._beforeTokenTransfer (super)  [empty default body]
+  |     |     +-- SLOAD `transferable`, SLOAD `transferWhitelist[from]`  (no calls; line 223-228)
+  |     |
+  |     +-- _balances[from] -= amount; _balances[to] += amount;        (SSTOREs only)
+  |     +-- emit Transfer(from, to, amount)                            (LOG, no call)
+  |     |
+  |     +-- ArmadaToken._afterTokenTransfer NOT overridden, falls to:
+  |           ERC20Votes._afterTokenTransfer(from, to, amount)
+  |           |
+  |           +-- ERC20._afterTokenTransfer (super; empty)
+  |           +-- _moveVotingPower(delegates(from), delegates(to), amount)
+  |                 |
+  |                 +-- _writeCheckpoint(_checkpoints[src], _subtract, amount)
+  |                 |     +-- SLOADs/SSTOREs on the checkpoints array
+  |                 |     +-- emit DelegateVotesChanged(src, oldWeight, newWeight)   (LOG, no call)
+  |                 +-- _writeCheckpoint(_checkpoints[dst], _add, amount)
+  |                       +-- SLOADs/SSTOREs
+  |                       +-- emit DelegateVotesChanged(dst, oldWeight, newWeight)   (LOG, no call)
+  |
+  +-- ArmadaToken._delegate(to, delegatee)        (override; line 236, called at line 199)
+        |
+        +-- SLOAD noDelegation[delegator]                                  (line 237)
+        +-- ERC20Votes._delegate(delegator, delegatee)  (super)
+              |
+              +-- delegates(delegator)            (SLOAD via _delegates mapping)
+              +-- _delegates[delegator] = delegatee   (SSTORE)
+              +-- emit DelegateChanged(delegator, currentDelegate, delegatee)   (LOG, no call)
+              +-- _moveVotingPower(currentDelegate, delegatee, balanceOf(delegator))
+                    +-- _writeCheckpoint(...) twice  (same as above; pure storage + LOG)
+```
+
+Total external (CALL/STATICCALL/DELEGATECALL) opcodes reachable from `transferAndDelegate`: **zero**.
+
+---
+
+## External call inventory
+
+| # | Caller site | Opcode | Destination | Attacker-controllable? |
+|---|---|---|---|---|
+| — | (none) | — | — | — |
+
+There are no `CALL`, `STATICCALL`, `DELEGATECALL`, `CALLCODE`, or `CREATE`/`CREATE2` operations on any path from `transferAndDelegate`. Every reachable line either:
+
+- reads/writes storage on `ArmadaToken` itself (balances, checkpoints, mappings),
+- performs arithmetic, or
+- emits a LOG (`Transfer`, `DelegateChanged`, `DelegateVotesChanged`).
+
+LOGs cannot trigger code execution on any address.
+
+---
+
+## Findings
+
+1. **(info)** `transferAndDelegate` is gated by `authorizedDelegator[msg.sender]` (`ArmadaToken.sol:197`). The whitelist is set once by deployer (`initAuthorizedDelegators`, line 120) and may be add-only extended by timelock (`addAuthorizedDelegator`, line 146). An attacker EOA cannot call it directly; only authorized contracts (RevenueLock, ArmadaCrowdfund) can. This is a defense-in-depth observation, not a fix requirement.
+
+2. **(info)** ERC20 `_transfer` writes `_balances` then emits `Transfer` — no recipient hook. OpenZeppelin 4.9.3 `ERC20.sol` does **not** implement ERC-777 `tokensReceived` or ERC-1363 `onTransferReceived` callbacks. Confirmed by inspecting the inheritance chain in `ArmadaToken.sol:6` (only `ERC20Votes` is imported, which extends `ERC20Permit` → `ERC20` with no callback extensions).
+
+3. **(info)** `_beforeTokenTransfer` override (`ArmadaToken.sol:217-230`) only performs SLOADs on `transferable` and `transferWhitelist[from]`. No external calls. No revert path that depends on attacker-controlled state beyond the `from`/`to` addresses (which are `msg.sender` and `to`, both passed by the authorized caller — Crowdfund passes its own address as `msg.sender` and the claimant as `to`).
+
+4. **(info)** `_delegate` override (`ArmadaToken.sol:236-239`) only performs an SLOAD on `noDelegation[delegator]` and forwards to `ERC20Votes._delegate`. `ERC20Votes._delegate` updates the `_delegates` mapping, emits `DelegateChanged`, and calls `_moveVotingPower`. `_moveVotingPower` invokes `_writeCheckpoint` which is pure storage + `DelegateVotesChanged` event emission. None of these touch external addresses.
+
+5. **(info)** No assembly blocks, no `address.call`, `staticcall`, `delegatecall`, `send`, or `transfer` (ETH) appear in `ArmadaToken.sol`. Grep confirms zero matches for these patterns inside the file.
+
+6. **(info)** The `delegatee` parameter is never used as a call target — only as a key in `_delegates[delegator] = delegatee` and as a topic in `DelegateChanged`. Even if `delegatee` is an arbitrary attacker contract, it receives no execution opportunity during the delegation step.
+
+7. **(info)** The `to` parameter is the recipient of the ARM balance update but, again, is never dispatched to via CALL. The `from`/`to` addresses appear only inside `_balances`, `_checkpoints`, `_delegates`, and event topics.
+
+8. **(low — design defense in depth)** `ArmadaCrowdfund.claim` is itself `nonReentrant` (line 529). Because OZ `Multicall` performs `Address.functionDelegateCall(address(this), data[i])`, the `ReentrancyGuard._status` SSTORE persists for the duration of each delegatecalled function. However, between sibling calls in a multicall bundle, `_status` is reset (the modifier exits normally each iteration). This is the *intended* multicall composition pattern and does **not** create a reentry path because the only external call from `claim` (`transferAndDelegate`) makes no further external calls (see graph above). Recorded here purely for reviewer context: the safety argument does not rely on the guard, it relies on the absence of attacker-reachable callsites.
+
+---
+
+## Conclusion
+
+`ArmadaToken.transferAndDelegate` executes a closed-world subgraph: ERC20 balance updates, ERC20Votes checkpoint updates, and event emissions. Every reachable line operates on `ArmadaToken`'s own storage or emits LOGs. There are zero `CALL`/`STATICCALL`/`DELEGATECALL` opcodes, zero ERC-777/1363/custom recipient hooks, zero assembly blocks, and zero fallback/proxy dispatches on the call graph rooted at `transferAndDelegate`. The `to` and `delegatee` parameters are consumed as storage keys and event topics only — never as call targets. Consequently, when `ArmadaCrowdfund.claim` is bundled inside an OZ `Multicall` invocation, there is no execution slot during the `transferAndDelegate` step where attacker code could run and re-enter `ArmadaCrowdfund` (or any sibling contract). Adding `Multicall` to `ArmadaCrowdfund` introduces **no reentrancy risk through the `claim → transferAndDelegate` edge**. The pre-existing `nonReentrant` modifier on `claim` and all other state-mutating Crowdfund functions remains a sound defense-in-depth measure but is not load-bearing for this specific edge.
+
+Open question for the reviewer (out of scope for this memo, but worth flagging): the `Multicall` evaluation should additionally confirm that *other* Crowdfund externals bundleable in the same call — e.g. `commit`, `claimRefund`, `withdrawUnallocatedArm` — do not reach attacker-controllable external addresses either. USDC is vanilla ERC20 per the task brief, so `safeTransfer(usdc, …)` is benign; the remaining audit surface is the launch-team / treasury / `IArmadaTokenCrowdfund` calls in those other functions.

--- a/test-foundry/CrowdfundMulticall.t.sol
+++ b/test-foundry/CrowdfundMulticall.t.sol
@@ -1,0 +1,711 @@
+// ABOUTME: Tests for OZ Multicall mixin on ArmadaCrowdfund — self-fill, atomicity, bounds, sender preservation, reentry.
+// ABOUTME: Covers §5.3 of .context/MULTICALL_EVAL.md. Companion to transferAndDelegate-audit.md and modifier-matrix.md.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/crowdfund/ArmadaCrowdfund.sol";
+import "../contracts/crowdfund/IArmadaCrowdfund.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/cctp/MockUSDCV2.sol";
+
+/// @notice Foundry tests for the bounded OZ Multicall mixin added in Phase 1.
+///         Each test name maps to a row in the §5.3 table. Where the spec's
+///         test name was misleading or wrong (see DoubleNonReentrant — was
+///         _Reverts, must be _Succeeds), the corrected name is used here and
+///         the spec mapping is recorded in the WHY comment.
+contract CrowdfundMulticallTest is Test {
+    ArmadaCrowdfund public crowdfund;
+    MockUSDCV2 public usdc;
+    ArmadaToken public armToken;
+
+    address public admin = address(this);
+    address public treasury = address(0xCAFE);
+    address public delegateAddr = address(0xDE1E);
+
+    // Single-seed setup for self-fill tests
+    address public seed0 = address(0xA001);
+
+    // Multi-seed setup (lazy-initialized via _setupForFinalization)
+    address[] public manySeeds;
+
+    uint256 constant ARM_FUNDING   = 1_800_000 * 1e18;
+    uint256 constant HOP0_CAP      = 15_000 * 1e6;
+    uint256 constant HOP1_CAP      = 4_000 * 1e6;
+    uint256 constant HOP2_CAP      = 1_000 * 1e6;
+    uint256 constant MIN_COMMIT    = 10 * 1e6;
+    uint256 constant SELF_FILL_TOTAL = 33_000 * 1e6; // $15K + 3×$4K + 6×$1K
+
+    function setUp() public {
+        usdc = new MockUSDCV2("Mock USDC", "USDC");
+        armToken = new ArmadaToken(admin, admin);
+
+        crowdfund = new ArmadaCrowdfund(
+            address(usdc),
+            address(armToken),
+            treasury,
+            admin,          // launchTeam
+            admin,          // securityCouncil
+            block.timestamp // window opens immediately
+        );
+
+        // ArmadaToken transferable whitelist: admin (for funding transfer)
+        // and the crowdfund (so claim()'s transferAndDelegate can move ARM out).
+        address[] memory wl = new address[](2);
+        wl[0] = admin;
+        wl[1] = address(crowdfund);
+        armToken.initWhitelist(wl);
+
+        // Authorize the crowdfund as a delegator so claim()'s
+        // transferAndDelegate is permitted. The ArmadaToken gate is the one
+        // documented in §5.2 audit memo (`authorizedDelegator[msg.sender]`).
+        address[] memory delegators = new address[](1);
+        delegators[0] = address(crowdfund);
+        armToken.initAuthorizedDelegators(delegators);
+
+        armToken.transfer(address(crowdfund), ARM_FUNDING);
+        crowdfund.loadArm();
+
+        // Single seed for self-fill tests. Finalization-path tests call
+        // _setupForFinalization() to populate 80 seeds and commit.
+        address[] memory s = new address[](1);
+        s[0] = seed0;
+        crowdfund.addSeeds(s);
+    }
+
+    // ============ Calldata encoding helpers ============
+    // WHY: every test builds a bytes[] of selector-encoded calls. Centralising
+    // the encoding keeps test bodies focused on assertions rather than ABI
+    // mechanics.
+
+    function _encInvite(address invitee, uint8 inviterHop) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(ArmadaCrowdfund.invite.selector, invitee, inviterHop);
+    }
+    function _encCommit(uint8 hop, uint256 amount) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(ArmadaCrowdfund.commit.selector, hop, amount);
+    }
+    function _encClaim(address d) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, d);
+    }
+    function _encClaimRefund() internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(ArmadaCrowdfund.claimRefund.selector);
+    }
+    function _encLaunchTeamInvite(address invitee, uint8 fromHop) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(ArmadaCrowdfund.launchTeamInvite.selector, invitee, fromHop);
+    }
+    function _encFinalize() internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(ArmadaCrowdfund.finalize.selector);
+    }
+
+    // ============ Self-fill plan builders ============
+    // WHY: replicates the §1 example plan: a hop-0 seed self-fills hop-1
+    // (×3) and hop-2 (×6), then commits at all three hops. Used by happy-path
+    // tests; the exact same builder will be useful for the frontend
+    // useSelfFillPlan hook in the follow-up UI PR.
+
+    function _seedSelfFillBundle(address self) internal pure returns (bytes[] memory calls) {
+        // 3 hop-1 self-invites (seed has invitesReceived=1, maxInvites=3)
+        // 6 hop-2 self-invites (each hop-1 stack = 3 received × maxInvites=2)
+        // commit hop-0 ($15K), hop-1 ($12K), hop-2 ($6K)
+        calls = new bytes[](12);
+        uint256 i = 0;
+        for (uint256 k = 0; k < 3; k++) { calls[i++] = _encInvite(self, 0); }
+        for (uint256 k = 0; k < 6; k++) { calls[i++] = _encInvite(self, 1); }
+        calls[i++] = _encCommit(0, HOP0_CAP);              // $15K
+        calls[i++] = _encCommit(1, HOP1_CAP * 3);          // $12K (3× cap, all at once)
+        calls[i++] = _encCommit(2, HOP2_CAP * 6);          // $6K  (6× cap)
+    }
+
+    function _hop1SelfFillBundle(address self) internal pure returns (bytes[] memory calls) {
+        // hop-1 wallet w/ invitesReceived=1, maxInvites=2 → 2 hop-2 self-invites
+        // Then commit hop-1 ($4K) and hop-2 ($2K).
+        calls = new bytes[](4);
+        calls[0] = _encInvite(self, 1);
+        calls[1] = _encInvite(self, 1);
+        calls[2] = _encCommit(1, HOP1_CAP);          // $4K
+        calls[3] = _encCommit(2, HOP2_CAP * 2);      // $2K
+    }
+
+    function _mintAndApprove(address who, uint256 amount) internal {
+        usdc.mint(who, amount);
+        vm.prank(who);
+        usdc.approve(address(crowdfund), amount);
+    }
+
+    /// @notice Populate 53 hop-0 seeds + 53 hop-1 invitees so the net
+    ///         post-ceiling allocation clears MIN_SALE and finalize() takes
+    ///         the success path. (Hop-0-only with 80 seeds caps the net
+    ///         allocation at the hop-0 ceiling ≈ $798K < $1M MIN_SALE,
+    ///         which forces refundMode — see audit-75 / hop ceilings.)
+    ///         Mirrors the pattern in CrowdfundDonationTest.
+    function _setupForFinalization() internal {
+        // 53 hop-0 seeds, each commits $15K → hop-0 capped demand $795K.
+        for (uint160 i = 0; i < 53; i++) {
+            address s = address(uint160(0xC000) + i);
+            manySeeds.push(s);
+        }
+        crowdfund.addSeeds(manySeeds);
+        for (uint256 i = 0; i < manySeeds.length; i++) {
+            _mintAndApprove(manySeeds[i], HOP0_CAP);
+            vm.prank(manySeeds[i]);
+            crowdfund.commit(0, HOP0_CAP);
+        }
+
+        // 53 hop-1 invitees, each commits $4K → hop-1 capped demand $212K.
+        // Total capped demand $1.007M > MIN_SALE $1M, and net allocation
+        // (hop-0 ceiling $798K + hop-1 actual $212K) ≥ $1M.
+        for (uint160 i = 0; i < 53; i++) {
+            address h1 = address(uint160(0xD000) + i);
+            vm.prank(manySeeds[i]);
+            crowdfund.invite(h1, 0);
+            _mintAndApprove(h1, HOP1_CAP);
+            vm.prank(h1);
+            crowdfund.commit(1, HOP1_CAP);
+        }
+
+        vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
+        assertEq(uint256(crowdfund.phase()), uint256(Phase.Finalized), "must be Finalized");
+        assertFalse(crowdfund.refundMode(), "must not be in refundMode");
+    }
+
+    // ===================================================================
+    //                        HAPPY PATHS  (§5.3 tier A)
+    // ===================================================================
+
+    /// @notice WHY: end-to-end exercise of the self-fill use case. A seed
+    /// wallet bundles 9 invites + 3 commits in one multicall. Verifies that
+    /// the EVM's sequential delegatecall ordering lets later commits see
+    /// the projected (post-self-invite) whitelist + effectiveCap state.
+    function test_SelfFill_Seed_FullTree() public {
+        _mintAndApprove(seed0, SELF_FILL_TOTAL);
+
+        bytes[] memory calls = _seedSelfFillBundle(seed0);
+
+        vm.prank(seed0);
+        crowdfund.multicall(calls);
+
+        assertEq(crowdfund.getInvitesReceived(seed0, 1), 3, "hop-1 stacked to 3");
+        assertEq(crowdfund.getInvitesReceived(seed0, 2), 6, "hop-2 stacked to 6");
+        assertEq(crowdfund.getCommitment(seed0, 0), HOP0_CAP, "hop-0 commit");
+        assertEq(crowdfund.getCommitment(seed0, 1), HOP1_CAP * 3, "hop-1 commit");
+        assertEq(crowdfund.getCommitment(seed0, 2), HOP2_CAP * 6, "hop-2 commit");
+        assertEq(crowdfund.totalCommitted(), SELF_FILL_TOTAL, "totalCommitted");
+        assertEq(usdc.balanceOf(seed0), 0, "USDC fully escrowed");
+    }
+
+    /// @notice WHY: same flow, but for a hop-1 wallet (not a seed). The
+    /// hop-1 invite-only subtree is the most common real-world case once
+    /// the seed pool is saturated.
+    function test_SelfFill_Hop1_Subtree() public {
+        address hop1Wallet = address(0xB001);
+
+        // First, seed0 invites hop1Wallet to hop-1 via a single tx (outside
+        // multicall, to set up state). Then hop1Wallet self-fills its subtree.
+        vm.prank(seed0);
+        crowdfund.invite(hop1Wallet, 0);
+        assertTrue(crowdfund.isWhitelisted(hop1Wallet, 1), "hop1Wallet whitelisted at hop-1");
+
+        _mintAndApprove(hop1Wallet, HOP1_CAP + HOP2_CAP * 2);
+
+        bytes[] memory calls = _hop1SelfFillBundle(hop1Wallet);
+        vm.prank(hop1Wallet);
+        crowdfund.multicall(calls);
+
+        assertEq(crowdfund.getInvitesReceived(hop1Wallet, 2), 2, "hop-2 stacked");
+        assertEq(crowdfund.getCommitment(hop1Wallet, 1), HOP1_CAP, "hop-1 commit");
+        assertEq(crowdfund.getCommitment(hop1Wallet, 2), HOP2_CAP * 2, "hop-2 commit");
+    }
+
+    /// @notice WHY: minimal invite+commit composition. Tests that an
+    /// invite issued in call[i] is visible to a commit in call[i+1] —
+    /// i.e. the in-multicall state mutation chain works as expected.
+    function test_Multicall_InviteThenCommitSameTx() public {
+        address hop1Wallet = address(0xB002);
+        _mintAndApprove(hop1Wallet, HOP1_CAP);
+
+        bytes[] memory calls = new bytes[](2);
+        // seed0 invites hop1Wallet, then hop1Wallet commits.
+        // BUT: msg.sender is fixed for the whole multicall, so seed0 must do
+        // BOTH calls. We instead test: seed0 commits at hop-0 after an
+        // (irrelevant) invite to itself. Pure ordering exercise.
+        calls[0] = _encInvite(hop1Wallet, 0);  // seed0 invites hop1Wallet to hop-1
+        calls[1] = _encCommit(0, HOP0_CAP);    // seed0 commits at hop-0
+
+        _mintAndApprove(seed0, HOP0_CAP);
+        vm.prank(seed0);
+        crowdfund.multicall(calls);
+
+        assertTrue(crowdfund.isWhitelisted(hop1Wallet, 1), "invite landed");
+        assertEq(crowdfund.getCommitment(seed0, 0), HOP0_CAP, "commit landed");
+    }
+
+    // ===================================================================
+    //                       REVERT PATHS  (§5.3 tier B)
+    // ===================================================================
+
+    /// @notice WHY: maps to spec's `OverCapCommit_Reverts`. The contract
+    /// accepts over-cap commits and pro-rates at settlement — there is no
+    /// "over cap" revert. The closest atomic-bundle revert path is a
+    /// commit that exceeds the user's USDC allowance, which makes
+    /// safeTransferFrom revert. The whole bundle must then roll back.
+    function test_Multicall_CommitExceedingAllowance_Reverts() public {
+        usdc.mint(seed0, HOP0_CAP);
+        vm.prank(seed0);
+        usdc.approve(address(crowdfund), MIN_COMMIT); // only $10 approved
+
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = _encCommit(0, HOP0_CAP); // try to commit $15K
+
+        vm.prank(seed0);
+        vm.expectRevert(); // ERC20 transfer revert reason
+        crowdfund.multicall(calls);
+
+        assertEq(crowdfund.getCommitment(seed0, 0), 0, "no commit landed");
+    }
+
+    /// @notice WHY: an EOA with no whitelist anywhere tries to commit via
+    /// multicall. The inline `p.isWhitelisted` check inside commit() must
+    /// bind under the delegatecall, and the bundle must roll back atomically.
+    function test_Multicall_NotWhitelisted_Reverts() public {
+        address nobody = address(0xDEAD);
+        _mintAndApprove(nobody, HOP1_CAP);
+
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = _encCommit(1, HOP1_CAP);
+
+        vm.prank(nobody);
+        vm.expectRevert("ArmadaCrowdfund: not whitelisted");
+        crowdfund.multicall(calls);
+    }
+
+    /// @notice WHY: `claim` sets `claimed[msg.sender] = true` before the
+    /// transferAndDelegate. A second `claim` in the same bundle must see
+    /// that flag and revert with "already claimed". This proves intra-
+    /// bundle state mutation is visible to later siblings AND that the
+    /// claimed-flag check binds under delegatecall — and the whole bundle
+    /// rolls back, so the user is NOT marked claimed after the failure.
+    function test_Multicall_DoubleClaim_Reverts() public {
+        _setupForFinalization();
+
+        // Use one of the 80 seeds from _setupForFinalization (manySeeds[0]).
+        address claimant = manySeeds[0];
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = _encClaim(delegateAddr);
+        calls[1] = _encClaim(delegateAddr);
+
+        vm.prank(claimant);
+        vm.expectRevert("ArmadaCrowdfund: already claimed");
+        crowdfund.multicall(calls);
+
+        assertFalse(crowdfund.claimed(claimant), "claimed flag rolled back");
+    }
+
+    /// @notice WHY: a bundle that contains a phase-transition (finalize)
+    /// followed by an action that requires the prior phase (commit) must
+    /// revert on the second call. Demonstrates that mid-bundle phase
+    /// changes ARE observed by later siblings — so anyone who tries to
+    /// race a finalize-and-commit cannot sneak through.
+    function test_Multicall_PhaseTransition_Reverts() public {
+        _mintAndApprove(seed0, HOP0_CAP);
+
+        // First commit something so finalize doesn't immediately enter
+        // refundMode (totalCommitted=0 → refundMode); doesn't need to
+        // exceed MIN_SALE for this test, refundMode is fine.
+        vm.prank(seed0);
+        crowdfund.commit(0, HOP0_CAP);
+
+        vm.warp(crowdfund.windowEnd() + 1);
+
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = _encFinalize();
+        calls[1] = _encCommit(0, MIN_COMMIT);
+
+        _mintAndApprove(seed0, MIN_COMMIT);
+        vm.prank(seed0);
+        vm.expectRevert("ArmadaCrowdfund: not active"); // _requireActiveCommitWindow → phase
+        crowdfund.multicall(calls);
+
+        assertEq(uint256(crowdfund.phase()), uint256(Phase.Active), "finalize rolled back too");
+    }
+
+    /// @notice WHY: explicit atomicity test — call[3] reverts after calls
+    /// [0..2] have already mutated state. Solidity reverts the entire
+    /// transaction, but we want to confirm specifically that the OZ Multicall
+    /// bubble-up does not swallow the revert. Verify no calls' state changes
+    /// persist after the bundle.
+    function test_Multicall_PartialFailure_RollsBackAll() public {
+        // seed0 budget = 1 invitesReceived × maxInvites(3) = 3 hop-1 invites.
+        // Bundle 4 invites — first 3 succeed, 4th reverts "invite limit reached".
+        bytes[] memory calls = new bytes[](4);
+        calls[0] = _encInvite(address(0xB101), 0);
+        calls[1] = _encInvite(address(0xB102), 0);
+        calls[2] = _encInvite(address(0xB103), 0);
+        calls[3] = _encInvite(address(0xB104), 0);
+
+        vm.prank(seed0);
+        vm.expectRevert("ArmadaCrowdfund: invite limit reached");
+        crowdfund.multicall(calls);
+
+        // None of the four invites must have landed.
+        assertFalse(crowdfund.isWhitelisted(address(0xB101), 1), "calls[0] rolled back");
+        assertFalse(crowdfund.isWhitelisted(address(0xB102), 1), "calls[1] rolled back");
+        assertFalse(crowdfund.isWhitelisted(address(0xB103), 1), "calls[2] rolled back");
+        assertFalse(crowdfund.isWhitelisted(address(0xB104), 1), "calls[3] rolled back");
+        // And the inviter's invitesSent counter is untouched.
+        (, , uint16 invitesSent,,) = crowdfund.participants(seed0, 0);
+        assertEq(invitesSent, 0, "invitesSent rolled back");
+    }
+
+    // ===================================================================
+    //                        BOUNDS  (§5.3 tier B)
+    // ===================================================================
+
+    /// @notice WHY: empty bundle should not revert — it's a degenerate
+    /// no-op. Important because the frontend may render a Self-Fill
+    /// button even when plan.calls.length == 0, and the underlying call
+    /// should fail silently rather than blow up.
+    function test_Multicall_EmptyArray_Succeeds() public {
+        bytes[] memory empty = new bytes[](0);
+        bytes[] memory results = crowdfund.multicall(empty);
+        assertEq(results.length, 0, "empty results");
+    }
+
+    // ===================================================================
+    //                  SENDER PRESERVATION  (§5.3 tier B)
+    // ===================================================================
+
+    /// @notice WHY: critical correctness property. DELEGATECALL preserves
+    /// msg.sender, so msg.sender-keyed access controls (onlyLaunchTeam,
+    /// securityCouncil check) must continue to bind. A non-launchTeam
+    /// EOA bundling launchTeamInvite must revert.
+    function test_Multicall_PreservesMsgSender_NonLaunchTeamCannotInvite() public {
+        address attacker = address(0xBADBAD);
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = _encLaunchTeamInvite(address(0xB201), 0);
+
+        vm.prank(attacker);
+        vm.expectRevert("ArmadaCrowdfund: not launch team");
+        crowdfund.multicall(calls);
+    }
+
+    /// @notice WHY: positive case — launchTeam EOA bundling launchTeamInvite
+    /// succeeds. Together with the negative case above, proves msg.sender
+    /// is preserved through DELEGATECALL and the gate is sender-conditional
+    /// rather than always-deny / always-allow.
+    function test_Multicall_PreservesMsgSender_LaunchTeamCanInvite() public {
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = _encLaunchTeamInvite(address(0xB202), 0);
+
+        // admin IS launchTeam in setUp; no prank needed because the
+        // test contract is admin.
+        crowdfund.multicall(calls);
+        assertTrue(crowdfund.isWhitelisted(address(0xB202), 1), "launchTeam invite landed");
+    }
+
+    // ===================================================================
+    //                  REENTRANCY & COMPOSITION  (§5.3 tier C)
+    // ===================================================================
+
+    /// @notice WHY: corrected from spec's `DoubleNonReentrant_Reverts`.
+    /// OZ Multicall is NOT itself nonReentrant; each delegatecalled
+    /// sibling enters and exits its own guard cycle. Bundling two
+    /// nonReentrant siblings MUST succeed — this is the intended
+    /// composition. The earlier spec assumed otherwise; this test
+    /// pins the correct behavior so a future accidental wrap of
+    /// multicall in nonReentrant would be caught.
+    function test_Multicall_BundledNonReentrantSiblings_Succeed() public {
+        // Seed has hop-0 whitelist by setup; add a hop-1 stack so it's
+        // also whitelisted at hop-1.
+        vm.prank(seed0);
+        crowdfund.invite(seed0, 0); // self-invite to hop-1
+
+        _mintAndApprove(seed0, HOP0_CAP + HOP1_CAP);
+
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = _encCommit(0, HOP0_CAP);   // nonReentrant
+        calls[1] = _encCommit(1, HOP1_CAP);   // nonReentrant
+
+        vm.prank(seed0);
+        crowdfund.multicall(calls);
+
+        assertEq(crowdfund.getCommitment(seed0, 0), HOP0_CAP, "first nonReentrant call landed");
+        assertEq(crowdfund.getCommitment(seed0, 1), HOP1_CAP, "second nonReentrant call landed");
+    }
+
+    /// @notice WHY: §5.2 / runtime companion to the static audit. Confirms
+    /// that bundling claim() — which calls transferAndDelegate — does NOT
+    /// reenter or otherwise misbehave. The static audit proved no reentry
+    /// path exists; this is the live smoke test that exercises it.
+    function test_Multicall_NoReentryViaArmTransfer() public {
+        _setupForFinalization();
+
+        address claimant = manySeeds[0];
+        uint256 armBefore = armToken.balanceOf(claimant);
+
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = _encClaim(delegateAddr);
+
+        vm.prank(claimant);
+        crowdfund.multicall(calls);
+
+        assertTrue(crowdfund.claimed(claimant), "claim landed");
+        assertGt(armToken.balanceOf(claimant) - armBefore, 0, "ARM transferred");
+        // No reentry into crowdfund occurred during the transferAndDelegate
+        // step (otherwise the second internal nonReentrant guard would have
+        // either reverted or left _status in a bad state — both are
+        // implicitly checked by this test passing without any vm.expectRevert).
+    }
+
+    // ===================================================================
+    //                       PHASE GATES  (§5.3 tier C)
+    // ===================================================================
+
+    /// @notice WHY: bundle execution honors pre-window-open timing gates.
+    /// commit requires windowStart <= block.timestamp <= windowEnd. Before
+    /// the window opens, both invite (windowEnd check) and commit (full
+    /// window check) must hit their respective reverts inside the bundle.
+    function test_Multicall_BeforeWindowOpen_AllRevert() public {
+        // Deploy a fresh crowdfund whose window opens 10 days in the future.
+        uint256 futureOpen = block.timestamp + 10 days;
+        MockUSDCV2 usdc2 = new MockUSDCV2("U2", "U2");
+        ArmadaToken arm2 = new ArmadaToken(admin, admin);
+        ArmadaCrowdfund c2 = new ArmadaCrowdfund(
+            address(usdc2), address(arm2), treasury, admin, admin, futureOpen
+        );
+        address[] memory wl = new address[](2);
+        wl[0] = admin; wl[1] = address(c2);
+        arm2.initWhitelist(wl);
+        arm2.transfer(address(c2), ARM_FUNDING);
+        c2.loadArm();
+
+        // Add a seed during week-1-of-future-window (warp forward),
+        // then warp back to BEFORE windowStart to test pre-open behavior.
+        vm.warp(futureOpen + 1);
+        address[] memory s = new address[](1);
+        s[0] = seed0;
+        c2.addSeeds(s);
+        vm.warp(futureOpen - 1); // back to pre-open
+
+        _mintAndApprove(seed0, HOP0_CAP);
+        vm.prank(seed0);
+        usdc2.approve(address(c2), HOP0_CAP);
+        usdc2.mint(seed0, HOP0_CAP);
+
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = _encCommit(0, HOP0_CAP);
+        vm.prank(seed0);
+        vm.expectRevert("ArmadaCrowdfund: not active window");
+        c2.multicall(calls);
+    }
+
+    /// @notice WHY: post-windowEnd, both invite and commit must revert.
+    /// Bundle them and confirm the first call's revert reason propagates
+    /// and the whole bundle aborts.
+    function test_Multicall_AfterWindowClose_InviteAndCommitRevert() public {
+        vm.warp(crowdfund.windowEnd() + 1);
+        _mintAndApprove(seed0, HOP0_CAP);
+
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = _encInvite(address(0xB301), 0);
+        calls[1] = _encCommit(0, HOP0_CAP);
+
+        vm.prank(seed0);
+        vm.expectRevert("ArmadaCrowdfund: window closed");
+        crowdfund.multicall(calls);
+    }
+
+    // ===================================================================
+    //              ADVERSARIAL — GAP COVERAGE (post-review)
+    // ===================================================================
+    // These pin behavior that the modifier-matrix already proves by
+    // reasoning but that the prior tests didn't directly exercise. Added
+    // after a code-review concern that we should verify all reachable
+    // bundleable functions retain their gates under DELEGATECALL.
+
+    /// @notice WHY: `addSeeds` uses the formal `onlyLaunchTeam` MODIFIER
+    /// (not an inline require like `launchTeamInvite`). Modifiers expand
+    /// to inline code at compile time and should behave identically under
+    /// DELEGATECALL, but pin it to make sure.
+    function test_Multicall_AddSeeds_NonLaunchTeam_Reverts() public {
+        address[] memory newSeeds = new address[](1);
+        newSeeds[0] = address(0xA999);
+
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.addSeeds.selector, newSeeds);
+
+        address attacker = address(0xBADBAD);
+        vm.prank(attacker);
+        vm.expectRevert("ArmadaCrowdfund: not launch team");
+        crowdfund.multicall(calls);
+
+        assertFalse(crowdfund.isWhitelisted(address(0xA999), 0), "seed not added");
+    }
+
+    /// @notice WHY: `cancel` is gated by `msg.sender == securityCouncil`.
+    /// Verify that gate binds under DELEGATECALL (any caller other than
+    /// the council EOA cannot trigger cancel via multicall).
+    function test_Multicall_Cancel_NonSecurityCouncil_Reverts() public {
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.cancel.selector);
+
+        address attacker = address(0xBADBAD);
+        vm.prank(attacker);
+        vm.expectRevert("ArmadaCrowdfund: not security council");
+        crowdfund.multicall(calls);
+
+        assertEq(uint256(crowdfund.phase()), uint256(Phase.Active), "phase unchanged");
+    }
+
+    /// @notice WHY: `commitWithInvite` does EIP-712 signature verification
+    /// on inputs. The signature path is pure logic on calldata, but pin
+    /// that bundling it doesn't accidentally bypass the verification
+    /// (e.g. by perturbing the EIP-712 domain or hash construction).
+    function test_Multicall_CommitWithInvite_BadSignature_Reverts() public {
+        address invitee = address(0xB501);
+        _mintAndApprove(invitee, HOP1_CAP);
+
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = abi.encodeWithSelector(
+            ArmadaCrowdfund.commitWithInvite.selector,
+            seed0,                       // inviter (claimed)
+            uint8(0),                    // fromHop
+            uint256(1),                  // nonce
+            block.timestamp + 1 hours,   // deadline
+            new bytes(65),               // bogus signature (zeros)
+            HOP1_CAP                     // amount
+        );
+
+        vm.prank(invitee);
+        vm.expectRevert("ArmadaCrowdfund: invalid invite signature");
+        crowdfund.multicall(calls);
+    }
+
+    /// @notice WHY: `claimRefund` requires `refundMode || phase == Canceled`.
+    /// Bundling it during the Active phase must hit the phase gate and
+    /// revert atomically. Structural parallel to `claim`, which IS tested.
+    function test_Multicall_ClaimRefund_InActivePhase_Reverts() public {
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = _encClaimRefund();
+
+        vm.prank(seed0);
+        vm.expectRevert("ArmadaCrowdfund: refund not available");
+        crowdfund.multicall(calls);
+    }
+
+    /// @notice WHY: `withdrawUnallocatedArm` requires phase ∈ {Finalized,
+    /// Canceled}. Bundling it during Active must revert. The function is
+    /// permissionless (any caller), so the only gate is the phase check —
+    /// pin that the gate binds under DELEGATECALL.
+    function test_Multicall_WithdrawUnallocatedArm_InActive_Reverts() public {
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.withdrawUnallocatedArm.selector);
+
+        vm.prank(seed0);
+        vm.expectRevert("ArmadaCrowdfund: not finalized or canceled");
+        crowdfund.multicall(calls);
+    }
+
+    /// @notice WHY: this is the "more than allotted allocation" property
+    /// from the invitee side. `_registerOrStackInvite` checks
+    /// `invitesReceived < maxInvitesReceived` (10 for hop-1). The
+    /// launchTeam has a 60-invite budget, so it CAN bundle 11 invites
+    /// targeting the same victim. The 11th must revert when invitesReceived
+    /// would overflow the per-hop cap. Bundle must roll back so the victim
+    /// ends up with zero stacked invites.
+    function test_Multicall_InviteeStackingCap_Reverts() public {
+        address victim = address(0xB401);
+
+        bytes[] memory calls = new bytes[](11);
+        for (uint256 i = 0; i < 11; i++) {
+            calls[i] = _encLaunchTeamInvite(victim, 0); // hop-1 invitee
+        }
+
+        // admin == launchTeam in setUp; no prank needed.
+        vm.expectRevert("ArmadaCrowdfund: max invites received");
+        crowdfund.multicall(calls);
+
+        // Atomic rollback: victim has no stacked invites.
+        assertFalse(crowdfund.isWhitelisted(victim, 1), "no invites landed");
+        assertEq(crowdfund.getInvitesReceived(victim, 1), 0, "stack count rolled back");
+    }
+
+    // ===================================================================
+    //                    PROPERTY FUZZ (post-review)
+    // ===================================================================
+
+    /// @notice WHY: property fuzz — for any reachable bundleable function
+    /// invocation, a single-call multicall bundle `[call]` must produce
+    /// the same success/fail outcome as a direct `call`. This is the
+    /// formal version of your colleague's "calls inside multicall fail
+    /// exactly like a single call" property. If the modifier-matrix
+    /// reasoning is correct, the property holds for every (selector, args,
+    /// caller) tuple. A failure here would indicate either a bug in
+    /// OZ Multicall's delegatecall handling, an error-data propagation
+    /// issue, or a gas/calldata difference we missed.
+    /// @dev    Direction-of-comparison: each fuzz iteration runs the
+    ///         direct call, snapshots+reverts state, then runs the same
+    ///         call via `multicall([call])`. We compare only the
+    ///         success/fail outcome — comparing post-state would require
+    ///         deep storage diffing that's overkill for this property.
+    function testFuzz_Multicall_OneCall_MatchesDirectCall(
+        uint8 selectorIdx,
+        address randomAddr,
+        uint8 hopArg,
+        uint256 amountArg
+    ) public {
+        // Constrain fuzz inputs to vaguely-reasonable ranges so the fuzzer
+        // spends cycles on the boundaries we care about, not on integer
+        // overflow exploration.
+        amountArg = bound(amountArg, 0, 100_000 * 1e6);
+        hopArg = uint8(bound(hopArg, 0, 5)); // include invalid hops (>= NUM_HOPS)
+
+        bytes memory callData = _buildFuzzedCall(selectorIdx, randomAddr, hopArg, amountArg);
+        address caller = seed0; // known whitelisted address → wider outcome coverage
+
+        // Pre-fund seed0 with enough USDC + approval so commit/commitWithInvite
+        // paths exercise actual escrow logic instead of always hitting allowance.
+        _mintAndApprove(caller, 100_000 * 1e6);
+
+        uint256 snap = vm.snapshotState();
+
+        // Path 1: direct external call
+        vm.prank(caller);
+        (bool directOk, ) = address(crowdfund).call(callData);
+
+        require(vm.revertToState(snap), "snapshot revert failed");
+
+        // Path 2: bundled via multicall(bytes[]) of length 1
+        bytes[] memory bundle = new bytes[](1);
+        bundle[0] = callData;
+        vm.prank(caller);
+        // `multicall` is inherited from OZ — `.selector` on inherited
+        // functions doesn't resolve, so use encodeWithSignature for the
+        // same effective selector (0xac9650d8).
+        (bool bundleOk, ) = address(crowdfund).call(
+            abi.encodeWithSignature("multicall(bytes[])", bundle)
+        );
+
+        assertEq(directOk, bundleOk, "single-call vs multicall-of-one outcome diverged");
+    }
+
+    /// @dev Map a fuzz seed to one of the bundleable state-changing
+    /// selectors with random args. Excludes selectors that take complex
+    /// nested structs (commitWithInvite — signature-bearing) or system-
+    /// gated ones we exercise directly (addSeeds, cancel, launchTeamInvite,
+    /// loadArm, revokeInviteNonce — out of fuzz scope to keep signal high).
+    function _buildFuzzedCall(
+        uint8 selectorIdx,
+        address addr,
+        uint8 hop,
+        uint256 amount
+    ) internal pure returns (bytes memory) {
+        uint8 choice = selectorIdx % 5;
+        if (choice == 0) return abi.encodeWithSelector(ArmadaCrowdfund.invite.selector, addr, hop);
+        if (choice == 1) return abi.encodeWithSelector(ArmadaCrowdfund.commit.selector, hop, amount);
+        if (choice == 2) return abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, addr);
+        if (choice == 3) return abi.encodeWithSelector(ArmadaCrowdfund.claimRefund.selector);
+        return abi.encodeWithSelector(ArmadaCrowdfund.finalize.selector);
+    }
+}

--- a/test/crowdfund_multicall.ts
+++ b/test/crowdfund_multicall.ts
@@ -1,0 +1,220 @@
+// ABOUTME: Hardhat integration tests for the OZ Multicall mixin on ArmadaCrowdfund (§5.4 of MULTICALL_EVAL.md).
+// ABOUTME: Covers approve+multicall pipeline, atomic revert on insufficient allowance, and event ordering.
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+import type { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+
+const USDC = (n: number) => ethers.parseUnits(n.toString(), 6);
+const ARM  = (n: number) => ethers.parseUnits(n.toString(), 18);
+
+// Per-hop slot caps + invite budgets (mirrors ArmadaCrowdfund constants).
+const HOP0_CAP = USDC(15_000);
+const HOP1_CAP = USDC(4_000);
+const HOP2_CAP = USDC(1_000);
+
+// A seed wallet's self-fill plan: 3× hop-1 invites + 6× hop-2 invites,
+// then commit $15K / $12K / $6K = $33K total.
+const SELF_FILL_TOTAL = USDC(33_000);
+
+describe("Crowdfund Multicall", function () {
+  let crowdfund: any;
+  let armToken: any;
+  let usdc: any;
+
+  let deployer: SignerWithAddress;
+  let seed: SignerWithAddress;
+  let treasury: SignerWithAddress;
+  let outsider: SignerWithAddress;
+  let delegateAddr: SignerWithAddress;
+
+  beforeEach(async function () {
+    [deployer, seed, treasury, outsider, delegateAddr] = await ethers.getSigners();
+
+    const MockUSDCV2 = await ethers.getContractFactory("MockUSDCV2");
+    usdc = await MockUSDCV2.deploy("Mock USDC", "USDC");
+    await usdc.waitForDeployment();
+
+    const ArmadaToken = await ethers.getContractFactory("ArmadaToken");
+    armToken = await ArmadaToken.deploy(deployer.address, deployer.address);
+    await armToken.waitForDeployment();
+    await armToken.initWhitelist([deployer.address]);
+
+    const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+    const openTimestamp = (await time.latest()) + 300;
+    crowdfund = await ArmadaCrowdfund.deploy(
+      await usdc.getAddress(),
+      await armToken.getAddress(),
+      treasury.address,
+      deployer.address,    // launchTeam
+      deployer.address,    // securityCouncil
+      openTimestamp,
+    );
+    await crowdfund.waitForDeployment();
+    const cfAddr = await crowdfund.getAddress();
+
+    await armToken.addToWhitelist(cfAddr);
+    await armToken.initAuthorizedDelegators([cfAddr]);
+
+    await armToken.transfer(cfAddr, ARM(1_800_000));
+    await crowdfund.loadArm();
+
+    // addSeeds requires block.timestamp >= windowStart, so warp first.
+    await time.increaseTo(await crowdfund.windowStart());
+    await crowdfund.addSeeds([seed.address]);
+  });
+
+  // ============ Bundle builders ============
+  // WHY: every test in this suite calls multicall with the same self-fill
+  // plan shape. Encoding lives here so test bodies focus on assertions.
+
+  function seedSelfFillBundle(selfAddress: string): string[] {
+    const iface = crowdfund.interface;
+    const calls: string[] = [];
+    for (let k = 0; k < 3; k++) calls.push(iface.encodeFunctionData("invite", [selfAddress, 0]));
+    for (let k = 0; k < 6; k++) calls.push(iface.encodeFunctionData("invite", [selfAddress, 1]));
+    calls.push(iface.encodeFunctionData("commit", [0, HOP0_CAP]));
+    calls.push(iface.encodeFunctionData("commit", [1, HOP1_CAP * 3n]));
+    calls.push(iface.encodeFunctionData("commit", [2, HOP2_CAP * 6n]));
+    return calls;
+  }
+
+  // =====================================================================
+
+  // WHY: end-to-end demonstration that the multicall mixin lets a seed
+  // execute their entire self-fill plan in one wallet signature. The 12-call
+  // bundle relies on intra-bundle state visibility — hop-2 invites only
+  // become valid AFTER the hop-1 self-invites land, and hop-1/2 commits
+  // only become valid (whitelist + effectiveCap) after their hop's
+  // self-invites land. If any of these intra-bundle ordering assumptions
+  // were broken, the call would revert; if a single ordering bug ever
+  // slipped into a Solidity upgrade or OZ Multicall change, this test
+  // catches it.
+  it("seed wallet fills entire tree in one multicall", async () => {
+    await usdc.mint(seed.address, SELF_FILL_TOTAL);
+    await usdc.connect(seed).approve(await crowdfund.getAddress(), SELF_FILL_TOTAL);
+
+    const calls = seedSelfFillBundle(seed.address);
+    expect(calls.length).to.equal(12);
+
+    await crowdfund.connect(seed).multicall(calls);
+
+    expect(await crowdfund.getInvitesReceived(seed.address, 1)).to.equal(3);
+    expect(await crowdfund.getInvitesReceived(seed.address, 2)).to.equal(6);
+    expect(await crowdfund.getCommitment(seed.address, 0)).to.equal(HOP0_CAP);
+    expect(await crowdfund.getCommitment(seed.address, 1)).to.equal(HOP1_CAP * 3n);
+    expect(await crowdfund.getCommitment(seed.address, 2)).to.equal(HOP2_CAP * 6n);
+    expect(await crowdfund.totalCommitted()).to.equal(SELF_FILL_TOTAL);
+    expect(await usdc.balanceOf(seed.address)).to.equal(0n);
+  });
+
+  // WHY: confirms the two-tx pipeline the frontend will actually use.
+  // USDC `approve` cannot be bundled inside the crowdfund's multicall
+  // (it's on a separate contract), so the live flow is: (1) approve total,
+  // (2) multicall. This test exercises both txs and asserts on the
+  // observable post-state. A future EIP-2612 permit integration could
+  // collapse this to one tx; until then, this is the canonical path.
+  it("approve + multicall pipeline lands the expected on-chain state", async () => {
+    const cfAddr = await crowdfund.getAddress();
+    await usdc.mint(seed.address, SELF_FILL_TOTAL);
+
+    // Tx 1: approve. Allowance starts at 0; bumping to exactly the bundle total.
+    const txApprove = await usdc.connect(seed).approve(cfAddr, SELF_FILL_TOTAL);
+    await txApprove.wait();
+    expect(await usdc.allowance(seed.address, cfAddr)).to.equal(SELF_FILL_TOTAL);
+
+    // Tx 2: multicall. Single wallet signature.
+    const calls = seedSelfFillBundle(seed.address);
+    const txMulti = await crowdfund.connect(seed).multicall(calls);
+    const receipt = await txMulti.wait();
+
+    expect(receipt.status).to.equal(1);
+    // Allowance fully consumed (each commit safeTransferFrom decrements it).
+    expect(await usdc.allowance(seed.address, cfAddr)).to.equal(0n);
+    // Crowdfund holds all the USDC.
+    expect(await usdc.balanceOf(cfAddr)).to.equal(SELF_FILL_TOTAL);
+    expect(await crowdfund.totalCommitted()).to.equal(SELF_FILL_TOTAL);
+  });
+
+  // WHY: critical atomicity property. The user approves only $20K but the
+  // self-fill plan needs $33K. When the hop-2 commit (final commit in the
+  // bundle) hits an allowance shortfall, the underlying ERC20 transferFrom
+  // reverts. OZ Multicall propagates that revert; Solidity rolls back the
+  // entire tx. We must verify NOTHING from the bundle persisted — no
+  // invites, no commits, no allowance burn. Without atomicity, a partial
+  // self-fill could leave a user in a broken state (whitelisted at hop-2
+  // but with no allowance to commit).
+  it("rejects multicall when total USDC exceeds approval", async () => {
+    const cfAddr = await crowdfund.getAddress();
+    await usdc.mint(seed.address, SELF_FILL_TOTAL);
+    // Only approve enough for hop-0 + hop-1 ($27K), not enough for the
+    // final $6K hop-2 commit.
+    const shortApproval = HOP0_CAP + HOP1_CAP * 3n;
+    await usdc.connect(seed).approve(cfAddr, shortApproval);
+
+    const calls = seedSelfFillBundle(seed.address);
+    await expect(crowdfund.connect(seed).multicall(calls)).to.be.reverted;
+
+    // All bundle state rolled back: zero invites stacked at hop-1/2.
+    // Seed's hop-0 invitesReceived is set by addSeeds (initial state = 1);
+    // hop-1 and hop-2 entries don't exist until the seed self-invites.
+    expect(await crowdfund.getInvitesReceived(seed.address, 0)).to.equal(1);  // initial seed state
+    expect(await crowdfund.getInvitesReceived(seed.address, 1)).to.equal(0);
+    expect(await crowdfund.getInvitesReceived(seed.address, 2)).to.equal(0);
+    expect(await crowdfund.getCommitment(seed.address, 0)).to.equal(0n);
+    expect(await crowdfund.getCommitment(seed.address, 1)).to.equal(0n);
+    expect(await crowdfund.getCommitment(seed.address, 2)).to.equal(0n);
+    expect(await crowdfund.totalCommitted()).to.equal(0n);
+    // Allowance untouched too (transferFrom never debited).
+    expect(await usdc.allowance(seed.address, cfAddr)).to.equal(shortApproval);
+  });
+
+  // WHY: the self-fill UX promises the user "you'll issue 9 invites and
+  // commit $33K". The frontend builds that promise from the planned call
+  // sequence; the contract MUST emit events in matching order so that
+  // off-chain indexers / the MyPosition card / NodeSphere render the
+  // resulting graph correctly. If the event order ever desynchronised
+  // from the call order (e.g. via batched / deferred emits), downstream
+  // UI state would corrupt silently. This test pins the contract-side
+  // guarantee.
+  it("emits Invited + Committed events in expected order", async () => {
+    const cfAddr = await crowdfund.getAddress();
+    await usdc.mint(seed.address, SELF_FILL_TOTAL);
+    await usdc.connect(seed).approve(cfAddr, SELF_FILL_TOTAL);
+
+    const calls = seedSelfFillBundle(seed.address);
+    const tx = await crowdfund.connect(seed).multicall(calls);
+    const receipt = await tx.wait();
+
+    // Filter to crowdfund logs only and decode. ArmadaToken emits no events
+    // during commit() since transferFrom is on USDC, not ARM.
+    const parsed: { name: string; args: any }[] = [];
+    for (const log of receipt.logs) {
+      if (log.address.toLowerCase() !== cfAddr.toLowerCase()) continue;
+      try {
+        const decoded = crowdfund.interface.parseLog(log);
+        if (decoded) parsed.push({ name: decoded.name, args: decoded.args });
+      } catch (e) {
+        // ignore non-crowdfund logs that may have matched address but failed decode
+      }
+    }
+
+    // Expected order: 9× Invited, then 3× Committed (hop-0, hop-1, hop-2).
+    const eventNames = parsed.map((p) => p.name);
+    expect(eventNames).to.deep.equal([
+      "Invited", "Invited", "Invited",          // hop-1 self-invites
+      "Invited", "Invited", "Invited",
+      "Invited", "Invited", "Invited",          // hop-2 self-invites (issued from hop-1)
+      "Committed",                              // hop-0 commit
+      "Committed",                              // hop-1 commit
+      "Committed",                              // hop-2 commit
+    ]);
+
+    // Spot-check the Committed event hops are in the right order.
+    const committed = parsed.filter((p) => p.name === "Committed");
+    expect(committed[0].args[1]).to.equal(0);
+    expect(committed[1].args[1]).to.equal(1);
+    expect(committed[2].args[1]).to.equal(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the OpenZeppelin `Multicall` mixin to `ArmadaCrowdfund` so users can bundle invite + commit operations (the "self-fill" UX) into a single wallet signature.

## Contract change

```
contracts/crowdfund/ArmadaCrowdfund.sol     +2 / -1
```

```diff
+ import "@openzeppelin/contracts/utils/Multicall.sol";
- contract ArmadaCrowdfund is ReentrancyGuard, EIP712 {
+ contract ArmadaCrowdfund is ReentrancyGuard, EIP712, Multicall {
```

No `MAX_MULTICALL_CALLS` bound. An overlong bundle reverts atomically on OOG with the caller paying gas; no state lands, no other user is harmed, no per-bundle accumulator on the contract amplifies anything. The bound would be UX (fail-fast on frontend bugs), not security, and it's not load-bearing for any correctness claim.

## Self-verifiable invariants

| Check | Result |
|---|---|
| Storage layout unchanged | empty diff |
| Methods diff: only `multicall(bytes[])` added | selector `0xac9650d8` (canonical OZ) |
| No selector collisions | confirmed |
| No payable functions added | confirmed |
| OZ Multicall >= 4.6 (msg.value bug fixed) | resolved to 4.9.6; zero `msg.value` refs in `node_modules/@openzeppelin/contracts/utils/Multicall.sol` |
| `transferAndDelegate` reentrancy audit | SAFE — see `reports/multicall/transferAndDelegate-audit.md` |
| Modifier preservation across DELEGATECALL | documented in `reports/multicall/modifier-matrix.md` + pinned by 22 Foundry tests |

## Test coverage detail

### Foundry — `test-foundry/CrowdfundMulticall.t.sol` — **22 tests, all passing**

**Happy paths (3)** — pins intra-bundle state visibility (later calls see earlier calls' mutations):
- `test_SelfFill_Seed_FullTree` — 12-call self-fill bundle (9 invites + 3 commits)
- `test_SelfFill_Hop1_Subtree` — same shape for a hop-1 wallet
- `test_Multicall_InviteThenCommitSameTx` — minimal 2-call composition

**Atomic-revert (5)** — pins that any revert rolls back the entire bundle:
- `test_Multicall_CommitExceedingAllowance_Reverts` — USDC allowance shortfall
- `test_Multicall_NotWhitelisted_Reverts` — inline whitelist gate
- `test_Multicall_DoubleClaim_Reverts` — `claimed[msg.sender]` set in call[0] visible to call[1]; rollback unsets
- `test_Multicall_PhaseTransition_Reverts` — `[finalize, commit]` reverts; finalize rolled back
- `test_Multicall_PartialFailure_RollsBackAll` — 4 invites, 4th hits inviter `invitesSent` budget; all 4 invitees end not-whitelisted, counter reset

**Sender preservation (2)** — pins that DELEGATECALL preserves `msg.sender`:
- `test_Multicall_PreservesMsgSender_NonLaunchTeamCannotInvite` (negative)
- `test_Multicall_PreservesMsgSender_LaunchTeamCanInvite` (positive)

**Reentrancy + composition (2)**:
- `test_Multicall_BundledNonReentrantSiblings_Succeed` — bundle of two `nonReentrant` siblings both succeed (each guard cycles independently between siblings)
- `test_Multicall_NoReentryViaArmTransfer` — `claim()` inside multicall completes; runtime companion to the static audit

**Phase gates (2)**:
- `test_Multicall_BeforeWindowOpen_AllRevert`
- `test_Multicall_AfterWindowClose_InviteAndCommitRevert`

**Bounds (1)**:
- `test_Multicall_EmptyArray_Succeeds`

**Gap-coverage adversarial (6)** — one direct multicall test per previously-only-reasoning-covered bundleable function:
- `test_Multicall_AddSeeds_NonLaunchTeam_Reverts` — `onlyLaunchTeam` **modifier** binds under DELEGATECALL
- `test_Multicall_Cancel_NonSecurityCouncil_Reverts` — `securityCouncil` inline gate binds
- `test_Multicall_CommitWithInvite_BadSignature_Reverts` — EIP-712 signature path binds (no domain perturbation)
- `test_Multicall_ClaimRefund_InActivePhase_Reverts` — `claimRefund` phase gate binds
- `test_Multicall_WithdrawUnallocatedArm_InActive_Reverts` — sweep phase gate binds
- `test_Multicall_InviteeStackingCap_Reverts` — invitee-side allocation cap (`maxInvitesReceived = 10`): launch-team bundles 11 hop-1 invites to one victim; 11th reverts on `_registerOrStackInvite`; all rolled back

**Property fuzz (1)**:
- `testFuzz_Multicall_OneCall_MatchesDirectCall` — for any (selector, args, caller) tuple drawn from `{invite, commit, claim, claimRefund, finalize}` with bounded inputs, `multicall([call]).success == directCall.success`. 256 runs. The formal property: bundling never changes the outcome of a single call.

### Hardhat — `test/crowdfund_multicall.ts` — **4 tests, all passing**

Wired into `npm run test:crowdfund` (132 passing in combined suite, 1 pre-existing pending).

- `seed wallet fills entire tree in one multicall` — end-to-end via ethers v6
- `approve + multicall pipeline lands the expected on-chain state` — the two-tx canonical flow (USDC approve cannot be bundled inside crowdfund.multicall)
- `rejects multicall when total USDC exceeds approval` — atomic rollback asserted via post-state `allowance == shortApproval` (transferFrom never debited)
- `emits Invited + Committed events in expected order` — pins call-order ↔ event-order correspondence

### Slither

| Run | Findings |
|---|---|
| Baseline (main) | 15 (all pre-existing) |
| Post-change | 15 (identical line-number-normalized set) |
| **New findings** | **0** |

### Halmos / invariants / Anvil E2E

Skipped with documented rationale: the contract has no per-bundle accumulator state, so invariant fuzzing through `multicall` re-verifies what existing single-call invariants already cover; Halmos symbolic verification is disproportionate to a 2-line inheritance change; Anvil E2E would duplicate Hardhat against a different EVM backend, which doesn't add signal for canonical OZ bytecode.

## Independent verification protocol for the reviewer

**Do not rely on this PR description to confirm coverage.** Reviewers should execute the following protocol themselves; each step is designed to be doable without trusting any documentation in this branch.

### 1. Reproduce the result

```bash
git checkout iskay/multicall-crowdfund-eval-plan
npm install --legacy-peer-deps
forge test --match-path test-foundry/CrowdfundMulticall.t.sol -v
npm run test:crowdfund
```

Expect: 22 Foundry tests pass, 132 Hardhat crowdfund tests pass (with 1 pre-existing pending).

### 2. Verify the contract diff is exactly what we claim

```bash
git diff main...HEAD -- contracts/crowdfund/ArmadaCrowdfund.sol
```

Expected output: **2 lines added, 1 line modified** (an OZ import + `Multicall` appended to the parent list). Anything beyond this is a red flag.

### 3. Verify storage layout + selector independently

```bash
git worktree add /tmp/crowdfund-baseline main
(cd /tmp/crowdfund-baseline && forge inspect ArmadaCrowdfund storage-layout) > /tmp/before-storage.json
forge inspect ArmadaCrowdfund storage-layout > /tmp/after-storage.json
diff /tmp/before-storage.json /tmp/after-storage.json    # expect empty
forge inspect ArmadaCrowdfund methods | grep ac9650d8   # expect one line: multicall(bytes[])
git worktree remove /tmp/crowdfund-baseline
```

### 4. Verify each test does what it claims (test-by-test reading protocol)

For every test in `test-foundry/CrowdfundMulticall.t.sol`:

1. Read the test body. **Skip the `WHY` comment.**
2. Identify the operation: what gets bundled, what's asserted afterward.
3. Match against your own understanding of the property being verified.
4. **Only then** read the `WHY` comment. If your independent reading diverges from the comment's claim, the comment is suspect — not the other way around.

### 5. Mutation tests (highest-confidence verification)

The strongest correctness signal: **temporarily break the contract and confirm the tests catch each break.**

| Mutation (apply to `ArmadaCrowdfund.sol`) | Test that **MUST** fail |
|---|---|
| Remove the `onlyLaunchTeam` modifier from `addSeeds` (~line 207) | `test_Multicall_AddSeeds_NonLaunchTeam_Reverts` |
| Remove the `msg.sender == securityCouncil` require from `cancel` (~line 414) | `test_Multicall_Cancel_NonSecurityCouncil_Reverts` |
| Change `< hopConfigs[inviteeHop].maxInvitesReceived` to `<=` in `_registerOrStackInvite` (~line 827) | `test_Multicall_InviteeStackingCap_Reverts` |
| Remove `require(p.isWhitelisted, ...)` from `commit` (~line 329) | `test_Multicall_NotWhitelisted_Reverts` |
| Wrap any future `multicall` override in `nonReentrant` | `test_Multicall_BundledNonReentrantSiblings_Succeed` |
| Remove `claimed[msg.sender] = true` from `claim` (~line 536) | `test_Multicall_DoubleClaim_Reverts` |

If a mutation that *should* be caught isn't, the test is not actually exercising the property it claims.

### 6. Verify the property fuzz is reaching the contract

```bash
forge test --match-test testFuzz_Multicall_OneCall_MatchesDirectCall -vvv | head -50
```

Inspect the trace to confirm the fuzz inputs are being varied and the call data is actually dispatched (look for delegatecall traces and varied `selectorIdx` values). To prove the test is reachable at all, prepend `vm.assume(false);` to the test body and re-run — the fuzzer should report "all runs discarded".

### 7. Independently confirm the Slither claim

```bash
slither contracts/crowdfund/ArmadaCrowdfund.sol --filter-paths "node_modules|test|lib|_legacy" 2>&1 | tail -1
git worktree add /tmp/crowdfund-baseline main
(cd /tmp/crowdfund-baseline && slither contracts/crowdfund/ArmadaCrowdfund.sol --filter-paths "node_modules|test|lib|_legacy" 2>&1 | tail -1)
git worktree remove /tmp/crowdfund-baseline
```

Both runs should report `15 result(s) found`.

### 8. Sanity-check the `transferAndDelegate` audit memo

Don't take the SAFE verdict on faith. Open `reports/multicall/transferAndDelegate-audit.md`, then independently verify the key claim:

```bash
grep -nE "\.call|staticcall|delegatecall|assembly" contracts/governance/ArmadaToken.sol
```

Expect: zero matches. Any external-call opcode in `ArmadaToken.sol` invalidates the audit's "no reentry path" conclusion.

### What this verification does NOT cover

- Frontend (`useSelfFillPlan` hook, `runSelfFill` action) — out of scope; follow-up PR
- Deployment-script changes — none needed; `scripts/deploy_crowdfund.ts` constructor args unchanged
- Sepolia/mainnet deploy — held pending sign-off

## Deployment

This PR does NOT deploy. `ArmadaCrowdfund` is non-upgradeable; deployment requires a fresh contract. Sepolia first, then mainnet on sign-off. No deployment-script changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)