### PR TITLE
feat(indexer): Docker Compose deploy for crowdfund indexer

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -28,7 +28,7 @@ fi
 # --- Check 3: .env file leak prevention ---
 # Only non-secret environment templates and committed public config envs are allowed.
 # All other .env files should be gitignored, but check as a safety net.
-ALLOWED_ENV_FILES="config/local.env config/sepolia.env config/secrets.env.template sample.env.dev sample.env.production"
+ALLOWED_ENV_FILES="config/local.env config/sepolia.env config/secrets.env.template sample.env.dev sample.env.production deploy/indexer.env.template"
 ENV_VIOLATIONS=""
 for f in $STAGED_FILES; do
   if [[ "$f" == *.env || "$f" == *.env.* ]]; then

--- a/crowdfund-ui/.dockerignore
+++ b/crowdfund-ui/.dockerignore
@@ -1,0 +1,11 @@
+# ABOUTME: Trims the crowdfund-ui Docker build context for the indexer image.
+# ABOUTME: Only packages/indexer and packages/shared source are needed.
+**/node_modules
+**/data
+**/dist
+packages/observer
+packages/committer
+packages/admin
+**/*.test.ts
+**/vitest.config.ts
+.git

--- a/crowdfund-ui/packages/indexer/.dockerignore
+++ b/crowdfund-ui/packages/indexer/.dockerignore
@@ -1,7 +1,0 @@
-# ABOUTME: Excludes dev-only and generated files from the indexer Docker build context.
-# ABOUTME: node_modules and data must be excluded so the image installs cleanly.
-node_modules
-data
-*.test.ts
-vitest.config.ts
-.git

--- a/crowdfund-ui/packages/indexer/.dockerignore
+++ b/crowdfund-ui/packages/indexer/.dockerignore
@@ -1,0 +1,7 @@
+# ABOUTME: Excludes dev-only and generated files from the indexer Docker build context.
+# ABOUTME: node_modules and data must be excluded so the image installs cleanly.
+node_modules
+data
+*.test.ts
+vitest.config.ts
+.git

--- a/crowdfund-ui/packages/indexer/package.json
+++ b/crowdfund-ui/packages/indexer/package.json
@@ -6,8 +6,8 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "dev": "node --no-warnings --loader ts-node/esm src/api/server.ts",
-    "cli": "node --no-warnings --loader ts-node/esm src/cli/index.ts",
+    "dev": "tsx src/api/server.ts",
+    "cli": "tsx src/cli/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
@@ -22,7 +22,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^22.15.0",
     "@types/pg": "^8.20.0",
-    "ts-node": "^10.9.2",
+    "tsx": "^4.20.6",
     "typescript": "~5.9.3",
     "vitest": "^4.0.8"
   }

--- a/crowdfund-ui/packages/indexer/package.json
+++ b/crowdfund-ui/packages/indexer/package.json
@@ -13,7 +13,6 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@armada/crowdfund-shared": "*",
     "@aws-sdk/client-s3": "^3.1038.0",
     "ethers": "^6.15.0",
     "express": "^5.2.1",

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -17,7 +17,7 @@ infra on the same host — each service runs its own commit-tagged image.
 ```bash
 # from a checkout of this repo
 SHA=$(git rev-parse --short HEAD)
-docker build -f deploy/indexer.Dockerfile -t crowdfund-indexer:$SHA crowdfund-ui/packages/indexer
+docker build -f deploy/indexer.Dockerfile -t crowdfund-indexer:$SHA crowdfund-ui
 ```
 
 ## 2. Configure (in your ops dir, e.g. /opt/armada-infra/)
@@ -56,7 +56,7 @@ reload. It proxies `https://<host>` → `127.0.0.1:3002`.
 
 ```bash
 git pull && SHA=$(git rev-parse --short HEAD)
-docker build -f deploy/indexer.Dockerfile -t crowdfund-indexer:$SHA crowdfund-ui/packages/indexer
+docker build -f deploy/indexer.Dockerfile -t crowdfund-indexer:$SHA crowdfund-ui
 # bump INDEXER_IMAGE in .env, then:
 docker compose up -d            # add --profile postgres if used
 ```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,76 @@
