### PR TITLE
Crowdfund indexer hardening: correctness, security, performance, reliability

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -28,7 +28,7 @@ fi
 # --- Check 3: .env file leak prevention ---
 # Only non-secret environment templates and committed public config envs are allowed.
 # All other .env files should be gitignored, but check as a safety net.
-ALLOWED_ENV_FILES="config/local.env config/sepolia.env config/secrets.env.template sample.env.dev sample.env.production"
+ALLOWED_ENV_FILES="config/local.env config/sepolia.env config/secrets.env.template sample.env.dev sample.env.production deploy/indexer.env.template"
 ENV_VIOLATIONS=""
 for f in $STAGED_FILES; do
   if [[ "$f" == *.env || "$f" == *.env.* ]]; then

--- a/crowdfund-ui/.dockerignore
+++ b/crowdfund-ui/.dockerignore
@@ -1,0 +1,11 @@
+# ABOUTME: Trims the crowdfund-ui Docker build context for the indexer image.
+# ABOUTME: Only packages/indexer and packages/shared source are needed.
+**/node_modules
+**/data
+**/dist
+packages/observer
+packages/committer
+packages/admin
+**/*.test.ts
+**/vitest.config.ts
+.git

--- a/crowdfund-ui/packages/indexer/package.json
+++ b/crowdfund-ui/packages/indexer/package.json
@@ -6,14 +6,13 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "dev": "node --no-warnings --loader ts-node/esm src/api/server.ts",
-    "cli": "node --no-warnings --loader ts-node/esm src/cli/index.ts",
+    "dev": "tsx src/api/server.ts",
+    "cli": "tsx src/cli/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@armada/crowdfund-shared": "*",
     "@aws-sdk/client-s3": "^3.1038.0",
     "ethers": "^6.15.0",
     "express": "^5.2.1",
@@ -23,7 +22,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^22.15.0",
     "@types/pg": "^8.20.0",
-    "ts-node": "^10.9.2",
+    "tsx": "^4.20.6",
     "typescript": "~5.9.3",
     "vitest": "^4.0.8"
   }

--- a/crowdfund-ui/packages/indexer/src/alerts/chainState.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/chainState.ts
@@ -9,6 +9,8 @@ export interface ChainStateReader {
   readFinalizedAt(): Promise<number>
   /** Treasury USDC balance in 6-decimal units. */
   readTreasuryUsdcBalance(): Promise<bigint>
+  /** Releases the underlying provider so a one-shot CLI process can exit promptly. */
+  close?(): void
 }
 
 export interface ChainStateOptions {
@@ -33,6 +35,9 @@ export function createRpcChainStateReader(options: ChainStateOptions): ChainStat
     },
     async readTreasuryUsdcBalance() {
       return await usdc.balanceOf(options.treasuryAddress)
+    },
+    close() {
+      provider.destroy()
     },
   }
 }

--- a/crowdfund-ui/packages/indexer/src/alerts/evaluator.test.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/evaluator.test.ts
@@ -1,9 +1,9 @@
 // ABOUTME: Unit tests for the alert evaluator — dispatch, dedupe, state persistence.
 // ABOUTME: Uses in-memory notifier and state store; no external IO.
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { evaluateAndDispatch } from './evaluator.js'
-import { createInMemoryNotifier } from './notifier.js'
+import { createInMemoryNotifier, type Notifier } from './notifier.js'
 import { createInMemoryAlertStateStore } from './state.js'
 import type { AlertContext, AlertEvent } from './types.js'
 
@@ -83,6 +83,39 @@ describe('evaluateAndDispatch', () => {
     })
     expect(second.delivered).toHaveLength(1)
     expect(second.delivered[0].dedupeKey).toBe('A4:100')
