### PR TITLE
test(crowdfund): adversarial fuzz suite for post-audit Multicall mixin

### DIFF
--- a/deployments/crowdfund-hub-sepolia.json
+++ b/deployments/crowdfund-hub-sepolia.json
@@ -1,13 +1,13 @@
 {
   "chainId": 11155111,
   "deployer": "0x98b1CBa0908C98c95c9C87D94e4fCdddc87C933d",
-  "deployBlock": 10892713,
+  "deployBlock": 11016090,
   "contracts": {
-    "armToken": "0x21EEA6EE528e966c3A54f912837CdA384BFA537d",
+    "armToken": "0x9203A4653a43e70083390cB41fc34712eafD7210",
     "usdc": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
-    "crowdfund": "0x24b63d7C35b6Da98FbE38AE969Be790E7E396D0b",
-    "treasury": "0x91cFA0c37Df43661DE90A3aa7CBE89ae7920871C",
-    "governor": "0x36B167ee7cd1717576f445AC7a76500899691Da5"
+    "crowdfund": "0xc85b43bd4ebe3d10C7a42AD2176580c57436921e",
+    "treasury": "0x7c62Ed35a7e2859944503741224a8fEB0D954fc1",
+    "governor": "0xFEEBa4bbEf78695E0f9D4e73262cee3060B00e7d"
   },
   "config": {
     "baseSale": "1200000",
@@ -16,5 +16,5 @@
     "armPrice": "1.00",
     "armFunded": "1800000"
   },
-  "timestamp": "2026-05-21T16:41:36.788Z"
+  "timestamp": "2026-06-08T14:56:36.585Z"
 }