+# Crowdfund Indexer — Docker Deploy
+
+Containerized deploy for the indexer API + Discord alert loop, with an optional
+Postgres store. Default store is **file** (a Docker volume). Coexists with other
+infra on the same host — each service runs its own commit-tagged image.
+
+## Layout
+
+- `indexer.Dockerfile` — build recipe (stays in this repo, builds from a checkout).
+- `docker-compose.yml` — the fleet (indexer, alerts, optional postgres). **Copy this
+  + your `.env` to a live ops dir outside the build checkout**, e.g. `/opt/armada-infra/`.
+- `indexer.env.template` — copy to `.env` and fill in. Never commit the real `.env`.
+- `nginx-indexer.conf` — host nginx server block; edit hostname + cert paths.
+
+## 1. Build (on the VPS)
+
+```bash
+# from a checkout of this repo
+SHA=$(git rev-parse --short HEAD)
+docker build -f deploy/indexer.Dockerfile -t crowdfund-indexer:$SHA crowdfund-ui/packages/indexer
+```
+
+## 2. Configure (in your ops dir, e.g. /opt/armada-infra/)
+
+```bash
+cp /path/to/repo/deploy/docker-compose.yml .
+cp /path/to/repo/deploy/indexer.env.template .env
+# edit .env: set INDEXER_IMAGE=crowdfund-indexer:<sha>, RPC URLs, contract
+# addresses, alert window timestamps, and Discord webhooks.
+```
+
+## 3. Run
+
+```bash
+docker compose up -d            # file store (default)
+docker compose ps
+docker compose logs -f indexer
+curl -s localhost:3002/health   # sanity check
+```
+
+Postgres instead of file store — set in `.env`:
+`CROWDFUND_INDEXER_STORE=postgres`,
+`CROWDFUND_DATABASE_URL=postgres://crowdfund:<pw>@postgres:5432/crowdfund`,
+`POSTGRES_PASSWORD=<pw>`, then:
+
+```bash
+docker compose --profile postgres up -d
+```
+
+## 4. nginx
+
+Edit `nginx-indexer.conf` (hostname + cert paths), drop it into your host nginx,
+reload. It proxies `https://<host>` → `127.0.0.1:3002`.
+
+## Update / redeploy
+
+```bash
+git pull && SHA=$(git rev-parse --short HEAD)
+docker build -f deploy/indexer.Dockerfile -t crowdfund-indexer:$SHA crowdfund-ui/packages/indexer
+# bump INDEXER_IMAGE in .env, then:
+docker compose up -d            # add --profile postgres if used
+```
+
+## Teardown
+
+```bash
+docker compose down             # stop; volumes (data) are kept
+docker compose down -v          # also delete data — destructive
+```
+
+## Persistence & backups
+
+State lives in named volumes: `crowdfund-indexer_indexer-data` (file store,
+snapshots, alert dedupe) and `crowdfund-indexer_postgres-data`. Both survive
+`down`/restart. Automated snapshot/restore of these volumes is a planned
+follow-up; for Postgres, `pg_dump`/`psql` per the indexer runbook works today.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command:
       - sh
       - -c
-      - 'while true; do node_modules/.bin/tsx src/cli/index.ts evaluate-alerts || true; sleep $${CROWDFUND_ALERT_INTERVAL_SECONDS:-60}; done'
+      - 'while true; do node_modules/.bin/tsx packages/indexer/src/cli/index.ts evaluate-alerts || true; sleep $${CROWDFUND_ALERT_INTERVAL_SECONDS:-60}; done'
 
   postgres:
     image: postgres:16-alpine

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,54 @@
+# ABOUTME: Docker Compose stack for the crowdfund indexer API, the Discord alert
+# ABOUTME: evaluator loop, and an optional Postgres store (--profile postgres).
+name: crowdfund-indexer
+
+services:
+  indexer:
+    image: ${INDEXER_IMAGE:?set INDEXER_IMAGE to a locally built tag, e.g. crowdfund-indexer:<git-sha>}
+    restart: unless-stopped
+    env_file: [.env]
+    ports:
+      # Bind to loopback only; the host nginx terminates TLS and proxies in.
+      - "127.0.0.1:${CROWDFUND_INDEXER_PORT:-3002}:${CROWDFUND_INDEXER_PORT:-3002}"
+    volumes:
+      - indexer-data:/app/data
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:'+(process.env.CROWDFUND_INDEXER_PORT||3002)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  alerts:
+    image: ${INDEXER_IMAGE:?set INDEXER_IMAGE to a locally built tag, e.g. crowdfund-indexer:<git-sha>}
+    restart: unless-stopped
+    env_file: [.env]
+    volumes:
+      # Shares the data volume with the indexer: reads the file store, owns alerts.json.
+      - indexer-data:/app/data
+    # One-shot evaluator on a fixed interval. $$ defers expansion to the
+    # container shell so CROWDFUND_ALERT_INTERVAL_SECONDS comes from .env.
+    command:
+      - sh
+      - -c
+      - 'while true; do node --no-warnings --loader ts-node/esm src/cli/index.ts evaluate-alerts || true; sleep $${CROWDFUND_ALERT_INTERVAL_SECONDS:-60}; done'
+
+  postgres:
+    image: postgres:16-alpine
+    profiles: ["postgres"]
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-crowdfund}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-crowdfund_local}
+      POSTGRES_DB: ${POSTGRES_DB:-crowdfund}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-crowdfund}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  indexer-data:
+  postgres-data:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command:
       - sh
       - -c