+  })
+
+  it('survives a mid-loop delivery failure and re-attempts only the failed alert', async () => {
+    const sampleA4: AlertEvent = { id: 'A4', severity: 'P2', dedupeKey: 'A4:80', title: 't', body: 'b', runbook: 'r' }
+    const delivered: string[] = []
+    // Notifier that throws for A11 only; succeeds for everything else.
+    let failA11 = true
+    const notifier: Notifier = {
+      async send(event) {
+        if (event.dedupeKey === 'A11' && failA11) throw new Error('Discord webhook P0 returned 503: unavailable')
+        delivered.push(event.dedupeKey)
+      },
+    }
+    const state = createInMemoryAlertStateStore()
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    try {
+      const evaluate = () => [SAMPLE_A1, SAMPLE_A11, sampleA4]
+      const first = await evaluateAndDispatch({ context: MINIMAL_CTX, notifier, stateStore: state, evaluate })
+
+      expect(first.delivered.map((e) => e.dedupeKey)).toEqual(['A1', 'A4:80'])
+      expect(first.failed.map((e) => e.dedupeKey)).toEqual(['A11'])
+      // The two successes were persisted despite A11 throwing in between them.
+      expect(Array.from((await state.read()).firedKeys).sort()).toEqual(['A1', 'A4:80'])
+
+      // Next tick with a healthy webhook re-attempts only the previously-failed A11.
+      failA11 = false
+      const second = await evaluateAndDispatch({ context: MINIMAL_CTX, notifier, stateStore: state, evaluate })
+      expect(second.delivered.map((e) => e.dedupeKey)).toEqual(['A11'])
+      expect(second.skipped.map((e) => e.dedupeKey)).toEqual(['A1', 'A4:80'])
+      expect(second.failed).toEqual([])
+    } finally {
+      stderrSpy.mockRestore()
+    }
   })
 
   it('persists state only when delivering at least one alert', async () => {

--- a/crowdfund-ui/packages/indexer/src/alerts/evaluator.test.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/evaluator.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it, vi } from 'vitest'
 import { evaluateAndDispatch } from './evaluator.js'
-import { createInMemoryNotifier, type Notifier } from './notifier.js'
+import { createInMemoryNotifier, NoWebhookConfiguredError, type Notifier } from './notifier.js'
 import { createInMemoryAlertStateStore } from './state.js'
 import type { AlertContext, AlertEvent } from './types.js'
 
@@ -116,6 +116,30 @@ describe('evaluateAndDispatch', () => {
     } finally {
       stderrSpy.mockRestore()
     }
+  })
+
+  it('does not dedupe an alert whose severity has no webhook, so it delivers once configured', async () => {
+    const state = createInMemoryAlertStateStore()
+    const evaluate = () => [SAMPLE_A1]
+    let hasWebhook = false
+    const notifier: Notifier = {
+      async send(event) {
+        if (!hasWebhook) throw new NoWebhookConfiguredError(`no webhook configured for severity ${event.severity}`)
+      },
+    }
+
+    const first = await evaluateAndDispatch({ context: MINIMAL_CTX, notifier, stateStore: state, evaluate })
+    expect(first.undelivered.map((e) => e.id)).toEqual(['A1'])
+    expect(first.delivered).toEqual([])
+    expect(first.failed).toEqual([])
+    // Crucially: not recorded as fired, so a missing webhook never silently consumes it.
+    expect(Array.from((await state.read()).firedKeys)).toEqual([])
+
+    // Once a webhook exists, the same still-true alert delivers on the next tick.
+    hasWebhook = true
+    const second = await evaluateAndDispatch({ context: MINIMAL_CTX, notifier, stateStore: state, evaluate })
+    expect(second.delivered.map((e) => e.id)).toEqual(['A1'])
+    expect(Array.from((await state.read()).firedKeys)).toEqual(['A1'])
   })
 
   it('persists state only when delivering at least one alert', async () => {

--- a/crowdfund-ui/packages/indexer/src/alerts/evaluator.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/evaluator.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Orchestrator — runs all alert rules, dispatches new alerts, persists fired-key state.
 // ABOUTME: Pure of side effects other than the injected notifier and state store.
 
+import { sanitizeErrorMessage } from '../ingest/errors.js'
 import { evaluateAllRules } from './rules.js'
 import type { Notifier } from './notifier.js'
 import type { AlertStateStore } from './state.js'
@@ -10,6 +11,8 @@ export interface EvaluatorResult {
   total: number
   delivered: AlertEvent[]
   skipped: AlertEvent[]
+  /** Candidates whose delivery threw (e.g. webhook outage); retried next tick. */
+  failed: AlertEvent[]
 }
 
 export interface EvaluateInput {
@@ -27,20 +30,29 @@ export async function evaluateAndDispatch(input: EvaluateInput): Promise<Evaluat
   const fired = new Set(state.firedKeys)
   const delivered: AlertEvent[] = []
   const skipped: AlertEvent[] = []
+  const failed: AlertEvent[] = []
 
   for (const event of candidates) {
     if (fired.has(event.dedupeKey)) {
       skipped.push(event)
       continue
     }
-    await input.notifier.send(event)
+    try {
+      await input.notifier.send(event)
+    } catch (err) {
+      // A single webhook failure must not abandon the remaining alerts nor lose the
+      // dedupe state for those already delivered this tick. Record and continue.
+      const message = sanitizeErrorMessage(err instanceof Error ? err.message : String(err))
+      process.stderr.write(`[alerts] delivery failed for ${event.id} (${event.dedupeKey}): ${message}\n`)
+      failed.push(event)
+      continue
+    }
     fired.add(event.dedupeKey)
     delivered.push(event)
-  }
-
-  if (delivered.length > 0) {
+    // Persist after every successful send so a later failure in this loop cannot cause
+    // an already-delivered alert to re-fire on the next tick.
     await input.stateStore.write({ firedKeys: fired })
   }
 
-  return { total: candidates.length, delivered, skipped }
+  return { total: candidates.length, delivered, skipped, failed }
 }

--- a/crowdfund-ui/packages/indexer/src/alerts/evaluator.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/evaluator.ts
@@ -3,7 +3,7 @@
 
 import { sanitizeErrorMessage } from '../ingest/errors.js'
 import { evaluateAllRules } from './rules.js'
-import type { Notifier } from './notifier.js'
+import { NoWebhookConfiguredError, type Notifier } from './notifier.js'
 import type { AlertStateStore } from './state.js'
 import type { AlertContext, AlertEvent } from './types.js'
 
@@ -13,6 +13,9 @@ export interface EvaluatorResult {
   skipped: AlertEvent[]
   /** Candidates whose delivery threw (e.g. webhook outage); retried next tick. */
   failed: AlertEvent[]
+  /** Candidates with no configured channel for their severity; not deduped, so they
+   *  deliver once a webhook is configured rather than being silently consumed. */
+  undelivered: AlertEvent[]
 }
 
 export interface EvaluateInput {
@@ -31,6 +34,7 @@ export async function evaluateAndDispatch(input: EvaluateInput): Promise<Evaluat
   const delivered: AlertEvent[] = []
   const skipped: AlertEvent[] = []
   const failed: AlertEvent[] = []
+  const undelivered: AlertEvent[] = []
 
   for (const event of candidates) {
     if (fired.has(event.dedupeKey)) {
@@ -40,6 +44,12 @@ export async function evaluateAndDispatch(input: EvaluateInput): Promise<Evaluat
     try {
       await input.notifier.send(event)
     } catch (err) {
+      if (err instanceof NoWebhookConfiguredError) {
+        // No channel for this severity: leave the alert undeduped so it delivers once
+        // a webhook is configured, rather than being silently consumed. Not a failure.
+        undelivered.push(event)
+        continue
+      }
       // A single webhook failure must not abandon the remaining alerts nor lose the
       // dedupe state for those already delivered this tick. Record and continue.
       const message = sanitizeErrorMessage(err instanceof Error ? err.message : String(err))
@@ -54,5 +64,5 @@ export async function evaluateAndDispatch(input: EvaluateInput): Promise<Evaluat
     await input.stateStore.write({ firedKeys: fired })
   }
 
-  return { total: candidates.length, delivered, skipped, failed }
+  return { total: candidates.length, delivered, skipped, failed, undelivered }
 }

--- a/crowdfund-ui/packages/indexer/src/alerts/notifier.test.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/notifier.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Stubs fetch to verify routing per severity and payload shape.
 
 import { describe, expect, it } from 'vitest'
-import { createDiscordNotifier } from './notifier.js'
+import { createDiscordNotifier, NoWebhookConfiguredError } from './notifier.js'
 import type { AlertEvent } from './types.js'
 
 function buildEvent(severity: AlertEvent['severity']): AlertEvent {
@@ -53,13 +53,13 @@ describe('Discord notifier', () => {
     expect(seenSignal).toBeInstanceOf(AbortSignal)
   })
 
-  it('skips delivery when severity has no webhook', async () => {
+  it('throws NoWebhookConfiguredError (does not silently drop) when severity has no webhook', async () => {
     let called = false
     const notifier = createDiscordNotifier({
       webhooks: { P0: 'https://discord.test/p0' },
       fetchImpl: (async () => { called = true; return new Response() }) as unknown as typeof fetch,
     })
-    await notifier.send(buildEvent('P2'))
+    await expect(notifier.send(buildEvent('P2'))).rejects.toBeInstanceOf(NoWebhookConfiguredError)
     expect(called).toBe(false)
   })
 

--- a/crowdfund-ui/packages/indexer/src/alerts/notifier.test.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/notifier.test.ts
@@ -39,6 +39,20 @@ describe('Discord notifier', () => {
     expect(payload.content).toContain('OPERATIONS.md §7')
   })
 
+  it('passes an abort signal so a hung webhook cannot stall forever', async () => {
+    let seenSignal: AbortSignal | null | undefined
+    const fetchImpl = async (_url: string | URL | Request, init?: RequestInit) => {
+      seenSignal = init?.signal
+      return new Response(null, { status: 204 })
+    }
+    const notifier = createDiscordNotifier({
+      webhooks: { P0: 'https://discord.test/p0' },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+    await notifier.send(buildEvent('P0'))
+    expect(seenSignal).toBeInstanceOf(AbortSignal)
+  })
+
   it('skips delivery when severity has no webhook', async () => {
     let called = false
     const notifier = createDiscordNotifier({

--- a/crowdfund-ui/packages/indexer/src/alerts/notifier.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/notifier.ts
@@ -3,6 +3,13 @@
 
 import type { AlertEvent, Severity } from './types.js'
 
+/**
+ * Thrown when an alert's severity has no configured channel. Distinct from a
+ * delivery failure so the evaluator can leave the alert undeduped (to deliver once
+ * a webhook is configured) rather than treating a config gap as a transient error.
+ */
+export class NoWebhookConfiguredError extends Error {}
+
 export interface Notifier {
   send(event: AlertEvent): Promise<void>
 }
@@ -38,8 +45,7 @@ export function createDiscordNotifier(config: DiscordWebhookConfig): Notifier {
     async send(event) {
       const url = config.webhooks[event.severity]
       if (!url) {
-        process.stderr.write(`[alerts] no webhook configured for severity ${event.severity}; skipping ${event.id}\n`)
-        return
+        throw new NoWebhookConfiguredError(`no webhook configured for severity ${event.severity}`)
       }
       const mention = config.mentions?.[event.severity]
       const res = await doFetch(url, {

--- a/crowdfund-ui/packages/indexer/src/alerts/notifier.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/notifier.ts
@@ -46,6 +46,8 @@ export function createDiscordNotifier(config: DiscordWebhookConfig): Notifier {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(formatPayload(event, mention)),
+        // Bound the request so one hung webhook cannot stall the whole evaluation tick.
+        signal: AbortSignal.timeout(10_000),
       })
       if (!res.ok) {
         const text = await res.text().catch(() => '')

--- a/crowdfund-ui/packages/indexer/src/alerts/rules.test.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/rules.test.ts
@@ -5,10 +5,12 @@ import { describe, expect, it } from 'vitest'
 import {
   ruleA1, ruleA2, ruleA3, ruleA4, ruleA5, ruleA6, ruleA7, ruleA8,
   ruleA9a, ruleA9b, ruleA10, ruleA11, ruleA12, ruleA13, ruleA17, ruleA18, ruleA19, ruleA20,
+  ruleAH1, ruleAH2,
   evaluateAllRules,
 } from './rules.js'
 import { ALERT_THRESHOLD_DEFAULTS } from './thresholds.js'
 import type { AlertContext, CrowdfundParams } from './types.js'
+import type { IndexerHealth, IndexerHealthStatus } from '../types.js'
 import type { CrowdfundEvent } from '../../../shared/src/lib/events.js'
 import type { AddressSummary, CrowdfundGraph, GraphEdge, GraphNode } from '../../../shared/src/lib/graph.js'
 
@@ -431,6 +433,66 @@ describe('time-gated rules', () => {
       } as never,
     })
     expect(ruleA20(ctx)[0]).toMatchObject({ id: 'A20' })
+  })
+})
+
+// ============ Health gating + AH1/AH2 ============
+function makeHealth(status: IndexerHealthStatus, overrides: Partial<IndexerHealth> = {}): IndexerHealth {
+  return {
+    status,
+    chainHead: 0, confirmedHead: 0, ingestedCursor: 0, verifiedCursor: 0, lagBlocks: 0,
+    lastIngestedAt: null, lastVerifiedAt: null, lastReconciledAt: null,
+    hasGaps: false, gapRanges: [], gapsRequiringIntervention: [],
+    lastError: null, latestSnapshotHash: null, latestStaticSnapshotUrl: null,
+    ...overrides,
+  }
+}
+
+describe('health gating of time-based rules', () => {
+  it('suppresses A2/A8/A9a/A9b when the indexer is unhealthy', () => {
+    const past = COMMIT_TS + 1
+    const ctx = makeContext({ now: past, health: makeHealth('unhealthy') })
+    expect(ruleA2(ctx)).toEqual([])
+    expect(ruleA8(ctx)).toEqual([])
+    expect(ruleA9a(ctx)).toEqual([])
+    expect(ruleA9b(ctx)).toEqual([])
+  })
+
+  it('suppresses A2 when the indexer is stale but fires it when healthy', () => {
+    expect(ruleA2(makeContext({ now: OPEN_TS + 1, health: makeHealth('stale') }))).toEqual([])
+    expect(ruleA2(makeContext({ now: OPEN_TS + 1, health: makeHealth('healthy') }))[0]).toMatchObject({ id: 'A2' })
+  })
+})
+
+describe('ruleAH1 — indexer health', () => {
+  it('fires P1 with a date-bucketed dedupe key when unhealthy', () => {
+    const ctx = makeContext({ health: makeHealth('unhealthy', { lastError: 'network: fetch failed' }) })
+    const out = ruleAH1(ctx)
+    expect(out[0]).toMatchObject({ id: 'AH1', severity: 'P1' })
+    expect(out[0].dedupeKey).toMatch(/^AH1:unhealthy:\d{4}-\d{2}-\d{2}$/)
+  })
+  it('fires P2 when stale', () => {
+    expect(ruleAH1(makeContext({ health: makeHealth('stale') }))[0]).toMatchObject({ id: 'AH1', severity: 'P2' })
+  })
+  it('does not fire when healthy or degraded', () => {
+    expect(ruleAH1(makeContext({ health: makeHealth('healthy') }))).toEqual([])
+    expect(ruleAH1(makeContext({ health: makeHealth('degraded') }))).toEqual([])
+  })
+})
+
+describe('ruleAH2 — gaps requiring intervention', () => {
+  it('fires P1 with the exhausted ranges in the dedupe key', () => {
+    const ctx = makeContext({
+      health: makeHealth('unhealthy', {
+        gapsRequiringIntervention: [{ fromBlock: 100, toBlock: 199 }, { fromBlock: 300, toBlock: 399 }],
+      }),
+    })
+    const out = ruleAH2(ctx)
+    expect(out[0]).toMatchObject({ id: 'AH2', severity: 'P1' })
+    expect(out[0].dedupeKey).toBe('AH2:100-199,300-399')
+  })
+  it('does not fire when there are no exhausted gaps', () => {
+    expect(ruleAH2(makeContext({ health: makeHealth('degraded') }))).toEqual([])
   })
 })
 

--- a/crowdfund-ui/packages/indexer/src/alerts/rules.test.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/rules.test.ts
@@ -208,7 +208,8 @@ describe('ruleA6 — duplicate same-hop slots', () => {
     }
     const graph: CrowdfundGraph = { ...emptyGraph(), nodes }
     const out = ruleA6(makeContext({ snapshot: { ...makeContext().snapshot, graph } as never }))
-    expect(out[0]).toMatchObject({ id: 'A6', severity: 'P2' })
+    // 3/10 = 30% → bucketed to the 30% band (not the raw percent).
+    expect(out[0]).toMatchObject({ id: 'A6', severity: 'P2', dedupeKey: 'A6:30' })
   })
   it('does not fire below threshold', () => {
     const nodes = new Map<string, GraphNode>()

--- a/crowdfund-ui/packages/indexer/src/alerts/rules.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/rules.ts
@@ -205,10 +205,13 @@ export const ruleA6: AlertRule = (ctx) => {
   const duplicates = duplicateSlotNodeCount(ctx.snapshot.graph)
   const ratio = duplicates / occupied
   if (ratio < ctx.thresholds.duplicateSlotFraction) return []
+  // Bucket the ratio into 10-point bands so a fluctuating ratio fires once per band
+  // rather than once per whole-percent (which produced up to ~100 distinct alerts).
+  const bucket = Math.floor((ratio * 100) / 10) * 10
   return [{
     id: 'A6',
     severity: 'P2',
-    dedupeKey: `A6:${Math.round(ratio * 100)}`,
+    dedupeKey: `A6:${bucket}`,
     title: `Duplicate same-hop slot ratio ${(ratio * 100).toFixed(1)}%`,
     body: `${duplicates}/${occupied} hop-1+hop-2 nodes have multiple slots. Intentional under the design; this is an awareness alert (see MONITORING.md §9.1).`,
     runbook: 'OPERATIONS.md §4/§5 monitoring; no automatic intervention',
@@ -351,6 +354,12 @@ export const ruleA12: AlertRule = (ctx) => {
 // participantNodes.length (NOT × NUM_HOPS as the spec text claims — see contract
 // line 511). Treasury balance increase must equal netProceeds within that
 // buffer; anything more is a real mismatch.
+//
+// LIMITATION: ctx.treasuryUsdcBalance is the treasury's CURRENT balance, not its balance
+// at the finalization block. A pre-existing balance, or any treasury inflow/outflow after
+// finalization, will skew the comparison and can produce a false positive. Properly fixing
+// this needs a balance-at-finalization-block read; until then the alert body tells the
+// responder to verify against the finalization-block balance before escalating.
 export const ruleA13: AlertRule = (ctx) => {
   const f = findLatestEvent(ctx.snapshot.events, 'Finalized')
   if (!f) return []
@@ -367,7 +376,7 @@ export const ruleA13: AlertRule = (ctx) => {
     severity: 'P0',
     dedupeKey: 'A13',
     title: 'Treasury proceeds mismatch',
-    body: `Treasury USDC balance=${ctx.treasuryUsdcBalance.toString()} vs Finalized.netProceeds=${netProceeds.toString()}; diff=${diff.toString()} exceeds rounding buffer ${participantNodes.toString()}.`,
+    body: `Treasury USDC balance=${ctx.treasuryUsdcBalance.toString()} vs Finalized.netProceeds=${netProceeds.toString()}; diff=${diff.toString()} exceeds rounding buffer ${participantNodes.toString()}. NOTE: this compares the treasury's CURRENT balance, not its balance at the finalization block — a pre-existing balance or later treasury movement can cause a false positive. Verify against the finalization-block balance before escalating.`,
     runbook: 'OPERATIONS.md §8 proceeds verification',
     context: {
       treasuryUsdcBalance: ctx.treasuryUsdcBalance.toString(),

--- a/crowdfund-ui/packages/indexer/src/alerts/rules.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/rules.ts
@@ -70,6 +70,22 @@ function severityForBudget(crossedTier: number): 'P1' | 'P2' {
   return crossedTier >= 100 ? 'P1' : 'P2'
 }
 
+// Time-vs-event rules compare wall-clock `now` against *indexed* events. When the
+// indexer is stale or unhealthy the snapshot may be missing recent events, so those
+// rules would fire false positives (e.g. "finalize required" because the Finalized
+// event has not been ingested yet). Suppress them in that case; AH1 separately pages
+// that the indexer itself is degraded.
+function isSnapshotTrustworthy(ctx: AlertContext): boolean {
+  return ctx.health.status !== 'unhealthy' && ctx.health.status !== 'stale'
+}
+
+// UTC calendar-day bucket (YYYY-MM-DD) derived from the injected clock. Used in
+// health-alert dedupe keys so a persistent outage re-pages once per day rather than on
+// every cron tick (dedupe keys persist forever with no resolve/re-arm mechanism).
+function utcDateBucket(nowSeconds: number): string {
+  return new Date(nowSeconds * 1000).toISOString().slice(0, 10)
+}
+
 // ============ Rule implementations ============
 
 // A1 — ARM loaded (P3, once)
@@ -88,6 +104,7 @@ export const ruleA1: AlertRule = (ctx) => {
 
 // A2 — Sale should be open but not yet armed (P1)
 export const ruleA2: AlertRule = (ctx) => {
+  if (!isSnapshotTrustworthy(ctx)) return []
   if (ctx.now < ctx.params.openTimestamp) return []
   const armed = eventsOfType(ctx.snapshot.events, 'ArmLoaded').length > 0
   if (armed) return []
@@ -220,6 +237,7 @@ export const ruleA7: AlertRule = (ctx) => {
 
 // A8 — Minimum raise at risk late in sale (P2)
 export const ruleA8: AlertRule = (ctx) => {
+  if (!isSnapshotTrustworthy(ctx)) return []
   const capped = cappedDemandTotal(ctx.snapshot.graph)
   if (capped >= CROWDFUND_CONSTANTS.MIN_SALE) return []
   const remaining = ctx.params.commitmentDeadline - ctx.now
@@ -243,6 +261,7 @@ export const ruleA8: AlertRule = (ctx) => {
 
 // A9a — Deadline passed, qualified, finalization needed (P1 → P0 after grace)
 export const ruleA9a: AlertRule = (ctx) => {
+  if (!isSnapshotTrustworthy(ctx)) return []
   if (ctx.now <= ctx.params.commitmentDeadline) return []
   const finalized = eventsOfType(ctx.snapshot.events, 'Finalized').length > 0
   const cancelled = eventsOfType(ctx.snapshot.events, 'Cancelled').length > 0
@@ -264,6 +283,7 @@ export const ruleA9a: AlertRule = (ctx) => {
 
 // A9b — Deadline passed, sub-minimum demand (P1)
 export const ruleA9b: AlertRule = (ctx) => {
+  if (!isSnapshotTrustworthy(ctx)) return []
   if (ctx.now <= ctx.params.commitmentDeadline) return []
   const finalized = eventsOfType(ctx.snapshot.events, 'Finalized').length > 0
   const cancelled = eventsOfType(ctx.snapshot.events, 'Cancelled').length > 0
@@ -455,6 +475,45 @@ export const ruleA20: AlertRule = (ctx) => {
   }]
 }
 
+// AH1 — Indexer health degraded (unhealthy → P1, stale → P2)
+//
+// Fires when the indexer can no longer be trusted to reflect chain state. The dedupe
+// key is bucketed by UTC day so a sustained outage re-pages once per day; a single
+// cron tick never double-fires.
+export const ruleAH1: AlertRule = (ctx) => {
+  const status = ctx.health.status
+  if (status !== 'unhealthy' && status !== 'stale') return []
+  const severity: 'P1' | 'P2' = status === 'unhealthy' ? 'P1' : 'P2'
+  return [{
+    id: 'AH1',
+    severity,
+    dedupeKey: `AH1:${status}:${utcDateBucket(ctx.now)}`,
+    title: `Indexer health ${status}`,
+    body: `Indexer status is ${status} (verifiedCursor=${ctx.health.verifiedCursor}, lagBlocks=${ctx.health.lagBlocks}, lastError=${ctx.health.lastError ?? 'none'}). Frontends are serving the last verified snapshot; time-based alerts are suppressed until it recovers.`,
+    runbook: 'CROWDFUND_INDEXER_RUNBOOK.md health triage',
+    context: { status, lagBlocks: ctx.health.lagBlocks, verifiedCursor: ctx.health.verifiedCursor },
+  }]
+}
+
+// AH2 — Indexer gaps require operator intervention (P0/manual) — P1
+//
+// Fires when auto-repair has exhausted its attempt limit on one or more ranges. The
+// dedupe key includes the formatted range list so a newly-exhausted gap re-pages.
+export const ruleAH2: AlertRule = (ctx) => {
+  const gaps = ctx.health.gapsRequiringIntervention
+  if (!gaps || gaps.length === 0) return []
+  const ranges = gaps.map((g) => `${g.fromBlock}-${g.toBlock}`).join(',')
+  return [{
+    id: 'AH2',
+    severity: 'P1',
+    dedupeKey: `AH2:${ranges}`,
+    title: 'Indexer gaps require operator intervention',
+    body: `${gaps.length} block range(s) have exhausted auto-repair and need manual repair: ${ranges}. Run: npm run crowdfund:indexer:cli -- repair`,
+    runbook: 'CROWDFUND_INDEXER_RUNBOOK.md gap repair',
+    context: { ranges, count: gaps.length },
+  }]
+}
+
 export const ALL_RULES: ReadonlyArray<{ id: string; rule: AlertRule }> = [
   { id: 'A1', rule: ruleA1 },
   { id: 'A2', rule: ruleA2 },
@@ -474,6 +533,8 @@ export const ALL_RULES: ReadonlyArray<{ id: string; rule: AlertRule }> = [
   { id: 'A18', rule: ruleA18 },
   { id: 'A19', rule: ruleA19 },
   { id: 'A20', rule: ruleA20 },
+  { id: 'AH1', rule: ruleAH1 },
+  { id: 'AH2', rule: ruleAH2 },
 ]
 
 export function evaluateAllRules(ctx: AlertContext): AlertEvent[] {

--- a/crowdfund-ui/packages/indexer/src/alerts/runner.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/runner.ts
@@ -21,6 +21,8 @@ export interface RunAlertsOnceInput {
   /** Used to read finalizedAt and treasury USDC balance. Optional — null when offline. */
   chainState: ChainStateReader | null
   notifier: Notifier
+  /** Wall-clock staleness budget (ms) for health classification; defaults to 5 minutes. */
+  staleAfterMs?: number
   /** Test seam — defaults to `() => Math.floor(Date.now() / 1000)`. */
   nowSeconds?: () => number
 }
@@ -45,6 +47,7 @@ export async function runAlertsOnce(input: RunAlertsOnceInput): Promise<Evaluato
     lastError: data.lastError,
     latestSnapshotHash: data.latestSnapshotHash,
     latestStaticSnapshotUrl: data.latestStaticSnapshotUrl,
+    staleAfterMs: input.staleAfterMs,
   })
 
   let finalizedAt: number | null = null

--- a/crowdfund-ui/packages/indexer/src/alerts/runner.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/runner.ts
@@ -28,25 +28,26 @@ export interface RunAlertsOnceInput {
 }
 
 export async function runAlertsOnce(input: RunAlertsOnceInput): Promise<EvaluatorResult> {
-  const data = await input.store.read()
+  const meta = await input.store.readMeta()
+  const rawLogs = await input.store.readLogs(meta.cursor.verifiedCursor)
   const now = input.nowSeconds ? input.nowSeconds() : Math.floor(Date.now() / 1000)
 
   const snapshot = buildSnapshot({
-    data,
+    data: { ...meta, rawLogs },
     chainId: input.params.chainId,
     contractAddress: input.params.contractAddress,
   })
 
   const health = buildHealth({
-    cursor: data.cursor,
-    gapRanges: getRepairRanges(data.ranges),
-    gapsRequiringIntervention: getExhaustedRepairRanges(data.ranges, input.repairMaxAttempts),
-    lastIngestedAt: data.lastIngestedAt,
-    lastVerifiedAt: data.lastVerifiedAt,
-    lastReconciledAt: data.lastReconciledAt,
-    lastError: data.lastError,
-    latestSnapshotHash: data.latestSnapshotHash,
-    latestStaticSnapshotUrl: data.latestStaticSnapshotUrl,
+    cursor: meta.cursor,
+    gapRanges: getRepairRanges(meta.ranges),
+    gapsRequiringIntervention: getExhaustedRepairRanges(meta.ranges, input.repairMaxAttempts),
+    lastIngestedAt: meta.lastIngestedAt,
+    lastVerifiedAt: meta.lastVerifiedAt,
+    lastReconciledAt: meta.lastReconciledAt,
+    lastError: meta.lastError,
+    latestSnapshotHash: meta.latestSnapshotHash,
+    latestStaticSnapshotUrl: meta.latestStaticSnapshotUrl,
     staleAfterMs: input.staleAfterMs,
   })
 

--- a/crowdfund-ui/packages/indexer/src/alerts/state.test.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/state.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Unit tests for alert-state persistence — file roundtrip + missing-file behavior.
 // ABOUTME: Uses a tmp directory; cleans up between tests.
 
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -32,5 +32,16 @@ describe('createFileAlertStateStore', () => {
     await store.write({ firedKeys: new Set(['A11', 'A1', 'A4:80']) })
     const reread = await store.read()
     expect(Array.from(reread.firedKeys).sort()).toEqual(['A1', 'A11', 'A4:80'])
+  })
+
+  it('overwrites prior state cleanly (atomic replace, no leftover temp file)', async () => {
+    const path = join(dir, 'state.json')
+    const store = createFileAlertStateStore(path)
+    await store.write({ firedKeys: new Set(['A1']) })
+    await store.write({ firedKeys: new Set(['A2']) })
+    const reread = await store.read()
+    expect(Array.from(reread.firedKeys)).toEqual(['A2'])
+    // The atomic write must not leave its temp file behind.
+    expect(readdirSync(dir).filter((f) => f.includes('.tmp'))).toEqual([])
   })
 })

--- a/crowdfund-ui/packages/indexer/src/alerts/state.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/state.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Persisted "already fired" alert dedupe state, stored as JSON next to the indexer store.
 // ABOUTME: Keeps a Set of dedupeKey strings; missing file is treated as empty.
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 
 export interface AlertState {
@@ -34,7 +34,11 @@ export function createFileAlertStateStore(filePath: string): AlertStateStore {
     async write(state) {
       const persisted: PersistedShape = { firedKeys: Array.from(state.firedKeys).sort() }
       await mkdir(dirname(filePath), { recursive: true })
-      await writeFile(filePath, JSON.stringify(persisted, null, 2) + '\n', 'utf8')
+      // Atomic write (tmp + rename) so a crash mid-write cannot corrupt the dedupe
+      // state and cause every alert to re-fire on the next tick.
+      const tmpPath = `${filePath}.${process.pid}.tmp`
+      await writeFile(tmpPath, JSON.stringify(persisted, null, 2) + '\n', 'utf8')
+      await rename(tmpPath, filePath)
     },
   }
 }

--- a/crowdfund-ui/packages/indexer/src/alerts/types.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/types.ts
@@ -3,10 +3,14 @@
 
 import type { CrowdfundSnapshot, IndexerHealth } from '../types.js'
 
-/** Alert identifier matching MONITORING.md §8 (A1–A20). */
+/**
+ * Alert identifier matching MONITORING.md §8 (A1–A20). AH1/AH2 are indexer-health
+ * alerts added by the hardening work (MONITORING.md §8 addendum).
+ */
 export type AlertId =
   | 'A1' | 'A2' | 'A3' | 'A4' | 'A5' | 'A6' | 'A7' | 'A8'
   | 'A9a' | 'A9b' | 'A10' | 'A11' | 'A12' | 'A13' | 'A17' | 'A18' | 'A19' | 'A20'
+  | 'AH1' | 'AH2'
 
 /** Severity class per MONITORING.md §4. */
 export type Severity = 'P0' | 'P1' | 'P2' | 'P3'

--- a/crowdfund-ui/packages/indexer/src/api/health.test.ts
+++ b/crowdfund-ui/packages/indexer/src/api/health.test.ts
@@ -99,6 +99,74 @@ describe('buildHealth', () => {
     expect(health.gapsRequiringIntervention).toEqual([{ fromBlock: 120, toBlock: 125 }])
   })
 
+  it('stays healthy when verification is recent and cursors are at the confirmed head', () => {
+    const now = () => new Date('2026-06-15T12:05:00.000Z')
+    const health = buildHealth({
+      cursor,
+      gapRanges: [],
+      lastIngestedAt: '2026-06-15T12:04:30.000Z',
+      lastVerifiedAt: '2026-06-15T12:04:30.000Z',
+      lastReconciledAt: null,
+      lastError: null,
+      latestSnapshotHash: null,
+      latestStaticSnapshotUrl: null,
+      staleAfterMs: 300_000,
+      now,
+    })
+    expect(health.status).toBe('healthy')
+  })
+
+  it('reports unhealthy when verification is stale by wall-clock and an error is pending', () => {
+    const now = () => new Date('2026-06-15T12:15:00.000Z')
+    const health = buildHealth({
+      cursor,
+      gapRanges: [],
+      lastIngestedAt: '2026-06-15T12:04:00.000Z',
+      lastVerifiedAt: '2026-06-15T12:04:00.000Z',
+      lastReconciledAt: null,
+      lastError: 'network: fetch failed',
+      latestSnapshotHash: null,
+      latestStaticSnapshotUrl: null,
+      staleAfterMs: 300_000,
+      now,
+    })
+    expect(health.status).toBe('unhealthy')
+  })
+
+  it('reports stale when verification is stale by wall-clock with no pending error', () => {
+    const now = () => new Date('2026-06-15T12:15:00.000Z')
+    const health = buildHealth({
+      cursor,
+      gapRanges: [],
+      lastIngestedAt: '2026-06-15T12:04:00.000Z',
+      lastVerifiedAt: '2026-06-15T12:04:00.000Z',
+      lastReconciledAt: null,
+      lastError: null,
+      latestSnapshotHash: null,
+      latestStaticSnapshotUrl: null,
+      staleAfterMs: 300_000,
+      now,
+    })
+    expect(health.status).toBe('stale')
+  })
+
+  it('reports unhealthy when nothing has ever verified and an error is pending', () => {
+    const now = () => new Date('2026-06-15T12:15:00.000Z')
+    const health = buildHealth({
+      cursor,
+      gapRanges: [],
+      lastIngestedAt: null,
+      lastVerifiedAt: null,
+      lastReconciledAt: null,
+      lastError: 'network: fetch failed',
+      latestSnapshotHash: null,
+      latestStaticSnapshotUrl: null,
+      staleAfterMs: 300_000,
+      now,
+    })
+    expect(health.status).toBe('unhealthy')
+  })
+
   it('keeps degraded (transient) status when gaps exist but none have exhausted auto-repair', () => {
     const health = buildHealth({
       cursor,

--- a/crowdfund-ui/packages/indexer/src/api/health.ts
+++ b/crowdfund-ui/packages/indexer/src/api/health.ts
@@ -16,22 +16,45 @@ export interface BuildHealthInput {
   latestSnapshotHash: string | null
   latestStaticSnapshotUrl: string | null
   staleAfterBlocks?: number
+  // Wall-clock budget (ms) after which a frozen indexer is considered stale even when
+  // there are no gaps and block-lag reads as 0 (e.g. the RPC died and cursors stopped
+  // advancing). Defaults to 5 minutes.
+  staleAfterMs?: number
+  // Injectable clock for deterministic tests; defaults to the current time.
+  now?: () => Date
 }
 
-function getHealthStatus(input: BuildHealthInput, lagBlocks: number): IndexerHealthStatus {
+const DEFAULT_STALE_AFTER_MS = 300_000
+
+function getHealthStatus(input: BuildHealthInput, lagBlocks: number, now: Date): IndexerHealthStatus {
   const exhausted = input.gapsRequiringIntervention?.length ?? 0
   // Surface unhealthy whenever auto-repair has given up on a gap, regardless of
   // whether a fresh transient error is currently pending.
   if (exhausted > 0) return 'unhealthy'
   if (input.lastError && input.gapRanges.length > 0) return 'unhealthy'
   if (input.gapRanges.length > 0) return 'degraded'
+
+  // Wall-clock staleness: when verification has not advanced within the time budget,
+  // the indexer is stuck (or dead) even if there are no recorded gaps and block-lag is
+  // 0 because confirmedHead stopped advancing. A pending error during that window
+  // escalates to unhealthy.
+  const staleAfterMs = input.staleAfterMs ?? DEFAULT_STALE_AFTER_MS
+  if (input.lastVerifiedAt !== null) {
+    const ageMs = now.getTime() - new Date(input.lastVerifiedAt).getTime()
+    if (ageMs > staleAfterMs) return input.lastError ? 'unhealthy' : 'stale'
+  } else if (input.lastError) {
+    // Nothing has ever verified and an error is pending → unhealthy.
+    return 'unhealthy'
+  }
+
   if (lagBlocks > (input.staleAfterBlocks ?? 25)) return 'stale'
   return 'healthy'
 }
 
 export function buildHealth(input: BuildHealthInput): IndexerHealth {
+  const now = (input.now ?? (() => new Date()))()
   const lagBlocks = Math.max(0, input.cursor.confirmedHead - input.cursor.verifiedCursor)
-  const status = getHealthStatus(input, lagBlocks)
+  const status = getHealthStatus(input, lagBlocks, now)
 
   return {
     status,

--- a/crowdfund-ui/packages/indexer/src/api/server.test.ts
+++ b/crowdfund-ui/packages/indexer/src/api/server.test.ts
@@ -62,7 +62,7 @@ describe('indexer API', () => {
   it('returns a generic 500 that does not leak the raw error (and its RPC key)', async () => {
     const leakyUrl = 'https://eth-sepolia.g.alchemy.com/v2/abc123SECRETkey'
     const failingStore = {
-      read: async () => {
+      readMeta: async () => {
         throw new Error(`could not detect network (req to ${leakyUrl} failed)`)
       },
     } as unknown as FileIndexerStore

--- a/crowdfund-ui/packages/indexer/src/api/server.test.ts
+++ b/crowdfund-ui/packages/indexer/src/api/server.test.ts
@@ -6,8 +6,9 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Interface } from 'ethers'
-import { createIndexerApi } from './server.js'
+import { createIndexerApi, selectStaticSnapshotUrl } from './server.js'
 import { FileIndexerStore } from '../db/fileStore.js'
+import type { PublishSnapshotResult } from '../snapshots/publish.js'
 import { CROWDFUND_ABI_FRAGMENTS } from '../../../shared/src/lib/constants.js'
 import type { CursorState, IndexedRawLog } from '../types.js'
 
@@ -56,6 +57,30 @@ async function makeStore(): Promise<FileIndexerStore> {
 
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe('selectStaticSnapshotUrl', () => {
+  it('uses the object-storage public URL when the publisher provides one', () => {
+    const result: PublishSnapshotResult = {
+      snapshotPath: 's3://bucket/crowdfund/snapshot-100.json',
+      latestPath: 's3://bucket/crowdfund/latest.json',
+      snapshotFileName: 'snapshot-100.json',
+      snapshotUrl: 'https://cdn.example.com/crowdfund/snapshot-100.json',
+      latestUrl: 'https://cdn.example.com/crowdfund/latest.json',
+    }
+    expect(selectStaticSnapshotUrl(result)).toBe('https://cdn.example.com/crowdfund/latest.json')
+  })
+
+  it('returns null for the file publisher instead of exposing the disk path', () => {
+    // The file publisher returns only a local latestPath; /health is public, so the
+    // path must never be served — the field is null when there is no public URL.
+    const result: PublishSnapshotResult = {
+      snapshotPath: 'data/crowdfund-indexer/snapshots/snapshot-100.json',
+      latestPath: 'data/crowdfund-indexer/snapshots/latest.json',
+      snapshotFileName: 'snapshot-100.json',
+    }
+    expect(selectStaticSnapshotUrl(result)).toBeNull()
+  })
 })
 
 describe('indexer API', () => {

--- a/crowdfund-ui/packages/indexer/src/api/server.test.ts
+++ b/crowdfund-ui/packages/indexer/src/api/server.test.ts
@@ -96,6 +96,47 @@ describe('indexer API', () => {
     }
   })
 
+  it('caches the built snapshot until verified state changes', async () => {
+    let readLogsCalls = 0
+    let lastVerifiedAt: string | null = '2026-06-15T00:00:00.000Z'
+    const fakeStore = {
+      readMeta: async () => ({
+        cursor,
+        ranges: [],
+        lastIngestedAt: null,
+        lastVerifiedAt,
+        lastReconciledAt: null,
+        lastError: null,
+        latestSnapshotHash: null,
+        latestStaticSnapshotUrl: null,
+      }),
+      readLogs: async () => {
+        readLogsCalls += 1
+        return []
+      },
+    } as unknown as FileIndexerStore
+
+    const app = createIndexerApi({ store: fakeStore, chainId: 11155111, contractAddress, repairMaxAttempts: 6 })
+    const server = app.listen(0)
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') throw new Error('missing test server address')
+      const baseUrl = `http://127.0.0.1:${address.port}`
+
+      await fetch(`${baseUrl}/snapshot`).then((res) => res.json())
+      await fetch(`${baseUrl}/events`).then((res) => res.json())
+      // Second request served from cache — no second rebuild.
+      expect(readLogsCalls).toBe(1)
+
+      // Verified state changes → cache key changes → rebuild.
+      lastVerifiedAt = '2026-06-15T01:00:00.000Z'
+      await fetch(`${baseUrl}/snapshot`).then((res) => res.json())
+      expect(readLogsCalls).toBe(2)
+    } finally {
+      server.close()
+    }
+  })
+
   it('serves health and snapshot data', async () => {
     const app = createIndexerApi({
       store: await makeStore(),

--- a/crowdfund-ui/packages/indexer/src/api/server.test.ts
+++ b/crowdfund-ui/packages/indexer/src/api/server.test.ts
@@ -4,7 +4,7 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Interface } from 'ethers'
 import { createIndexerApi } from './server.js'
 import { FileIndexerStore } from '../db/fileStore.js'
@@ -59,6 +59,43 @@ afterEach(async () => {
 })
 
 describe('indexer API', () => {
+  it('returns a generic 500 that does not leak the raw error (and its RPC key)', async () => {
+    const leakyUrl = 'https://eth-sepolia.g.alchemy.com/v2/abc123SECRETkey'
+    const failingStore = {
+      read: async () => {
+        throw new Error(`could not detect network (req to ${leakyUrl} failed)`)
+      },
+    } as unknown as FileIndexerStore
+    const app = createIndexerApi({
+      store: failingStore,
+      chainId: 11155111,
+      contractAddress,
+      repairMaxAttempts: 6,
+    })
+    const stderrLines: string[] = []
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stderrLines.push(String(chunk))
+      return true
+    })
+    const server = app.listen(0)
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') throw new Error('missing test server address')
+      const res = await fetch(`http://127.0.0.1:${address.port}/health`)
+      const body = await res.json() as { error: string }
+      expect(res.status).toBe(500)
+      expect(body.error).toBe('internal indexer error')
+      expect(JSON.stringify(body)).not.toContain('abc123SECRETkey')
+      // The server-side log is written but sanitized — host kept, key stripped.
+      const logged = stderrLines.join('')
+      expect(logged).not.toContain('abc123SECRETkey')
+      expect(logged).toContain('https://eth-sepolia.g.alchemy.com/[redacted]')
+    } finally {
+      stderrSpy.mockRestore()
+      server.close()
+    }
+  })
+
   it('serves health and snapshot data', async () => {
     const app = createIndexerApi({
       store: await makeStore(),

--- a/crowdfund-ui/packages/indexer/src/api/server.ts
+++ b/crowdfund-ui/packages/indexer/src/api/server.ts
@@ -195,13 +195,26 @@ async function main(): Promise<void> {
     repairMaxAttempts: config.repairMaxAttempts,
     staleAfterMs: config.staleAfterMs,
   })
-  app.listen(config.port, () => {
+  const server = app.listen(config.port, () => {
     process.stdout.write(`Crowdfund indexer API listening on ${config.port}\n`)
   })
+
+  // Release the store backend (e.g. Postgres pool) on shutdown signals.
+  const shutdown = () => {
+    server.close()
+    void store.close().finally(() => process.exit(0))
+  }
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
 
   if (config.pollOnStart || config.backfillOnStart) {
     if (!config.primaryRpcUrl) throw new Error('Missing required environment variable: CROWDFUND_PRIMARY_RPC_URL')
     const primaryRpcUrl = config.primaryRpcUrl
+    if (!config.auditRpcUrl) {
+      process.stderr.write(
+        'Warning: CROWDFUND_AUDIT_RPC_URL is unset — ranges are verified against the same provider twice (no independent audit).\n',
+      )
+    }
     const poller = new CrowdfundIndexerPoller({
       chainId: config.chainId,
       contractAddress: config.contractAddress,

--- a/crowdfund-ui/packages/indexer/src/api/server.ts
+++ b/crowdfund-ui/packages/indexer/src/api/server.ts
@@ -13,10 +13,10 @@ import { getExhaustedRepairRanges } from '../ingest/reconcile.js'
 import { createJsonRpcRangeProvider } from '../ingest/rpc.js'
 import { sanitizeErrorMessage } from '../ingest/errors.js'
 import { createReadableCrowdfundContract, reconcileSnapshot } from '../reconcile/contract.js'
-import { buildSnapshot } from '../snapshots/build.js'
+import { buildSnapshot, withReconciliation } from '../snapshots/build.js'
 import { toJsonValue } from '../snapshots/json.js'
 import { publishSnapshot, publishSnapshotToObjectStorage } from '../snapshots/publish.js'
-import type { CursorState, IndexerStoreData, ReconciliationResult } from '../types.js'
+import type { CursorState, IndexerStoreData } from '../types.js'
 
 export interface CreateIndexerApiOptions {
   store: IndexerStore
@@ -91,21 +91,24 @@ async function publishCurrentSnapshot(
   primaryRpcUrl: string | null,
 ): Promise<void> {
   const data = await store.read()
-  let reconciliation: ReconciliationResult | undefined
-  const pendingSnapshot = buildSnapshot({ data, chainId, contractAddress })
+  let snapshot = buildSnapshot({ data, chainId, contractAddress })
 
   if (primaryRpcUrl) {
     const provider = new JsonRpcProvider(primaryRpcUrl)
-    const contract = createReadableCrowdfundContract(provider, contractAddress)
-    reconciliation = await reconcileSnapshot({
-      graph: pendingSnapshot.graph,
-      contract,
-      checkedBlock: data.cursor.verifiedCursor,
-      providerName: 'primary',
-    })
+    try {
+      const contract = createReadableCrowdfundContract(provider, contractAddress)
+      const reconciliation = await reconcileSnapshot({
+        graph: snapshot.graph,
+        contract,
+        checkedBlock: data.cursor.verifiedCursor,
+        providerName: 'primary',
+      })
+      snapshot = withReconciliation(snapshot, reconciliation)
+    } finally {
+      provider.destroy()
+    }
   }
 
-  const snapshot = buildSnapshot({ data, chainId, contractAddress, reconciliation })
   if (snapshot.metadata.reconciliation.status === 'failed') {
     throw new Error(`Refusing to publish failed reconciliation: ${snapshot.metadata.reconciliation.mismatches.join('; ')}`)
   }

--- a/crowdfund-ui/packages/indexer/src/api/server.ts
+++ b/crowdfund-ui/packages/indexer/src/api/server.ts
@@ -23,6 +23,7 @@ export interface CreateIndexerApiOptions {
   chainId: number
   contractAddress: string
   repairMaxAttempts: number
+  staleAfterMs?: number
 }
 
 function readNumberEnv(name: string, fallback: number): number {
@@ -62,7 +63,7 @@ function getInitialCursor(): CursorState {
   }
 }
 
-function buildHealthFromStore(data: IndexerStoreData, repairMaxAttempts: number) {
+function buildHealthFromStore(data: IndexerStoreData, repairMaxAttempts: number, staleAfterMs?: number) {
   return buildHealth({
     cursor: data.cursor,
     gapRanges: getRepairRanges(data.ranges),
@@ -73,6 +74,7 @@ function buildHealthFromStore(data: IndexerStoreData, repairMaxAttempts: number)
     lastError: data.lastError,
     latestSnapshotHash: data.latestSnapshotHash,
     latestStaticSnapshotUrl: data.latestStaticSnapshotUrl,
+    staleAfterMs,
   })
 }
 
@@ -145,7 +147,7 @@ export function createIndexerApi(options: CreateIndexerApiOptions) {
   app.get('/health', async (_req, res, next) => {
     try {
       const data = await options.store.read()
-      res.json(buildHealthFromStore(data, options.repairMaxAttempts))
+      res.json(buildHealthFromStore(data, options.repairMaxAttempts, options.staleAfterMs))
     } catch (err) {
       next(err)
     }
@@ -211,11 +213,12 @@ async function main(): Promise<void> {
   const repairMaxAttempts = readNumberEnv('CROWDFUND_REPAIR_MAX_ATTEMPTS', 6)
   const repairBackoffBaseMs = readNumberEnv('CROWDFUND_REPAIR_BACKOFF_BASE_MS', 30_000)
   const repairBackoffMaxMs = readNumberEnv('CROWDFUND_REPAIR_BACKOFF_MAX_MS', 1_800_000)
+  const staleAfterMs = readNumberEnv('CROWDFUND_STALE_AFTER_MS', 300_000)
   const store = createIndexerStore({
     defaultFilePath: join(process.cwd(), 'data/crowdfund-indexer/store.json'),
     initialCursor: getInitialCursor(),
   })
-  const app = createIndexerApi({ store, chainId, contractAddress, repairMaxAttempts })
+  const app = createIndexerApi({ store, chainId, contractAddress, repairMaxAttempts, staleAfterMs })
   app.listen(port, () => {
     process.stdout.write(`Crowdfund indexer API listening on ${port}\n`)
   })

--- a/crowdfund-ui/packages/indexer/src/api/server.ts
+++ b/crowdfund-ui/packages/indexer/src/api/server.ts
@@ -5,6 +5,7 @@ import express from 'express'
 import { join } from 'node:path'
 import { JsonRpcProvider } from 'ethers'
 import { buildHealth } from './health.js'
+import { getInitialCursor, loadIndexerConfig, readBooleanEnv, readRequiredEnv } from '../config.js'
 import { createIndexerStore } from '../db/createStore.js'
 import type { IndexerMeta, IndexerStore } from '../db/store.js'
 import { CrowdfundIndexerPoller } from '../ingest/poller.js'
@@ -16,7 +17,7 @@ import { createReadableCrowdfundContract, reconcileSnapshot } from '../reconcile
 import { buildSnapshot, withReconciliation } from '../snapshots/build.js'
 import { toJsonValue } from '../snapshots/json.js'
 import { publishSnapshot, publishSnapshotToObjectStorage } from '../snapshots/publish.js'
-import type { CursorState, IndexerStoreData } from '../types.js'
+import type { IndexerStoreData } from '../types.js'
 
 export interface CreateIndexerApiOptions {
   store: IndexerStore
@@ -24,43 +25,6 @@ export interface CreateIndexerApiOptions {
   contractAddress: string
   repairMaxAttempts: number
   staleAfterMs?: number
-}
-
-function readNumberEnv(name: string, fallback: number): number {
-  const raw = process.env[name]
-  if (!raw) return fallback
-  const parsed = Number(raw)
-  if (!Number.isSafeInteger(parsed) || parsed < 0) {
-    throw new Error(`Invalid numeric environment variable: ${name}`)
-  }
-  return parsed
-}
-
-function readRequiredEnv(name: string): string {
-  const value = process.env[name]
-  if (!value) throw new Error(`Missing required environment variable: ${name}`)
-  return value
-}
-
-function readBooleanEnv(name: string, fallback: boolean): boolean {
-  const value = process.env[name]
-  if (!value) return fallback
-  if (value === 'true') return true
-  if (value === 'false') return false
-  throw new Error(`Invalid boolean environment variable: ${name}`)
-}
-
-function getInitialCursor(): CursorState {
-  const deployBlock = readNumberEnv('CROWDFUND_DEPLOY_BLOCK', 0)
-  return {
-    deployBlock,
-    confirmationDepth: readNumberEnv('CROWDFUND_CONFIRMATION_DEPTH', 12),
-    overlapWindow: readNumberEnv('CROWDFUND_OVERLAP_WINDOW', 100),
-    chainHead: deployBlock,
-    confirmedHead: deployBlock,
-    ingestedCursor: deployBlock > 0 ? deployBlock - 1 : 0,
-    verifiedCursor: deployBlock > 0 ? deployBlock - 1 : 0,
-  }
 }
 
 function buildHealthFromStore(data: IndexerMeta, repairMaxAttempts: number, staleAfterMs?: number) {
@@ -219,53 +183,49 @@ export function createIndexerApi(options: CreateIndexerApiOptions) {
 }
 
 async function main(): Promise<void> {
-  const chainId = readNumberEnv('CROWDFUND_CHAIN_ID', 11155111)
-  const contractAddress = readRequiredEnv('CROWDFUND_CONTRACT_ADDRESS')
-  const port = readNumberEnv('CROWDFUND_INDEXER_PORT', 3002)
-  const maxBlockRange = readNumberEnv('CROWDFUND_MAX_BLOCK_RANGE', 500)
-  const pollOnStart = readBooleanEnv('CROWDFUND_POLL_ON_START', false)
-  const backfillOnStart = readBooleanEnv('CROWDFUND_BACKFILL_ON_START', false)
-  const publishOnPoll = readBooleanEnv('CROWDFUND_PUBLISH_ON_POLL', false)
-  const repairMaxAttempts = readNumberEnv('CROWDFUND_REPAIR_MAX_ATTEMPTS', 6)
-  const repairBackoffBaseMs = readNumberEnv('CROWDFUND_REPAIR_BACKOFF_BASE_MS', 30_000)
-  const repairBackoffMaxMs = readNumberEnv('CROWDFUND_REPAIR_BACKOFF_MAX_MS', 1_800_000)
-  const staleAfterMs = readNumberEnv('CROWDFUND_STALE_AFTER_MS', 300_000)
+  const config = loadIndexerConfig()
   const store = createIndexerStore({
     defaultFilePath: join(process.cwd(), 'data/crowdfund-indexer/store.json'),
     initialCursor: getInitialCursor(),
   })
-  const app = createIndexerApi({ store, chainId, contractAddress, repairMaxAttempts, staleAfterMs })
-  app.listen(port, () => {
-    process.stdout.write(`Crowdfund indexer API listening on ${port}\n`)
+  const app = createIndexerApi({
+    store,
+    chainId: config.chainId,
+    contractAddress: config.contractAddress,
+    repairMaxAttempts: config.repairMaxAttempts,
+    staleAfterMs: config.staleAfterMs,
+  })
+  app.listen(config.port, () => {
+    process.stdout.write(`Crowdfund indexer API listening on ${config.port}\n`)
   })
 
-  if (pollOnStart || backfillOnStart) {
-    const primaryRpcUrl = readRequiredEnv('CROWDFUND_PRIMARY_RPC_URL')
-    const auditRpcUrl = process.env.CROWDFUND_AUDIT_RPC_URL
+  if (config.pollOnStart || config.backfillOnStart) {
+    if (!config.primaryRpcUrl) throw new Error('Missing required environment variable: CROWDFUND_PRIMARY_RPC_URL')
+    const primaryRpcUrl = config.primaryRpcUrl
     const poller = new CrowdfundIndexerPoller({
-      chainId,
-      contractAddress,
+      chainId: config.chainId,
+      contractAddress: config.contractAddress,
       providerName: 'primary',
       store,
       provider: createJsonRpcRangeProvider(primaryRpcUrl),
-      auditProvider: auditRpcUrl ? createJsonRpcRangeProvider(auditRpcUrl) : undefined,
-      auditProviderName: auditRpcUrl ? 'audit' : undefined,
-      maxBlockRange,
-      pollIntervalMs: readNumberEnv('CROWDFUND_POLL_INTERVAL_MS', 15_000),
-      errorBackoffMs: readNumberEnv('CROWDFUND_POLL_ERROR_BACKOFF_MS', 60_000),
-      rpcTimeoutMs: readNumberEnv('CROWDFUND_RPC_TIMEOUT_MS', 15_000),
-      rpcMaxRetries: readNumberEnv('CROWDFUND_RPC_MAX_RETRIES', 3),
-      retryBaseDelayMs: readNumberEnv('CROWDFUND_RPC_RETRY_BASE_DELAY_MS', 1_000),
-      retryJitterMs: readNumberEnv('CROWDFUND_RPC_RETRY_JITTER_MS', 250),
+      auditProvider: config.auditRpcUrl ? createJsonRpcRangeProvider(config.auditRpcUrl) : undefined,
+      auditProviderName: config.auditRpcUrl ? 'audit' : undefined,
+      maxBlockRange: config.maxBlockRange,
+      pollIntervalMs: config.pollIntervalMs,
+      errorBackoffMs: config.errorBackoffMs,
+      rpcTimeoutMs: config.rpcTimeoutMs,
+      rpcMaxRetries: config.rpcMaxRetries,
+      retryBaseDelayMs: config.retryBaseDelayMs,
+      retryJitterMs: config.retryJitterMs,
       reconcileOptions: {
-        maxAttempts: repairMaxAttempts,
-        backoffBaseMs: repairBackoffBaseMs,
-        backoffMaxMs: repairBackoffMaxMs,
+        maxAttempts: config.repairMaxAttempts,
+        backoffBaseMs: config.repairBackoffBaseMs,
+        backoffMaxMs: config.repairBackoffMaxMs,
       },
-      publishOnPoll,
-      snapshotPublishIntervalMs: readNumberEnv('CROWDFUND_SNAPSHOT_PUBLISH_INTERVAL_MS', 60_000),
-      publishSnapshot: publishOnPoll
-        ? () => publishCurrentSnapshot(store, chainId, contractAddress, primaryRpcUrl)
+      publishOnPoll: config.publishOnPoll,
+      snapshotPublishIntervalMs: config.snapshotPublishIntervalMs,
+      publishSnapshot: config.publishOnPoll
+        ? () => publishCurrentSnapshot(store, config.chainId, config.contractAddress, primaryRpcUrl)
         : undefined,
       logger: {
         info: (message) => process.stdout.write(`${message}\n`),
@@ -273,7 +233,7 @@ async function main(): Promise<void> {
         error: (message) => process.stderr.write(`${message}\n`),
       },
     })
-    if (pollOnStart) {
+    if (config.pollOnStart) {
       poller.start()
       process.stdout.write('Crowdfund indexer polling worker started\n')
     } else {

--- a/crowdfund-ui/packages/indexer/src/api/server.ts
+++ b/crowdfund-ui/packages/indexer/src/api/server.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path'
 import { JsonRpcProvider } from 'ethers'
 import { buildHealth } from './health.js'
 import { createIndexerStore } from '../db/createStore.js'
-import type { IndexerStore } from '../db/store.js'
+import type { IndexerMeta, IndexerStore } from '../db/store.js'
 import { CrowdfundIndexerPoller } from '../ingest/poller.js'
 import { getRepairRanges } from '../ingest/ranges.js'
 import { getExhaustedRepairRanges } from '../ingest/reconcile.js'
@@ -63,7 +63,7 @@ function getInitialCursor(): CursorState {
   }
 }
 
-function buildHealthFromStore(data: IndexerStoreData, repairMaxAttempts: number, staleAfterMs?: number) {
+function buildHealthFromStore(data: IndexerMeta, repairMaxAttempts: number, staleAfterMs?: number) {
   return buildHealth({
     cursor: data.cursor,
     gapRanges: getRepairRanges(data.ranges),
@@ -90,7 +90,8 @@ async function publishCurrentSnapshot(
   contractAddress: string,
   primaryRpcUrl: string | null,
 ): Promise<void> {
-  const data = await store.read()
+  const meta = await store.readMeta()
+  const data: IndexerStoreData = { ...meta, rawLogs: await store.readLogs(meta.cursor.verifiedCursor) }
   let snapshot = buildSnapshot({ data, chainId, contractAddress })
 
   if (primaryRpcUrl) {
@@ -129,17 +130,26 @@ async function publishCurrentSnapshot(
         process.env.CROWDFUND_SNAPSHOT_DIR ?? join(process.cwd(), 'data/crowdfund-indexer/snapshots'),
       )
 
-  await store.update((current) => ({
-    ...current,
+  await store.patchMeta({
     latestSnapshotHash: snapshot.metadata.snapshotHash,
     latestStaticSnapshotUrl: result.latestUrl ?? result.latestPath,
-    lastReconciledAt: snapshot.metadata.reconciliation.checkedAt ?? current.lastReconciledAt,
+    ...(snapshot.metadata.reconciliation.checkedAt
+      ? { lastReconciledAt: snapshot.metadata.reconciliation.checkedAt }
+      : {}),
     lastError: null,
-  }))
+  })
 }
 
 export function createIndexerApi(options: CreateIndexerApiOptions) {
   const app = express()
+
+  // Compose just the data buildSnapshot needs: metadata + the verified-and-below logs.
+  // Avoids reading the entire raw-log table on every /snapshot and /events request.
+  async function readSnapshotData(): Promise<IndexerStoreData> {
+    const meta = await options.store.readMeta()
+    const rawLogs = await options.store.readLogs(meta.cursor.verifiedCursor)
+    return { ...meta, rawLogs }
+  }
 
   app.use((_req, res, next) => {
     res.setHeader('Access-Control-Allow-Origin', '*')
@@ -149,8 +159,8 @@ export function createIndexerApi(options: CreateIndexerApiOptions) {
 
   app.get('/health', async (_req, res, next) => {
     try {
-      const data = await options.store.read()
-      res.json(buildHealthFromStore(data, options.repairMaxAttempts, options.staleAfterMs))
+      const meta = await options.store.readMeta()
+      res.json(buildHealthFromStore(meta, options.repairMaxAttempts, options.staleAfterMs))
     } catch (err) {
       next(err)
     }
@@ -158,9 +168,8 @@ export function createIndexerApi(options: CreateIndexerApiOptions) {
 
   app.get('/snapshot', async (_req, res, next) => {
     try {
-      const data = await options.store.read()
       const snapshot = buildSnapshot({
-        data,
+        data: await readSnapshotData(),
         chainId: options.chainId,
         contractAddress: options.contractAddress,
       })
@@ -174,9 +183,8 @@ export function createIndexerApi(options: CreateIndexerApiOptions) {
     try {
       const afterBlock = readOptionalNumber(req.query.afterBlock)
       const afterLogIndex = readOptionalNumber(req.query.afterLogIndex) ?? -1
-      const data = await options.store.read()
       const snapshot = buildSnapshot({
-        data,
+        data: await readSnapshotData(),
         chainId: options.chainId,
         contractAddress: options.contractAddress,
       })

--- a/crowdfund-ui/packages/indexer/src/api/server.ts
+++ b/crowdfund-ui/packages/indexer/src/api/server.ts
@@ -11,6 +11,7 @@ import { CrowdfundIndexerPoller } from '../ingest/poller.js'
 import { getRepairRanges } from '../ingest/ranges.js'
 import { getExhaustedRepairRanges } from '../ingest/reconcile.js'
 import { createJsonRpcRangeProvider } from '../ingest/rpc.js'
+import { sanitizeErrorMessage } from '../ingest/errors.js'
 import { createReadableCrowdfundContract, reconcileSnapshot } from '../reconcile/contract.js'
 import { buildSnapshot } from '../snapshots/build.js'
 import { toJsonValue } from '../snapshots/json.js'
@@ -189,8 +190,11 @@ export function createIndexerApi(options: CreateIndexerApiOptions) {
   })
 
   app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    // Never echo the raw error to the client — it can carry RPC keys or DB credentials.
+    // Log the sanitized real message server-side; return a fixed message to the caller.
     const message = err instanceof Error ? err.message : 'Unknown indexer API error'
-    res.status(500).json({ error: message })
+    process.stderr.write(`Crowdfund indexer API error: ${sanitizeErrorMessage(message)}\n`)
+    res.status(500).json({ error: 'internal indexer error' })
   })
 
   return app

--- a/crowdfund-ui/packages/indexer/src/api/server.ts
+++ b/crowdfund-ui/packages/indexer/src/api/server.ts
@@ -16,7 +16,7 @@ import { sanitizeErrorMessage } from '../ingest/errors.js'
 import { createReadableCrowdfundContract, reconcileSnapshot } from '../reconcile/contract.js'
 import { buildSnapshot, withReconciliation } from '../snapshots/build.js'
 import { toJsonValue } from '../snapshots/json.js'
-import { publishSnapshot, publishSnapshotToObjectStorage } from '../snapshots/publish.js'
+import { publishSnapshot, publishSnapshotToObjectStorage, type PublishSnapshotResult } from '../snapshots/publish.js'
 import type { IndexerStoreData } from '../types.js'
 
 export interface CreateIndexerApiOptions {
@@ -46,6 +46,14 @@ function readOptionalNumber(value: unknown): number | null {
   if (typeof value !== 'string' || value.length === 0) return null
   const parsed = Number(value)
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null
+}
+
+// Only a publicly fetchable URL belongs in latestStaticSnapshotUrl, which is served
+// on the unauthenticated /health endpoint. The object-storage publisher provides a
+// real URL; the file publisher returns only a local disk path, which must not be
+// exposed — so fall back to null rather than leaking the path.
+export function selectStaticSnapshotUrl(result: PublishSnapshotResult): string | null {
+  return result.latestUrl ?? null
 }
 
 async function publishCurrentSnapshot(
@@ -96,7 +104,7 @@ async function publishCurrentSnapshot(
 
   await store.patchMeta({
     latestSnapshotHash: snapshot.metadata.snapshotHash,
-    latestStaticSnapshotUrl: result.latestUrl ?? result.latestPath,
+    latestStaticSnapshotUrl: selectStaticSnapshotUrl(result),
     ...(snapshot.metadata.reconciliation.checkedAt
       ? { lastReconciledAt: snapshot.metadata.reconciliation.checkedAt }
       : {}),

--- a/crowdfund-ui/packages/indexer/src/api/server.ts
+++ b/crowdfund-ui/packages/indexer/src/api/server.ts
@@ -143,12 +143,26 @@ async function publishCurrentSnapshot(
 export function createIndexerApi(options: CreateIndexerApiOptions) {
   const app = express()
 
-  // Compose just the data buildSnapshot needs: metadata + the verified-and-below logs.
-  // Avoids reading the entire raw-log table on every /snapshot and /events request.
-  async function readSnapshotData(): Promise<IndexerStoreData> {
+  // Per-process snapshot cache keyed on the verified state. Building a snapshot parses
+  // every verified log and rebuilds the graph; without this, every /snapshot and /events
+  // request repeats that work. The key changes iff verified data changed (verifiedCursor
+  // advances and lastVerifiedAt updates together on each successful verification), so no
+  // TTL is needed. NOTE: this is not a request-rate limiter — front the service with a
+  // reverse proxy for that (tracked separately).
+  let snapshotCache: { key: string; snapshot: ReturnType<typeof buildSnapshot> } | null = null
+
+  async function getSnapshot(): Promise<ReturnType<typeof buildSnapshot>> {
     const meta = await options.store.readMeta()
+    const key = `${meta.cursor.verifiedCursor}:${meta.lastVerifiedAt ?? ''}`
+    if (snapshotCache && snapshotCache.key === key) return snapshotCache.snapshot
     const rawLogs = await options.store.readLogs(meta.cursor.verifiedCursor)
-    return { ...meta, rawLogs }
+    const snapshot = buildSnapshot({
+      data: { ...meta, rawLogs },
+      chainId: options.chainId,
+      contractAddress: options.contractAddress,
+    })
+    snapshotCache = { key, snapshot }
+    return snapshot
   }
 
   app.use((_req, res, next) => {
@@ -168,12 +182,7 @@ export function createIndexerApi(options: CreateIndexerApiOptions) {
 
   app.get('/snapshot', async (_req, res, next) => {
     try {
-      const snapshot = buildSnapshot({
-        data: await readSnapshotData(),
-        chainId: options.chainId,
-        contractAddress: options.contractAddress,
-      })
-      res.json(toJsonValue(snapshot))
+      res.json(toJsonValue(await getSnapshot()))
     } catch (err) {
       next(err)
     }
@@ -183,11 +192,7 @@ export function createIndexerApi(options: CreateIndexerApiOptions) {
     try {
       const afterBlock = readOptionalNumber(req.query.afterBlock)
       const afterLogIndex = readOptionalNumber(req.query.afterLogIndex) ?? -1
-      const snapshot = buildSnapshot({
-        data: await readSnapshotData(),
-        chainId: options.chainId,
-        contractAddress: options.contractAddress,
-      })
+      const snapshot = await getSnapshot()
       const events = snapshot.events.filter((event) => {
         if (afterBlock === null) return true
         if (event.blockNumber > afterBlock) return true

--- a/crowdfund-ui/packages/indexer/src/cli/commands.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/commands.ts
@@ -3,7 +3,8 @@
 
 import { buildHealth } from '../api/health.js'
 import { getRepairRanges } from '../ingest/ranges.js'
-import type { BlockRange, IndexerHealth, IndexerStoreData } from '../types.js'
+import type { IndexerMeta } from '../db/store.js'
+import type { BlockRange, IndexerHealth } from '../types.js'
 
 export type CliCommand =
   | 'status'
@@ -82,7 +83,7 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
   }
 }
 
-export function getStatusHealth(data: IndexerStoreData, staleAfterMs?: number): IndexerHealth {
+export function getStatusHealth(data: IndexerMeta, staleAfterMs?: number): IndexerHealth {
   return buildHealth({
     cursor: data.cursor,
     gapRanges: getRepairRanges(data.ranges),
@@ -100,7 +101,7 @@ export function formatRange(range: BlockRange): string {
   return `${range.fromBlock}-${range.toBlock}`
 }
 
-export function formatStatus(data: IndexerStoreData, staleAfterMs?: number): string {
+export function formatStatus(data: IndexerMeta, staleAfterMs?: number): string {
   const health = getStatusHealth(data, staleAfterMs)
   const gaps = health.gapRanges.length > 0
     ? health.gapRanges.map(formatRange).join(', ')
@@ -123,7 +124,7 @@ export function formatStatus(data: IndexerStoreData, staleAfterMs?: number): str
 // Handles the read-only `status` command. RPC-backed commands (verify/repair/backfill,
 // rebuild-snapshot, publish-snapshot) are dispatched in cli/index.ts before reaching here,
 // so this function intentionally accepts only `status`.
-export function runReadOnlyCommand(args: ParsedCliArgs, data: IndexerStoreData, staleAfterMs?: number): CliCommandResult {
+export function runReadOnlyCommand(args: ParsedCliArgs, data: IndexerMeta, staleAfterMs?: number): CliCommandResult {
   if (args.command !== 'status') {
     throw new Error(`runReadOnlyCommand received non-status command: ${args.command}`)
   }

--- a/crowdfund-ui/packages/indexer/src/cli/commands.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/commands.ts
@@ -82,7 +82,7 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
   }
 }
 
-export function getStatusHealth(data: IndexerStoreData): IndexerHealth {
+export function getStatusHealth(data: IndexerStoreData, staleAfterMs?: number): IndexerHealth {
   return buildHealth({
     cursor: data.cursor,
     gapRanges: getRepairRanges(data.ranges),
@@ -92,6 +92,7 @@ export function getStatusHealth(data: IndexerStoreData): IndexerHealth {
     lastError: data.lastError,
     latestSnapshotHash: data.latestSnapshotHash,
     latestStaticSnapshotUrl: data.latestStaticSnapshotUrl,
+    staleAfterMs,
   })
 }
 
@@ -99,8 +100,8 @@ export function formatRange(range: BlockRange): string {
   return `${range.fromBlock}-${range.toBlock}`
 }
 
-export function formatStatus(data: IndexerStoreData): string {
-  const health = getStatusHealth(data)
+export function formatStatus(data: IndexerStoreData, staleAfterMs?: number): string {
+  const health = getStatusHealth(data, staleAfterMs)
   const gaps = health.gapRanges.length > 0
     ? health.gapRanges.map(formatRange).join(', ')
     : 'none'
@@ -122,9 +123,9 @@ export function formatStatus(data: IndexerStoreData): string {
 // Handles the read-only `status` command. RPC-backed commands (verify/repair/backfill,
 // rebuild-snapshot, publish-snapshot) are dispatched in cli/index.ts before reaching here,
 // so this function intentionally accepts only `status`.
-export function runReadOnlyCommand(args: ParsedCliArgs, data: IndexerStoreData): CliCommandResult {
+export function runReadOnlyCommand(args: ParsedCliArgs, data: IndexerStoreData, staleAfterMs?: number): CliCommandResult {
   if (args.command !== 'status') {
     throw new Error(`runReadOnlyCommand received non-status command: ${args.command}`)
   }
-  return { exitCode: 0, output: formatStatus(data) }
+  return { exitCode: 0, output: formatStatus(data, staleAfterMs) }
 }

--- a/crowdfund-ui/packages/indexer/src/cli/index.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/index.ts
@@ -246,6 +246,7 @@ async function main(): Promise<void> {
       stateStore: createFileAlertStateStore(stateFile),
       params,
       repairMaxAttempts: readNumberEnv('CROWDFUND_REPAIR_MAX_ATTEMPTS', 6),
+      staleAfterMs: readNumberEnv('CROWDFUND_STALE_AFTER_MS', 300_000),
       chainState,
       notifier: createDiscordNotifierFromEnv(),
     })
@@ -258,7 +259,7 @@ async function main(): Promise<void> {
     return
   }
 
-  const result = runReadOnlyCommand(args, data)
+  const result = runReadOnlyCommand(args, data, readNumberEnv('CROWDFUND_STALE_AFTER_MS', 300_000))
   process.stdout.write(`${result.output}\n`)
   process.exitCode = result.exitCode
 }

--- a/crowdfund-ui/packages/indexer/src/cli/index.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/index.ts
@@ -250,10 +250,13 @@ async function runCommand(args: ParsedCliArgs, store: IndexerStore): Promise<voi
       chainState?.close?.()
     }
     process.stdout.write(
-      `evaluated ${result.total} candidates; delivered ${result.delivered.length}; skipped ${result.skipped.length}; failed ${result.failed.length}\n`,
+      `evaluated ${result.total} candidates; delivered ${result.delivered.length}; skipped ${result.skipped.length}; failed ${result.failed.length}; undelivered ${result.undelivered.length}\n`,
     )
     for (const e of result.delivered) {
       process.stdout.write(`  [${e.severity} ${e.id}] ${e.title} (key=${e.dedupeKey})\n`)
+    }
+    for (const e of result.undelivered) {
+      process.stderr.write(`  UNDELIVERED [${e.severity} ${e.id}] ${e.title} — no webhook configured for ${e.severity}\n`)
     }
     for (const e of result.failed) {
       process.stderr.write(`  FAILED [${e.severity} ${e.id}] ${e.title} (key=${e.dedupeKey})\n`)

--- a/crowdfund-ui/packages/indexer/src/cli/index.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/index.ts
@@ -3,6 +3,7 @@
 
 import { join } from 'node:path'
 import { JsonRpcProvider } from 'ethers'
+import { getInitialCursor, readBooleanEnv, readNumberEnv, readRequiredEnv } from '../config.js'
 import { createIndexerStore } from '../db/createStore.js'
 import { parseCliArgs, runReadOnlyCommand } from './commands.js'
 import { createRpcChainStateReader } from '../alerts/chainState.js'
@@ -15,44 +16,6 @@ import { createJsonRpcRangeProvider, repairRanges, verifyRange } from '../ingest
 import { createReadableCrowdfundContract, reconcileSnapshot } from '../reconcile/contract.js'
 import { buildSnapshot, withReconciliation } from '../snapshots/build.js'
 import { publishSnapshot, publishSnapshotToObjectStorage } from '../snapshots/publish.js'
-import type { CursorState } from '../types.js'
-
-function readNumberEnv(name: string, fallback: number): number {
-  const raw = process.env[name]
-  if (!raw) return fallback
-  const parsed = Number(raw)
-  if (!Number.isSafeInteger(parsed) || parsed < 0) {
-    throw new Error(`Invalid numeric environment variable: ${name}`)
-  }
-  return parsed
-}
-
-function getInitialCursor(): CursorState {
-  const deployBlock = readNumberEnv('CROWDFUND_DEPLOY_BLOCK', 0)
-  return {
-    deployBlock,
-    confirmationDepth: readNumberEnv('CROWDFUND_CONFIRMATION_DEPTH', 12),
-    overlapWindow: readNumberEnv('CROWDFUND_OVERLAP_WINDOW', 100),
-    chainHead: deployBlock,
-    confirmedHead: deployBlock,
-    ingestedCursor: deployBlock > 0 ? deployBlock - 1 : 0,
-    verifiedCursor: deployBlock > 0 ? deployBlock - 1 : 0,
-  }
-}
-
-function readRequiredEnv(name: string): string {
-  const value = process.env[name]
-  if (!value) throw new Error(`Missing required environment variable: ${name}`)
-  return value
-}
-
-function readBooleanEnv(name: string, fallback: boolean): boolean {
-  const value = process.env[name]
-  if (!value) return fallback
-  if (value === 'true') return true
-  if (value === 'false') return false
-  throw new Error(`Invalid boolean environment variable: ${name}`)
-}
 
 async function resolveToBlock(
   toBlock: number | 'latest' | null,

--- a/crowdfund-ui/packages/indexer/src/cli/index.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/index.ts
@@ -10,6 +10,7 @@ import { createFileAlertStateStore } from '../alerts/state.js'
 import { createDiscordNotifierFromEnv, runAlertsOnce } from '../alerts/runner.js'
 import type { CrowdfundParams } from '../alerts/types.js'
 import { backfillVerifiedRanges } from '../ingest/backfill.js'
+import { sanitizeErrorMessage } from '../ingest/errors.js'
 import { createJsonRpcRangeProvider, repairRanges, verifyRange } from '../ingest/rpc.js'
 import { createReadableCrowdfundContract, reconcileSnapshot } from '../reconcile/contract.js'
 import { buildSnapshot } from '../snapshots/build.js'
@@ -180,7 +181,7 @@ async function main(): Promise<void> {
         latestSnapshotHash: snapshot.metadata.snapshotHash,
         lastReconciledAt: snapshot.metadata.reconciliation.checkedAt ?? current.lastReconciledAt,
         lastError: snapshot.metadata.reconciliation.status === 'failed'
-          ? snapshot.metadata.reconciliation.mismatches.join('; ')
+          ? sanitizeErrorMessage(snapshot.metadata.reconciliation.mismatches.join('; '))
           : current.lastError,
       }))
       process.stdout.write(`rebuilt snapshot ${snapshot.metadata.snapshotHash} at block ${snapshot.metadata.verifiedBlock}\n`)

--- a/crowdfund-ui/packages/indexer/src/cli/index.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/index.ts
@@ -70,7 +70,9 @@ async function main(): Promise<void> {
     defaultFilePath: join(process.cwd(), 'data/crowdfund-indexer/store.json'),
     initialCursor: getInitialCursor(),
   })
-  const data = await store.read()
+  // Operator commands only need cursor/range/metadata state; the snapshot commands add
+  // raw logs on demand below.
+  const data = await store.readMeta()
 
   if (args.command === 'verify' || args.command === 'repair' || args.command === 'backfill') {
     const provider = createJsonRpcRangeProvider(readRequiredEnv('CROWDFUND_PRIMARY_RPC_URL'))
@@ -160,7 +162,8 @@ async function main(): Promise<void> {
     const chainId = readNumberEnv('CROWDFUND_CHAIN_ID', 11155111)
     const contractAddress = readRequiredEnv('CROWDFUND_CONTRACT_ADDRESS')
 
-    let snapshot = buildSnapshot({ data, chainId, contractAddress })
+    const snapshotData = { ...data, rawLogs: await store.readLogs(data.cursor.verifiedCursor) }
+    let snapshot = buildSnapshot({ data: snapshotData, chainId, contractAddress })
     const rpcUrl = process.env.CROWDFUND_PRIMARY_RPC_URL
     if (rpcUrl) {
       const provider = new JsonRpcProvider(rpcUrl)
@@ -178,14 +181,15 @@ async function main(): Promise<void> {
       }
     }
     if (args.command === 'rebuild-snapshot') {
-      await store.update((current) => ({
-        ...current,
+      await store.patchMeta({
         latestSnapshotHash: snapshot.metadata.snapshotHash,
-        lastReconciledAt: snapshot.metadata.reconciliation.checkedAt ?? current.lastReconciledAt,
-        lastError: snapshot.metadata.reconciliation.status === 'failed'
-          ? sanitizeErrorMessage(snapshot.metadata.reconciliation.mismatches.join('; '))
-          : current.lastError,
-      }))
+        ...(snapshot.metadata.reconciliation.checkedAt
+          ? { lastReconciledAt: snapshot.metadata.reconciliation.checkedAt }
+          : {}),
+        ...(snapshot.metadata.reconciliation.status === 'failed'
+          ? { lastError: sanitizeErrorMessage(snapshot.metadata.reconciliation.mismatches.join('; ')) }
+          : {}),
+      })
       process.stdout.write(`rebuilt snapshot ${snapshot.metadata.snapshotHash} at block ${snapshot.metadata.verifiedBlock}\n`)
       return
     }
@@ -211,13 +215,14 @@ async function main(): Promise<void> {
           snapshot,
           process.env.CROWDFUND_SNAPSHOT_DIR ?? join(process.cwd(), 'data/crowdfund-indexer/snapshots'),
         )
-    await store.update((current) => ({
-      ...current,
+    await store.patchMeta({
       latestSnapshotHash: snapshot.metadata.snapshotHash,
       latestStaticSnapshotUrl: result.latestUrl ?? result.latestPath,
-      lastReconciledAt: snapshot.metadata.reconciliation.checkedAt ?? current.lastReconciledAt,
+      ...(snapshot.metadata.reconciliation.checkedAt
+        ? { lastReconciledAt: snapshot.metadata.reconciliation.checkedAt }
+        : {}),
       lastError: null,
-    }))
+    })
     process.stdout.write(`published ${result.snapshotFileName}\nlatest ${result.latestUrl ?? result.latestPath}\n`)
     return
   }

--- a/crowdfund-ui/packages/indexer/src/cli/index.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/index.ts
@@ -5,12 +5,15 @@ import { join } from 'node:path'
 import { JsonRpcProvider } from 'ethers'
 import { getInitialCursor, readBooleanEnv, readNumberEnv, readRequiredEnv } from '../config.js'
 import { createIndexerStore } from '../db/createStore.js'
+import type { IndexerStore } from '../db/store.js'
+import type { IngestRangeRecord } from '../types.js'
 import { parseCliArgs, runReadOnlyCommand } from './commands.js'
+import type { ParsedCliArgs } from './commands.js'
 import { createRpcChainStateReader } from '../alerts/chainState.js'
 import { createFileAlertStateStore } from '../alerts/state.js'
 import { createDiscordNotifierFromEnv, runAlertsOnce } from '../alerts/runner.js'
 import type { CrowdfundParams } from '../alerts/types.js'
-import { backfillVerifiedRanges } from '../ingest/backfill.js'
+import { backfillVerifiedRanges, planBackfillRanges } from '../ingest/backfill.js'
 import { sanitizeErrorMessage } from '../ingest/errors.js'
 import { createJsonRpcRangeProvider, repairRanges, verifyRange } from '../ingest/rpc.js'
 import { createReadableCrowdfundContract, reconcileSnapshot } from '../reconcile/contract.js'
@@ -33,6 +36,15 @@ async function main(): Promise<void> {
     defaultFilePath: join(process.cwd(), 'data/crowdfund-indexer/store.json'),
     initialCursor: getInitialCursor(),
   })
+  try {
+    await runCommand(args, store)
+  } finally {
+    // Release the Postgres pool (no-op for the file store) so the CLI exits promptly.
+    await store.close()
+  }
+}
+
+async function runCommand(args: ParsedCliArgs, store: IndexerStore): Promise<void> {
   // Operator commands only need cursor/range/metadata state; the snapshot commands add
   // raw logs on demand below.
   const data = await store.readMeta()
@@ -41,6 +53,11 @@ async function main(): Promise<void> {
     const provider = createJsonRpcRangeProvider(readRequiredEnv('CROWDFUND_PRIMARY_RPC_URL'))
     const auditRpcUrl = process.env.CROWDFUND_AUDIT_RPC_URL
     const auditProvider = auditRpcUrl ? createJsonRpcRangeProvider(auditRpcUrl) : undefined
+    if (!auditRpcUrl) {
+      process.stderr.write(
+        'Warning: CROWDFUND_AUDIT_RPC_URL is unset — ranges are verified against the same provider twice (no independent audit).\n',
+      )
+    }
     const config = {
       chainId: readNumberEnv('CROWDFUND_CHAIN_ID', 11155111),
       contractAddress: readRequiredEnv('CROWDFUND_CONTRACT_ADDRESS'),
@@ -96,24 +113,31 @@ async function main(): Promise<void> {
       return
     }
 
-    const range = { fromBlock, toBlock }
-    const records = args.command === 'verify'
-      ? [await verifyRange({
+    // Chunk an explicit span so a large --from/--to range does not hit a single oversized
+    // getLogs call (which providers reject). One chunk reproduces the previous behavior.
+    const chunks = planBackfillRanges({ fromBlock, toBlock, maxBlockRange: readNumberEnv('CROWDFUND_MAX_BLOCK_RANGE', 500) })
+    const records: IngestRangeRecord[] = []
+    if (args.command === 'verify') {
+      for (const chunk of chunks) {
+        records.push(await verifyRange({
           ...config,
           store,
           provider,
           auditProvider,
           auditProviderName: auditProvider ? 'audit' : undefined,
-          range,
-        })]
-      : await repairRanges({
-          ...config,
-          store,
-          provider,
-          auditProvider,
-          auditProviderName: auditProvider ? 'audit' : undefined,
-          ranges: [range],
-        })
+          range: chunk,
+        }))
+      }
+    } else {
+      records.push(...await repairRanges({
+        ...config,
+        store,
+        provider,
+        auditProvider,
+        auditProviderName: auditProvider ? 'audit' : undefined,
+        ranges: chunks,
+      }))
+    }
 
     process.stdout.write(
       records.map((record) => `${record.status}: ${record.fromBlock}-${record.toBlock} (${record.logCount} logs)`).join('\n') + '\n',

--- a/crowdfund-ui/packages/indexer/src/cli/index.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/index.ts
@@ -13,9 +13,9 @@ import { backfillVerifiedRanges } from '../ingest/backfill.js'
 import { sanitizeErrorMessage } from '../ingest/errors.js'
 import { createJsonRpcRangeProvider, repairRanges, verifyRange } from '../ingest/rpc.js'
 import { createReadableCrowdfundContract, reconcileSnapshot } from '../reconcile/contract.js'
-import { buildSnapshot } from '../snapshots/build.js'
+import { buildSnapshot, withReconciliation } from '../snapshots/build.js'
 import { publishSnapshot, publishSnapshotToObjectStorage } from '../snapshots/publish.js'
-import type { CursorState, ReconciliationResult } from '../types.js'
+import type { CursorState } from '../types.js'
 
 function readNumberEnv(name: string, fallback: number): number {
   const raw = process.env[name]
@@ -159,22 +159,24 @@ async function main(): Promise<void> {
   if (args.command === 'rebuild-snapshot' || args.command === 'publish-snapshot') {
     const chainId = readNumberEnv('CROWDFUND_CHAIN_ID', 11155111)
     const contractAddress = readRequiredEnv('CROWDFUND_CONTRACT_ADDRESS')
-    let reconciliation: ReconciliationResult | undefined
 
-    const pendingSnapshot = buildSnapshot({ data, chainId, contractAddress })
+    let snapshot = buildSnapshot({ data, chainId, contractAddress })
     const rpcUrl = process.env.CROWDFUND_PRIMARY_RPC_URL
     if (rpcUrl) {
       const provider = new JsonRpcProvider(rpcUrl)
-      const contract = createReadableCrowdfundContract(provider, contractAddress)
-      reconciliation = await reconcileSnapshot({
-        graph: pendingSnapshot.graph,
-        contract,
-        checkedBlock: data.cursor.verifiedCursor,
-        providerName: 'primary',
-      })
+      try {
+        const contract = createReadableCrowdfundContract(provider, contractAddress)
+        const reconciliation = await reconcileSnapshot({
+          graph: snapshot.graph,
+          contract,
+          checkedBlock: data.cursor.verifiedCursor,
+          providerName: 'primary',
+        })
+        snapshot = withReconciliation(snapshot, reconciliation)
+      } finally {
+        provider.destroy()
+      }
     }
-
-    const snapshot = buildSnapshot({ data, chainId, contractAddress, reconciliation })
     if (args.command === 'rebuild-snapshot') {
       await store.update((current) => ({
         ...current,
@@ -241,15 +243,20 @@ async function main(): Promise<void> {
       : null
     const stateFile = process.env.CROWDFUND_ALERT_STATE_FILE
       ?? join(process.cwd(), 'data/crowdfund-indexer/alerts.json')
-    const result = await runAlertsOnce({
-      store,
-      stateStore: createFileAlertStateStore(stateFile),
-      params,
-      repairMaxAttempts: readNumberEnv('CROWDFUND_REPAIR_MAX_ATTEMPTS', 6),
-      staleAfterMs: readNumberEnv('CROWDFUND_STALE_AFTER_MS', 300_000),
-      chainState,
-      notifier: createDiscordNotifierFromEnv(),
-    })
+    let result
+    try {
+      result = await runAlertsOnce({
+        store,
+        stateStore: createFileAlertStateStore(stateFile),
+        params,
+        repairMaxAttempts: readNumberEnv('CROWDFUND_REPAIR_MAX_ATTEMPTS', 6),
+        staleAfterMs: readNumberEnv('CROWDFUND_STALE_AFTER_MS', 300_000),
+        chainState,
+        notifier: createDiscordNotifierFromEnv(),
+      })
+    } finally {
+      chainState?.close?.()
+    }
     process.stdout.write(
       `evaluated ${result.total} candidates; delivered ${result.delivered.length}; skipped ${result.skipped.length}; failed ${result.failed.length}\n`,
     )

--- a/crowdfund-ui/packages/indexer/src/cli/index.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/index.ts
@@ -251,11 +251,16 @@ async function main(): Promise<void> {
       notifier: createDiscordNotifierFromEnv(),
     })
     process.stdout.write(
-      `evaluated ${result.total} candidates; delivered ${result.delivered.length}; skipped ${result.skipped.length}\n`,
+      `evaluated ${result.total} candidates; delivered ${result.delivered.length}; skipped ${result.skipped.length}; failed ${result.failed.length}\n`,
     )
     for (const e of result.delivered) {
       process.stdout.write(`  [${e.severity} ${e.id}] ${e.title} (key=${e.dedupeKey})\n`)
     }
+    for (const e of result.failed) {
+      process.stderr.write(`  FAILED [${e.severity} ${e.id}] ${e.title} (key=${e.dedupeKey})\n`)
+    }
+    // Non-zero exit so a scheduler surfaces delivery failures (and retries next tick).
+    if (result.failed.length > 0) process.exitCode = 1
     return
   }
 

--- a/crowdfund-ui/packages/indexer/src/config.test.ts
+++ b/crowdfund-ui/packages/indexer/src/config.test.ts
@@ -1,0 +1,95 @@
+// ABOUTME: Unit tests for indexer environment configuration parsing.
+// ABOUTME: Locks in defaults, overrides, and required-variable enforcement.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getInitialCursor, loadIndexerConfig } from './config.js'
+
+const TOUCHED = [
+  'CROWDFUND_CONTRACT_ADDRESS', 'CROWDFUND_CHAIN_ID', 'CROWDFUND_DEPLOY_BLOCK',
+  'CROWDFUND_PRIMARY_RPC_URL', 'CROWDFUND_AUDIT_RPC_URL', 'CROWDFUND_CONFIRMATION_DEPTH',
+  'CROWDFUND_OVERLAP_WINDOW', 'CROWDFUND_MAX_BLOCK_RANGE', 'CROWDFUND_INDEXER_PORT',
+  'CROWDFUND_STALE_AFTER_MS', 'CROWDFUND_REPAIR_MAX_ATTEMPTS', 'CROWDFUND_POLL_ON_START',
+  'CROWDFUND_POLL_INTERVAL_MS', 'CROWDFUND_RPC_MAX_RETRIES',
+]
+
+const saved: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  for (const key of TOUCHED) {
+    saved[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(() => {
+  for (const key of TOUCHED) {
+    if (saved[key] === undefined) delete process.env[key]
+    else process.env[key] = saved[key]
+  }
+})
+
+describe('loadIndexerConfig', () => {
+  it('applies documented defaults when only the contract address is set', () => {
+    process.env.CROWDFUND_CONTRACT_ADDRESS = '0xabc'
+    const config = loadIndexerConfig()
+    expect(config).toMatchObject({
+      chainId: 11155111,
+      contractAddress: '0xabc',
+      deployBlock: 0,
+      primaryRpcUrl: null,
+      auditRpcUrl: null,
+      confirmationDepth: 12,
+      overlapWindow: 100,
+      maxBlockRange: 500,
+      port: 3002,
+      staleAfterMs: 300_000,
+      repairMaxAttempts: 6,
+      pollOnStart: false,
+      pollIntervalMs: 15_000,
+      rpcMaxRetries: 3,
+    })
+  })
+
+  it('parses overrides from the environment', () => {
+    process.env.CROWDFUND_CONTRACT_ADDRESS = '0xabc'
+    process.env.CROWDFUND_CHAIN_ID = '1'
+    process.env.CROWDFUND_PRIMARY_RPC_URL = 'https://rpc.example.com/key'
+    process.env.CROWDFUND_POLL_ON_START = 'true'
+    process.env.CROWDFUND_STALE_AFTER_MS = '120000'
+    const config = loadIndexerConfig()
+    expect(config.chainId).toBe(1)
+    expect(config.primaryRpcUrl).toBe('https://rpc.example.com/key')
+    expect(config.pollOnStart).toBe(true)
+    expect(config.staleAfterMs).toBe(120_000)
+  })
+
+  it('throws when the required contract address is missing', () => {
+    expect(() => loadIndexerConfig()).toThrow('CROWDFUND_CONTRACT_ADDRESS')
+  })
+
+  it('rejects an invalid numeric variable', () => {
+    process.env.CROWDFUND_CONTRACT_ADDRESS = '0xabc'
+    process.env.CROWDFUND_MAX_BLOCK_RANGE = '-5'
+    expect(() => loadIndexerConfig()).toThrow('CROWDFUND_MAX_BLOCK_RANGE')
+  })
+})
+
+describe('getInitialCursor', () => {
+  it('seeds cursors one block before deployBlock when deployBlock is set', () => {
+    process.env.CROWDFUND_DEPLOY_BLOCK = '500'
+    const cursor = getInitialCursor()
+    expect(cursor).toMatchObject({
+      deployBlock: 500,
+      chainHead: 500,
+      confirmedHead: 500,
+      ingestedCursor: 499,
+      verifiedCursor: 499,
+    })
+  })
+
+  it('keeps cursors at 0 when deployBlock is unset', () => {
+    const cursor = getInitialCursor()
+    expect(cursor.ingestedCursor).toBe(0)
+    expect(cursor.verifiedCursor).toBe(0)
+  })
+})

--- a/crowdfund-ui/packages/indexer/src/config.ts
+++ b/crowdfund-ui/packages/indexer/src/config.ts
@@ -1,25 +1,42 @@
 // ABOUTME: Environment configuration parsing for the crowdfund indexer service.
-// ABOUTME: Keeps deployment-specific values explicit and validates required runtime inputs.
+// ABOUTME: Single source of truth for env readers, the initial cursor, and runtime config.
+
+import type { CursorState } from './types.js'
 
 export interface IndexerConfig {
   chainId: number
   contractAddress: string
   deployBlock: number
-  primaryRpcUrl: string
+  // Optional so the API can run read-only without an RPC; required only when polling.
+  primaryRpcUrl: string | null
   auditRpcUrl: string | null
   confirmationDepth: number
   overlapWindow: number
   maxBlockRange: number
   port: number
+  staleAfterMs: number
+  repairMaxAttempts: number
+  repairBackoffBaseMs: number
+  repairBackoffMaxMs: number
+  pollOnStart: boolean
+  backfillOnStart: boolean
+  publishOnPoll: boolean
+  pollIntervalMs: number
+  errorBackoffMs: number
+  rpcTimeoutMs: number
+  rpcMaxRetries: number
+  retryBaseDelayMs: number
+  retryJitterMs: number
+  snapshotPublishIntervalMs: number
 }
 
-function readRequiredEnv(name: string): string {
+export function readRequiredEnv(name: string): string {
   const value = process.env[name]
   if (!value) throw new Error(`Missing required environment variable: ${name}`)
   return value
 }
 
-function readNumberEnv(name: string, fallback: number): number {
+export function readNumberEnv(name: string, fallback: number): number {
   const raw = process.env[name]
   if (!raw) return fallback
   const parsed = Number(raw)
@@ -29,16 +46,51 @@ function readNumberEnv(name: string, fallback: number): number {
   return parsed
 }
 
+export function readBooleanEnv(name: string, fallback: boolean): boolean {
+  const value = process.env[name]
+  if (!value) return fallback
+  if (value === 'true') return true
+  if (value === 'false') return false
+  throw new Error(`Invalid boolean environment variable: ${name}`)
+}
+
+export function getInitialCursor(): CursorState {
+  const deployBlock = readNumberEnv('CROWDFUND_DEPLOY_BLOCK', 0)
+  return {
+    deployBlock,
+    confirmationDepth: readNumberEnv('CROWDFUND_CONFIRMATION_DEPTH', 12),
+    overlapWindow: readNumberEnv('CROWDFUND_OVERLAP_WINDOW', 100),
+    chainHead: deployBlock,
+    confirmedHead: deployBlock,
+    ingestedCursor: deployBlock > 0 ? deployBlock - 1 : 0,
+    verifiedCursor: deployBlock > 0 ? deployBlock - 1 : 0,
+  }
+}
+
 export function loadIndexerConfig(): IndexerConfig {
   return {
     chainId: readNumberEnv('CROWDFUND_CHAIN_ID', 11155111),
     contractAddress: readRequiredEnv('CROWDFUND_CONTRACT_ADDRESS'),
     deployBlock: readNumberEnv('CROWDFUND_DEPLOY_BLOCK', 0),
-    primaryRpcUrl: readRequiredEnv('CROWDFUND_PRIMARY_RPC_URL'),
+    primaryRpcUrl: process.env.CROWDFUND_PRIMARY_RPC_URL ?? null,
     auditRpcUrl: process.env.CROWDFUND_AUDIT_RPC_URL ?? null,
     confirmationDepth: readNumberEnv('CROWDFUND_CONFIRMATION_DEPTH', 12),
     overlapWindow: readNumberEnv('CROWDFUND_OVERLAP_WINDOW', 100),
     maxBlockRange: readNumberEnv('CROWDFUND_MAX_BLOCK_RANGE', 500),
     port: readNumberEnv('CROWDFUND_INDEXER_PORT', 3002),
+    staleAfterMs: readNumberEnv('CROWDFUND_STALE_AFTER_MS', 300_000),
+    repairMaxAttempts: readNumberEnv('CROWDFUND_REPAIR_MAX_ATTEMPTS', 6),
+    repairBackoffBaseMs: readNumberEnv('CROWDFUND_REPAIR_BACKOFF_BASE_MS', 30_000),
+    repairBackoffMaxMs: readNumberEnv('CROWDFUND_REPAIR_BACKOFF_MAX_MS', 1_800_000),
+    pollOnStart: readBooleanEnv('CROWDFUND_POLL_ON_START', false),
+    backfillOnStart: readBooleanEnv('CROWDFUND_BACKFILL_ON_START', false),
+    publishOnPoll: readBooleanEnv('CROWDFUND_PUBLISH_ON_POLL', false),
+    pollIntervalMs: readNumberEnv('CROWDFUND_POLL_INTERVAL_MS', 15_000),
+    errorBackoffMs: readNumberEnv('CROWDFUND_POLL_ERROR_BACKOFF_MS', 60_000),
+    rpcTimeoutMs: readNumberEnv('CROWDFUND_RPC_TIMEOUT_MS', 15_000),
+    rpcMaxRetries: readNumberEnv('CROWDFUND_RPC_MAX_RETRIES', 3),
+    retryBaseDelayMs: readNumberEnv('CROWDFUND_RPC_RETRY_BASE_DELAY_MS', 1_000),
+    retryJitterMs: readNumberEnv('CROWDFUND_RPC_RETRY_JITTER_MS', 250),
+    snapshotPublishIntervalMs: readNumberEnv('CROWDFUND_SNAPSHOT_PUBLISH_INTERVAL_MS', 60_000),
   }
 }

--- a/crowdfund-ui/packages/indexer/src/db/fileStore.test.ts
+++ b/crowdfund-ui/packages/indexer/src/db/fileStore.test.ts
@@ -92,6 +92,11 @@ describe('FileIndexerStore', () => {
     ])
   })
 
+  it('close resolves without error (no backend handle to release)', async () => {
+    const store = await makeStore()
+    await expect(store.close()).resolves.toBeUndefined()
+  })
+
   it('readMeta returns store metadata without raw logs', async () => {
     const store = await makeStore()
     await store.upsertRawLogs([{

--- a/crowdfund-ui/packages/indexer/src/db/fileStore.test.ts
+++ b/crowdfund-ui/packages/indexer/src/db/fileStore.test.ts
@@ -92,6 +92,64 @@ describe('FileIndexerStore', () => {
     ])
   })
 
+  it('readMeta returns store metadata without raw logs', async () => {
+    const store = await makeStore()
+    await store.upsertRawLogs([{
+      chainId: 11155111,
+      contractAddress: '0xF681A7c700420e5CA93f77c8988d3eED02767035',
+      blockNumber: 120,
+      blockHash: '0x' + '11'.repeat(32),
+      transactionHash: '0x' + '22'.repeat(32),
+      logIndex: 0,
+      topics: ['0x' + '33'.repeat(32)],
+      data: '0x01',
+    }])
+    await store.upsertRange(makeRange({ fromBlock: 100, toBlock: 109, status: 'verified' }))
+
+    const meta = await store.readMeta()
+    expect('rawLogs' in meta).toBe(false)
+    expect(meta.ranges.map((r) => r.status)).toEqual(['verified'])
+    expect(meta.cursor.verifiedCursor).toBe(99)
+  })
+
+  it('readLogs filters by upper block bound', async () => {
+    const store = await makeStore()
+    const base = {
+      chainId: 11155111,
+      contractAddress: '0xF681A7c700420e5CA93f77c8988d3eED02767035',
+      blockHash: '0x' + '11'.repeat(32),
+      topics: ['0x' + '33'.repeat(32)],
+      data: '0x01',
+    }
+    await store.appendRawLogs([
+      { ...base, blockNumber: 100, transactionHash: '0x' + 'a1'.repeat(32), logIndex: 0 },
+      { ...base, blockNumber: 200, transactionHash: '0x' + 'a2'.repeat(32), logIndex: 0 },
+    ])
+
+    expect((await store.readLogs()).length).toBe(2)
+    expect((await store.readLogs(150)).map((l) => l.blockNumber)).toEqual([100])
+  })
+
+  it('patchRange and patchMeta update only the targeted fields', async () => {
+    const store = await makeStore()
+    await store.patchRange(makeRange({ fromBlock: 120, toBlock: 129, status: 'failed' }))
+    await store.patchMeta({ lastError: 'boom', latestSnapshotHash: '0xhash' })
+
+    const data = await store.read()
+    expect(data.ranges.map((r) => [r.fromBlock, r.status])).toEqual([[120, 'failed']])
+    expect(data.lastError).toBe('boom')
+    expect(data.latestSnapshotHash).toBe('0xhash')
+    // Untouched fields keep their prior value.
+    expect(data.lastVerifiedAt).toBeNull()
+    expect(data.cursor.verifiedCursor).toBe(99)
+
+    // A null patch clears a field; an absent field is left as-is.
+    await store.patchMeta({ lastError: null })
+    const cleared = await store.read()
+    expect(cleared.lastError).toBeNull()
+    expect(cleared.latestSnapshotHash).toBe('0xhash')
+  })
+
   it('upserts raw logs by canonical identity and keeps them sorted', async () => {
     const store = await makeStore()
     const first = {

--- a/crowdfund-ui/packages/indexer/src/db/fileStore.ts
+++ b/crowdfund-ui/packages/indexer/src/db/fileStore.ts
@@ -159,4 +159,8 @@ export class FileIndexerStore implements IndexerStore {
   async patchMeta(patch: IndexerMetaPatch): Promise<void> {
     await this.update((data) => applyMetaPatch(data, patch))
   }
+
+  async close(): Promise<void> {
+    // No persistent backend handle to release.
+  }
 }

--- a/crowdfund-ui/packages/indexer/src/db/fileStore.ts
+++ b/crowdfund-ui/packages/indexer/src/db/fileStore.ts
@@ -4,7 +4,8 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { getLogIdentity } from '../ingest/ranges.js'
-import type { IndexerStore } from './store.js'
+import { applyMetaPatch } from './store.js'
+import type { IndexerMeta, IndexerMetaPatch, IndexerStore } from './store.js'
 import type { CursorState, IndexedRawLog, IndexerStoreData, IngestRangeRecord } from '../types.js'
 
 export interface FileStoreOptions {
@@ -131,5 +132,31 @@ export class FileIndexerStore implements IndexerStore {
         rawLogs: sortLogs([...records.values()]),
       }
     })
+  }
+
+  // The file store has no incremental backend, so the narrow operations are implemented
+  // on top of read()/write(). They exist so call sites can use one storage-agnostic API
+  // that becomes genuinely incremental on the Postgres backend.
+
+  async readMeta(): Promise<IndexerMeta> {
+    const { rawLogs: _rawLogs, ...meta } = await this.read()
+    return meta
+  }
+
+  async readLogs(upToBlock?: number): Promise<readonly IndexedRawLog[]> {
+    const { rawLogs } = await this.read()
+    return upToBlock === undefined ? rawLogs : rawLogs.filter((log) => log.blockNumber <= upToBlock)
+  }
+
+  async appendRawLogs(logs: readonly IndexedRawLog[]): Promise<void> {
+    await this.upsertRawLogs(logs)
+  }
+
+  async patchRange(record: IngestRangeRecord): Promise<void> {
+    await this.upsertRange(record)
+  }
+
+  async patchMeta(patch: IndexerMetaPatch): Promise<void> {
+    await this.update((data) => applyMetaPatch(data, patch))
   }
 }

--- a/crowdfund-ui/packages/indexer/src/db/postgresStore.test.ts
+++ b/crowdfund-ui/packages/indexer/src/db/postgresStore.test.ts
@@ -2,7 +2,9 @@
 // ABOUTME: Guards the durable store tables needed for no-gap ingestion and snapshot recovery.
 
 import { describe, expect, it } from 'vitest'
-import { POSTGRES_SCHEMA_SQL } from './postgresStore.js'
+import { POSTGRES_SCHEMA_SQL, PostgresIndexerStore } from './postgresStore.js'
+import type { Pool } from 'pg'
+import type { CursorState, IndexedRawLog, IngestRangeRecord } from '../types.js'
 
 describe('POSTGRES_SCHEMA_SQL', () => {
   it('creates durable cursor, range, raw log, and metadata tables', () => {
@@ -16,5 +18,131 @@ describe('POSTGRES_SCHEMA_SQL', () => {
     expect(POSTGRES_SCHEMA_SQL).toContain('PRIMARY KEY (chain_id, contract_address, transaction_hash, log_index)')
     expect(POSTGRES_SCHEMA_SQL).toContain("status IN ('pending', 'staged', 'verified', 'failed', 'suspicious')")
     expect(POSTGRES_SCHEMA_SQL).toContain('PRIMARY KEY (from_block, to_block)')
+  })
+})
+
+// A recording fake pool: captures every query so we can assert WHICH statements the
+// narrow operations issue (the whole point of the perf fix is the query shape, not just
+// the result). Returns canned rows for SELECTs so reads resolve.
+function makeFakePool(rows: { cursor?: unknown[]; metadata?: unknown[]; ranges?: unknown[]; rawLogs?: unknown[] } = {}) {
+  const queries: Array<{ text: string; values?: readonly unknown[] }> = []
+  const respond = (text: string) => {
+    if (/from crowdfund_indexer_cursor/i.test(text)) return { rows: rows.cursor ?? [] }
+    if (/from crowdfund_indexer_metadata/i.test(text)) return { rows: rows.metadata ?? [] }
+    if (/from crowdfund_indexer_ranges/i.test(text)) return { rows: rows.ranges ?? [] }
+    if (/from crowdfund_indexer_raw_logs/i.test(text)) return { rows: rows.rawLogs ?? [] }
+    return { rows: [] }
+  }
+  const query = async (text: string, values?: readonly unknown[]) => {
+    queries.push({ text, values })
+    return respond(text)
+  }
+  const client = { query, release() {} }
+  const pool = { query, connect: async () => client, end: async () => {} }
+  return { pool: pool as unknown as Pool, queries }
+}
+
+const initialCursor: CursorState = {
+  deployBlock: 100, confirmationDepth: 12, overlapWindow: 100,
+  chainHead: 0, confirmedHead: 0, ingestedCursor: 99, verifiedCursor: 99,
+}
+
+const cursorRow = {
+  deploy_block: 100, confirmation_depth: 12, overlap_window: 100,
+  chain_head: 150, confirmed_head: 138, ingested_cursor: 120, verified_cursor: 110,
+}
+
+const metaRow = {
+  last_ingested_at: null, last_verified_at: null, last_reconciled_at: null,
+  last_error: null, latest_snapshot_hash: null, latest_static_snapshot_url: null,
+}
+
+function makeLog(blockNumber: number, txSuffix: string): IndexedRawLog {
+  return {
+    chainId: 11155111,
+    contractAddress: '0xF681A7c700420e5CA93f77c8988d3eED02767035',
+    blockNumber,
+    blockHash: '0x' + '11'.repeat(32),
+    transactionHash: '0x' + txSuffix.repeat(32),
+    logIndex: 0,
+    topics: ['0x' + '33'.repeat(32)],
+    data: '0x',
+  }
+}
+
+function makeRange(): IngestRangeRecord {
+  return {
+    fromBlock: 120, toBlock: 129, status: 'verified', provider: 'primary/audit',
+    attempts: 1, logCount: 0, digest: '0xd', fetchedAt: null, verifiedAt: null,
+    lastError: null, nextRetryAt: null,
+  }
+}
+
+describe('PostgresIndexerStore narrow operations', () => {
+  it('appendRawLogs writes only the given logs (no full read, no range rewrite)', async () => {
+    const { pool, queries } = makeFakePool({ cursor: [cursorRow] })
+    const store = new PostgresIndexerStore({ pool, initialCursor })
+    await store.migrate()
+    queries.length = 0
+
+    await store.appendRawLogs([makeLog(120, 'a1'), makeLog(121, 'a2')])
+
+    const logInserts = queries.filter((q) => /insert into crowdfund_indexer_raw_logs/i.test(q.text))
+    expect(logInserts).toHaveLength(2)
+    expect(queries.some((q) => /select .*from crowdfund_indexer_raw_logs/i.test(q.text))).toBe(false)
+    expect(queries.some((q) => /crowdfund_indexer_ranges/i.test(q.text))).toBe(false)
+  })
+
+  it('patchRange upserts exactly one range row and touches no logs', async () => {
+    const { pool, queries } = makeFakePool({ cursor: [cursorRow] })
+    const store = new PostgresIndexerStore({ pool, initialCursor })
+    await store.migrate()
+    queries.length = 0
+
+    await store.patchRange(makeRange())
+
+    expect(queries.filter((q) => /insert into crowdfund_indexer_ranges/i.test(q.text))).toHaveLength(1)
+    expect(queries.some((q) => /raw_logs/i.test(q.text))).toBe(false)
+  })
+
+  it('readMeta does not read the raw log table', async () => {
+    const { pool, queries } = makeFakePool({ cursor: [cursorRow], metadata: [metaRow], ranges: [] })
+    const store = new PostgresIndexerStore({ pool, initialCursor })
+    await store.migrate()
+    queries.length = 0
+
+    const meta = await store.readMeta()
+
+    expect(meta.cursor.verifiedCursor).toBe(110)
+    expect(queries.some((q) => /raw_logs/i.test(q.text))).toBe(false)
+  })
+
+  it('readLogs filters by an upper block bound', async () => {
+    const { pool, queries } = makeFakePool({ rawLogs: [] })
+    const store = new PostgresIndexerStore({ pool, initialCursor })
+    await store.migrate()
+    queries.length = 0
+
+    await store.readLogs(150)
+
+    const select = queries.find((q) => /select .*from crowdfund_indexer_raw_logs/i.test(q.text))
+    expect(select?.text).toMatch(/block_number <= \$1/)
+    expect(select?.values).toEqual([150])
+  })
+
+  it('patchMeta updates only the provided columns and skips the cursor when absent', async () => {
+    const { pool, queries } = makeFakePool({ cursor: [cursorRow] })
+    const store = new PostgresIndexerStore({ pool, initialCursor })
+    await store.migrate()
+    queries.length = 0
+
+    await store.patchMeta({ lastError: 'boom', latestSnapshotHash: '0xhash' })
+
+    const update = queries.find((q) => /update crowdfund_indexer_metadata/i.test(q.text))
+    expect(update).toBeDefined()
+    expect(update!.text).toMatch(/last_error = \$1/)
+    expect(update!.text).toMatch(/latest_snapshot_hash = \$2/)
+    expect(update!.values).toEqual(['boom', '0xhash'])
+    expect(queries.some((q) => /insert into crowdfund_indexer_cursor/i.test(q.text))).toBe(false)
   })
 })

--- a/crowdfund-ui/packages/indexer/src/db/postgresStore.ts
+++ b/crowdfund-ui/packages/indexer/src/db/postgresStore.ts
@@ -4,7 +4,7 @@
 import { Pool } from 'pg'
 import { getLogIdentity } from '../ingest/ranges.js'
 import { createEmptyStoreData } from './fileStore.js'
-import type { IndexerStore } from './store.js'
+import type { IndexerMeta, IndexerMetaPatch, IndexerStore } from './store.js'
 import type { CursorState, IndexedRawLog, IndexerStoreData, IngestRangeRecord, IngestRangeStatus } from '../types.js'
 import type { PoolClient, PoolConfig, QueryResult } from 'pg'
 
@@ -220,6 +220,124 @@ async function ensureSeedRows(client: DbClient, initialCursor: CursorState): Pro
   await client.query('INSERT INTO crowdfund_indexer_metadata (id) VALUES (true) ON CONFLICT (id) DO NOTHING')
 }
 
+// Per-row upsert helpers. These hold the single source of truth for each table's write
+// SQL and are reused both by the whole-store writeWithClient and by the narrow ops, so
+// the two paths can never drift.
+
+async function upsertCursorRow(client: DbClient, cursor: CursorState): Promise<void> {
+  await client.query(
+    `INSERT INTO crowdfund_indexer_cursor (
+      id, deploy_block, confirmation_depth, overlap_window, chain_head, confirmed_head, ingested_cursor, verified_cursor
+    )
+    VALUES (true, $1, $2, $3, $4, $5, $6, $7)
+    ON CONFLICT (id) DO UPDATE SET
+      deploy_block = EXCLUDED.deploy_block,
+      confirmation_depth = EXCLUDED.confirmation_depth,
+      overlap_window = EXCLUDED.overlap_window,
+      chain_head = EXCLUDED.chain_head,
+      confirmed_head = EXCLUDED.confirmed_head,
+      ingested_cursor = EXCLUDED.ingested_cursor,
+      verified_cursor = EXCLUDED.verified_cursor,
+      updated_at = now()`,
+    [
+      cursor.deployBlock,
+      cursor.confirmationDepth,
+      cursor.overlapWindow,
+      cursor.chainHead,
+      cursor.confirmedHead,
+      cursor.ingestedCursor,
+      cursor.verifiedCursor,
+    ],
+  )
+}
+
+type MetadataFields = Pick<
+  IndexerStoreData,
+  'lastIngestedAt' | 'lastVerifiedAt' | 'lastReconciledAt' | 'lastError' | 'latestSnapshotHash' | 'latestStaticSnapshotUrl'
+>
+
+async function upsertMetadataRow(client: DbClient, data: MetadataFields): Promise<void> {
+  await client.query(
+    `INSERT INTO crowdfund_indexer_metadata (
+      id, last_ingested_at, last_verified_at, last_reconciled_at, last_error, latest_snapshot_hash, latest_static_snapshot_url
+    )
+    VALUES (true, $1, $2, $3, $4, $5, $6)
+    ON CONFLICT (id) DO UPDATE SET
+      last_ingested_at = EXCLUDED.last_ingested_at,
+      last_verified_at = EXCLUDED.last_verified_at,
+      last_reconciled_at = EXCLUDED.last_reconciled_at,
+      last_error = EXCLUDED.last_error,
+      latest_snapshot_hash = EXCLUDED.latest_snapshot_hash,
+      latest_static_snapshot_url = EXCLUDED.latest_static_snapshot_url,
+      updated_at = now()`,
+    [
+      data.lastIngestedAt,
+      data.lastVerifiedAt,
+      data.lastReconciledAt,
+      data.lastError,
+      data.latestSnapshotHash,
+      data.latestStaticSnapshotUrl,
+    ],
+  )
+}
+
+async function upsertRangeRow(client: DbClient, range: IngestRangeRecord): Promise<void> {
+  await client.query(
+    `INSERT INTO crowdfund_indexer_ranges (
+      from_block, to_block, status, provider, attempts, log_count, digest, fetched_at, verified_at, last_error, next_retry_at
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+    ON CONFLICT (from_block, to_block) DO UPDATE SET
+      status = EXCLUDED.status,
+      provider = EXCLUDED.provider,
+      attempts = EXCLUDED.attempts,
+      log_count = EXCLUDED.log_count,
+      digest = EXCLUDED.digest,
+      fetched_at = EXCLUDED.fetched_at,
+      verified_at = EXCLUDED.verified_at,
+      last_error = EXCLUDED.last_error,
+      next_retry_at = EXCLUDED.next_retry_at,
+      updated_at = now()`,
+    [
+      range.fromBlock,
+      range.toBlock,
+      range.status,
+      range.provider,
+      range.attempts,
+      range.logCount,
+      range.digest,
+      range.fetchedAt,
+      range.verifiedAt,
+      range.lastError,
+      range.nextRetryAt,
+    ],
+  )
+}
+
+async function upsertRawLogRow(client: DbClient, log: IndexedRawLog): Promise<void> {
+  await client.query(
+    `INSERT INTO crowdfund_indexer_raw_logs (
+      chain_id, contract_address, block_number, block_hash, transaction_hash, log_index, topics, data
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+    ON CONFLICT (chain_id, contract_address, transaction_hash, log_index) DO UPDATE SET
+      block_number = EXCLUDED.block_number,
+      block_hash = EXCLUDED.block_hash,
+      topics = EXCLUDED.topics,
+      data = EXCLUDED.data`,
+    [
+      log.chainId,
+      log.contractAddress.toLowerCase(),
+      log.blockNumber,
+      log.blockHash,
+      log.transactionHash,
+      log.logIndex,
+      JSON.stringify(log.topics),
+      log.data,
+    ],
+  )
+}
+
 export class PostgresIndexerStore implements IndexerStore {
   private readonly pool: Pool
   private readonly initialCursor: CursorState
@@ -334,108 +452,86 @@ export class PostgresIndexerStore implements IndexerStore {
   }
 
   private async writeWithClient(client: DbClient, data: IndexerStoreData): Promise<void> {
-    await client.query(
-      `INSERT INTO crowdfund_indexer_cursor (
-        id, deploy_block, confirmation_depth, overlap_window, chain_head, confirmed_head, ingested_cursor, verified_cursor
-      )
-      VALUES (true, $1, $2, $3, $4, $5, $6, $7)
-      ON CONFLICT (id) DO UPDATE SET
-        deploy_block = EXCLUDED.deploy_block,
-        confirmation_depth = EXCLUDED.confirmation_depth,
-        overlap_window = EXCLUDED.overlap_window,
-        chain_head = EXCLUDED.chain_head,
-        confirmed_head = EXCLUDED.confirmed_head,
-        ingested_cursor = EXCLUDED.ingested_cursor,
-        verified_cursor = EXCLUDED.verified_cursor,
-        updated_at = now()`,
-      [
-        data.cursor.deployBlock,
-        data.cursor.confirmationDepth,
-        data.cursor.overlapWindow,
-        data.cursor.chainHead,
-        data.cursor.confirmedHead,
-        data.cursor.ingestedCursor,
-        data.cursor.verifiedCursor,
-      ],
-    )
-    await client.query(
-      `INSERT INTO crowdfund_indexer_metadata (
-        id, last_ingested_at, last_verified_at, last_reconciled_at, last_error, latest_snapshot_hash, latest_static_snapshot_url
-      )
-      VALUES (true, $1, $2, $3, $4, $5, $6)
-      ON CONFLICT (id) DO UPDATE SET
-        last_ingested_at = EXCLUDED.last_ingested_at,
-        last_verified_at = EXCLUDED.last_verified_at,
-        last_reconciled_at = EXCLUDED.last_reconciled_at,
-        last_error = EXCLUDED.last_error,
-        latest_snapshot_hash = EXCLUDED.latest_snapshot_hash,
-        latest_static_snapshot_url = EXCLUDED.latest_static_snapshot_url,
-        updated_at = now()`,
-      [
-        data.lastIngestedAt,
-        data.lastVerifiedAt,
-        data.lastReconciledAt,
-        data.lastError,
-        data.latestSnapshotHash,
-        data.latestStaticSnapshotUrl,
-      ],
-    )
+    await upsertCursorRow(client, data.cursor)
+    await upsertMetadataRow(client, data)
+    for (const range of sortRanges(data.ranges)) await upsertRangeRow(client, range)
+    for (const log of sortLogs(dedupeLogs(data.rawLogs))) await upsertRawLogRow(client, log)
+  }
 
-    for (const range of sortRanges(data.ranges)) {
-      await client.query(
-        `INSERT INTO crowdfund_indexer_ranges (
-          from_block, to_block, status, provider, attempts, log_count, digest, fetched_at, verified_at, last_error, next_retry_at
-        )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-        ON CONFLICT (from_block, to_block) DO UPDATE SET
-          status = EXCLUDED.status,
-          provider = EXCLUDED.provider,
-          attempts = EXCLUDED.attempts,
-          log_count = EXCLUDED.log_count,
-          digest = EXCLUDED.digest,
-          fetched_at = EXCLUDED.fetched_at,
-          verified_at = EXCLUDED.verified_at,
-          last_error = EXCLUDED.last_error,
-          next_retry_at = EXCLUDED.next_retry_at,
-          updated_at = now()`,
-        [
-          range.fromBlock,
-          range.toBlock,
-          range.status,
-          range.provider,
-          range.attempts,
-          range.logCount,
-          range.digest,
-          range.fetchedAt,
-          range.verifiedAt,
-          range.lastError,
-          range.nextRetryAt,
-        ],
-      )
-    }
+  // --- Narrow operations: touch only affected rows, no whole-store read or rewrite. ---
 
-    for (const log of sortLogs(dedupeLogs(data.rawLogs))) {
-      await client.query(
-        `INSERT INTO crowdfund_indexer_raw_logs (
-          chain_id, contract_address, block_number, block_hash, transaction_hash, log_index, topics, data
-        )
-        VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
-        ON CONFLICT (chain_id, contract_address, transaction_hash, log_index) DO UPDATE SET
-          block_number = EXCLUDED.block_number,
-          block_hash = EXCLUDED.block_hash,
-          topics = EXCLUDED.topics,
-          data = EXCLUDED.data`,
-        [
-          log.chainId,
-          log.contractAddress.toLowerCase(),
-          log.blockNumber,
-          log.blockHash,
-          log.transactionHash,
-          log.logIndex,
-          JSON.stringify(log.topics),
-          log.data,
-        ],
-      )
+  async readMeta(): Promise<IndexerMeta> {
+    await this.ensureReady()
+    const cursor = await this.pool.query<CursorRow>('SELECT * FROM crowdfund_indexer_cursor WHERE id = true')
+    if (cursor.rows.length === 0) {
+      const { rawLogs: _rawLogs, ...meta } = createEmptyStoreData(this.initialCursor)
+      return meta
     }
+    const metadata = await this.pool.query<MetadataRow>('SELECT * FROM crowdfund_indexer_metadata WHERE id = true')
+    const ranges = await this.pool.query<RangeRow>('SELECT * FROM crowdfund_indexer_ranges ORDER BY from_block, to_block')
+    const meta = metadata.rows[0]
+    return {
+      cursor: toCursor(cursor.rows[0]),
+      ranges: ranges.rows.map(toRange),
+      lastIngestedAt: meta ? toIso(meta.last_ingested_at) : null,
+      lastVerifiedAt: meta ? toIso(meta.last_verified_at) : null,
+      lastReconciledAt: meta ? toIso(meta.last_reconciled_at) : null,
+      lastError: meta?.last_error ?? null,
+      latestSnapshotHash: meta?.latest_snapshot_hash ?? null,
+      latestStaticSnapshotUrl: meta?.latest_static_snapshot_url ?? null,
+    }
+  }
+
+  async readLogs(upToBlock?: number): Promise<readonly IndexedRawLog[]> {
+    await this.ensureReady()
+    const result = upToBlock === undefined
+      ? await this.pool.query<RawLogRow>(
+          'SELECT * FROM crowdfund_indexer_raw_logs ORDER BY block_number, log_index, transaction_hash',
+        )
+      : await this.pool.query<RawLogRow>(
+          'SELECT * FROM crowdfund_indexer_raw_logs WHERE block_number <= $1 ORDER BY block_number, log_index, transaction_hash',
+          [upToBlock],
+        )
+    return result.rows.map(toRawLog)
+  }
+
+  async appendRawLogs(logs: readonly IndexedRawLog[]): Promise<void> {
+    await this.ensureReady()
+    const deduped = sortLogs(dedupeLogs(logs))
+    if (deduped.length === 0) return
+    await this.withTransaction(async (client) => {
+      for (const log of deduped) await upsertRawLogRow(client, log)
+    })
+  }
+
+  async patchRange(record: IngestRangeRecord): Promise<void> {
+    await this.ensureReady()
+    await upsertRangeRow(this.pool, record)
+  }
+
+  async patchMeta(patch: IndexerMetaPatch): Promise<void> {
+    await this.ensureReady()
+    await this.withTransaction(async (client) => {
+      if (patch.cursor) await upsertCursorRow(client, patch.cursor)
+
+      const columns: Array<{ col: string; value: string | null }> = []
+      if (patch.lastIngestedAt !== undefined) columns.push({ col: 'last_ingested_at', value: patch.lastIngestedAt })
+      if (patch.lastVerifiedAt !== undefined) columns.push({ col: 'last_verified_at', value: patch.lastVerifiedAt })
+      if (patch.lastReconciledAt !== undefined) columns.push({ col: 'last_reconciled_at', value: patch.lastReconciledAt })
+      if (patch.lastError !== undefined) columns.push({ col: 'last_error', value: patch.lastError })
+      if (patch.latestSnapshotHash !== undefined) columns.push({ col: 'latest_snapshot_hash', value: patch.latestSnapshotHash })
+      if (patch.latestStaticSnapshotUrl !== undefined) {
+        columns.push({ col: 'latest_static_snapshot_url', value: patch.latestStaticSnapshotUrl })
+      }
+
+      if (columns.length > 0) {
+        const sets = columns.map((c, i) => `${c.col} = $${i + 1}`)
+        sets.push('updated_at = now()')
+        await client.query(
+          `UPDATE crowdfund_indexer_metadata SET ${sets.join(', ')} WHERE id = true`,
+          columns.map((c) => c.value),
+        )
+      }
+    })
   }
 }

--- a/crowdfund-ui/packages/indexer/src/db/store.ts
+++ b/crowdfund-ui/packages/indexer/src/db/store.ts
@@ -3,6 +3,22 @@
 
 import type { CursorState, IndexedRawLog, IndexerStoreData, IngestRangeRecord } from '../types.js'
 
+// Metadata view of the store without the (potentially large) raw-log set. Hot paths that
+// only need cursor/range/metadata state read this instead of the whole store.
+export type IndexerMeta = Omit<IndexerStoreData, 'rawLogs'>
+
+// Partial metadata update. A field left `undefined` is untouched; an explicit `null`
+// clears it. `cursor`, when present, replaces the cursor wholesale.
+export interface IndexerMetaPatch {
+  cursor?: CursorState
+  lastIngestedAt?: string | null
+  lastVerifiedAt?: string | null
+  lastReconciledAt?: string | null
+  lastError?: string | null
+  latestSnapshotHash?: string | null
+  latestStaticSnapshotUrl?: string | null
+}
+
 export interface IndexerStore {
   read(): Promise<IndexerStoreData>
   write(data: IndexerStoreData): Promise<void>
@@ -10,4 +26,29 @@ export interface IndexerStore {
   upsertRange(record: IngestRangeRecord): Promise<IndexerStoreData>
   updateCursor(cursor: CursorState): Promise<IndexerStoreData>
   upsertRawLogs(logs: readonly IndexedRawLog[]): Promise<IndexerStoreData>
+
+  // Narrow operations — touch only the affected rows so hot ingest/API paths avoid the
+  // whole-store read-modify-write cost (critical for the Postgres backend, where the
+  // legacy update() rewrites every range and log row on each call).
+  readMeta(): Promise<IndexerMeta>
+  readLogs(upToBlock?: number): Promise<readonly IndexedRawLog[]>
+  appendRawLogs(logs: readonly IndexedRawLog[]): Promise<void>
+  patchRange(record: IngestRangeRecord): Promise<void>
+  patchMeta(patch: IndexerMetaPatch): Promise<void>
+}
+
+// Applies a metadata patch to an in-memory store snapshot (used by the file store and as
+// the reference semantics for the Postgres patchMeta implementation).
+export function applyMetaPatch(data: IndexerStoreData, patch: IndexerMetaPatch): IndexerStoreData {
+  return {
+    ...data,
+    cursor: patch.cursor ?? data.cursor,
+    lastIngestedAt: patch.lastIngestedAt !== undefined ? patch.lastIngestedAt : data.lastIngestedAt,
+    lastVerifiedAt: patch.lastVerifiedAt !== undefined ? patch.lastVerifiedAt : data.lastVerifiedAt,
+    lastReconciledAt: patch.lastReconciledAt !== undefined ? patch.lastReconciledAt : data.lastReconciledAt,
+    lastError: patch.lastError !== undefined ? patch.lastError : data.lastError,
+    latestSnapshotHash: patch.latestSnapshotHash !== undefined ? patch.latestSnapshotHash : data.latestSnapshotHash,
+    latestStaticSnapshotUrl:
+      patch.latestStaticSnapshotUrl !== undefined ? patch.latestStaticSnapshotUrl : data.latestStaticSnapshotUrl,
+  }
 }

--- a/crowdfund-ui/packages/indexer/src/db/store.ts
+++ b/crowdfund-ui/packages/indexer/src/db/store.ts
@@ -35,6 +35,10 @@ export interface IndexerStore {
   appendRawLogs(logs: readonly IndexedRawLog[]): Promise<void>
   patchRange(record: IngestRangeRecord): Promise<void>
   patchMeta(patch: IndexerMetaPatch): Promise<void>
+
+  // Releases any backend resources (e.g. the Postgres pool) so a one-shot process can
+  // exit promptly. No-op for the file store.
+  close(): Promise<void>
 }
 
 // Applies a metadata patch to an in-memory store snapshot (used by the file store and as

--- a/crowdfund-ui/packages/indexer/src/index.ts
+++ b/crowdfund-ui/packages/indexer/src/index.ts
@@ -82,7 +82,7 @@ export type {
   ReconcileSnapshotInput,
 } from './reconcile/contract.js'
 
-export { buildSnapshot } from './snapshots/build.js'
+export { buildSnapshot, withReconciliation } from './snapshots/build.js'
 export type { BuildSnapshotInput } from './snapshots/build.js'
 export { stableStringify, toJsonValue } from './snapshots/json.js'
 export { publishSnapshot, publishSnapshotToObjectStorage } from './snapshots/publish.js'

--- a/crowdfund-ui/packages/indexer/src/ingest/backfill.test.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/backfill.test.ts
@@ -92,6 +92,106 @@ describe('chunked backfill', () => {
     expect(data.cursor.verifiedCursor).toBe(110)
   })
 
+  function makeCountingProvider(logs: Map<string, readonly RpcLog[]>, counter: { calls: number }): RangeLogProvider {
+    return {
+      getBlockNumber: async () => 112,
+      getLogs: async ({ fromBlock, toBlock }) => {
+        counter.calls += 1
+        return logs.get(`${fromBlock}-${toBlock}`) ?? []
+      },
+    }
+  }
+
+  function seedFailedRange(store: FileIndexerStore, overrides: { attempts: number; nextRetryAt: string | null }) {
+    return store.upsertRange({
+      fromBlock: 100,
+      toBlock: 104,
+      status: 'failed',
+      provider: 'primary',
+      attempts: overrides.attempts,
+      logCount: 0,
+      digest: null,
+      fetchedAt: '2026-05-01T00:00:00.000Z',
+      verifiedAt: null,
+      lastError: 'RPC timeout',
+      nextRetryAt: overrides.nextRetryAt,
+    })
+  }
+
+  it('defers a failed chunk still inside its backoff window (no RPC, stops early)', async () => {
+    const store = await makeStore()
+    const now = () => new Date('2026-06-15T12:00:00.000Z')
+    await seedFailedRange(store, { attempts: 1, nextRetryAt: '2026-06-15T12:05:00.000Z' })
+    const counter = { calls: 0 }
+    const provider = makeCountingProvider(new Map(), counter)
+
+    const result = await backfillVerifiedRanges({
+      ...config,
+      store,
+      provider,
+      maxBlockRange: 5,
+      retryPolicy: { maxAttempts: 6, now },
+    })
+
+    expect(counter.calls).toBe(0)
+    expect(result.stoppedEarly).toBe(true)
+    expect(result.ranges).toHaveLength(0)
+    expect((await store.read()).cursor.verifiedCursor).toBe(99)
+  })
+
+  it('retries a failed chunk once its backoff window has elapsed', async () => {
+    const store = await makeStore()
+    const now = () => new Date('2026-06-15T12:00:00.000Z')
+    await seedFailedRange(store, { attempts: 1, nextRetryAt: '2026-06-15T11:55:00.000Z' })
+    const logs = new Map<string, readonly RpcLog[]>([['100-104', [makeLog(100)]]])
+    const counter = { calls: 0 }
+    const provider = makeCountingProvider(logs, counter)
+
+    const result = await backfillVerifiedRanges({
+      ...config,
+      store,
+      provider,
+      auditProvider: makeCountingProvider(logs, { calls: 0 }),
+      auditProviderName: 'audit',
+      maxBlockRange: 5,
+      retryPolicy: { maxAttempts: 6, now },
+    })
+
+    expect(counter.calls).toBeGreaterThan(0)
+    expect(result.ranges[0]?.status).toBe('verified')
+  })
+
+  it('skips an exhausted chunk under policy but retries it without one (CLI path)', async () => {
+    const logs = new Map<string, readonly RpcLog[]>([['100-104', [makeLog(100)]]])
+
+    const polled = await makeStore()
+    await seedFailedRange(polled, { attempts: 3, nextRetryAt: null })
+    const polledCounter = { calls: 0 }
+    const polledResult = await backfillVerifiedRanges({
+      ...config,
+      store: polled,
+      provider: makeCountingProvider(logs, polledCounter),
+      maxBlockRange: 5,
+      retryPolicy: { maxAttempts: 3 },
+    })
+    expect(polledCounter.calls).toBe(0)
+    expect(polledResult.stoppedEarly).toBe(true)
+
+    const cli = await makeStore()
+    await seedFailedRange(cli, { attempts: 3, nextRetryAt: null })
+    const cliCounter = { calls: 0 }
+    const cliResult = await backfillVerifiedRanges({
+      ...config,
+      store: cli,
+      provider: makeCountingProvider(logs, cliCounter),
+      auditProvider: makeCountingProvider(logs, { calls: 0 }),
+      auditProviderName: 'audit',
+      maxBlockRange: 5,
+    })
+    expect(cliCounter.calls).toBeGreaterThan(0)
+    expect(cliResult.ranges[0]?.status).toBe('verified')
+  })
+
   it('stops when a chunk fails verification', async () => {
     const store = await makeStore()
     const primaryLogs = new Map<string, readonly RpcLog[]>([

--- a/crowdfund-ui/packages/indexer/src/ingest/backfill.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/backfill.ts
@@ -12,6 +12,17 @@ export interface PlanBackfillRangesInput {
   maxBlockRange: number
 }
 
+// When set, backfill skips a chunk whose existing record is failed/suspicious and is
+// still within its repair backoff window or has exhausted its attempt limit. This keeps
+// the poll loop from re-verifying a stuck range every cycle (which both ignored the
+// backoff and double-incremented `attempts` alongside auto-reconcile). The operator CLI
+// passes no policy, so `repair`/`backfill` remain an explicit immediate retry.
+export interface BackfillRetryPolicy {
+  maxAttempts: number
+  // Injectable clock for deterministic tests.
+  now?: () => Date
+}
+
 export interface BackfillInput extends RangePipelineConfig {
   store: IndexerStore
   provider: RangeLogProvider
@@ -20,6 +31,7 @@ export interface BackfillInput extends RangePipelineConfig {
   maxBlockRange: number
   toBlock?: number
   stopOnUnverified?: boolean
+  retryPolicy?: BackfillRetryPolicy
 }
 
 export interface BackfillResult {
@@ -27,6 +39,22 @@ export interface BackfillResult {
   toBlock: number
   ranges: readonly IngestRangeRecord[]
   stoppedEarly: boolean
+}
+
+// True when an existing record for this range should NOT be re-verified yet under the
+// given policy: it is failed/suspicious and either still inside its backoff window or
+// already at the attempt limit. Ranges with no prior record (or non-failed records) are
+// never deferred.
+function isDeferredByPolicy(
+  record: IngestRangeRecord | undefined,
+  policy: BackfillRetryPolicy,
+): boolean {
+  if (!record) return false
+  if (record.status !== 'failed' && record.status !== 'suspicious') return false
+  if (policy.maxAttempts > 0 && record.attempts >= policy.maxAttempts) return true
+  if (record.nextRetryAt === null) return false
+  const now = (policy.now ?? (() => new Date()))()
+  return new Date(record.nextRetryAt).getTime() > now.getTime()
 }
 
 export function planBackfillRanges(input: PlanBackfillRangesInput): BlockRange[] {
@@ -67,6 +95,18 @@ export async function backfillVerifiedRanges(input: BackfillInput): Promise<Back
   const records: IngestRangeRecord[] = []
   let stoppedEarly = false
   for (const range of ranges) {
+    // Respect the repair backoff/attempt limit before re-verifying a known-bad chunk.
+    // Because the verified cursor never skips a gap, a deferred chunk also stops every
+    // later chunk this cycle — they cannot be promoted past it anyway.
+    if (input.retryPolicy) {
+      const existing = data.ranges.find(
+        (record) => record.fromBlock === range.fromBlock && record.toBlock === range.toBlock,
+      )
+      if (isDeferredByPolicy(existing, input.retryPolicy)) {
+        stoppedEarly = true
+        break
+      }
+    }
     const record = await verifyRange({ ...input, range })
     records.push(record)
     if ((input.stopOnUnverified ?? true) && record.status !== 'verified') {

--- a/crowdfund-ui/packages/indexer/src/ingest/backfill.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/backfill.ts
@@ -72,25 +72,24 @@ export function planBackfillRanges(input: PlanBackfillRangesInput): BlockRange[]
 }
 
 export async function backfillVerifiedRanges(input: BackfillInput): Promise<BackfillResult> {
-  const data = await input.store.read()
+  const meta = await input.store.readMeta()
   const chainHead = await input.provider.getBlockNumber()
-  const confirmedHead = Math.max(0, chainHead - data.cursor.confirmationDepth)
+  const confirmedHead = Math.max(0, chainHead - meta.cursor.confirmationDepth)
   const toBlock = input.toBlock === undefined ? confirmedHead : Math.min(input.toBlock, confirmedHead)
-  const fromBlock = data.cursor.verifiedCursor + 1
+  const fromBlock = meta.cursor.verifiedCursor + 1
   const ranges = planBackfillRanges({
     fromBlock,
     toBlock,
     maxBlockRange: input.maxBlockRange,
   })
 
-  await input.store.update((current) => ({
-    ...current,
+  await input.store.patchMeta({
     cursor: {
-      ...current.cursor,
+      ...meta.cursor,
       chainHead,
       confirmedHead,
     },
-  }))
+  })
 
   const records: IngestRangeRecord[] = []
   let stoppedEarly = false
@@ -99,7 +98,7 @@ export async function backfillVerifiedRanges(input: BackfillInput): Promise<Back
     // Because the verified cursor never skips a gap, a deferred chunk also stops every
     // later chunk this cycle — they cannot be promoted past it anyway.
     if (input.retryPolicy) {
-      const existing = data.ranges.find(
+      const existing = meta.ranges.find(
         (record) => record.fromBlock === range.fromBlock && record.toBlock === range.toBlock,
       )
       if (isDeferredByPolicy(existing, input.retryPolicy)) {

--- a/crowdfund-ui/packages/indexer/src/ingest/errors.test.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/errors.test.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Unit tests for indexer error-message sanitization.
+// ABOUTME: Verifies RPC keys and DB credentials are redacted while messages stay legible.
+
+import { describe, expect, it } from 'vitest'
+import { sanitizeErrorMessage } from './errors.js'
+
+describe('sanitizeErrorMessage', () => {
+  it('strips an Alchemy-style API key from the URL path', () => {
+    const out = sanitizeErrorMessage(
+      'could not detect network (req to https://eth-sepolia.g.alchemy.com/v2/abc123SECRETkey failed)',
+    )
+    expect(out).not.toContain('abc123SECRETkey')
+    expect(out).toContain('https://eth-sepolia.g.alchemy.com/[redacted]')
+  })
+
+  it('strips an Infura project secret from the URL path', () => {
+    const out = sanitizeErrorMessage('timeout https://sepolia.infura.io/v3/PROJECTSECRET99')
+    expect(out).not.toContain('PROJECTSECRET99')
+    expect(out).toContain('https://sepolia.infura.io/[redacted]')
+  })
+
+  it('strips a key passed as a query parameter', () => {
+    const out = sanitizeErrorMessage('fetch failed: https://rpc.example.com?apikey=SUPERSECRET')
+    expect(out).not.toContain('SUPERSECRET')
+    expect(out).toContain('https://rpc.example.com/[redacted]')
+  })
+
+  it('redacts Postgres connection credentials', () => {
+    const out = sanitizeErrorMessage('connection to postgres://admin:hunter2@db.host:5432/crowdfund refused')
+    expect(out).not.toContain('hunter2')
+    expect(out).toContain('postgres://[redacted]@db.host:5432/crowdfund')
+  })
+
+  it('truncates very long messages', () => {
+    const out = sanitizeErrorMessage('x'.repeat(600))
+    expect(out.length).toBeLessThanOrEqual(520)
+    expect(out).toContain('(truncated)')
+  })
+
+  it('passes through messages with no secrets unchanged', () => {
+    const msg = 'RPC timeout after 15000ms during getLogs 100-200'
+    expect(sanitizeErrorMessage(msg)).toBe(msg)
+  })
+})

--- a/crowdfund-ui/packages/indexer/src/ingest/errors.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/errors.ts
@@ -1,0 +1,25 @@
+// ABOUTME: Error-message sanitization for the crowdfund indexer.
+// ABOUTME: Strips RPC URL paths/queries and DB credentials so secrets never reach logs or the API.
+
+const MAX_LENGTH = 500
+
+// Redacts secrets that commonly travel inside error messages before they are persisted
+// (lastError) or returned to clients. RPC providers embed API keys in the URL path/query
+// (Alchemy/Infura), and connection errors embed DB credentials in userinfo. Neither
+// belongs in a stored field served by the unauthenticated /health endpoint.
+export function sanitizeErrorMessage(message: string): string {
+  let out = message
+
+  // 1. Redact credentials in any `scheme://user:pass@host` userinfo segment.
+  out = out.replace(/\b([a-z][a-z0-9+.-]*):\/\/[^/\s@]*@/gi, '$1://[redacted]@')
+
+  // 2. Strip path/query/fragment from http(s)/ws(s) URLs — that is where RPC keys live.
+  //    Keep scheme+host so the message still says which provider failed.
+  out = out.replace(
+    /\b((?:https?|wss?):\/\/[^/?#\s"')]+)([/?#][^\s"')]*)?/gi,
+    (_match, base: string, rest: string | undefined) => (rest ? `${base}/[redacted]` : base),
+  )
+
+  if (out.length > MAX_LENGTH) out = `${out.slice(0, MAX_LENGTH)}…(truncated)`
+  return out
+}

--- a/crowdfund-ui/packages/indexer/src/ingest/poller.test.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/poller.test.ts
@@ -282,9 +282,11 @@ describe('CrowdfundIndexerPoller', () => {
     })
 
     const first = poller.runOnce()
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    // Wait until the first cycle is actually blocked inside getBlockNumber before
+    // starting the second, so the overlap check is deterministic regardless of how many
+    // async hops precede the blocking call.
+    while (!controls.releaseBlockNumber) await new Promise((resolve) => setTimeout(resolve, 1))
     const second = await poller.runOnce()
-    if (!controls.releaseBlockNumber) throw new Error('provider did not start')
     controls.releaseBlockNumber()
     const firstResult = await first
 

--- a/crowdfund-ui/packages/indexer/src/ingest/poller.test.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/poller.test.ts
@@ -215,6 +215,48 @@ describe('CrowdfundIndexerPoller', () => {
     expect(seeded?.status).toBe('failed')
   })
 
+  it('keeps the poll cycle completed when snapshot publishing fails', async () => {
+    const store = await makeStore()
+    const provider: RangeLogProvider = {
+      getBlockNumber: async () => 102,
+      getLogs: async ({ fromBlock }) => [makeLog(fromBlock)],
+    }
+    const warnings: string[] = []
+    const logger = {
+      info: () => {},
+      warn: (message: string) => warnings.push(message),
+      error: () => {},
+    }
+
+    const poller = new CrowdfundIndexerPoller({
+      ...config,
+      store,
+      provider,
+      auditProvider: provider,
+      auditProviderName: 'audit',
+      maxBlockRange: 5,
+      rpcTimeoutMs: 50,
+      rpcMaxRetries: 0,
+      retryBaseDelayMs: 1,
+      pollIntervalMs: 1000,
+      errorBackoffMs: 1000,
+      publishOnPoll: true,
+      publishSnapshot: async () => {
+        throw new Error('Refusing to publish failed reconciliation: hop0.totalCommitted mismatch')
+      },
+      logger,
+    })
+
+    const result = await poller.runOnce()
+    const data = await store.read()
+
+    // Backfill succeeded, so the cycle is completed even though publishing threw.
+    expect(result.status).toBe('completed')
+    expect(data.cursor.verifiedCursor).toBeGreaterThanOrEqual(100)
+    expect(warnings.some((w) => w.includes('publish'))).toBe(true)
+    expect(data.lastError).toContain('Refusing to publish')
+  })
+
   it('does not run overlapping poll cycles', async () => {
     const store = await makeStore()
     const controls: { releaseBlockNumber?: () => void } = {}

--- a/crowdfund-ui/packages/indexer/src/ingest/poller.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/poller.ts
@@ -247,9 +247,21 @@ export class CrowdfundIndexerPoller {
     const interval = this.options.snapshotPublishIntervalMs ?? this.options.pollIntervalMs
     if (this.lastPublishedAt > 0 && now - this.lastPublishedAt < interval) return
 
-    await this.options.publishSnapshot()
-    this.lastPublishedAt = now
-    this.logger.info('Crowdfund indexer poll published snapshot')
+    // A publish/reconcile failure must not fail the ingest cycle — ingestion already
+    // succeeded by this point. Record it as lastError and retry next cycle (we leave
+    // lastPublishedAt unchanged so the interval gate does not defer the retry).
+    try {
+      await this.options.publishSnapshot()
+      this.lastPublishedAt = now
+      this.logger.info('Crowdfund indexer poll published snapshot')
+    } catch (err) {
+      const message = getErrorMessage(err)
+      this.logger.warn(`Crowdfund indexer poll snapshot publish failed: ${message}`)
+      await this.options.store.update((data) => ({
+        ...data,
+        lastError: message,
+      }))
+    }
   }
 
   private schedule(delayMs: number): void {

--- a/crowdfund-ui/packages/indexer/src/ingest/poller.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/poller.ts
@@ -4,6 +4,7 @@
 import type { IndexerStore } from '../db/store.js'
 import { backfillVerifiedRanges } from './backfill.js'
 import type { BackfillResult } from './backfill.js'
+import { sanitizeErrorMessage } from './errors.js'
 import { autoReconcileGaps } from './reconcile.js'
 import type { AutoReconcileOptions, AutoReconcileResult } from './reconcile.js'
 import type { RangeLogProvider, RangePipelineConfig } from './rpc.js'
@@ -126,7 +127,7 @@ async function withRetries<T>(
   }
 
   const kind = classifyRpcError(lastError)
-  throw new Error(`${kind}: ${getErrorMessage(lastError)}`)
+  throw new Error(`${kind}: ${sanitizeErrorMessage(getErrorMessage(lastError))}`)
 }
 
 export function createResilientRangeProvider(
@@ -227,7 +228,7 @@ export class CrowdfundIndexerPoller {
       await this.maybePublish(result)
       return { status: 'completed', backfill: result, reconcile }
     } catch (err) {
-      const message = getErrorMessage(err)
+      const message = sanitizeErrorMessage(getErrorMessage(err))
       await this.options.store.update((data) => ({
         ...data,
         lastError: message,
@@ -255,7 +256,7 @@ export class CrowdfundIndexerPoller {
       this.lastPublishedAt = now
       this.logger.info('Crowdfund indexer poll published snapshot')
     } catch (err) {
-      const message = getErrorMessage(err)
+      const message = sanitizeErrorMessage(getErrorMessage(err))
       this.logger.warn(`Crowdfund indexer poll snapshot publish failed: ${message}`)
       await this.options.store.update((data) => ({
         ...data,

--- a/crowdfund-ui/packages/indexer/src/ingest/poller.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/poller.ts
@@ -222,6 +222,11 @@ export class CrowdfundIndexerPoller {
         auditProvider: resilientAuditProvider,
         auditProviderName: this.options.auditProviderName,
         maxBlockRange: this.options.maxBlockRange,
+        // Defer chunks that auto-reconcile is already backing off on, so a stuck range
+        // is not re-verified every poll cycle (and `attempts` is not double-incremented).
+        retryPolicy: this.options.reconcileOptions && this.options.reconcileOptions.maxAttempts > 0
+          ? { maxAttempts: this.options.reconcileOptions.maxAttempts }
+          : undefined,
       })
 
       this.logger.info(`Crowdfund indexer poll checked ${result.ranges.length} chunks; stoppedEarly=${result.stoppedEarly ? 'yes' : 'no'}`)

--- a/crowdfund-ui/packages/indexer/src/ingest/ranges.test.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/ranges.test.ts
@@ -105,4 +105,21 @@ describe('range ingestion helpers', () => {
       { fromBlock: 21, toBlock: 30 },
     ])
   })
+
+  it('ignores a failed range fully covered by verified ranges', () => {
+    const repairRanges = getRepairRanges([
+      makeRange({ fromBlock: 100, toBlock: 599, status: 'failed' }),
+      makeRange({ fromBlock: 100, toBlock: 349, status: 'verified' }),
+      makeRange({ fromBlock: 350, toBlock: 599, status: 'verified' }),
+    ])
+    expect(repairRanges).toEqual([])
+  })
+
+  it('still reports a failed range only partially covered by verified ranges', () => {
+    const repairRanges = getRepairRanges([
+      makeRange({ fromBlock: 100, toBlock: 599, status: 'failed' }),
+      makeRange({ fromBlock: 100, toBlock: 349, status: 'verified' }),
+    ])
+    expect(repairRanges).toEqual([{ fromBlock: 100, toBlock: 599 }])
+  })
 })

--- a/crowdfund-ui/packages/indexer/src/ingest/ranges.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/ranges.ts
@@ -78,8 +78,15 @@ export function getContiguousVerifiedCursor(
 }
 
 export function getRepairRanges(records: readonly IngestRangeRecord[]): BlockRange[] {
+  // A failed/suspicious record whose span is fully covered by verified ranges is a
+  // phantom gap — its blocks were re-verified under different chunk boundaries (e.g.
+  // after CROWDFUND_MAX_BLOCK_RANGE changed). Drop it so it is not reported as a gap.
+  const verified = records
+    .filter((record) => record.status === 'verified')
+    .map((record) => ({ fromBlock: record.fromBlock, toBlock: record.toBlock }))
   return records
     .filter((record) => record.status === 'failed' || record.status === 'suspicious')
+    .filter((record) => findFirstGap(verified, record.fromBlock, record.toBlock) !== null)
     .map((record) => ({
       fromBlock: record.fromBlock,
       toBlock: record.toBlock,

--- a/crowdfund-ui/packages/indexer/src/ingest/reconcile.test.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/reconcile.test.ts
@@ -168,6 +168,15 @@ describe('getExhaustedRepairRanges', () => {
     const ranges = [makeRange({ status: 'failed', attempts: 99 })]
     expect(getExhaustedRepairRanges(ranges, 0)).toEqual([])
   })
+
+  it('ignores an exhausted range fully covered by verified ranges', () => {
+    const ranges = [
+      makeRange({ fromBlock: 100, toBlock: 199, status: 'failed', attempts: 6 }),
+      makeRange({ fromBlock: 100, toBlock: 149, status: 'verified', attempts: 1 }),
+      makeRange({ fromBlock: 150, toBlock: 199, status: 'verified', attempts: 1 }),
+    ]
+    expect(getExhaustedRepairRanges(ranges, 3)).toEqual([])
+  })
 })
 
 describe('autoReconcileGaps', () => {

--- a/crowdfund-ui/packages/indexer/src/ingest/reconcile.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/reconcile.ts
@@ -105,8 +105,8 @@ export async function autoReconcileGaps(input: AutoReconcileInput): Promise<Auto
   }
 
   const now = (input.now ?? (() => new Date()))()
-  const data = await input.store.read()
-  const { eligible, deferred, exhausted } = classifyRepairableRanges(data.ranges, input.options, now)
+  const meta = await input.store.readMeta()
+  const { eligible, deferred, exhausted } = classifyRepairableRanges(meta.ranges, input.options, now)
 
   const attempted: IngestRangeRecord[] = []
   for (const candidate of eligible) {
@@ -127,7 +127,7 @@ export async function autoReconcileGaps(input: AutoReconcileInput): Promise<Auto
     // written record back from the store so that `attempts` reflects the increment
     // applied during this cycle.
     if (result.status !== 'verified') {
-      const after = await input.store.read()
+      const after = await input.store.readMeta()
       const written = after.ranges.find(
         (record) => record.fromBlock === range.fromBlock && record.toBlock === range.toBlock,
       )
@@ -136,16 +136,15 @@ export async function autoReconcileGaps(input: AutoReconcileInput): Promise<Auto
           ...written,
           nextRetryAt: computeNextRetryAt(written.attempts, input.options, (input.now ?? (() => new Date()))()),
         }
-        await input.store.upsertRange(scheduled)
+        await input.store.patchRange(scheduled)
       }
     }
   }
 
   if (attempted.length > 0) {
-    await input.store.update((current) => ({
-      ...current,
+    await input.store.patchMeta({
       lastReconciledAt: (input.now ?? (() => new Date()))().toISOString(),
-    }))
+    })
   }
 
   return {

--- a/crowdfund-ui/packages/indexer/src/ingest/reconcile.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/reconcile.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Auto-reconcile orchestration with bounded retry and exponential backoff.
 // ABOUTME: Lets the polling loop self-heal transient gaps while escalating persistent failures.
 
+import { findFirstGap } from './ranges.js'
 import { verifyRange } from './rpc.js'
 import type { IndexerStore } from '../db/store.js'
 import type { RangeLogProvider, RangePipelineConfig } from './rpc.js'
@@ -93,9 +94,15 @@ export function getExhaustedRepairRanges(
   maxAttempts: number,
 ): BlockRange[] {
   if (maxAttempts <= 0) return []
+  // Skip exhausted records that are actually covered by verified ranges (phantom gaps
+  // from a chunk-boundary change), so health does not demand operator action for them.
+  const verified = records
+    .filter((record) => record.status === 'verified')
+    .map((record) => ({ fromBlock: record.fromBlock, toBlock: record.toBlock }))
   return records
     .filter(isRepairCandidate)
     .filter((record) => record.attempts >= maxAttempts)
+    .filter((record) => findFirstGap(verified, record.fromBlock, record.toBlock) !== null)
     .map((record) => ({ fromBlock: record.fromBlock, toBlock: record.toBlock }))
 }
 

--- a/crowdfund-ui/packages/indexer/src/ingest/rpc.test.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/rpc.test.ts
@@ -118,6 +118,7 @@ describe('RPC range pipeline', () => {
 
     const data = await store.read()
     expect(record.status).toBe('verified')
+    expect(record.provider).toBe('primary/audit')
     expect(data.cursor.verifiedCursor).toBe(109)
     expect(data.lastVerifiedAt).not.toBeNull()
   })

--- a/crowdfund-ui/packages/indexer/src/ingest/rpc.test.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/rpc.test.ts
@@ -156,6 +156,23 @@ describe('RPC range pipeline', () => {
     expect(data.lastError).toBe('RPC timeout')
   })
 
+  it('sanitizes RPC keys out of the persisted lastError', async () => {
+    const store = await makeStore()
+    const leakyUrl = 'https://eth-sepolia.g.alchemy.com/v2/abc123SECRETkey'
+
+    const record = await stageRange({
+      ...config,
+      store,
+      provider: makeFailingProvider(`could not detect network (req to ${leakyUrl} failed)`),
+      range: { fromBlock: 120, toBlock: 129 },
+    })
+
+    const data = await store.read()
+    expect(record.status).toBe('failed')
+    expect(data.lastError).not.toContain('abc123SECRETkey')
+    expect(data.lastError).toContain('https://eth-sepolia.g.alchemy.com/[redacted]')
+  })
+
   it('rejects malformed log responses instead of treating them as empty data', async () => {
     const store = await makeStore()
 

--- a/crowdfund-ui/packages/indexer/src/ingest/rpc.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/rpc.ts
@@ -213,7 +213,10 @@ export async function verifyRange(input: VerifyRangeInput): Promise<IngestRangeR
     const record: IngestRangeRecord = {
       ...staged,
       status,
-      provider: status === 'verified' ? auditProviderName : `${staged.provider}/${auditProviderName}`,
+      // Record both who staged the data and who audited it (e.g. "primary/audit"), so a
+      // verified record does not lose its staging provider. Single-provider self-audit
+      // reads as "primary/primary", which usefully signals no independent verification.
+      provider: `${staged.provider}/${auditProviderName}`,
       verifiedAt: status === 'verified' ? timestamp : null,
       lastError: status === 'verified' ? null : `Digest mismatch: staged ${staged.digest}, audit ${auditDigest}`,
     }

--- a/crowdfund-ui/packages/indexer/src/ingest/rpc.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/rpc.ts
@@ -5,7 +5,7 @@ import { JsonRpcProvider } from 'ethers'
 import type { IndexerStore } from '../db/store.js'
 import { sanitizeErrorMessage } from './errors.js'
 import { createRangeDigest, getContiguousVerifiedCursor } from './ranges.js'
-import type { BlockRange, IndexedRawLog, IndexerStoreData, IngestRangeRecord } from '../types.js'
+import type { BlockRange, IndexedRawLog, IngestRangeRecord } from '../types.js'
 
 export interface RpcLog {
   blockNumber: number
@@ -100,8 +100,8 @@ function toIndexedRawLog(
   }
 }
 
-function getExistingAttempts(data: IndexerStoreData, range: BlockRange): number {
-  return data.ranges.find((record) => record.fromBlock === range.fromBlock && record.toBlock === range.toBlock)?.attempts ?? 0
+function getExistingAttempts(ranges: readonly IngestRangeRecord[], range: BlockRange): number {
+  return ranges.find((record) => record.fromBlock === range.fromBlock && record.toBlock === range.toBlock)?.attempts ?? 0
 }
 
 function createRecord(
@@ -127,17 +127,6 @@ function createRecord(
   }
 }
 
-function promoteVerifiedCursor(data: IndexerStoreData): IndexerStoreData {
-  const verifiedCursor = getContiguousVerifiedCursor(data.ranges, data.cursor.verifiedCursor)
-  return {
-    ...data,
-    cursor: {
-      ...data.cursor,
-      verifiedCursor,
-    },
-  }
-}
-
 export function createJsonRpcRangeProvider(url: string): RangeLogProvider {
   return new JsonRpcProvider(url) as unknown as RangeLogProvider
 }
@@ -159,25 +148,24 @@ export async function stageRange(input: StageRangeInput): Promise<IngestRangeRec
   const timestamp = nowIso()
   try {
     const logs = await fetchIndexedLogs(input.provider, input, input.range)
-    const current = await input.store.read()
-    const attempts = getExistingAttempts(current, input.range) + 1
+    const meta = await input.store.readMeta()
+    const attempts = getExistingAttempts(meta.ranges, input.range) + 1
     const record = createRecord(input.range, 'staged', input.providerName, attempts, logs, timestamp, null)
-    await input.store.upsertRawLogs(logs)
-    await input.store.update((data) => ({
-      ...data,
-      ranges: [...data.ranges.filter((range) => range.fromBlock !== input.range.fromBlock || range.toBlock !== input.range.toBlock), record],
+    await input.store.appendRawLogs(logs)
+    await input.store.patchRange(record)
+    await input.store.patchMeta({
       cursor: {
-        ...data.cursor,
-        ingestedCursor: Math.max(data.cursor.ingestedCursor, input.range.toBlock),
+        ...meta.cursor,
+        ingestedCursor: Math.max(meta.cursor.ingestedCursor, input.range.toBlock),
       },
       lastIngestedAt: timestamp,
       lastError: null,
-    }))
+    })
     return record
   } catch (err) {
     const message = sanitizeErrorMessage(err instanceof Error ? err.message : 'Unknown range staging error')
-    const current = await input.store.read()
-    const attempts = getExistingAttempts(current, input.range) + 1
+    const meta = await input.store.readMeta()
+    const attempts = getExistingAttempts(meta.ranges, input.range) + 1
     const record: IngestRangeRecord = {
       ...input.range,
       status: 'failed',
@@ -190,11 +178,8 @@ export async function stageRange(input: StageRangeInput): Promise<IngestRangeRec
       lastError: message,
       nextRetryAt: null,
     }
-    await input.store.upsertRange(record)
-    await input.store.update((data) => ({
-      ...data,
-      lastError: message,
-    }))
+    await input.store.patchRange(record)
+    await input.store.patchMeta({ lastError: message })
     return record
   }
 }
@@ -221,18 +206,20 @@ export async function verifyRange(input: VerifyRangeInput): Promise<IngestRangeR
       lastError: status === 'verified' ? null : `Digest mismatch: staged ${staged.digest}, audit ${auditDigest}`,
     }
 
-    await input.store.upsertRange(record)
+    await input.store.patchRange(record)
     if (status === 'verified') {
-      await input.store.update((data) => promoteVerifiedCursor({
-        ...data,
+      // Recompute the contiguous verified cursor from the freshly-written ranges.
+      const meta = await input.store.readMeta()
+      await input.store.patchMeta({
+        cursor: {
+          ...meta.cursor,
+          verifiedCursor: getContiguousVerifiedCursor(meta.ranges, meta.cursor.verifiedCursor),
+        },
         lastVerifiedAt: timestamp,
         lastError: null,
-      }))
+      })
     } else {
-      await input.store.update((data) => ({
-        ...data,
-        lastError: record.lastError,
-      }))
+      await input.store.patchMeta({ lastError: record.lastError })
     }
     return record
   } catch (err) {
@@ -245,11 +232,8 @@ export async function verifyRange(input: VerifyRangeInput): Promise<IngestRangeR
       lastError: message,
       nextRetryAt: null,
     }
-    await input.store.upsertRange(record)
-    await input.store.update((data) => ({
-      ...data,
-      lastError: message,
-    }))
+    await input.store.patchRange(record)
+    await input.store.patchMeta({ lastError: message })
     return record
   }
 }

--- a/crowdfund-ui/packages/indexer/src/ingest/rpc.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/rpc.ts
@@ -3,6 +3,7 @@
 
 import { JsonRpcProvider } from 'ethers'
 import type { IndexerStore } from '../db/store.js'
+import { sanitizeErrorMessage } from './errors.js'
 import { createRangeDigest, getContiguousVerifiedCursor } from './ranges.js'
 import type { BlockRange, IndexedRawLog, IndexerStoreData, IngestRangeRecord } from '../types.js'
 
@@ -174,7 +175,7 @@ export async function stageRange(input: StageRangeInput): Promise<IngestRangeRec
     }))
     return record
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown range staging error'
+    const message = sanitizeErrorMessage(err instanceof Error ? err.message : 'Unknown range staging error')
     const current = await input.store.read()
     const attempts = getExistingAttempts(current, input.range) + 1
     const record: IngestRangeRecord = {
@@ -232,7 +233,7 @@ export async function verifyRange(input: VerifyRangeInput): Promise<IngestRangeR
     }
     return record
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown range verification error'
+    const message = sanitizeErrorMessage(err instanceof Error ? err.message : 'Unknown range verification error')
     const record: IngestRangeRecord = {
       ...staged,
       status: 'failed',

--- a/crowdfund-ui/packages/indexer/src/reconcile/contract.test.ts
+++ b/crowdfund-ui/packages/indexer/src/reconcile/contract.test.ts
@@ -52,6 +52,47 @@ describe('contract reconciliation', () => {
     })
   })
 
+  it('counts whitelisted addresses per hop, not stacked invites', () => {
+    // Two seeds invite the same invitee into hop-1. On-chain this whitelists the
+    // invitee once (hopStats[1].whitelistCount == 1) and only stacks its
+    // invitesReceived. Reconciliation must count the distinct whitelisted node,
+    // not the sum of invites, or it over-counts against the contract.
+    const seedA = '0x1111111111111111111111111111111111111111'
+    const seedB = '0x2222222222222222222222222222222222222222'
+    const invitee = '0x3333333333333333333333333333333333333333'
+    const graph = buildGraph([
+      makeEvent('SeedAdded', { seed: seedA }, 100),
+      makeEvent('SeedAdded', { seed: seedB }, 101),
+      makeEvent('Invited', { inviter: seedA, invitee, hop: 1 }, 102),
+      makeEvent('Invited', { inviter: seedB, invitee, hop: 1 }, 103),
+    ])
+
+    const stats = deriveGraphAggregateStats(graph)
+    expect(stats.perHopWhitelistCount).toEqual([2, 1, 0])
+    // seedA, seedB, invitee — three distinct (address, hop) participant nodes.
+    expect(stats.participantCount).toBe(3)
+  })
+
+  it('counts a multi-hop address once per hop it is whitelisted in', () => {
+    // An address whitelisted at both hop-1 and hop-2 is two participant nodes
+    // on-chain (getParticipantCount returns participantNodes.length, which counts
+    // (address, hop) pairs), so reconciliation must not de-duplicate it to one.
+    const seed = '0x1111111111111111111111111111111111111111'
+    const hop1Inviter = '0x2222222222222222222222222222222222222222'
+    const multi = '0x3333333333333333333333333333333333333333'
+    const graph = buildGraph([
+      makeEvent('SeedAdded', { seed }, 100),
+      makeEvent('Invited', { inviter: seed, invitee: hop1Inviter, hop: 1 }, 101),
+      makeEvent('Invited', { inviter: seed, invitee: multi, hop: 1 }, 102),
+      makeEvent('Invited', { inviter: hop1Inviter, invitee: multi, hop: 2 }, 103),
+    ])
+
+    const stats = deriveGraphAggregateStats(graph)
+    // seed@0, hop1Inviter@1, multi@1, multi@2 = 4 participant nodes.
+    expect(stats.participantCount).toBe(4)
+    expect(stats.perHopWhitelistCount).toEqual([1, 2, 1])
+  })
+
   it('passes when contract reads match event-derived aggregates', async () => {
     const graph = buildGraph([
       makeEvent('SeedAdded', { seed: participant }, 100),

--- a/crowdfund-ui/packages/indexer/src/reconcile/contract.test.ts
+++ b/crowdfund-ui/packages/indexer/src/reconcile/contract.test.ts
@@ -69,6 +69,66 @@ describe('contract reconciliation', () => {
     expect(result.mismatches).toEqual([])
   })
 
+  it('pins every contract read to the checked block', async () => {
+    const graph = buildGraph([
+      makeEvent('SeedAdded', { seed: participant }, 100),
+      makeEvent('Committed', { participant, hop: 0, amount: 1_000_000n }, 101),
+    ])
+    const seenBlockTags: Array<number | undefined> = []
+    const contract: CrowdfundReadable = {
+      getParticipantCount: async (overrides) => {
+        seenBlockTags.push(overrides?.blockTag)
+        return 1n
+      },
+      getEstimatedCappedDemand: async (overrides) => {
+        seenBlockTags.push(overrides?.blockTag)
+        return [1_000_000n, [1_000_000n, 0n, 0n]]
+      },
+      getHopStats: async (hop, overrides) => {
+        seenBlockTags.push(overrides?.blockTag)
+        return hop === 0 ? [1_000_000n, 1_000_000n, 1n, 1n] : [0n, 0n, 0n, 0n]
+      },
+    }
+
+    const result = await reconcileSnapshot({ graph, contract, checkedBlock: 110, providerName: 'primary' })
+
+    expect(result.status).toBe('passed')
+    expect(seenBlockTags).toHaveLength(5)
+    expect(seenBlockTags.every((tag) => tag === 110)).toBe(true)
+  })
+
+  it('returns pending (not failed) when historical state is unavailable', async () => {
+    const graph = buildGraph([makeEvent('SeedAdded', { seed: participant }, 100)])
+    const contract: CrowdfundReadable = {
+      getParticipantCount: async () => {
+        throw new Error('missing trie node 0xabc (path ) state 0xdef is not available')
+      },
+      getEstimatedCappedDemand: async () => [0n, [0n, 0n, 0n]],
+      getHopStats: async () => [0n, 0n, 0n, 0n],
+    }
+
+    const result = await reconcileSnapshot({ graph, contract, checkedBlock: 110, providerName: 'primary' })
+
+    expect(result.status).toBe('pending')
+    expect(result.checkedBlock).toBe(110)
+    expect(result.mismatches.join(' ')).toContain('historical state')
+  })
+
+  it('rethrows non-state read errors', async () => {
+    const graph = buildGraph([makeEvent('SeedAdded', { seed: participant }, 100)])
+    const contract: CrowdfundReadable = {
+      getParticipantCount: async () => {
+        throw new Error('connection refused')
+      },
+      getEstimatedCappedDemand: async () => [0n, [0n, 0n, 0n]],
+      getHopStats: async () => [0n, 0n, 0n, 0n],
+    }
+
+    await expect(
+      reconcileSnapshot({ graph, contract, checkedBlock: 110, providerName: 'primary' }),
+    ).rejects.toThrow('connection refused')
+  })
+
   it('fails when contract reads disagree with event-derived aggregates', async () => {
     const graph = buildGraph([
       makeEvent('SeedAdded', { seed: participant }, 100),

--- a/crowdfund-ui/packages/indexer/src/reconcile/contract.ts
+++ b/crowdfund-ui/packages/indexer/src/reconcile/contract.ts
@@ -19,10 +19,17 @@ export interface EstimatedCappedDemandRead {
   perHopCapped: readonly bigint[]
 }
 
+// ethers v6 accepts a trailing overrides object on read calls; `blockTag` pins the
+// read to a historical block so reconciliation compares the graph and the chain at the
+// SAME height (the snapshot's verifiedCursor), not at `latest`.
+export interface CrowdfundReadOverrides {
+  blockTag?: number
+}
+
 export interface CrowdfundReadable {
-  getParticipantCount(): Promise<bigint | number>
-  getHopStats(hop: number): Promise<HopStatsRead | readonly [bigint, bigint, bigint, bigint]>
-  getEstimatedCappedDemand(): Promise<EstimatedCappedDemandRead | readonly [bigint, readonly bigint[]]>
+  getParticipantCount(overrides?: CrowdfundReadOverrides): Promise<bigint | number>
+  getHopStats(hop: number, overrides?: CrowdfundReadOverrides): Promise<HopStatsRead | readonly [bigint, bigint, bigint, bigint]>
+  getEstimatedCappedDemand(overrides?: CrowdfundReadOverrides): Promise<EstimatedCappedDemandRead | readonly [bigint, readonly bigint[]]>
 }
 
 export interface ReconcileSnapshotInput {
@@ -97,15 +104,55 @@ function addMismatch(mismatches: string[], label: string, expected: bigint | num
   }
 }
 
+// Non-archive nodes prune historical state, so a blockTag read at an old block can fail
+// with a "missing trie node"/"state not available" error. That is not a reconciliation
+// failure — it means we cannot check at this height, so we degrade to `pending` (the
+// same status used when no audit RPC is configured) rather than blocking publishing.
+function isHistoricalStateUnavailable(err: unknown): boolean {
+  const message = (err instanceof Error ? err.message : String(err)).toLowerCase()
+  return (
+    message.includes('missing trie node') ||
+    message.includes('historical state') ||
+    message.includes('state is not available') ||
+    message.includes('state not available') ||
+    message.includes('missing state') ||
+    message.includes('header not found')
+  )
+}
+
 export async function reconcileSnapshot(input: ReconcileSnapshotInput): Promise<ReconciliationResult> {
   const stats = deriveGraphAggregateStats(input.graph)
-  const [participantCount, estimated, hop0, hop1, hop2] = await Promise.all([
-    input.contract.getParticipantCount(),
-    input.contract.getEstimatedCappedDemand(),
-    input.contract.getHopStats(0),
-    input.contract.getHopStats(1),
-    input.contract.getHopStats(2),
-  ])
+  // Pin all reads to the snapshot's verified block so the chain side and the
+  // event-derived side are compared at the same height.
+  const overrides: CrowdfundReadOverrides = { blockTag: input.checkedBlock }
+  let participantCount: bigint | number
+  let estimated: EstimatedCappedDemandRead | readonly [bigint, readonly bigint[]]
+  let hop0: HopStatsRead | readonly [bigint, bigint, bigint, bigint]
+  let hop1: HopStatsRead | readonly [bigint, bigint, bigint, bigint]
+  let hop2: HopStatsRead | readonly [bigint, bigint, bigint, bigint]
+  try {
+    [participantCount, estimated, hop0, hop1, hop2] = await Promise.all([
+      input.contract.getParticipantCount(overrides),
+      input.contract.getEstimatedCappedDemand(overrides),
+      input.contract.getHopStats(0, overrides),
+      input.contract.getHopStats(1, overrides),
+      input.contract.getHopStats(2, overrides),
+    ])
+  } catch (err) {
+    if (isHistoricalStateUnavailable(err)) {
+      const reason = err instanceof Error ? err.message : String(err)
+      return {
+        status: 'pending',
+        checkedBlock: input.checkedBlock,
+        provider: input.providerName,
+        checkedAt: new Date().toISOString(),
+        mismatches: [
+          `Reconciliation skipped: historical state at block ${input.checkedBlock} unavailable from ${input.providerName} (non-archive node): ${reason}`,
+        ],
+      }
+    }
+    throw err
+  }
 
   const parsedEstimated = parseEstimated(estimated)
   const hopStats = [parseHopStats(hop0), parseHopStats(hop1), parseHopStats(hop2)] as const

--- a/crowdfund-ui/packages/indexer/src/reconcile/contract.ts
+++ b/crowdfund-ui/packages/indexer/src/reconcile/contract.ts
@@ -80,17 +80,27 @@ export function deriveGraphAggregateStats(graph: CrowdfundGraph): GraphAggregate
   const perHopCappedCommitted: [bigint, bigint, bigint] = [0n, 0n, 0n]
   const perHopUniqueCommitters: [number, number, number] = [0, 0, 0]
   const perHopWhitelistCount: [number, number, number] = [0, 0, 0]
+  // Counts distinct whitelisted (address, hop) nodes to match the contract's
+  // getParticipantCount() == participantNodes.length, which counts (address, hop)
+  // pairs. A multi-hop address is one node per hop, not de-duplicated by address.
+  let participantCount = 0
 
   for (const node of graph.nodes.values()) {
     if (node.hop < 0 || node.hop > 2) continue
     perHopTotalCommitted[node.hop] += node.rawDeposited
     perHopCappedCommitted[node.hop] += node.committed
     if (node.rawDeposited > 0n) perHopUniqueCommitters[node.hop] += 1
-    if (nodeHasWhitelist(node)) perHopWhitelistCount[node.hop] += node.invitesReceived
+    // hopStats[hop].whitelistCount on-chain counts distinct whitelisted addresses
+    // at the hop; a re-invited node stacks invitesReceived but is whitelisted once,
+    // so count the node, not its invites.
+    if (nodeHasWhitelist(node)) {
+      perHopWhitelistCount[node.hop] += 1
+      participantCount += 1
+    }
   }
 
   return {
-    participantCount: graph.summaries.size,
+    participantCount,
     perHopTotalCommitted,
     perHopCappedCommitted,
     perHopUniqueCommitters,

--- a/crowdfund-ui/packages/indexer/src/snapshots/build.test.ts
+++ b/crowdfund-ui/packages/indexer/src/snapshots/build.test.ts
@@ -66,6 +66,19 @@ describe('buildSnapshot', () => {
     expect(snapshot.metadata.snapshotHash).toMatch(/^0x[0-9a-f]{64}$/)
   })
 
+  it('excludes logs from a different chain or contract', () => {
+    const good = makeLog('SeedAdded', [participant], 100)
+    const foreignContract = { ...makeLog('SeedAdded', [participant], 101), contractAddress: '0x' + 'ab'.repeat(20) }
+    const foreignChain = { ...makeLog('Committed', [participant, 0, 5_000_000n], 102), chainId: 1 }
+    const snapshot = buildSnapshot({
+      data: makeStoreData([good, foreignContract, foreignChain]),
+      chainId: 11155111,
+      contractAddress,
+    })
+    expect(snapshot.events).toHaveLength(1)
+    expect(snapshot.events[0].type).toBe('SeedAdded')
+  })
+
   it('produces a stable hash across wall-clock changes (content address)', () => {
     const data = makeStoreData([
       makeLog('SeedAdded', [participant], 100),

--- a/crowdfund-ui/packages/indexer/src/snapshots/build.test.ts
+++ b/crowdfund-ui/packages/indexer/src/snapshots/build.test.ts
@@ -2,10 +2,10 @@
 // ABOUTME: Uses real ABI-encoded logs to verify parsing, graph building, and deterministic metadata.
 
 import { Interface } from 'ethers'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { CROWDFUND_ABI_FRAGMENTS } from '../../../shared/src/lib/constants.js'
-import { buildSnapshot } from './build.js'
-import type { IndexedRawLog, IndexerStoreData } from '../types.js'
+import { buildSnapshot, withReconciliation } from './build.js'
+import type { IndexedRawLog, IndexerStoreData, ReconciliationResult } from '../types.js'
 
 const iface = new Interface(CROWDFUND_ABI_FRAGMENTS)
 const participant = '0x1111111111111111111111111111111111111111'
@@ -64,5 +64,47 @@ describe('buildSnapshot', () => {
     expect(summary?.totalCommitted).toBe(1_000_000n)
     expect(snapshot.metadata.verifiedBlock).toBe(110)
     expect(snapshot.metadata.snapshotHash).toMatch(/^0x[0-9a-f]{64}$/)
+  })
+
+  it('produces a stable hash across wall-clock changes (content address)', () => {
+    const data = makeStoreData([
+      makeLog('SeedAdded', [participant], 100),
+      makeLog('Committed', [participant, 0, 1_000_000n], 105),
+    ])
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-06-15T00:00:00.000Z'))
+      const a = buildSnapshot({ data, chainId: 11155111, contractAddress })
+      vi.setSystemTime(new Date('2026-06-15T01:00:00.000Z'))
+      const b = buildSnapshot({ data, chainId: 11155111, contractAddress })
+      expect(a.metadata.generatedAt).not.toBe(b.metadata.generatedAt)
+      expect(a.metadata.snapshotHash).toBe(b.metadata.snapshotHash)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('changes the hash when verified events change', () => {
+    const base = makeStoreData([makeLog('SeedAdded', [participant], 100)])
+    const more = makeStoreData([
+      makeLog('SeedAdded', [participant], 100),
+      makeLog('Committed', [participant, 0, 1_000_000n], 105),
+    ])
+    const a = buildSnapshot({ data: base, chainId: 11155111, contractAddress })
+    const b = buildSnapshot({ data: more, chainId: 11155111, contractAddress })
+    expect(a.metadata.snapshotHash).not.toBe(b.metadata.snapshotHash)
+  })
+
+  it('withReconciliation swaps reconciliation without changing the hash or events', () => {
+    const data = makeStoreData([makeLog('SeedAdded', [participant], 100)])
+    const snapshot = buildSnapshot({ data, chainId: 11155111, contractAddress })
+    const reconciliation: ReconciliationResult = {
+      status: 'passed', checkedBlock: 110, provider: 'primary',
+      checkedAt: '2026-06-15T00:00:00.000Z', mismatches: [],
+    }
+    const updated = withReconciliation(snapshot, reconciliation)
+    expect(updated.metadata.snapshotHash).toBe(snapshot.metadata.snapshotHash)
+    expect(updated.metadata.reconciliation.status).toBe('passed')
+    expect(updated.events).toBe(snapshot.events)
   })
 })

--- a/crowdfund-ui/packages/indexer/src/snapshots/build.ts
+++ b/crowdfund-ui/packages/indexer/src/snapshots/build.ts
@@ -43,9 +43,25 @@ function getVerifiedBlockHash(logs: readonly IndexedRawLog[], verifiedBlockHash?
   return lastLog?.blockHash ?? ZERO_BLOCK_HASH
 }
 
-function createSnapshotHash(snapshot: Omit<CrowdfundSnapshot, 'metadata'> & { metadata: Omit<SnapshotMetadata, 'snapshotHash'> }): string {
+// The snapshot hash is a CONTENT ADDRESS: it must be byte-identical for identical
+// verified chain state. It therefore hashes only the content-defining fields and
+// deliberately excludes `generatedAt` (wall-clock, changes every build) and
+// `reconciliation` (a post-hoc check that withReconciliation can swap in without
+// altering snapshot identity).
+interface SnapshotHashInput {
+  schemaVersion: SnapshotMetadata['schemaVersion']
+  chainId: number
+  contractAddress: string
+  deployBlock: number
+  verifiedBlock: number
+  verifiedBlockHash: string
+  events: CrowdfundSnapshot['events']
+  graph: CrowdfundSnapshot['graph']
+}
+
+function createSnapshotHash(input: SnapshotHashInput): string {
   const hash = createHash('sha256')
-  hash.update(stableStringify(snapshot))
+  hash.update(stableStringify(input))
   return `0x${hash.digest('hex')}`
 }
 
@@ -80,7 +96,12 @@ export function buildSnapshot(input: BuildSnapshotInput): CrowdfundSnapshot {
     reconciliation: input.reconciliation ?? pendingReconciliation(),
   }
   const snapshotHash = createSnapshotHash({
-    metadata: metadataWithoutHash,
+    schemaVersion: metadataWithoutHash.schemaVersion,
+    chainId: metadataWithoutHash.chainId,
+    contractAddress: metadataWithoutHash.contractAddress,
+    deployBlock: metadataWithoutHash.deployBlock,
+    verifiedBlock: metadataWithoutHash.verifiedBlock,
+    verifiedBlockHash: metadataWithoutHash.verifiedBlockHash,
     events,
     graph,
   })
@@ -92,5 +113,21 @@ export function buildSnapshot(input: BuildSnapshotInput): CrowdfundSnapshot {
     },
     events,
     graph,
+  }
+}
+
+// Returns a snapshot with its reconciliation result swapped in. Because reconciliation
+// is excluded from the content hash, this does NOT rebuild or rehash the snapshot — it
+// lets callers reconcile once and attach the result without a second buildSnapshot pass.
+export function withReconciliation(
+  snapshot: CrowdfundSnapshot,
+  reconciliation: ReconciliationResult,
+): CrowdfundSnapshot {
+  return {
+    ...snapshot,
+    metadata: {
+      ...snapshot.metadata,
+      reconciliation,
+    },
   }
 }

--- a/crowdfund-ui/packages/indexer/src/snapshots/build.ts
+++ b/crowdfund-ui/packages/indexer/src/snapshots/build.ts
@@ -24,9 +24,18 @@ export interface BuildSnapshotInput {
   verifiedBlockHash?: string
 }
 
-function getVerifiedLogs(data: IndexerStoreData): IndexedRawLog[] {
+// Only logs matching this chain AND contract (and within the verified cursor) feed the
+// snapshot. Filtering on chain/contract prevents stale events from a previous deployment
+// — if the store ever holds logs for another address/chain — from silently merging into a
+// snapshot whose metadata claims the current address.
+function getVerifiedLogs(data: IndexerStoreData, chainId: number, contractAddress: string): IndexedRawLog[] {
+  const wantAddress = contractAddress.toLowerCase()
   return data.rawLogs
-    .filter((log) => log.blockNumber <= data.cursor.verifiedCursor)
+    .filter((log) =>
+      log.blockNumber <= data.cursor.verifiedCursor &&
+      log.chainId === chainId &&
+      log.contractAddress.toLowerCase() === wantAddress,
+    )
     .sort((a, b) => {
       if (a.blockNumber !== b.blockNumber) return a.blockNumber - b.blockNumber
       if (a.logIndex !== b.logIndex) return a.logIndex - b.logIndex
@@ -76,7 +85,7 @@ function pendingReconciliation(): ReconciliationResult {
 }
 
 export function buildSnapshot(input: BuildSnapshotInput): CrowdfundSnapshot {
-  const logs = getVerifiedLogs(input.data)
+  const logs = getVerifiedLogs(input.data, input.chainId, input.contractAddress)
   const events = parseCrowdfundEvents(logs.map((log) => ({
     blockNumber: log.blockNumber,
     transactionHash: log.transactionHash,

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,76 @@
+# Crowdfund Indexer — Docker Deploy
+
+Containerized deploy for the indexer API + Discord alert loop, with an optional
+Postgres store. Default store is **file** (a Docker volume). Coexists with other
+infra on the same host — each service runs its own commit-tagged image.
+
+## Layout
+
+- `indexer.Dockerfile` — build recipe (stays in this repo, builds from a checkout).
+- `docker-compose.yml` — the fleet (indexer, alerts, optional postgres). **Copy this
+  + your `.env` to a live ops dir outside the build checkout**, e.g. `/opt/armada-infra/`.
+- `indexer.env.template` — copy to `.env` and fill in. Never commit the real `.env`.
+- `nginx-indexer.conf` — host nginx server block; edit hostname + cert paths.
+
+## 1. Build (on the VPS)
+
+```bash
+# from a checkout of this repo
+SHA=$(git rev-parse --short HEAD)
+docker build -f deploy/indexer.Dockerfile -t crowdfund-indexer:$SHA crowdfund-ui
+```
+
+## 2. Configure (in your ops dir, e.g. /opt/armada-infra/)
+
+```bash
+cp /path/to/repo/deploy/docker-compose.yml .
+cp /path/to/repo/deploy/indexer.env.template .env
+# edit .env: set INDEXER_IMAGE=crowdfund-indexer:<sha>, RPC URLs, contract
+# addresses, alert window timestamps, and Discord webhooks.
+```
+
+## 3. Run
+
+```bash
+docker compose up -d            # file store (default)
+docker compose ps
+docker compose logs -f indexer
+curl -s localhost:3002/health   # sanity check
+```
+
+Postgres instead of file store — set in `.env`:
+`CROWDFUND_INDEXER_STORE=postgres`,
+`CROWDFUND_DATABASE_URL=postgres://crowdfund:<pw>@postgres:5432/crowdfund`,
+`POSTGRES_PASSWORD=<pw>`, then:
+
+```bash
+docker compose --profile postgres up -d
+```
+
+## 4. nginx
+
+Edit `nginx-indexer.conf` (hostname + cert paths), drop it into your host nginx,
+reload. It proxies `https://<host>` → `127.0.0.1:3002`.
+
+## Update / redeploy
+
+```bash
+git pull && SHA=$(git rev-parse --short HEAD)
+docker build -f deploy/indexer.Dockerfile -t crowdfund-indexer:$SHA crowdfund-ui
+# bump INDEXER_IMAGE in .env, then:
+docker compose up -d            # add --profile postgres if used
+```
+
+## Teardown
+
+```bash
+docker compose down             # stop; volumes (data) are kept
+docker compose down -v          # also delete data — destructive
+```
+
+## Persistence & backups
+
+State lives in named volumes: `crowdfund-indexer_indexer-data` (file store,
+snapshots, alert dedupe) and `crowdfund-indexer_postgres-data`. Both survive
+`down`/restart. Automated snapshot/restore of these volumes is a planned
+follow-up; for Postgres, `pg_dump`/`psql` per the indexer runbook works today.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,54 @@
+# ABOUTME: Docker Compose stack for the crowdfund indexer API, the Discord alert
+# ABOUTME: evaluator loop, and an optional Postgres store (--profile postgres).
+name: crowdfund-indexer
+
+services:
+  indexer:
+    image: ${INDEXER_IMAGE:?set INDEXER_IMAGE to a locally built tag, e.g. crowdfund-indexer:<git-sha>}
+    restart: unless-stopped
+    env_file: [.env]
+    ports:
+      # Bind to loopback only; the host nginx terminates TLS and proxies in.
+      - "127.0.0.1:${CROWDFUND_INDEXER_PORT:-3002}:${CROWDFUND_INDEXER_PORT:-3002}"
+    volumes:
+      - indexer-data:/app/data
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:'+(process.env.CROWDFUND_INDEXER_PORT||3002)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  alerts:
+    image: ${INDEXER_IMAGE:?set INDEXER_IMAGE to a locally built tag, e.g. crowdfund-indexer:<git-sha>}
+    restart: unless-stopped
+    env_file: [.env]
+    volumes:
+      # Shares the data volume with the indexer: reads the file store, owns alerts.json.
+      - indexer-data:/app/data
+    # One-shot evaluator on a fixed interval. $$ defers expansion to the
+    # container shell so CROWDFUND_ALERT_INTERVAL_SECONDS comes from .env.
+    command:
+      - sh
+      - -c
+      - 'while true; do node_modules/.bin/tsx packages/indexer/src/cli/index.ts evaluate-alerts || true; sleep $${CROWDFUND_ALERT_INTERVAL_SECONDS:-60}; done'
+
+  postgres:
+    image: postgres:16-alpine
+    profiles: ["postgres"]
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-crowdfund}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-crowdfund_local}
+      POSTGRES_DB: ${POSTGRES_DB:-crowdfund}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-crowdfund}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  indexer-data:
+  postgres-data:

--- a/deploy/indexer.Dockerfile
+++ b/deploy/indexer.Dockerfile
@@ -1,0 +1,36 @@
+# ABOUTME: Container image for the crowdfund indexer API and the Discord alert
+# ABOUTME: evaluator, run directly from TypeScript via tsx.
+
+# Build context is crowdfund-ui/ so the indexer's relative imports into the
+# sibling shared package (../../../shared/src/lib/*) resolve. Build with:
+#   docker build -f deploy/indexer.Dockerfile -t crowdfund-indexer:<tag> crowdfund-ui
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+# Install the indexer's dependencies hoisted at /app/node_modules so both the
+# indexer and the shared source files (which import `ethers`) resolve them by
+# walking up the tree. tsx (the TypeScript/ESM runner) is a devDependency
+# required at runtime, so do not omit dev deps here. The indexer package has no
+# workspace deps, so it installs standalone (no --legacy-peer-deps).
+COPY packages/indexer/package.json ./package.json
+RUN npm install --no-audit --no-fund
+
+# Application source: the indexer plus the shared package it imports via
+# relative paths. The /app/packages/{indexer,shared} layout mirrors the
+# monorepo so those ../../../shared/src/lib/* imports resolve.
+COPY packages/indexer ./packages/indexer
+COPY packages/shared ./packages/shared
+
+# Run as the unprivileged node user; pre-create the data dir so the named
+# volume mounted at /app/data inherits node ownership.
+RUN mkdir -p /app/data && chown -R node:node /app
+USER node
+
+ENV NODE_ENV=production
+
+# Default API port (overridable via CROWDFUND_INDEXER_PORT).
+EXPOSE 3002
+
+# API server by default; the alerts container overrides this command.
+CMD ["node_modules/.bin/tsx", "packages/indexer/src/api/server.ts"]

--- a/deploy/indexer.env.template
+++ b/deploy/indexer.env.template
@@ -1,0 +1,59 @@
+# ABOUTME: Environment template for the crowdfund indexer Docker Compose stack.
+# ABOUTME: Copy to `.env` next to docker-compose.yml and fill in real values.
+
+# --- Compose orchestration ---------------------------------------------------
+# Image tag to run. Build it first (see README), e.g. crowdfund-indexer:<git-sha>.
+INDEXER_IMAGE=crowdfund-indexer:latest
+# Seconds between Discord alert evaluations (alerts loop container).
+CROWDFUND_ALERT_INTERVAL_SECONDS=60
+
+# --- Crowdfund target --------------------------------------------------------
+CROWDFUND_CHAIN_ID=11155111
+CROWDFUND_CONTRACT_ADDRESS=
+CROWDFUND_TREASURY_ADDRESS=
+CROWDFUND_USDC_ADDRESS=
+CROWDFUND_DEPLOY_BLOCK=0
+# Primary ingestion RPC (required) + independent audit RPC (recommended).
+CROWDFUND_PRIMARY_RPC_URL=
+CROWDFUND_AUDIT_RPC_URL=
+
+# --- Indexer API -------------------------------------------------------------
+CROWDFUND_INDEXER_PORT=3002
+
+# --- Store (default: file) ---------------------------------------------------
+# File store persists under /app/data (the `indexer-data` volume).
+CROWDFUND_INDEXER_STORE=file
+CROWDFUND_INDEXER_STORE_PATH=data/crowdfund-indexer/store.json
+# To use Postgres instead: bring the stack up with `--profile postgres`, then set:
+#   CROWDFUND_INDEXER_STORE=postgres
+#   CROWDFUND_DATABASE_URL=postgres://crowdfund:<password>@postgres:5432/crowdfund
+#   POSTGRES_PASSWORD=<password>            (consumed by the postgres service)
+# POSTGRES_USER / POSTGRES_DB default to "crowdfund".
+
+# --- Polling -----------------------------------------------------------------
+CROWDFUND_POLL_ON_START=true
+CROWDFUND_POLL_INTERVAL_MS=15000
+CROWDFUND_CONFIRMATION_DEPTH=12
+
+# --- Snapshots (default: local file under the data volume) -------------------
+CROWDFUND_PUBLISH_ON_POLL=true
+CROWDFUND_SNAPSHOT_PUBLISHER=file
+CROWDFUND_SNAPSHOT_DIR=data/crowdfund-indexer/snapshots
+# For S3/R2 fallback snapshots, see ../sample.env.production for the full var set.
+
+# --- Alert window timestamps (unix seconds; read from the deployed contract) --
+CROWDFUND_OPEN_TIMESTAMP=
+CROWDFUND_WEEK1_DEADLINE=
+CROWDFUND_COMMITMENT_DEADLINE=
+
+# --- Discord alert webhooks (secrets — one URL per severity) -----------------
+CROWDFUND_ALERT_WEBHOOK_P0=
+CROWDFUND_ALERT_WEBHOOK_P1=
+CROWDFUND_ALERT_WEBHOOK_P2=
+CROWDFUND_ALERT_WEBHOOK_P3=
+CROWDFUND_ALERT_STATE_FILE=data/crowdfund-indexer/alerts.json
+
+# --- Postgres service (only used with --profile postgres) --------------------
+# Override for any non-local deployment. The DB port is not published; it is
+# only reachable on the compose network.
+POSTGRES_PASSWORD=crowdfund_local

--- a/deploy/nginx-indexer.conf
+++ b/deploy/nginx-indexer.conf
@@ -1,0 +1,30 @@
+# ABOUTME: nginx reverse-proxy server block for the crowdfund indexer API.
+# ABOUTME: Drop into your host nginx (sites-available) and adjust server_name + certs.
+
+# The indexer sets permissive CORS itself, so no CORS handling is needed here.
+
+server {
+    listen 443 ssl;
+    server_name indexer.example.com;            # <-- your hostname
+
+    # Managed by your existing certbot / cert tooling:
+    ssl_certificate     /etc/letsencrypt/live/indexer.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/indexer.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:3002;       # CROWDFUND_INDEXER_PORT
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 30s;
+    }
+}
+
+# Redirect HTTP -> HTTPS
+server {
+    listen 80;
+    server_name indexer.example.com;            # <-- your hostname
+    return 301 https://$host$request_uri;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,7 +223,6 @@
       "name": "@armada/crowdfund-indexer",
       "version": "0.1.0",
       "dependencies": {
-        "@armada/crowdfund-shared": "*",
         "@aws-sdk/client-s3": "^3.1038.0",
         "ethers": "^6.15.0",
         "express": "^5.2.1",
@@ -233,7 +232,7 @@
         "@types/express": "^5.0.6",
         "@types/node": "^22.15.0",
         "@types/pg": "^8.20.0",
-        "ts-node": "^10.9.2",
+        "tsx": "^4.20.6",
         "typescript": "~5.9.3",
         "vitest": "^4.0.8"
       }
@@ -2123,6 +2122,74 @@
         "esbuild": "*"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.2",
       "cpu": [
@@ -2132,6 +2199,363 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -15140,6 +15564,406 @@
         "@esbuild/win32-x64": "0.27.2"
       }
     },
+    "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "license": "MIT",
@@ -23122,6 +23946,84 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/tty-browserify": {
       "version": "0.0.1",

--- a/sample.env.dev
+++ b/sample.env.dev
@@ -42,6 +42,9 @@ CROWDFUND_REPAIR_MAX_ATTEMPTS=6
 CROWDFUND_REPAIR_BACKOFF_BASE_MS=30000
 CROWDFUND_REPAIR_BACKOFF_MAX_MS=1800000
 
+# Wall-clock budget after which a frozen indexer reports stale/unhealthy (default 5 min).
+CROWDFUND_STALE_AFTER_MS=300000
+
 # Local file snapshot publication for dev smoke tests.
 CROWDFUND_PUBLISH_ON_POLL=false
 CROWDFUND_SNAPSHOT_PUBLISH_INTERVAL_MS=60000

--- a/sample.env.production
+++ b/sample.env.production
@@ -49,6 +49,9 @@ CROWDFUND_REPAIR_MAX_ATTEMPTS=6
 CROWDFUND_REPAIR_BACKOFF_BASE_MS=30000
 CROWDFUND_REPAIR_BACKOFF_MAX_MS=1800000
 
+# Wall-clock budget after which a frozen indexer reports stale/unhealthy (default 5 min).
+CROWDFUND_STALE_AFTER_MS=300000
+
 # ============================================================================
 # Static snapshot fallback
 # ============================================================================

--- a/specs/CROWDFUND_INDEXER_RUNBOOK.md
+++ b/specs/CROWDFUND_INDEXER_RUNBOOK.md
@@ -120,7 +120,7 @@ Cursor and range variables:
 | Variable | Default | Behavior |
 |----------|---------|----------|
 | `CROWDFUND_CONFIRMATION_DEPTH` | `12` | Blocks behind chain head required before data is verified. Lower only for dev. |
-| `CROWDFUND_OVERLAP_WINDOW` | `100` | Stored cursor setting reserved for overlap/rescan policy. |
+| `CROWDFUND_OVERLAP_WINDOW` | `100` | Stored cursor setting reserved for a future overlap/rescan policy. **Not yet consumed by any code path** — it does not currently provide reorg protection beyond `CROWDFUND_CONFIRMATION_DEPTH`. Tracked for implementation-or-removal (see GitHub issues). |
 | `CROWDFUND_MAX_BLOCK_RANGE` | `500` | Maximum inclusive block range per `eth_getLogs` chunk. |
 
 API and polling variables:
@@ -141,6 +141,7 @@ API and polling variables:
 | `CROWDFUND_REPAIR_MAX_ATTEMPTS` | `6` | Total attempts (initial + auto-repair retries) before a range is exhausted and surfaced in `gapsRequiringIntervention`. Set to `0` to disable auto-reconcile entirely. |
 | `CROWDFUND_REPAIR_BACKOFF_BASE_MS` | `30000` | Base delay for exponential backoff between auto-repair attempts. The Nth attempt waits `base * 2^(attempts-1)`, capped by `BACKOFF_MAX_MS`. |
 | `CROWDFUND_REPAIR_BACKOFF_MAX_MS` | `1800000` | Cap on the backoff delay between auto-repair attempts (default 30 minutes). |
+| `CROWDFUND_STALE_AFTER_MS` | `300000` | Wall-clock budget after which a frozen indexer is reported `stale` (or `unhealthy` if an error is pending) even when there are no gaps and block-lag reads 0. Detects a dead/stuck RPC where cursors stop advancing. Default 5 minutes. |
 
 Snapshot publication variables:
 
@@ -222,6 +223,13 @@ export CROWDFUND_INDEXER_STORE_PATH=data/crowdfund-indexer/store.json
 
 Do not use the JSON file store for production campaigns.
 
+**Single-writer only.** The JSON file store has no cross-process lock. Its writes are
+read-modify-write, so running a mutating CLI command (`verify`, `repair`, `backfill`)
+while the API's polling worker is active will race — the last writer wins and updates are
+lost. Stop the polling worker before running mutating CLI commands against the file store,
+or use the Postgres backend (which serializes writes via an advisory lock). Read-only
+commands (`status`) are always safe.
+
 ---
 
 ## Static Snapshot Publishing
@@ -285,6 +293,17 @@ Expected healthy fields:
 - `hasGaps: false`
 - `lagBlocks` near `0`
 - `verifiedCursor` close to `confirmedHead`
+
+### Health status semantics
+
+`status` is derived in this order:
+
+- `unhealthy` — one or more gaps have exhausted auto-repair (`gapsRequiringIntervention` non-empty); or a gap exists alongside a current `lastError`; or nothing has ever verified while an error is pending.
+- `degraded` — gaps exist but auto-repair is still retrying them.
+- `stale` — verification has not advanced within `CROWDFUND_STALE_AFTER_MS` (wall-clock), **or** block-lag exceeds the SLA threshold. The wall-clock check catches a dead/stuck RPC where the cursors freeze and `lagBlocks` would otherwise read `0`. If an error is pending during that window, status escalates to `unhealthy`.
+- `healthy` — none of the above.
+
+Two alerts watch the indexer itself (see `MONITORING.md` §8 addendum): **AH1** pages when `status` is `stale` (P2) or `unhealthy` (P1); **AH2** pages when `gapsRequiringIntervention` is non-empty (P1). While the indexer is `stale`/`unhealthy`, the time-based crowdfund alerts (A2/A8/A9a/A9b) are suppressed to avoid false pages off a lagging snapshot.
 
 ---
 

--- a/specs/MONITORING.md
+++ b/specs/MONITORING.md
@@ -362,6 +362,38 @@ Post-finalization, track:
 
 ---
 
+### Addendum — Indexer-health alerts (AH1, AH2)
+
+These alerts watch the indexer itself rather than the crowdfund. They exist because the
+time-vs-event rules (A2, A8, A9a, A9b) trust the indexed snapshot to be current. When the
+indexer falls behind or breaks, those rules are **suppressed** (a stale/unhealthy snapshot
+would otherwise produce false pages such as "finalize required" when the `Finalized` event
+simply has not been ingested). AH1 covers the resulting blind spot.
+
+#### AH1 — Indexer health degraded
+
+| Field | Value |
+|---|---|
+| **Signal** | `health.status` from the indexer health endpoint |
+| **Condition** | `status === 'unhealthy'` (P1) or `status === 'stale'` (P2) |
+| **Severity** | P1 (unhealthy) / P2 (stale) |
+| **Meaning** | The indexer cannot be trusted to reflect chain state; frontends serve the last verified snapshot and time-based alerts are paused until it recovers. |
+| **Dedupe** | `AH1:<status>:<UTC-date>` — a sustained outage re-pages once per day. |
+| **Runbook** | `CROWDFUND_INDEXER_RUNBOOK.md` health triage |
+
+#### AH2 — Indexer gaps require operator intervention
+
+| Field | Value |
+|---|---|
+| **Signal** | `health.gapsRequiringIntervention` |
+| **Condition** | one or more ranges have exhausted auto-repair attempts |
+| **Severity** | P1 |
+| **Meaning** | Auto-repair has given up on a block range; an operator must run `npm run crowdfund:indexer:cli -- repair`. |
+| **Dedupe** | `AH2:<from>-<to>,…` — a newly-exhausted gap re-pages. |
+| **Runbook** | `CROWDFUND_INDEXER_RUNBOOK.md` gap repair |
+
+---
+
 ## 9. Special Monitoring Notes
 
 ### 9.1 Duplicate same-hop invites are not an exploit


### PR DESCRIPTION
Hardening pass on the crowdfund indexer from a full bug / performance / security / reliability review. 16 fix items across 5 phases, one commit each (4.1 split into 4.1a/4.1b). 155 tests pass (+52 over baseline), typecheck clean.

## Deployment
- **The indexer runs on a hosted VPS — it needs a pull + restart after merge.** Stop → pull → restart is safe for the JSON-file store: no re-index, no store deletion, no build step (runs via ts-node).
- **One new optional env var: `CROWDFUND_STALE_AFTER_MS`** (default `300000`). Documented in `specs/CROWDFUND_INDEXER_RUNBOOK.md` and added to `sample.env.dev` / `sample.env.production`.
- **No frontend change required.** The committer/observer consume only `GET /snapshot` and `GET /health`; both response shapes are unchanged and the `status` enum is unchanged. (An optional `StaleDataBanner` copy nicety is tracked separately, not in this PR.)

## Phase 1 — Critical correctness / security
- **Reconcile at `verifiedCursor` block, not `latest`** (`fb50991`): pins contract reads to the snapshot's verified block via `blockTag`, so event-derived totals and on-chain reads compare at the same height. Stops spurious reconciliation failures during active commit traffic. Publish/reconcile failures no longer fail the whole poll cycle.
- **Sanitize persisted/served error messages** (`a3145f6`): strips RPC URL paths/queries (API keys) and DB credentials from `lastError`; the API 500 handler returns a fixed message. Closes a key-leak via the public `/health` endpoint.

## Phase 2 — Honest monitoring
- **Wall-clock staleness in `/health`** (`0a53bba`): reports `stale`/`unhealthy` when verification hasn't advanced within `CROWDFUND_STALE_AFTER_MS`, catching a dead RPC where cursors freeze and block-lag reads 0.
- **Gate time-based alerts on health + AH1/AH2** (`5e8cbc8`): suppresses A2/A8/A9a/A9b on a stale/unhealthy snapshot; adds AH1 (indexer health) and AH2 (gaps needing intervention). MONITORING.md §8 addendum.
- **Resilient alert dispatch** (`130f503`): persists dedupe state after each successful send, adds a webhook timeout, and writes the alert-state file atomically.

## Phase 3 — Ingest correctness
- **Backfill honors repair backoff** (`125632b`): stops re-verifying a stuck range every poll cycle (which double-counted attempts and falsely exhausted the repair limit).
- **Deterministic `snapshotHash`** (`7f9b836`): excludes `generatedAt`/`reconciliation` so identical chain state yields a stable content hash; adds `withReconciliation`.
- **Chain/contract log filtering** (`b8182c9`): snapshots include only logs matching the configured chain + contract.
- **Provider attribution / single build / provider cleanup** (`83ff528`): verified records keep their staging provider, snapshots build once per publish, ethers providers are destroyed.

## Phase 4 — Performance
- **Narrow store operations** (`c22c112`): adds `readMeta`/`readLogs`/`appendRawLogs`/`patchRange`/`patchMeta` alongside the whole-store API.
- **Hot paths off whole-store updates** (`9c86aa5`): ingest, `/health`, `/snapshot`, `/events`, and alerts no longer read-modify-write the entire store each op (Postgres was O(total logs) per chunk).
- **Snapshot cache** (`0e56a32`): `/snapshot` and `/events` serve a cached build keyed on verified state.

## Phase 5 — Polish / operability
- **Single source of truth for env config** (`743aea3`): consolidates env readers + `loadIndexerConfig` + `getInitialCursor`.
- **CLI chunking, store close, single-provider warning** (`21e3311`): chunks explicit `--from/--to` spans, adds `store.close()` for clean exit, warns when no audit RPC is set.
- **A6 noise + A13/A3 docs** (`e943911`): buckets A6 dedupe keys; documents A13's current-balance caveat; A3 inertness tracked.
- **Ignore phantom gaps** (`96a48e9`): failed/suspicious records fully covered by verified ranges no longer reported as gaps.
- **Docs sweep** (`31f0bc1`): runbook health semantics, file-store single-writer warning, overlap-window honesty, sample-env updates.

## Deferred (tracked as `claude-generated` issues, not in this PR)
- #332 rate limiting at the reverse proxy
- #333 alert A3 needs event timestamps (or removal)
- #334 `CROWDFUND_OVERLAP_WINDOW` unused — implement overlap rescan or remove
- #335 deep-reorg orphaned-log cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