--- a/test-foundry/CrowdfundMulticallExploits.t.sol
+++ b/test-foundry/CrowdfundMulticallExploits.t.sol
@@ -1,0 +1,602 @@
+// ABOUTME: Adversarial exploit suite for the Multicall mixin — each test is a named attack an attacker would actually try.
+// ABOUTME: Every test asserts the attack fails atomically with no partial state damage. Run at high fuzz runs for the fuzz cases.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/crowdfund/ArmadaCrowdfund.sol";
+import "../contracts/crowdfund/IArmadaCrowdfund.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/cctp/MockUSDCV2.sol";
+
+/// @notice Hostile contract that attempts to re-enter ArmadaCrowdfund when it
+///         receives ARM or USDC. The audit at reports/multicall/transferAndDelegate-audit.md
+///         already establishes that ArmadaToken.transferAndDelegate makes zero
+///         external CALL opcodes, so the attacker has no callback surface. This
+///         contract is the runtime guard: if a future change ever introduces a
+///         hook, these tests fail loudly.
+contract HostileReceiver {
+    ArmadaCrowdfund public immutable target;
+    bool public attempted;
+    bytes public reentryCalldata;
+
+    constructor(ArmadaCrowdfund _target) {
+        target = _target;
+    }
+
+    function setReentryCalldata(bytes memory data) external {
+        reentryCalldata = data;
+    }
+
+    /// @dev OZ ERC20 has no transfer hook — but if the token were ever changed
+    ///      to ERC777 or ERC1363 or similar, this fallback would receive the
+    ///      callback. The function attempts re-entry; the tests assert the
+    ///      outer call still succeeds (no callback = no re-entry executed) or,
+    ///      if a future token does invoke a hook, that reentry is blocked by
+    ///      nonReentrant on the outer ArmadaCrowdfund function.
+    receive() external payable {
+        if (reentryCalldata.length > 0 && !attempted) {
+            attempted = true;
+            (bool ok,) = address(target).call(reentryCalldata);
+            ok; // ignored — we just want to attempt
+        }
+    }
+
+    fallback() external payable {
+        if (reentryCalldata.length > 0 && !attempted) {
+            attempted = true;
+            (bool ok,) = address(target).call(reentryCalldata);
+            ok;
+        }
+    }
+
+    function commit(uint8 hop, uint256 amount) external {
+        target.commit(hop, amount);
+    }
+
+    function callMulticall(bytes[] calldata calls) external {
+        target.multicall(calls);
+    }
+}
+
+contract CrowdfundMulticallExploitsTest is Test {
+    ArmadaCrowdfund internal crowdfund;
+    MockUSDCV2 internal usdc;
+    ArmadaToken internal armToken;
+    address internal admin;
+    address internal treasury;
+    address internal launchTeam;
+    address internal securityCouncil;
+    address internal seed;
+    address internal attacker;
+    HostileReceiver internal hostile;
+
+    uint256 constant ARM_FUNDING = 1_800_000 * 1e18;
+    uint256 constant HOP0_CAP = 15_000 * 1e6;
+    uint256 constant HOP1_CAP = 4_000 * 1e6;
+    uint256 constant HOP2_CAP = 1_000 * 1e6;
+    uint256 constant MIN_COMMIT = 10 * 1e6;
+
+    function setUp() public {
+        admin = address(this);
+        treasury = address(0xCAFE);
+        launchTeam = address(0xBEEF);
+        securityCouncil = address(0xC0FFEE5C);
+        seed = address(0xC0FFEE);
+        attacker = address(0xBADD);
+
+        usdc = new MockUSDCV2("Mock USDC", "USDC");
+        armToken = new ArmadaToken(admin, admin);
+        crowdfund = new ArmadaCrowdfund(
+            address(usdc), address(armToken), treasury, launchTeam, securityCouncil, block.timestamp
+        );
+
+        address[] memory wl = new address[](2);
+        wl[0] = admin;
+        wl[1] = address(crowdfund);
+        armToken.initWhitelist(wl);
+
+        // Crowdfund's claim() calls armToken.transferAndDelegate, which requires
+        // the caller to be in authorizedDelegator. Without this the double-claim
+        // path reverts on the wrong gate ("not authorized delegator") instead of
+        // the claimed[] flag we're trying to exercise.
+        address[] memory delegators = new address[](1);
+        delegators[0] = address(crowdfund);
+        armToken.initAuthorizedDelegators(delegators);
+
+        armToken.transfer(address(crowdfund), ARM_FUNDING);
+        crowdfund.loadArm();
+
+        vm.prank(launchTeam);
+        crowdfund.addSeed(seed);
+
+        usdc.mint(seed, HOP0_CAP * 4);
+        usdc.mint(attacker, HOP0_CAP);
+
+        hostile = new HostileReceiver(crowdfund);
+    }
+
+    // ==========================================================================
+    // ATOMIC STATE-MACHINE ATTACKS
+    // Each `claimed[msg.sender]` flag is the lock — atomicity within a tx (and
+    // therefore within a multicall) means the second attempt in any bundle that
+    // would double-spend must observe the flag set by the first attempt.
+    // ==========================================================================
+
+    /// @dev EXPLOIT: bundle [claim(D), claim(D)] for the same user against a
+    ///      SUCCESS finalization. If the claimed flag were checked but not
+    ///      set atomically, the user could double-claim ARM. We assert the
+    ///      second call reverts on `already claimed` and the whole bundle
+    ///      rolls back.
+    function test_exploit_doubleClaimInBundle_atomicallyReverts() public {
+        _populateAndFinalizeTrueSuccess();
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, seed);
+        calls[1] = abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, seed);
+
+        vm.prank(seed);
+        vm.expectRevert(bytes("ArmadaCrowdfund: already claimed"));
+        crowdfund.multicall(calls);
+
+        // Flag must still be FALSE — entire bundle reverted, including the first
+        // claim's state change.
+        assertFalse(crowdfund.claimed(seed), "claimed flag must roll back with atomic bundle");
+    }
+
+    /// @dev EXPLOIT: bundle [claimRefund, claimRefund] in refund mode. Same
+    ///      double-spend pattern but on the refund path.
+    function test_exploit_doubleRefundInBundle_atomicallyReverts() public {
+        _populateAndFinalizeRefundMode();
+
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.claimRefund.selector);
+        calls[1] = abi.encodeWithSelector(ArmadaCrowdfund.claimRefund.selector);
+
+        vm.prank(seed);
+        vm.expectRevert(bytes("ArmadaCrowdfund: already claimed"));
+        crowdfund.multicall(calls);
+
+        assertFalse(crowdfund.claimed(seed), "claimed flag rolls back");
+    }
+
+    /// @dev EXPLOIT: bundle [claim, claimRefund] — both gates use the same
+    ///      `claimed` flag. After successful refundMode finalization the user
+    ///      can claimRefund; claim() is gated by `!refundMode`, but let's
+    ///      verify the path where claim fails first then claimRefund would
+    ///      run: bundle must still revert atomically.
+    function test_exploit_claimThenRefundInBundle_revertsOnFirstGate() public {
+        _populateAndFinalizeRefundMode();
+
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, seed);
+        calls[1] = abi.encodeWithSelector(ArmadaCrowdfund.claimRefund.selector);
+
+        // Snapshot seed's USDC before the attack. The seed has unspent USDC
+        // from setUp() — we care that the BUNDLE didn't move any of it, not
+        // that the wallet is empty.
+        uint256 seedUsdcBefore = usdc.balanceOf(seed);
+
+        vm.prank(seed);
+        vm.expectRevert(bytes("ArmadaCrowdfund: sale in refund mode"));
+        crowdfund.multicall(calls);
+
+        // Neither call landed.
+        assertFalse(crowdfund.claimed(seed), "claimed flag untouched");
+        assertEq(usdc.balanceOf(seed), seedUsdcBefore, "no refund leaked");
+    }
+
+    // ==========================================================================
+    // SIGNATURE / NONCE REPLAY ATTACKS
+    // ==========================================================================
+
+    /// @dev EXPLOIT: bundle [commitWithInvite(N), commitWithInvite(N)] with the
+    ///      same nonce. usedNonces[inviter][N] check must see the flag set by
+    ///      the first call and reject the second.
+    function test_exploit_signatureReplayInBundle_atomicallyReverts() public {
+        // Set up a real signing inviter as the seed (privKey known)
+        uint256 inviterPk = 0xA11CE;
+        address inviter = vm.addr(inviterPk);
+        usdc.mint(inviter, HOP0_CAP * 2);
+
+        vm.prank(launchTeam);
+        crowdfund.addSeed(inviter);
+
+        // attacker is a fresh address that will receive the invite at hop-1.
+        usdc.mint(attacker, HOP1_CAP * 2);
+
+        // Build a valid invite signature with nonce=42, fromHop=0.
+        uint256 nonce = 42;
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 structHash = keccak256(abi.encode(
+            crowdfund.INVITE_TYPEHASH(), inviter, uint8(0), nonce, deadline
+        ));
+        bytes32 digest = _domainSeparatorV4Digest(structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(inviterPk, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        // attacker approves USDC up to two commits' worth — proves they tried to use the same nonce twice.
+        vm.prank(attacker);
+        usdc.approve(address(crowdfund), MIN_COMMIT * 2);
+
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeWithSelector(
+            ArmadaCrowdfund.commitWithInvite.selector, inviter, uint8(0), nonce, deadline, sig, MIN_COMMIT
+        );
+        calls[1] = abi.encodeWithSelector(
+            ArmadaCrowdfund.commitWithInvite.selector, inviter, uint8(0), nonce, deadline, sig, MIN_COMMIT
+        );
+
+        vm.prank(attacker);
+        vm.expectRevert(bytes("ArmadaCrowdfund: nonce already used"));
+        crowdfund.multicall(calls);
+
+        // No invite credited, no USDC moved.
+        (, uint16 ir,, , uint256 committed) = crowdfund.participants(attacker, 1);
+        assertEq(ir, 0, "no invite credited under replay attempt");
+        assertEq(committed, 0, "no commit landed under replay attempt");
+        assertEq(usdc.balanceOf(address(crowdfund)), 0, "no escrow leaked");
+    }
+
+    /// @dev EXPLOIT: bundle [revokeInviteNonce(N), commitWithInvite(N, ...)]
+    ///      using the inviter's own signature. revokeInviteNonce sets the flag;
+    ///      the bundled commitWithInvite must then revert as if the nonce were
+    ///      already used.
+    function test_exploit_revokeThenUseInBundle_atomicallyReverts() public {
+        uint256 inviterPk = 0xA11CE;
+        address inviter = vm.addr(inviterPk);
+        usdc.mint(inviter, HOP0_CAP * 2);
+        vm.prank(launchTeam);
+        crowdfund.addSeed(inviter);
+
+        uint256 nonce = 7;
+        uint256 deadline = block.timestamp + 1 days;
+        bytes32 structHash = keccak256(abi.encode(
+            crowdfund.INVITE_TYPEHASH(), inviter, uint8(0), nonce, deadline
+        ));
+        bytes32 digest = _domainSeparatorV4Digest(structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(inviterPk, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+
+        // Inviter bundles their own revoke + an attempt to use the nonce.
+        // (A real attacker would be the invitee, not the inviter — but the
+        // strongest test is to give the attacker the inviter's authority and
+        // still ensure the order-of-operations protects the nonce.)
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.revokeInviteNonce.selector, nonce);
+        calls[1] = abi.encodeWithSelector(
+            ArmadaCrowdfund.commitWithInvite.selector, inviter, uint8(0), nonce, deadline, sig, MIN_COMMIT
+        );
+
+        vm.prank(inviter);
+        usdc.approve(address(crowdfund), MIN_COMMIT);
+
+        vm.prank(inviter);
+        vm.expectRevert(bytes("ArmadaCrowdfund: nonce already used"));
+        crowdfund.multicall(calls);
+    }
+
+    // ==========================================================================
+    // PHASE-BYPASS ATTACKS
+    // The phase state machine is supposed to be irreversible. Multicall must
+    // not give a way to combine actions that span phases.
+    // ==========================================================================
+
+    /// @dev EXPLOIT: bundle [finalize, commit]. After finalize the phase moves
+    ///      to Finalized; the bundled commit must revert on phase check.
+    function test_exploit_commitAfterFinalizeInBundle_revertsAtomically() public {
+        _populateForSuccessFinalize();
+        vm.warp(crowdfund.windowEnd() + 1);
+
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.finalize.selector);
+        // Fresh whitelisted address tries to commit AFTER finalize in the same bundle.
+        calls[1] = abi.encodeWithSelector(ArmadaCrowdfund.commit.selector, uint8(0), MIN_COMMIT);
+
+        vm.prank(seed);
+        usdc.approve(address(crowdfund), MIN_COMMIT);
+        vm.prank(seed);
+        vm.expectRevert(bytes("ArmadaCrowdfund: not active"));
+        crowdfund.multicall(calls);
+
+        // Phase is unchanged — the failed finalize rolled back too.
+        assertEq(uint8(crowdfund.phase()), uint8(0), "phase must still be Active after atomic revert");
+    }
+
+    /// @dev EXPLOIT: bundle [claim, claim] BEFORE finalize. claim requires
+    ///      Phase.Finalized; both fail on the same gate. Verifies the gate is
+    ///      respected under bundling.
+    function test_exploit_claimBeforeFinalizeInBundle_revertsAtomically() public {
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, seed);
+
+        vm.prank(seed);
+        vm.expectRevert(bytes("ArmadaCrowdfund: not finalized"));
+        crowdfund.multicall(calls);
+    }
+
+    /// @dev EXPLOIT: bundle [cancel, claim]. Cancel sets phase = Canceled;
+    ///      claim requires phase == Finalized, so the bundled claim must
+    ///      revert. Whole bundle reverts atomically.
+    function test_exploit_cancelThenClaimInBundle_revertsAtomically() public {
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.cancel.selector);
+        calls[1] = abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, seed);
+
+        // SC submits the bundle.
+        vm.prank(securityCouncil);
+        vm.expectRevert(bytes("ArmadaCrowdfund: not finalized"));
+        crowdfund.multicall(calls);
+
+        // Cancel did not land — bundle was atomic.
+        assertEq(uint8(crowdfund.phase()), uint8(0), "phase must still be Active");
+    }
+
+    // ==========================================================================
+    // AUTH-BYPASS ATTACKS
+    // ==========================================================================
+
+    /// @dev EXPLOIT: attacker (non-launch-team, non-SC) tries to invoke
+    ///      every privileged function via multicall. msg.sender preservation
+    ///      under delegatecall must keep these gated.
+    function test_exploit_nonAuthCallerCantHitPrivilegedFunctionsViaMulticall() public {
+        // addSeed — onlyLaunchTeam
+        bytes[] memory calls1 = new bytes[](1);
+        calls1[0] = abi.encodeWithSelector(ArmadaCrowdfund.addSeed.selector, attacker);
+        vm.prank(attacker);
+        vm.expectRevert(bytes("ArmadaCrowdfund: not launch team"));
+        crowdfund.multicall(calls1);
+
+        // cancel — securityCouncil only
+        bytes[] memory calls2 = new bytes[](1);
+        calls2[0] = abi.encodeWithSelector(ArmadaCrowdfund.cancel.selector);
+        vm.prank(attacker);
+        vm.expectRevert(bytes("ArmadaCrowdfund: not security council"));
+        crowdfund.multicall(calls2);
+
+        // launchTeamInvite — onlyLaunchTeam
+        bytes[] memory calls3 = new bytes[](1);
+        calls3[0] = abi.encodeWithSelector(ArmadaCrowdfund.launchTeamInvite.selector, attacker, uint8(1));
+        vm.prank(attacker);
+        vm.expectRevert(bytes("ArmadaCrowdfund: not launch team"));
+        crowdfund.multicall(calls3);
+    }
+
+    /// @dev EXPLOIT: an attacker contract calls multicall on behalf of itself
+    ///      and tries to invite/commit. msg.sender becomes the contract
+    ///      address, which is not whitelisted. All entry attempts must revert.
+    function test_exploit_attackerContractCallsMulticall_revertsOnWhitelistGate() public {
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.invite.selector, attacker, uint8(0));
+
+        // attacker contract (hostile) is not on the whitelist.
+        vm.expectRevert(bytes("ArmadaCrowdfund: not whitelisted"));
+        hostile.callMulticall(calls);
+    }
+
+    // ==========================================================================
+    // INVITER-BUDGET ATTACKS
+    // ==========================================================================
+
+    /// @dev EXPLOIT: bundle 100 self-invites — way past any inviter budget.
+    ///      Must revert atomically with no state change.
+    function test_exploit_extremelyLargeBundleOverBudget_atomicallyReverts() public {
+        bytes[] memory calls = new bytes[](100);
+        for (uint256 i = 0; i < 100; i++) {
+            calls[i] = abi.encodeWithSelector(
+                ArmadaCrowdfund.invite.selector, address(uint160(0xD0000 + i)), uint8(0)
+            );
+        }
+
+        vm.prank(seed);
+        vm.expectRevert(bytes("ArmadaCrowdfund: invite limit reached"));
+        crowdfund.multicall(calls);
+
+        // No invitee was whitelisted, inviter budget intact.
+        (, , uint16 invitesSent, , ) = crowdfund.participants(seed, 0);
+        assertEq(invitesSent, 0, "no invites credited under over-budget bundle");
+    }
+
+    // ==========================================================================
+    // CAP / ACCOUNTING ATTACKS
+    // ==========================================================================
+
+    /// @dev EXPLOIT: bundle a commit at every hop without being whitelisted at
+    ///      that hop. Each commit must revert on whitelist check.
+    function test_exploit_commitAtUnwhitelistedHopInBundle_reverts() public {
+        // attacker has no whitelist anywhere.
+        vm.prank(attacker);
+        usdc.approve(address(crowdfund), MIN_COMMIT);
+
+        bytes[] memory calls = new bytes[](1);
+        calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.commit.selector, uint8(2), MIN_COMMIT);
+
+        vm.prank(attacker);
+        vm.expectRevert(bytes("ArmadaCrowdfund: not whitelisted"));
+        crowdfund.multicall(calls);
+    }
+
+    /// @dev EXPLOIT: random orderings of valid + invalid calls — fuzz attempts
+    ///      to find a sequence where partial state leaks despite a revert.
+    function testFuzz_exploit_arbitraryBundleNeverLeaksPartialState(
+        uint8 actionMask,
+        uint64 amount
+    ) public {
+        amount = uint64(bound(amount, 0, HOP0_CAP));
+        actionMask = uint8(bound(actionMask, 0, 31));
+
+        bytes[] memory calls = _buildAttackerBundle(actionMask, amount);
+        if (calls.length == 0) return;
+
+        // attacker is NOT whitelisted at any hop, so anything that mutates
+        // participant state must revert. Some calls (e.g. revokeInviteNonce)
+        // legitimately succeed even for non-whitelisted callers.
+        uint256 attackerUsdcBefore = usdc.balanceOf(attacker);
+        uint256 crowdfundUsdcBefore = usdc.balanceOf(address(crowdfund));
+
+        vm.prank(attacker);
+        usdc.approve(address(crowdfund), type(uint256).max);
+
+        vm.prank(attacker);
+        (bool ok, ) = address(crowdfund).call(
+            abi.encodeWithSelector(crowdfund.multicall.selector, calls)
+        );
+
+        if (!ok) {
+            // Bundle reverted — no state should have moved.
+            assertEq(usdc.balanceOf(attacker), attackerUsdcBefore, "attacker USDC unchanged");
+            assertEq(usdc.balanceOf(address(crowdfund)), crowdfundUsdcBefore, "contract USDC unchanged");
+            (, uint16 ir,,, uint256 committed) = crowdfund.participants(attacker, 0);
+            assertEq(ir, 0, "no hop-0 invite credited");
+            assertEq(committed, 0, "no commit landed");
+        }
+        // If ok: bundle was all-no-ops (e.g. just revokeInviteNonce with new nonces).
+        // No state invariant violated.
+    }
+
+    // ==========================================================================
+    // HELPERS
+    // ==========================================================================
+
+    function _buildAttackerBundle(uint8 mask, uint64 amount) internal view returns (bytes[] memory) {
+        uint256 count;
+        if (mask & 1 != 0) count++;
+        if (mask & 2 != 0) count++;
+        if (mask & 4 != 0) count++;
+        if (mask & 8 != 0) count++;
+        if (mask & 16 != 0) count++;
+        bytes[] memory calls = new bytes[](count);
+        uint256 idx;
+        if (mask & 1 != 0) {
+            calls[idx++] = abi.encodeWithSelector(ArmadaCrowdfund.invite.selector, seed, uint8(0));
+        }
+        if (mask & 2 != 0) {
+            calls[idx++] = abi.encodeWithSelector(ArmadaCrowdfund.commit.selector, uint8(0), uint256(amount));
+        }
+        if (mask & 4 != 0) {
+            calls[idx++] = abi.encodeWithSelector(ArmadaCrowdfund.claim.selector, attacker);
+        }
+        if (mask & 8 != 0) {
+            calls[idx++] = abi.encodeWithSelector(ArmadaCrowdfund.claimRefund.selector);
+        }
+        if (mask & 16 != 0) {
+            calls[idx++] = abi.encodeWithSelector(ArmadaCrowdfund.revokeInviteNonce.selector, uint256(1));
+        }
+        return calls;
+    }
+
+    function _populateForSuccessFinalize() internal {
+        // Used by commitAfterFinalizeInBundle: doesn't care about success vs
+        // refundMode, just needs cappedDemand ≥ MIN_SALE so finalize() doesn't
+        // revert and the bundle's commit attempt can fail on the phase check.
+        for (uint160 i = 1; i <= 67; i++) {
+            address s = address(0x100000 + i);
+            vm.prank(launchTeam);
+            crowdfund.addSeed(s);
+            usdc.mint(s, HOP0_CAP);
+            vm.prank(s);
+            usdc.approve(address(crowdfund), HOP0_CAP);
+            vm.prank(s);
+            crowdfund.commit(0, HOP0_CAP);
+        }
+    }
+
+    /// @dev Populate enough demand across all three hops to push cappedDemand
+    ///      past ELASTIC_TRIGGER ($1.5M) so finalize() expands to MAX_SALE and
+    ///      avoids the hop-0 oversub trap that would otherwise trigger
+    ///      refundMode. Composition: 100 seeds × $15k + 54 hop-1 × $4k + 54
+    ///      hop-2 × $1k = $1.77M cappedDemand → MAX_SALE; allocations land at
+    ///      $1.467M ≥ MIN_SALE → SUCCESS finalization.
+    function _populateAndFinalizeTrueSuccess() internal {
+        // Existing seed commits at hop-0.
+        vm.prank(seed);
+        usdc.approve(address(crowdfund), HOP0_CAP);
+        vm.prank(seed);
+        crowdfund.commit(0, HOP0_CAP);
+
+        // 99 more seeds + commits → 100 seeds × $15k total.
+        for (uint160 i = 1; i <= 99; i++) {
+            address s = address(0x300000 + i);
+            vm.prank(launchTeam);
+            crowdfund.addSeed(s);
+            usdc.mint(s, HOP0_CAP);
+            vm.prank(s);
+            usdc.approve(address(crowdfund), HOP0_CAP);
+            vm.prank(s);
+            crowdfund.commit(0, HOP0_CAP);
+        }
+
+        // 18 of those seeds each invite 3 hop-1 → 54 hop-1 nodes, each commits $4k.
+        // Pull the inviting seeds as the first 18 of our added-by-launchTeam set
+        // (indexes 1..18 above; address(0x300001) through address(0x300012)).
+        for (uint256 i = 1; i <= 18; i++) {
+            address inviterSeed = address(uint160(0x300000 + i));
+            for (uint256 j = 0; j < 3; j++) {
+                address h1 = address(uint160(0x400000 + (i - 1) * 3 + j));
+                vm.prank(inviterSeed);
+                crowdfund.invite(h1, 0);
+                usdc.mint(h1, HOP1_CAP);
+                vm.prank(h1);
+                usdc.approve(address(crowdfund), HOP1_CAP);
+                vm.prank(h1);
+                crowdfund.commit(1, HOP1_CAP);
+            }
+        }
+
+        // 27 of the 54 hop-1 nodes invite 2 hop-2 each → 54 hop-2 nodes, each commits $1k.
+        for (uint256 i = 0; i < 27; i++) {
+            address h1 = address(uint160(0x400000 + i));
+            for (uint256 j = 0; j < 2; j++) {
+                address h2 = address(uint160(0x500000 + i * 2 + j));
+                vm.prank(h1);
+                crowdfund.invite(h2, 1);
+                usdc.mint(h2, HOP2_CAP);
+                vm.prank(h2);
+                usdc.approve(address(crowdfund), HOP2_CAP);
+                vm.prank(h2);
+                crowdfund.commit(2, HOP2_CAP);
+            }
+        }
+
+        vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
+        require(!crowdfund.refundMode(), "helper must produce SUCCESS (not refundMode)");
+    }
+
+    function _populateAndFinalizeRefundMode() internal {
+        // Hop-0 oversub → refundMode. 67 seeds × $15k = $1.005M. Hop-0 ceiling
+        // at BASE_SALE = 70% × 95% × $1.2M = $798k. Net proceeds = $798k <
+        // $1M MIN_SALE → refundMode triggered post-allocation.
+        vm.prank(seed);
+        usdc.approve(address(crowdfund), HOP0_CAP);
+        vm.prank(seed);
+        crowdfund.commit(0, HOP0_CAP);
+        // Add 66 more committers to clear MIN_SALE at hop-0 only.
+        for (uint160 i = 1; i <= 66; i++) {
+            address s = address(0x200000 + i);
+            vm.prank(launchTeam);
+            crowdfund.addSeed(s);
+            usdc.mint(s, HOP0_CAP);
+            vm.prank(s);
+            usdc.approve(address(crowdfund), HOP0_CAP);
+            vm.prank(s);
+            crowdfund.commit(0, HOP0_CAP);
+        }
+        vm.warp(crowdfund.windowEnd() + 1);
+        crowdfund.finalize();
+        require(crowdfund.refundMode(), "helper must produce refundMode");
+    }
+
+    function _domainSeparatorV4Digest(bytes32 structHash) internal view returns (bytes32) {
+        // EIP-712 domain hash matching what _hashTypedDataV4 produces.
+        bytes32 typeHash = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+        bytes32 domainSep = keccak256(abi.encode(
+            typeHash,
+            keccak256(bytes("ArmadaCrowdfund")),
+            keccak256(bytes("1")),
+            block.chainid,
+            address(crowdfund)
+        ));
+        return keccak256(abi.encodePacked("\x19\x01", domainSep, structHash));
+    }
+}