-      - 'while true; do node --no-warnings --loader ts-node/esm src/cli/index.ts evaluate-alerts || true; sleep $${CROWDFUND_ALERT_INTERVAL_SECONDS:-60}; done'
+      - 'while true; do node_modules/.bin/tsx src/cli/index.ts evaluate-alerts || true; sleep $${CROWDFUND_ALERT_INTERVAL_SECONDS:-60}; done'
 
   postgres:
     image: postgres:16-alpine

--- a/deploy/indexer.Dockerfile
+++ b/deploy/indexer.Dockerfile
@@ -1,21 +1,26 @@
-# ABOUTME: Standalone container image for the crowdfund indexer API and the
-# ABOUTME: Discord alert evaluator, run directly from TypeScript via ts-node.
+# ABOUTME: Container image for the crowdfund indexer API and the Discord alert
+# ABOUTME: evaluator, run directly from TypeScript via tsx.
 
-# Build context is the indexer package dir, e.g.:
-#   docker build -f deploy/indexer.Dockerfile -t crowdfund-indexer:<tag> crowdfund-ui/packages/indexer
+# Build context is crowdfund-ui/ so the indexer's relative imports into the
+# sibling shared package (../../../shared/src/lib/*) resolve. Build with:
+#   docker build -f deploy/indexer.Dockerfile -t crowdfund-indexer:<tag> crowdfund-ui
 FROM node:22-bookworm-slim
 
 WORKDIR /app
 
-# Install only the indexer package's own dependencies. The indexer has no
-# workspace deps, so it installs standalone without the rest of the monorepo
-# (and without --legacy-peer-deps). tsx (the TypeScript/ESM runner) is a
-# devDependency and is required at runtime, so do not omit dev deps here.
-COPY package.json ./
+# Install the indexer's dependencies hoisted at /app/node_modules so both the
+# indexer and the shared source files (which import `ethers`) resolve them by
+# walking up the tree. tsx (the TypeScript/ESM runner) is a devDependency
+# required at runtime, so do not omit dev deps here. The indexer package has no
+# workspace deps, so it installs standalone (no --legacy-peer-deps).
+COPY packages/indexer/package.json ./package.json
 RUN npm install --no-audit --no-fund
 
-# Application source (node_modules and data/ are excluded via .dockerignore).
-COPY . .
+# Application source: the indexer plus the shared package it imports via
+# relative paths. The /app/packages/{indexer,shared} layout mirrors the
+# monorepo so those ../../../shared/src/lib/* imports resolve.
+COPY packages/indexer ./packages/indexer
+COPY packages/shared ./packages/shared
 
 # Run as the unprivileged node user; pre-create the data dir so the named
 # volume mounted at /app/data inherits node ownership.
@@ -28,4 +33,4 @@ ENV NODE_ENV=production
 EXPOSE 3002
 
 # API server by default; the alerts container overrides this command.
-CMD ["node_modules/.bin/tsx", "src/api/server.ts"]
+CMD ["node_modules/.bin/tsx", "packages/indexer/src/api/server.ts"]

--- a/deploy/indexer.Dockerfile
+++ b/deploy/indexer.Dockerfile
@@ -1,0 +1,31 @@
+# ABOUTME: Standalone container image for the crowdfund indexer API and the
+# ABOUTME: Discord alert evaluator, run directly from TypeScript via ts-node.
+
+# Build context is the indexer package dir, e.g.:
+#   docker build -f deploy/indexer.Dockerfile -t crowdfund-indexer:<tag> crowdfund-ui/packages/indexer
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+# Install only the indexer package's own dependencies. The indexer has no
+# workspace deps, so it installs standalone without the rest of the monorepo
+# (and without --legacy-peer-deps). ts-node/typescript are devDependencies and
+# are required at runtime, so do not omit dev deps here.
+COPY package.json ./
+RUN npm install --no-audit --no-fund
+
+# Application source (node_modules and data/ are excluded via .dockerignore).
+COPY . .
+
+# Run as the unprivileged node user; pre-create the data dir so the named
+# volume mounted at /app/data inherits node ownership.
+RUN mkdir -p /app/data && chown -R node:node /app
+USER node
+
+ENV NODE_ENV=production
+
+# Default API port (overridable via CROWDFUND_INDEXER_PORT).
+EXPOSE 3002
+
+# API server by default; the alerts container overrides this command.
+CMD ["node", "--no-warnings", "--loader", "ts-node/esm", "src/api/server.ts"]

--- a/deploy/indexer.Dockerfile
+++ b/deploy/indexer.Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /app
 
 # Install only the indexer package's own dependencies. The indexer has no
 # workspace deps, so it installs standalone without the rest of the monorepo
-# (and without --legacy-peer-deps). ts-node/typescript are devDependencies and
-# are required at runtime, so do not omit dev deps here.
+# (and without --legacy-peer-deps). tsx (the TypeScript/ESM runner) is a
+# devDependency and is required at runtime, so do not omit dev deps here.
 COPY package.json ./
 RUN npm install --no-audit --no-fund
 
@@ -28,4 +28,4 @@ ENV NODE_ENV=production
 EXPOSE 3002
 
 # API server by default; the alerts container overrides this command.
-CMD ["node", "--no-warnings", "--loader", "ts-node/esm", "src/api/server.ts"]
+CMD ["node_modules/.bin/tsx", "src/api/server.ts"]

--- a/deploy/indexer.env.template
+++ b/deploy/indexer.env.template
@@ -1,0 +1,59 @@
+# ABOUTME: Environment template for the crowdfund indexer Docker Compose stack.
+# ABOUTME: Copy to `.env` next to docker-compose.yml and fill in real values.
+
+# --- Compose orchestration ---------------------------------------------------
+# Image tag to run. Build it first (see README), e.g. crowdfund-indexer:<git-sha>.
+INDEXER_IMAGE=crowdfund-indexer:latest
+# Seconds between Discord alert evaluations (alerts loop container).
+CROWDFUND_ALERT_INTERVAL_SECONDS=60
+
+# --- Crowdfund target --------------------------------------------------------
+CROWDFUND_CHAIN_ID=11155111
+CROWDFUND_CONTRACT_ADDRESS=
+CROWDFUND_TREASURY_ADDRESS=
+CROWDFUND_USDC_ADDRESS=
+CROWDFUND_DEPLOY_BLOCK=0
+# Primary ingestion RPC (required) + independent audit RPC (recommended).
+CROWDFUND_PRIMARY_RPC_URL=
+CROWDFUND_AUDIT_RPC_URL=
+
+# --- Indexer API -------------------------------------------------------------
+CROWDFUND_INDEXER_PORT=3002
+
+# --- Store (default: file) ---------------------------------------------------
+# File store persists under /app/data (the `indexer-data` volume).
+CROWDFUND_INDEXER_STORE=file
+CROWDFUND_INDEXER_STORE_PATH=data/crowdfund-indexer/store.json
+# To use Postgres instead: bring the stack up with `--profile postgres`, then set:
+#   CROWDFUND_INDEXER_STORE=postgres
+#   CROWDFUND_DATABASE_URL=postgres://crowdfund:<password>@postgres:5432/crowdfund
+#   POSTGRES_PASSWORD=<password>            (consumed by the postgres service)
+# POSTGRES_USER / POSTGRES_DB default to "crowdfund".
+
+# --- Polling -----------------------------------------------------------------
+CROWDFUND_POLL_ON_START=true
+CROWDFUND_POLL_INTERVAL_MS=15000
+CROWDFUND_CONFIRMATION_DEPTH=12
+
+# --- Snapshots (default: local file under the data volume) -------------------
+CROWDFUND_PUBLISH_ON_POLL=true
+CROWDFUND_SNAPSHOT_PUBLISHER=file
+CROWDFUND_SNAPSHOT_DIR=data/crowdfund-indexer/snapshots
+# For S3/R2 fallback snapshots, see ../sample.env.production for the full var set.
+
+# --- Alert window timestamps (unix seconds; read from the deployed contract) --
+CROWDFUND_OPEN_TIMESTAMP=
+CROWDFUND_WEEK1_DEADLINE=
+CROWDFUND_COMMITMENT_DEADLINE=
+
+# --- Discord alert webhooks (secrets — one URL per severity) -----------------
+CROWDFUND_ALERT_WEBHOOK_P0=
+CROWDFUND_ALERT_WEBHOOK_P1=
+CROWDFUND_ALERT_WEBHOOK_P2=
+CROWDFUND_ALERT_WEBHOOK_P3=
+CROWDFUND_ALERT_STATE_FILE=data/crowdfund-indexer/alerts.json
+
+# --- Postgres service (only used with --profile postgres) --------------------
+# Override for any non-local deployment. The DB port is not published; it is
+# only reachable on the compose network.
+POSTGRES_PASSWORD=crowdfund_local