--- a/test-foundry/CrowdfundMulticallFuzz.t.sol
+++ b/test-foundry/CrowdfundMulticallFuzz.t.sol
@@ -1,0 +1,343 @@
+// ABOUTME: Adversarial fuzz suite for the Multicall mixin added post-audit in PR #266.
+// ABOUTME: Targets msg.value replay, sequential-vs-bundled equivalence, atomicity, and lock release across random bundles.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/crowdfund/ArmadaCrowdfund.sol";
+import "../contracts/crowdfund/IArmadaCrowdfund.sol";
+import "../contracts/governance/ArmadaToken.sol";
+import "../contracts/cctp/MockUSDCV2.sol";
+
+/// @notice Post-audit fuzz coverage for the OpenZeppelin Multicall mixin on
+///         ArmadaCrowdfund. The deterministic suite (CrowdfundMulticall.t.sol)
+///         pins the obvious safety properties on a fixed self-stack bundle;
+///         this suite drives random bundle shapes against the same invariants
+///         plus several adversarial cases the deterministic tests don't cover:
+///
+///         * No msg.value replay surface — no entry point on the contract is
+///           payable, so even if a future OZ Multicall variant became payable,
+///           inner calls would refuse ETH.
+///         * Bundled execution is state-equivalent to sequential execution
+///           across random valid call sequences (the strong invariant).
+///         * Atomicity holds for adversarially-shaped bundles (over-budget
+///           invites, malformed orderings).
+///         * The nonReentrant lock truly releases between bundled calls under
+///           arbitrary bundle sizes up to a deep nesting count.
+///         * Inviter budget integrity holds when multicall packs k invites
+///           against a known cap.
+contract CrowdfundMulticallFuzzTest is Test {
+    ArmadaCrowdfund internal crowdfund;
+    MockUSDCV2 internal usdc;
+    ArmadaToken internal armToken;
+    address internal admin;
+    address internal treasury;
+    address internal launchTeam;
+    address internal seed;
+
+    uint256 constant ARM_FUNDING = 1_800_000 * 1e18;
+    uint256 constant HOP0_CAP = 15_000 * 1e6;
+    uint256 constant HOP1_CAP = 4_000 * 1e6;
+    uint256 constant HOP2_CAP = 1_000 * 1e6;
+    uint256 constant MIN_COMMIT = 10 * 1e6;
+
+    function setUp() public {
+        admin = address(this);
+        treasury = address(0xCAFE);
+        launchTeam = address(0xBEEF);
+        seed = address(0xC0FFEE);
+
+        usdc = new MockUSDCV2("Mock USDC", "USDC");
+        armToken = new ArmadaToken(admin, admin);
+        crowdfund = new ArmadaCrowdfund(
+            address(usdc), address(armToken), treasury, launchTeam, admin, block.timestamp
+        );
+
+        address[] memory wl = new address[](2);
+        wl[0] = admin;
+        wl[1] = address(crowdfund);
+        armToken.initWhitelist(wl);
+
+        armToken.transfer(address(crowdfund), ARM_FUNDING);
+        crowdfund.loadArm();
+
+        vm.prank(launchTeam);
+        crowdfund.addSeed(seed);
+
+        // Deal seed enough USDC for any commit pattern + ETH for payable-surface fuzz.
+        usdc.mint(seed, HOP0_CAP * 3);
+        vm.deal(seed, 100 ether);
+        vm.deal(address(this), 100 ether);
+    }
+
+    // ============ msg.value / payable surface ============
+
+    /// @notice WHY: The notorious Multicall pitfall (Uniswap V2 2024 incident) is
+    ///         msg.value replay across delegatecalled bundled calls when any
+    ///         bundled function is payable. ArmadaCrowdfund declares no payable
+    ///         functions. This fuzz drives a random ETH amount + random valid
+    ///         action and asserts the tx reverts atomically, leaving no ETH
+    ///         stuck on the contract and no state change.
+    function testFuzz_noPayableSurfaceUnderMulticall(uint256 ethAmount, uint8 actionPicker) public {
+        ethAmount = bound(ethAmount, 1, 100 ether);
+        actionPicker = uint8(bound(actionPicker, 0, 2));
+
+        bytes[] memory calls = new bytes[](1);
+        if (actionPicker == 0) {
+            calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.commit.selector, uint8(0), MIN_COMMIT);
+        } else if (actionPicker == 1) {
+            calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.invite.selector, seed, uint8(0));
+        } else {
+            calls[0] = abi.encodeWithSelector(ArmadaCrowdfund.loadArm.selector);
+        }
+
+        uint256 balBefore = address(crowdfund).balance;
+        vm.prank(seed);
+        (bool success,) = address(crowdfund).call{value: ethAmount}(
+            abi.encodeWithSelector(crowdfund.multicall.selector, calls)
+        );
+        assertFalse(success, "multicall with msg.value > 0 must revert (no payable surface)");
+        assertEq(address(crowdfund).balance, balBefore, "no ETH may stick on the contract");
+    }
+
+    /// @notice WHY: Belt-and-suspenders direct probe. Even without going through
+    ///         multicall, the contract must refuse plain ETH sends — confirming
+    ///         no fallback / receive() snuck in via an OZ inheritance path.
+    function testFuzz_noPayableSurfaceDirect(uint256 ethAmount) public {
+        ethAmount = bound(ethAmount, 1, 100 ether);
+        (bool success,) = address(crowdfund).call{value: ethAmount}("");
+        assertFalse(success, "direct ETH send must revert");
+        assertEq(address(crowdfund).balance, 0, "contract must hold zero ETH");
+    }
+
+    // ============ Sequential ↔ multicall equivalence ============
+
+    /// @notice WHY: The strongest safety property — bundled execution must be
+    ///         observably identical to running the same calls one-by-one as
+    ///         separate txs. If this holds across random valid bundles, no
+    ///         hidden state divergence is introduced by the delegatecall path.
+    ///         Snapshot-then-revert lets us run both modes against an identical
+    ///         baseline and compare the resulting state fingerprint.
+    function testFuzz_multicallEquivalentToSequential(
+        uint8 nHop1Invites,
+        uint8 nHop2Invites,
+        uint64 commitH0Amount,
+        uint64 commitH1Amount,
+        uint64 commitH2Amount
+    ) public {
+        // Bound to legal ranges: hop-0 inviter has budget = 1 × maxInvites(0) = 3,
+        // so at most 3 hop-1 invites. Each hop-1 node lets 2 hop-2 invites.
+        nHop1Invites = uint8(bound(nHop1Invites, 0, 3));
+        uint256 hop2Budget = nHop1Invites == 0 ? 0 : 2 * uint256(nHop1Invites);
+        nHop2Invites = uint8(bound(nHop2Invites, 0, hop2Budget));
+
+        // Commit amounts: 0 (skip) or in [MIN_COMMIT, cap×stacks]. 0 means
+        // "no commit at this hop" — encoded by leaving the call out below.
+        commitH0Amount = uint64(bound(commitH0Amount, 0, HOP0_CAP));
+        uint256 h1Cap = HOP1_CAP * uint256(nHop1Invites);
+        commitH1Amount = uint64(bound(commitH1Amount, 0, h1Cap));
+        uint256 h2Cap = HOP2_CAP * uint256(nHop2Invites);
+        commitH2Amount = uint64(bound(commitH2Amount, 0, h2Cap));
+
+        // Skip degenerate runs where every input is below MIN_COMMIT — nothing
+        // would happen and the equivalence claim is vacuous.
+        vm.assume(commitH0Amount >= MIN_COMMIT || commitH1Amount >= MIN_COMMIT || commitH2Amount >= MIN_COMMIT
+            || nHop1Invites > 0);
+
+        bytes[] memory calls = _buildBundle(
+            nHop1Invites,
+            nHop2Invites,
+            commitH0Amount >= MIN_COMMIT ? commitH0Amount : 0,
+            commitH1Amount >= MIN_COMMIT ? commitH1Amount : 0,
+            commitH2Amount >= MIN_COMMIT ? commitH2Amount : 0
+        );
+        if (calls.length == 0) return;
+
+        // --- Run sequential ---
+        uint256 baseline = vm.snapshot();
+        bool sequentialReverted = !_runSequential(calls);
+        bytes32 sequentialHash = sequentialReverted ? bytes32(0) : _fingerprintState();
+
+        // --- Reset, run multicall ---
+        vm.revertTo(baseline);
+        bool multicallReverted = !_runMulticall(calls);
+        bytes32 multicallHash = multicallReverted ? bytes32(0) : _fingerprintState();
+
+        assertEq(sequentialReverted, multicallReverted, "revert parity must hold");
+        assertEq(sequentialHash, multicallHash, "post-state must match");
+    }
+
+    // ============ Adversarial bundles ============
+
+    /// @notice WHY: Multicall must atomically roll back any partial state when
+    ///         a bundled invite exceeds the inviter's effective budget. Tests
+    ///         the boundary at k ∈ [4, 30] — anything ≥ 4 must revert since
+    ///         hop-0 budget is 1 × maxInvites=3.
+    function testFuzz_multicallOverInviteBudgetIsAtomic(uint8 k) public {
+        k = uint8(bound(k, 4, 30));
+        bytes[] memory calls = new bytes[](k);
+        for (uint256 i = 0; i < k; i++) {
+            calls[i] = abi.encodeWithSelector(
+                ArmadaCrowdfund.invite.selector, address(uint160(0x10000 + i)), uint8(0)
+            );
+        }
+
+        vm.prank(seed);
+        vm.expectRevert(bytes("ArmadaCrowdfund: invite limit reached"));
+        crowdfund.multicall(calls);
+
+        // No partial state: none of the would-be invitees are whitelisted.
+        for (uint256 i = 0; i < k; i++) {
+            address invitee = address(uint160(0x10000 + i));
+            (, uint16 ir,,,) = crowdfund.participants(invitee, 1);
+            assertEq(ir, 0, "no partial invite state must persist after revert");
+        }
+        // Inviter's invitesSent must also be 0 — must not have leaked through the revert.
+        (, , uint16 invitesSent, , ) = crowdfund.participants(seed, 0);
+        assertEq(invitesSent, 0, "inviter invitesSent must reset to 0 after atomic revert");
+    }
+
+    // ============ nonReentrant lock release ============
+
+    /// @notice WHY: OZ Multicall delegate-calls each item sequentially. The
+    ///         nonReentrant guard acquired by call N must release before call
+    ///         N+1 enters. A regression where the guard nests instead of
+    ///         sequences would show up as the second commit reverting with
+    ///         "ReentrancyGuard: reentrant call". Fuzz the bundle size up to
+    ///         N=50 to exercise large bundles a real frontend would never
+    ///         emit but a malicious caller might.
+    function testFuzz_nonReentrantReleasesAcrossN(uint8 n) public {
+        n = uint8(bound(n, 2, 50));
+
+        // Pre-fund + approve for n commits of MIN_COMMIT to hop-0.
+        usdc.mint(seed, MIN_COMMIT * uint256(n));
+        vm.prank(seed);
+        usdc.approve(address(crowdfund), type(uint256).max);
+
+        bytes[] memory calls = new bytes[](n);
+        for (uint256 i = 0; i < n; i++) {
+            calls[i] = abi.encodeWithSelector(
+                ArmadaCrowdfund.commit.selector, uint8(0), MIN_COMMIT
+            );
+        }
+
+        vm.prank(seed);
+        crowdfund.multicall(calls);
+
+        (,,,, uint256 committed) = crowdfund.participants(seed, 0);
+        assertEq(committed, MIN_COMMIT * uint256(n), "all n commits must accumulate");
+    }
+
+    // ============ Inviter budget integrity ============
+
+    /// @notice WHY: At the legal boundary — k = budget — every invite must
+    ///         land. At k = budget + 1, the bundle must atomically revert.
+    ///         Fuzz this exactly at and around the boundary to catch any
+    ///         off-by-one introduced by the bundled execution path.
+    function testFuzz_inviterBudgetExactBoundary(uint8 k) public {
+        k = uint8(bound(k, 1, 6));
+        bytes[] memory calls = new bytes[](k);
+        for (uint256 i = 0; i < k; i++) {
+            calls[i] = abi.encodeWithSelector(
+                ArmadaCrowdfund.invite.selector, address(uint160(0x20000 + i)), uint8(0)
+            );
+        }
+
+        if (k <= 3) {
+            vm.prank(seed);
+            crowdfund.multicall(calls);
+            (, , uint16 invitesSent, , ) = crowdfund.participants(seed, 0);
+            assertEq(invitesSent, k, "invitesSent must equal k when within budget");
+            for (uint256 i = 0; i < k; i++) {
+                address invitee = address(uint160(0x20000 + i));
+                (, uint16 ir,,,) = crowdfund.participants(invitee, 1);
+                assertEq(ir, 1, "each invitee must be whitelisted at hop-1");
+            }
+        } else {
+            vm.prank(seed);
+            vm.expectRevert(bytes("ArmadaCrowdfund: invite limit reached"));
+            crowdfund.multicall(calls);
+        }
+    }
+
+    // ============ Helpers ============
+
+    /// @dev Build the calldata bundle in canonical order: hop-1 self-invites,
+    ///      then hop-2 self-invites (each from a hop-1 node — but the seed
+    ///      has only ONE hop-1 invitesReceived slot per self-invite, so each
+    ///      hop-2 invite uses `fromHop=1`), then commits at each hop.
+    function _buildBundle(
+        uint8 nHop1,
+        uint8 nHop2,
+        uint64 commitH0,
+        uint64 commitH1,
+        uint64 commitH2
+    ) internal pure returns (bytes[] memory calls) {
+        uint256 total = uint256(nHop1) + uint256(nHop2);
+        if (commitH0 > 0) total++;
+        if (commitH1 > 0) total++;
+        if (commitH2 > 0) total++;
+        calls = new bytes[](total);
+        uint256 idx;
+        for (uint256 i = 0; i < nHop1; i++) {
+            calls[idx++] = abi.encodeWithSelector(ArmadaCrowdfund.invite.selector, _self(), uint8(0));
+        }
+        for (uint256 i = 0; i < nHop2; i++) {
+            calls[idx++] = abi.encodeWithSelector(ArmadaCrowdfund.invite.selector, _self(), uint8(1));
+        }
+        if (commitH0 > 0) {
+            calls[idx++] = abi.encodeWithSelector(ArmadaCrowdfund.commit.selector, uint8(0), uint256(commitH0));
+        }
+        if (commitH1 > 0) {
+            calls[idx++] = abi.encodeWithSelector(ArmadaCrowdfund.commit.selector, uint8(1), uint256(commitH1));
+        }
+        if (commitH2 > 0) {
+            calls[idx++] = abi.encodeWithSelector(ArmadaCrowdfund.commit.selector, uint8(2), uint256(commitH2));
+        }
+    }
+
+    function _self() internal pure returns (address) {
+        return address(0xC0FFEE); // matches `seed` set in setUp()
+    }
+
+    function _runSequential(bytes[] memory calls) internal returns (bool ok) {
+        vm.prank(seed);
+        usdc.approve(address(crowdfund), type(uint256).max);
+        for (uint256 i = 0; i < calls.length; i++) {
+            vm.prank(seed);
+            (bool callOk,) = address(crowdfund).call(calls[i]);
+            if (!callOk) return false;
+        }
+        return true;
+    }
+
+    function _runMulticall(bytes[] memory calls) internal returns (bool ok) {
+        vm.prank(seed);
+        usdc.approve(address(crowdfund), type(uint256).max);
+        vm.prank(seed);
+        (bool callOk,) = address(crowdfund).call(
+            abi.encodeWithSelector(crowdfund.multicall.selector, calls)
+        );
+        return callOk;
+    }
+
+    /// @dev Fingerprint the state that participants observe — accounting + graph.
+    function _fingerprintState() internal view returns (bytes32) {
+        bytes32 h0 = _fingerprintHop(0);
+        bytes32 h1 = _fingerprintHop(1);
+        bytes32 h2 = _fingerprintHop(2);
+        return keccak256(abi.encode(
+            h0, h1, h2,
+            crowdfund.totalCommitted(),
+            crowdfund.getParticipantCount(),
+            usdc.balanceOf(address(crowdfund)),
+            usdc.balanceOf(seed)
+        ));
+    }
+
+    function _fingerprintHop(uint8 hop) internal view returns (bytes32) {
+        (, uint16 ir, uint16 isent, , uint256 c) = crowdfund.participants(seed, hop);
+        return keccak256(abi.encode(hop, ir, isent, c));
+    }
+}