--- a/deploy/nginx-indexer.conf
+++ b/deploy/nginx-indexer.conf
@@ -1,0 +1,30 @@
+# ABOUTME: nginx reverse-proxy server block for the crowdfund indexer API.
+# ABOUTME: Drop into your host nginx (sites-available) and adjust server_name + certs.
+
+# The indexer sets permissive CORS itself, so no CORS handling is needed here.
+
+server {
+    listen 443 ssl;
+    server_name indexer.example.com;            # <-- your hostname
+
+    # Managed by your existing certbot / cert tooling:
+    ssl_certificate     /etc/letsencrypt/live/indexer.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/indexer.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:3002;       # CROWDFUND_INDEXER_PORT
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 30s;
+    }
+}
+
+# Redirect HTTP -> HTTPS
+server {
+    listen 80;
+    server_name indexer.example.com;            # <-- your hostname
+    return 301 https://$host$request_uri;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,7 +223,6 @@
       "name": "@armada/crowdfund-indexer",
       "version": "0.1.0",
       "dependencies": {
-        "@armada/crowdfund-shared": "*",
         "@aws-sdk/client-s3": "^3.1038.0",
         "ethers": "^6.15.0",
         "express": "^5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -232,7 +232,7 @@
         "@types/express": "^5.0.6",
         "@types/node": "^22.15.0",
         "@types/pg": "^8.20.0",
-        "ts-node": "^10.9.2",
+        "tsx": "^4.20.6",
         "typescript": "~5.9.3",
         "vitest": "^4.0.8"
       }
@@ -2122,6 +2122,74 @@
         "esbuild": "*"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.2",
       "cpu": [
@@ -2131,6 +2199,363 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -15139,6 +15564,406 @@
         "@esbuild/win32-x64": "0.27.2"
       }
     },
+    "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "license": "MIT",
@@ -23121,6 +23946,84 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/tty-browserify": {
       "version": "0.0.1",


### PR DESCRIPTION
## What

Containerized deploy for the crowdfund indexer, replacing the systemd-on-a-shared-checkout setup. Lives in a new \`deploy/\` dir referencing commit-tagged images, so the indexer can run alongside other infra at different commits.

**\`deploy/\`**
- \`indexer.Dockerfile\` — slim standalone image (\`node:22-bookworm-slim\`, non-root \`node\` user). Build context is just the indexer package; installs only its real deps — no monorepo, no \`--legacy-peer-deps\`.
- \`docker-compose.yml\` — \`indexer\` (API on \`127.0.0.1:3002\`, healthchecked), \`alerts\` (Discord \`evaluate-alerts\` loop container), and \`postgres\` behind \`--profile postgres\`. Default store is **file** (a named volume). \`restart: unless-stopped\` throughout.
- \`indexer.env.template\` → copy to gitignored \`.env\`. Postgres opt-in documented inline.
- \`nginx-indexer.conf\` — host-nginx server block proxying to the loopback port (keeps existing certs).
- \`README.md\` — succinct build → configure → run → update → teardown.

**Phantom dependency fix (folded in):** dropped the unused \`@armada/crowdfund-shared\` from the indexer's \`package.json\` + \`package-lock.json\`. This is what lets the image build standalone.

**Tooling:** added \`deploy/indexer.env.template\` to the pre-commit hook's \`ALLOWED_ENV_FILES\` (secret-free template, like the existing \`*.template\` entries).

## Verification

- Indexer typecheck clean; 155/155 tests pass without the phantom dep.
- Lockfile diff is one line.
- \`docker compose config\` validates both profiles (default → indexer+alerts; \`--profile postgres\` adds postgres).
- Not yet executed: \`docker build\` + runtime smoke test (no Docker daemon on the dev machine). Build happens on the VPS; see PR thread for the pre-merge test plan.

## Deploy note

This is new deploy infra (does not touch the running relayer/config). Migration of the live VPS from systemd to compose is a separate, manual step after merge.