--- a/test/crowdfund_multicall_live_exploits.ts
+++ b/test/crowdfund_multicall_live_exploits.ts
@@ -1,0 +1,460 @@
+// ABOUTME: Live-network exploit verification script for ArmadaCrowdfund's Multicall surface — phase-agnostic.
+// ABOUTME: Runs against any deployment (local Anvil or Sepolia) — verifies attacker-class exploits all revert on the live bytecode.
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { expect } from "chai";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import hre, { ethers, network } from "hardhat";
+import type { Signer } from "ethers";
+
+/**
+ * Resolve the crowdfund contract address for the connected network.
+ *
+ * Local (`hub`)        → deployments/crowdfund-hub.json
+ * Sepolia (`sepoliaHub`) → deployments/crowdfund-hub-sepolia.json
+ * Override via env     → CROWDFUND_CONTRACT_ADDRESS
+ *
+ * The latter is useful for re-pointing the script at a redeploy without
+ * having to update the manifest first.
+ */
+function resolveCrowdfundAddress(): string {
+  const envOverride = process.env.CROWDFUND_CONTRACT_ADDRESS;
+  if (envOverride) return envOverride;
+
+  const manifestName =
+    network.name === "sepoliaHub" || network.name === "sepolia"
+      ? "crowdfund-hub-sepolia.json"
+      : "crowdfund-hub.json";
+  const manifestPath = join(__dirname, "..", "deployments", manifestName);
+  if (!existsSync(manifestPath)) {
+    throw new Error(
+      `No deployment manifest at ${manifestPath}. Set CROWDFUND_CONTRACT_ADDRESS or run npm run setup first.`,
+    );
+  }
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+    contracts?: { crowdfund?: string };
+  };
+  const address = manifest.contracts?.crowdfund;
+  if (!address) {
+    throw new Error(`Manifest ${manifestName} missing contracts.crowdfund`);
+  }
+  return address;
+}
+
+/**
+ * Resolve an attacker signer.
+ *
+ * On local networks (Hardhat / Anvil) we use a high-index default signer so
+ * we don't collide with deployer/launchTeam/etc. On Sepolia and other public
+ * networks the only signer the runtime configures is the deployer key from
+ * config/secrets.env — that's NOT an attacker — so we require an explicit
+ * CROWDFUND_ATTACKER_PRIVATE_KEY env var pointing at a separate funded EOA.
+ */
+async function resolveAttacker(): Promise<Signer> {
+  const envKey = process.env.CROWDFUND_ATTACKER_PRIVATE_KEY;
+  if (envKey) {
+    return new ethers.Wallet(envKey, ethers.provider);
+  }
+  if (network.name === "hub" || network.name === "hardhat" || network.name === "localhost") {
+    const signers = await ethers.getSigners();
+    if (signers.length < 20) {
+      throw new Error(
+        `Local network exposed only ${signers.length} signers; expected ≥ 20 to pick a non-conflict attacker index.`,
+      );
+    }
+    return signers[19];
+  }
+  throw new Error(
+    `Live network ${network.name} requires CROWDFUND_ATTACKER_PRIVATE_KEY (funded EOA distinct from deployer).`,
+  );
+}
+
+/**
+ * Probe whether the deployed contract has the Multicall mixin compiled in.
+ * Useful because the *current* Sepolia deployment (block 10892680) does NOT
+ * have Multicall — the upgraded version landing via #325 will. This lets the
+ * test suite emit a friendly skip rather than throwing an opaque selector
+ * decode error.
+ */
+async function contractHasMulticall(address: string): Promise<boolean> {
+  // multicall(bytes[]) selector under the standard OZ shape is 0xac9650d8.
+  // We probe by calling it with an empty array — it must return without
+  // reverting on a Multicall-equipped contract, and revert (no such function)
+  // on a contract without it.
+  try {
+    const tx = await ethers.provider.call({
+      to: address,
+      data: "0xac9650d8" + "0000000000000000000000000000000000000000000000000000000000000020"
+        + "0000000000000000000000000000000000000000000000000000000000000000",
+    });
+    return tx !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+describe("Crowdfund Multicall — live-network exploit verification", function () {
+  // Real network calls can be slow; bump timeout generously for Sepolia.
+  this.timeout(120_000);
+
+  let crowdfundAddress: string;
+  let crowdfund: any;
+  let attacker: Signer;
+  let attackerAddress: string;
+  let hasMulticall: boolean;
+
+  before(async function () {
+    crowdfundAddress = resolveCrowdfundAddress();
+    attacker = await resolveAttacker();
+    attackerAddress = await attacker.getAddress();
+
+    const ArmadaCrowdfund = await ethers.getContractFactory("ArmadaCrowdfund");
+    crowdfund = ArmadaCrowdfund.attach(crowdfundAddress).connect(attacker);
+
+    hasMulticall = await contractHasMulticall(crowdfundAddress);
+
+    // eslint-disable-next-line no-console
+    console.log(`\n  network=${network.name}`);
+    // eslint-disable-next-line no-console
+    console.log(`  crowdfund=${crowdfundAddress}`);
+    // eslint-disable-next-line no-console
+    console.log(`  attacker=${attackerAddress}`);
+    // eslint-disable-next-line no-console
+    console.log(`  multicall_present=${hasMulticall}\n`);
+  });
+
+  // ==========================================================================
+  // PAYABLE SURFACE
+  // Run on every network. msg.value replay (the Uniswap V2 2024 class) is
+  // structurally impossible if no entry point is payable.
+  // ==========================================================================
+
+  it("[direct] sending ETH to the contract reverts; no ETH stuck", async function () {
+    const balBefore = await ethers.provider.getBalance(crowdfundAddress);
+    await expect(
+      attacker.sendTransaction({ to: crowdfundAddress, value: 1n }),
+    ).to.be.reverted;
+    const balAfter = await ethers.provider.getBalance(crowdfundAddress);
+    expect(balAfter).to.equal(balBefore);
+  });
+
+  it("[multicall] sending ETH alongside a bundled call reverts; no ETH stuck", async function () {
+    if (!hasMulticall) {
+      this.skip();
+      return;
+    }
+    const balBefore = await ethers.provider.getBalance(crowdfundAddress);
+    // Build a bundle containing a single benign-but-revertible call
+    // (commit at hop-0 by a non-whitelisted attacker — would revert anyway,
+    // but we want the OUTER multicall to reject the ETH first).
+    const iface = crowdfund.interface;
+    const calls = [iface.encodeFunctionData("commit", [0, 10_000_000n])];
+    await expect(
+      attacker.sendTransaction({
+        to: crowdfundAddress,
+        value: 1n,
+        data: iface.encodeFunctionData("multicall", [calls]),
+      }),
+    ).to.be.reverted;
+    const balAfter = await ethers.provider.getBalance(crowdfundAddress);
+    expect(balAfter).to.equal(balBefore);
+  });
+
+  // ==========================================================================
+  // AUTH BYPASS via Multicall
+  // msg.sender preservation under delegatecall — attacker is not whitelisted,
+  // not launch team, not security council. Every privileged path must remain
+  // gated even when wrapped in multicall.
+  // ==========================================================================
+
+  it("[multicall] non-launchTeam attacker cannot addSeed via multicall", async function () {
+    if (!hasMulticall) {
+      this.skip();
+      return;
+    }
+    const iface = crowdfund.interface;
+    const calls = [iface.encodeFunctionData("addSeed", [attackerAddress])];
+    await expect(crowdfund.multicall(calls)).to.be.revertedWith(
+      "ArmadaCrowdfund: not launch team",
+    );
+  });
+
+  it("[multicall] non-securityCouncil attacker cannot cancel via multicall", async function () {
+    if (!hasMulticall) {
+      this.skip();
+      return;
+    }
+    const iface = crowdfund.interface;
+    const calls = [iface.encodeFunctionData("cancel", [])];
+    await expect(crowdfund.multicall(calls)).to.be.revertedWith(
+      "ArmadaCrowdfund: not security council",
+    );
+  });
+
+  it("[multicall] non-launchTeam attacker cannot launchTeamInvite via multicall", async function () {
+    if (!hasMulticall) {
+      this.skip();
+      return;
+    }
+    const iface = crowdfund.interface;
+    const calls = [iface.encodeFunctionData("launchTeamInvite", [attackerAddress, 1])];
+    await expect(crowdfund.multicall(calls)).to.be.revertedWith(
+      "ArmadaCrowdfund: not launch team",
+    );
+  });
+
+  it("[multicall] attacker cannot invite from a hop where they're not whitelisted", async function () {
+    if (!hasMulticall) {
+      this.skip();
+      return;
+    }
+    // If attacker is a hop-0 seed they CAN invite via inviterHop=0; the
+    // unauthorized case is inviterHop=1 (or 2) where they have no node.
+    const iface = crowdfund.interface;
+    const calls = [iface.encodeFunctionData("invite", [attackerAddress, 1])];
+    await expect(crowdfund.multicall(calls)).to.be.reverted;
+  });
+
+  it("[multicall] attacker cannot commit at a hop where they're not whitelisted", async function () {
+    if (!hasMulticall) {
+      this.skip();
+      return;
+    }
+    // Attacker is whitelisted at hop-0 (seed); hop-1/2 must still reject.
+    const iface = crowdfund.interface;
+    const calls = [iface.encodeFunctionData("commit", [1, 10_000_000n])];
+    await expect(crowdfund.multicall(calls)).to.be.reverted;
+  });
+
+  // ==========================================================================
+  // BUNDLED AUTH BYPASS — privileged + non-privileged in same bundle
+  // Catches a hypothetical regression where a non-privileged call wrapping a
+  // privileged call somehow swaps msg.sender mid-bundle.
+  // ==========================================================================
+
+  it("[multicall] bundle [addSeed(freshAddr), invite(freshAddr)] fully reverts; no whitelist landed", async function () {
+    if (!hasMulticall) {
+      this.skip();
+      return;
+    }
+    // Use a fresh address (not the attacker, who may already be a seed) so
+    // the "no whitelist landed" assertion is unambiguous about whether the
+    // failed addSeed leaked any state. Lowercase hex — ethers v6 rejects
+    // mixed-case literals that don't satisfy EIP-55 checksum.
+    const freshAddr = "0xdead000000000000000000000000000000000001";
+    const beforeParticipant = await crowdfund.participants(freshAddr, 0);
+
+    const iface = crowdfund.interface;
+    const calls = [
+      iface.encodeFunctionData("addSeed", [freshAddr]),
+      iface.encodeFunctionData("invite", [freshAddr, 0]),
+    ];
+    await expect(crowdfund.multicall(calls)).to.be.reverted;
+
+    const afterParticipant = await crowdfund.participants(freshAddr, 0);
+    expect(afterParticipant.isWhitelisted).to.equal(beforeParticipant.isWhitelisted);
+    expect(afterParticipant.committed).to.equal(beforeParticipant.committed);
+  });
+
+  // ==========================================================================
+  // EMPTY-BUNDLE NO-OP
+  // multicall([]) must complete without state change and without crashing.
+  // ==========================================================================
+
+  it("[multicall] empty bundle succeeds and changes no participant state", async function () {
+    if (!hasMulticall) {
+      this.skip();
+      return;
+    }
+    const beforeParticipant = await crowdfund.participants(attackerAddress, 0);
+    const beforeCount = await crowdfund.getParticipantCount();
+    await crowdfund.multicall([]);
+    const afterParticipant = await crowdfund.participants(attackerAddress, 0);
+    const afterCount = await crowdfund.getParticipantCount();
+
+    expect(afterParticipant.isWhitelisted).to.equal(beforeParticipant.isWhitelisted);
+    expect(afterParticipant.committed).to.equal(beforeParticipant.committed);
+    expect(afterCount).to.equal(beforeCount);
+  });
+
+  // ==========================================================================
+  // BUNDLE OF MIXED REVERTING CALLS — atomicity sentinel
+  // Mixed sequence of operations all of which should revert, verifying the
+  // whole bundle rolls back and the contract state is observably unchanged.
+  // ==========================================================================
+
+  it("[multicall] mixed-revert bundle leaves no observable state delta", async function () {
+    if (!hasMulticall) {
+      this.skip();
+      return;
+    }
+    const totalCommittedBefore = await crowdfund.totalCommitted();
+    const participantCountBefore = await crowdfund.getParticipantCount();
+
+    const iface = crowdfund.interface;
+    const calls = [
+      iface.encodeFunctionData("invite", [attackerAddress, 1]),   // hop-1 not whitelisted → revert
+      iface.encodeFunctionData("commit", [1, 1n]),                 // hop-1 not whitelisted → revert
+      iface.encodeFunctionData("claim", [attackerAddress]),       // not finalized → revert
+      iface.encodeFunctionData("claimRefund", []),                // not refundable → revert
+    ];
+    await expect(crowdfund.multicall(calls)).to.be.reverted;
+
+    expect(await crowdfund.totalCommitted()).to.equal(totalCommittedBefore);
+    expect(await crowdfund.getParticipantCount()).to.equal(participantCountBefore);
+  });
+
+  // ==========================================================================
+  // STATE-DEPENDENT EXPLOITS (require attacker to be a participant)
+  // The previous block ran from an unprivileged EOA. These exercise the
+  // bundle-attack surface that opens once the attacker is whitelisted — the
+  // most realistic adversarial scenarios for a launched crowdfund.
+  // ==========================================================================
+
+  it("[multicall] inviter bundles 4+ self-invites; revert atomic on budget overflow", async function () {
+    if (!hasMulticall) {
+      this.skip();
+      return;
+    }
+    const participant = await crowdfund.participants(attackerAddress, 0);
+    if (!participant.isWhitelisted) {
+      // eslint-disable-next-line no-console
+      console.log("    SKIP: attacker not whitelisted at hop-0 — coordinate with launchTeam to addSeed(attacker)");
+      this.skip();
+      return;
+    }
+    // For hop-0 seeds budget is 1 × maxInvites=3 = 3. Already-consumed slots
+    // (invitesSent) eat into that. Build a bundle just past whatever's left.
+    const invitesSent = Number(participant.invitesSent);
+    const remaining = 3 - invitesSent;
+    if (remaining <= 0) {
+      // eslint-disable-next-line no-console
+      console.log(`    NOTE: attacker has 0 budget left (invitesSent=${invitesSent}); single invite alone would revert`);
+    }
+    const bundleSize = remaining + 1; // exactly one over remaining
+
+    const iface = crowdfund.interface;
+    const calls: string[] = [];
+    for (let i = 0; i < bundleSize; i++) {
+      // Deterministic fresh hop-1 addresses derived from attacker + index.
+      const fresh = ethers.getAddress(
+        "0xdea1000000000000000000000000000000" + (i + 1).toString(16).padStart(6, "0"),
+      );
+      calls.push(iface.encodeFunctionData("invite", [fresh, 0]));
+    }
+
+    await expect(crowdfund.multicall(calls)).to.be.revertedWith(
+      "ArmadaCrowdfund: invite limit reached",
+    );
+
+    // Atomic: invitesSent did not change; none of the fresh invitees were whitelisted.
+    const after = await crowdfund.participants(attackerAddress, 0);
+    expect(after.invitesSent).to.equal(participant.invitesSent);
+    for (let i = 0; i < bundleSize; i++) {
+      const fresh = ethers.getAddress(
+        "0xdea1000000000000000000000000000000" + (i + 1).toString(16).padStart(6, "0"),
+      );
+      const inviteeParticipant = await crowdfund.participants(fresh, 1);
+      expect(inviteeParticipant.isWhitelisted).to.equal(false);
+    }
+  });
+
+  it("[multicall] signature replay in bundle reverts on nonce check; no commit landed", async function () {
+    if (!hasMulticall) {
+      this.skip();
+      return;
+    }
+    const participant = await crowdfund.participants(attackerAddress, 0);
+    if (!participant.isWhitelisted) {
+      // eslint-disable-next-line no-console
+      console.log("    SKIP: attacker not whitelisted at hop-0");
+      this.skip();
+      return;
+    }
+
+    const MIN_COMMIT = 10n * 10n ** 6n; // 10 USDC
+
+    // Find the USDC token from the contract (no env coupling).
+    const usdcAddress = await crowdfund.usdc();
+    const usdcAbi = [
+      "function balanceOf(address) view returns (uint256)",
+      "function approve(address spender, uint256 amount) returns (bool)",
+      "function allowance(address owner, address spender) view returns (uint256)",
+    ];
+    const usdcContract = new ethers.Contract(usdcAddress, usdcAbi, attacker);
+
+    const usdcBalance = await usdcContract.balanceOf(attackerAddress);
+    if (usdcBalance < MIN_COMMIT) {
+      // eslint-disable-next-line no-console
+      console.log(`    SKIP: attacker has ${usdcBalance} raw USDC, need >= ${MIN_COMMIT} (10 USDC)`);
+      this.skip();
+      return;
+    }
+
+    // EIP-712 invite signature (the attacker invites themselves at hop-0
+    // → would land as a hop-1 stack on the attacker if the multicall didn't
+    // revert. Note that msg.sender is the invitee per commitWithInvite — so
+    // bundling against the same nonce twice is a clean signature-replay
+    // attempt from a single tx).
+    const domain = {
+      name: "ArmadaCrowdfund",
+      version: "1",
+      chainId: 11155111,
+      verifyingContract: crowdfundAddress,
+    };
+    const types = {
+      Invite: [
+        { name: "inviter", type: "address" },
+        { name: "fromHop", type: "uint8" },
+        { name: "nonce", type: "uint256" },
+        { name: "deadline", type: "uint256" },
+      ],
+    };
+    const nonce = BigInt(Math.floor(Math.random() * 1e9)) + 1n;
+    const latestBlock = await ethers.provider.getBlock("latest");
+    const deadline = BigInt(latestBlock!.timestamp) + 3600n;
+    const sig = await (attacker as any).signTypedData(domain, types, {
+      inviter: attackerAddress,
+      fromHop: 0,
+      nonce,
+      deadline,
+    });
+
+    // Approve USDC for the would-be transfer (atomicity means it won't actually move).
+    // Public Sepolia RPCs are load-balanced and can race on mempool propagation —
+    // earlier tests in this suite broadcast revert probes via chai's `revertedWith`,
+    // and the approve sometimes lands on a cluster node that still sees the prior tx
+    // as pending, producing "replacement transaction underpriced". Wait briefly for
+    // propagation, then explicit-nonce + bumped gas to win any replacement contest.
+    await new Promise((r) => setTimeout(r, 4000));
+    const pendingNonce = await ethers.provider.getTransactionCount(attackerAddress, "pending");
+    const approveTx = await usdcContract.approve(crowdfundAddress, MIN_COMMIT * 2n, {
+      nonce: pendingNonce,
+      maxFeePerGas: ethers.parseUnits("30", "gwei"),
+      maxPriorityFeePerGas: ethers.parseUnits("3", "gwei"),
+    });
+    await approveTx.wait();
+
+    const balanceBefore = await usdcContract.balanceOf(attackerAddress);
+    const usedBefore = await crowdfund.usedNonces(attackerAddress, nonce);
+    expect(usedBefore).to.equal(false);
+
+    const iface = crowdfund.interface;
+    const callOne = iface.encodeFunctionData("commitWithInvite", [
+      attackerAddress, 0, nonce, deadline, sig, MIN_COMMIT,
+    ]);
+    const calls = [callOne, callOne]; // same nonce twice
+
+    await expect(crowdfund.multicall(calls)).to.be.revertedWith(
+      "ArmadaCrowdfund: nonce already used",
+    );
+
+    // Atomic: nonce flag unchanged, USDC balance unchanged.
+    const usedAfter = await crowdfund.usedNonces(attackerAddress, nonce);
+    expect(usedAfter).to.equal(false);
+    const balanceAfter = await usdcContract.balanceOf(attackerAddress);
+    expect(balanceAfter).to.equal(balanceBefore);
+  });
+});


### PR DESCRIPTION
Stacked on top of #325 — adds adversarial fuzz + exploit suite + a live-network pen-test script as belt-and-suspenders post-audit coverage for the Multicall mixin.

## Three artifacts

| File | Purpose | Result |
|---|---|---|
| `test-foundry/CrowdfundMulticallFuzz.t.sol` | 6 fuzz properties, 10k runs each | 60,000 inputs / 0 counter-examples |
| `test-foundry/CrowdfundMulticallExploits.t.sol` | 13 named adversarial exploit attempts | All atomically revert as expected |
| `test/crowdfund_multicall_live_exploits.ts` | Hardhat integration script — runs same class of exploits against the **deployed Sepolia bytecode** | **12/12 pass on live Sepolia** |

## Live-network pen test ran against the upgraded Sepolia contract

`0xc85b43bd4ebe3d10C7a42AD2176580c57436921e` (deployBlock 11016090). Attacker EOA `0x99455bf42783d80168BDfE63C75DD5FccbbEF9C9` with 0.5 ETH + 20 USDC, registered as a hop-0 seed for the state-dependent tests.

```
network=sepoliaHub
crowdfund=0xc85b43bd4ebe3d10C7a42AD2176580c57436921e
multicall_present=true

  ✔ [direct] sending ETH to the contract reverts; no ETH stuck
  ✔ [multicall] sending ETH alongside a bundled call reverts; no ETH stuck
  ✔ [multicall] non-launchTeam attacker cannot addSeed via multicall
  ✔ [multicall] non-securityCouncil attacker cannot cancel via multicall
  ✔ [multicall] non-launchTeam attacker cannot launchTeamInvite via multicall
  ✔ [multicall] attacker cannot invite from a hop where they're not whitelisted
  ✔ [multicall] attacker cannot commit at a hop where they're not whitelisted
  ✔ [multicall] bundle [addSeed(freshAddr), invite(freshAddr)] fully reverts; no whitelist landed
  ✔ [multicall] empty bundle succeeds and changes no participant state
  ✔ [multicall] mixed-revert bundle leaves no observable state delta
  ✔ [multicall] inviter bundles 4+ self-invites; revert atomic on budget overflow
  ✔ [multicall] signature replay in bundle reverts on nonce check; no commit landed

  12 passing
```

The signature-replay test is the most adversarial — attacker signed a real EIP-712 invite, approved real USDC, bundled two `commitWithInvite(nonce=N)` calls in one tx. Contract rejected the second on the nonce check and atomically rolled back: `usedNonces[attacker][N]` stayed `false` and the USDC balance was unchanged on-chain.

## Coverage matrix relative to #325

| Property | This PR's parent #325 | This PR |
|---|---|---|
| Multicall vs direct, single call | `testFuzz_Multicall_OneCall_MatchesDirectCall` | — |
| Multi-call bundle equivalence (state fingerprint) | — | `testFuzz_multicallEquivalentToSequential` |
| No payable surface (build-time invariant) | self-verified in PR body | `testFuzz_noPayableSurfaceUnderMulticall` + direct fuzz |
| nonReentrant lock release across N | `test_Multicall_BundledNonReentrantSiblings_Succeed` (N=2) | `testFuzz_nonReentrantReleasesAcrossN` (N ∈ [2,50]) |
| Inviter budget atomicity | `test_Multicall_InviteeStackingCap_Reverts` (single case) | randomized boundary + over-budget fuzz |
| Live-network exploit verification | — | 12 exploits against deployed Sepolia bytecode |

## Why this rounds out the post-audit safety case

1. **The strong equivalence invariant holds across randomized bundles** — bundled execution is state-identical to sequential. Audit conclusions about sequential calls transfer.
2. **`msg.value` replay is structurally eliminated** — confirmed by build-time invariant in #325 + runtime fuzz here + runtime check against the live contract.
3. **Atomicity, sender preservation, lock release, and budget integrity** are tested deterministically (in #325), under 60k randomized inputs (here), AND end-to-end against the live deployed contract.
4. **Regression sentinels are in place** — any future change that adds a payable function, breaks bundled-equivalent-to-sequential, or breaks budget atomicity will trip these tests in CI.
5. **A real attacker scenario was run against the live contract** with the right shape (whitelisted seed, real signature, real USDC) and rejected cleanly.

## Test plan

- [x] `forge test --offline` — 749/749 pass across 58 contracts
- [x] `forge test --offline --match-contract CrowdfundMulticallFuzzTest --fuzz-runs 10000` — 6/6 pass, 60k adversarial inputs total, 0 counter-examples
- [x] `forge test --offline --match-contract CrowdfundMulticallExploitsTest` — 13/13 pass
- [x] `set -a && . config/secrets.env && set +a && npx hardhat test --network sepoliaHub test/crowdfund_multicall_live_exploits.ts` against live Sepolia — 12/12 pass

cc @iskay