### PR TITLE
fix(committer): claim/refund tx visibility + in-progress recovery (#339 Level 1)

### DIFF
--- a/crowdfund-ui/packages/committer/src/App.tsx
+++ b/crowdfund-ui/packages/committer/src/App.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { useStore, useAtomValue } from 'jotai'
+import { toast } from 'sonner'
 import { type JsonRpcProvider } from 'ethers'
 import { ConnectButton, useConnectModal } from '@rainbow-me/rainbowkit'
 import { useAccount, useDisconnect } from 'wagmi'
@@ -414,10 +415,31 @@ export function App() {
   // mid-session — via the fallback provider. On resolution, refresh balances and
   // flip the matching pipeline row to done/reverted (post-timeout watcher).
   const onWatchedTxResolved = useCallback(
-    (txHash: string, status: 'pending' | 'confirmed' | 'failed') => {
+    (txHash: string, status: 'pending' | 'confirmed' | 'failed', label: string) => {
       void allowance.refresh()
       if (status !== 'pending') {
         applyWatchedTxResult(jotaiStore, txHash, status === 'confirmed' ? 'confirmed' : 'reverted')
+      }
+      // Surface a reverted tx cross-page. The header chip only renders the
+      // in-flight (pending) state and clears on any resolution, so without this
+      // a failure that lands while the user is on another page (or after they
+      // closed the flow) is otherwise silent. Covers every flow that persists a
+      // pending tx (commit, invite, claim).
+      if (status === 'failed') {
+        const explorerUrl = getExplorerUrl()
+        toast.error(`${label} failed`, {
+          description: 'The transaction reverted on-chain.',
+          duration: 10_000,
+          ...(explorerUrl
+            ? {
+                action: {
+                  label: 'View',
+                  onClick: () =>
+                    window.open(`${explorerUrl}/tx/${txHash}`, '_blank', 'noopener,noreferrer'),
+                },
+              }
+            : {}),
+        })
       }
     },
     [allowance, jotaiStore],

--- a/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.test.tsx
+++ b/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.test.tsx
@@ -8,6 +8,8 @@ import { createElement, type ReactElement, type ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { JsonRpcProvider } from 'ethers'
 import { ClaimFlowV2, type ClaimFlowV2Props } from './ClaimFlowV2'
+import { clearClaimInFlight } from '@/lib/claimInFlight'
+import { clearPendingTxs } from '@/lib/pendingTx'
 
 // ClaimFlowV2 reads via react-query — each render gets a fresh client so query
 // caches don't leak across tests.
@@ -66,6 +68,10 @@ const baseProps: ClaimFlowV2Props = {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Isolate sessionStorage between tests so an in-flight claim marker (or pending
+  // tx) from one test doesn't make the next reconstruct an in-progress state.
+  clearClaimInFlight()
+  clearPendingTxs()
   claimedFor = () => Promise.resolve(false)
   allocationFor = () => Promise.resolve([0n, 0n])
   claimImpl = () => Promise.resolve({ hash: '0xclaim', wait: () => Promise.resolve({ status: 1, logs: [] }) })

--- a/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.tsx
+++ b/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.tsx
@@ -341,6 +341,10 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
         })
         setTxs([{ label: opLabel, status: 'loading', phaseLabel: 'Submitting…', hash, explorerUrl }])
       },
+      // Race the direct read provider against the wallet's tx.wait() so the done
+      // screen lands as soon as the chain confirms, instead of waiting on the
+      // wallet provider's slower poll (which lagged the header chip by seconds).
+      provider,
     )
     runningRef.current = false
     setSubmitting(false)

--- a/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.tsx
+++ b/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.tsx
@@ -22,10 +22,11 @@ import {
 import { Steps, Button as ArmadaButton, Tooltip } from '@armada/ui'
 import { InformationCircleIcon } from '@heroicons/react/24/solid'
 import { sendAndWaitTx } from '@/lib/sendAndWaitTx'
+import { savePendingTx, removePendingTx } from '@/lib/pendingTx'
 import { resolveSigner, describeSignerError } from '@/lib/resolveSigner'
 import { isMobileBrowser } from '@/lib/isMobileBrowser'
 import { submitTxViaWagmi } from '@/lib/mobileTxSubmit'
-import { getExplorerUrl } from '@/config/network'
+import { getExplorerUrl, getHubChainId } from '@/config/network'
 import { useBeforeUnloadGuard } from '@/hooks/useBeforeUnloadGuard'
 import { getHubNetworkLabel } from '@/config/network'
 import styles from './ClaimFlowV2.module.css'
@@ -327,11 +328,26 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
         }
         return mode === 'arm' ? crowdfund.claim(delegateAddress!) : crowdfund.claimRefund()
       },
-      (hash) =>
-        setTxs([{ label: opLabel, status: 'loading', phaseLabel: 'Submitting…', hash, explorerUrl }]),
+      (hash) => {
+        // Persist the broadcast so the header tx chip (via usePendingTxWatcher)
+        // surfaces it across pages, and the watcher refreshes balances + resolves
+        // it even if the user navigates away or reloads before it confirms.
+        savePendingTx({
+          chainId: getHubChainId(),
+          address: startAddress ?? '',
+          txHash: hash,
+          label: opLabel,
+          sentAt: Date.now(),
+        })
+        setTxs([{ label: opLabel, status: 'loading', phaseLabel: 'Submitting…', hash, explorerUrl }])
+      },
     )
     runningRef.current = false
     setSubmitting(false)
+
+    // A resolved tx no longer needs watching; a timed-out one may still confirm,
+    // so it stays persisted for the post-timeout watcher. Mirrors the commit pipeline.
+    if (result.hash && result.outcome !== 'timeout') removePendingTx(result.hash)
 
     if (result.outcome === 'success') {
       setTxs([{ label: opLabel, status: 'done', hash: result.hash, explorerUrl }])

--- a/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.tsx
+++ b/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.tsx
@@ -23,6 +23,8 @@ import { Steps, Button as ArmadaButton, Tooltip } from '@armada/ui'
 import { InformationCircleIcon } from '@heroicons/react/24/solid'
 import { sendAndWaitTx } from '@/lib/sendAndWaitTx'
 import { savePendingTx, removePendingTx } from '@/lib/pendingTx'
+import { setClaimInFlight, getClaimInFlight, clearClaimInFlight } from '@/lib/claimInFlight'
+import { TX_WAIT_TIMEOUT_MS } from '@/lib/txWait'
 import { resolveSigner, describeSignerError } from '@/lib/resolveSigner'
 import { isMobileBrowser } from '@/lib/isMobileBrowser'
 import { submitTxViaWagmi } from '@/lib/mobileTxSubmit'
@@ -137,13 +139,72 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
   // Warn before a refresh/tab-close drops the user while a claim is broadcasting.
   useBeforeUnloadGuard(submitting)
 
-  const [step, setStep] = useState<FlowStep>('review')
-  const [txs, setTxs] = useState<Step4Transaction[] | null>(null)
+  // Reconstruct in-progress state from a persisted in-flight claim marker, so
+  // navigating away and back lands on "Submitting…" (or the eventual outcome)
+  // rather than resetting to the Review form — which looks un-submitted and
+  // invites a duplicate claim. The marker is keyed by wallet address.
+  const [step, setStep] = useState<FlowStep>(() =>
+    getClaimInFlight(walletAddress) ? 'submit' : 'review',
+  )
+  const [txs, setTxs] = useState<Step4Transaction[] | null>(() => {
+    const marker = getClaimInFlight(walletAddress)
+    if (!marker) return null
+    const opLabel = marker.mode === 'arm' ? 'Claim ARM' : 'Claim USDC refund'
+    return [
+      { label: opLabel, status: 'loading', phaseLabel: 'Submitting…', hash: marker.hash, explorerUrl: getExplorerUrl() },
+    ]
+  })
 
   // Decide claim mode based on contract state. Phase 2 (cancelled) → refund.
   // Phase 0 with refundMode (cappedDemand < min) → refund. Otherwise → ARM.
   // This mirrors v1 ClaimTab's mode derivation.
   const mode: ClaimMode = phase === 2 || refundMode ? 'refund' : 'arm'
+
+  // Watch a reconstructed in-flight claim (from the marker) to its outcome.
+  // Pure observation via the read provider — it never re-sends, so there's no
+  // double-claim risk. Runs once per mount (the page is keyed by wallet address).
+  useEffect(() => {
+    const marker = getClaimInFlight(walletAddress)
+    if (!marker || !provider) return
+    let watchCancelled = false
+    const opLabel = marker.mode === 'arm' ? 'Claim ARM' : 'Claim USDC refund'
+    const explorerUrl = getExplorerUrl()
+    provider
+      .waitForTransaction(marker.hash, 1, TX_WAIT_TIMEOUT_MS)
+      .then((receipt) => {
+        if (watchCancelled) return
+        if (receipt && receipt.status === 1) {
+          onReceiptLogs?.(receipt.logs as unknown as readonly ReceiptLogLike[])
+          void refreshAllowance?.()
+          clearClaimInFlight()
+          setJustClaimed(true)
+          setStep('done')
+          return
+        }
+        // status 0 = reverted; null = our wait window elapsed (still pending).
+        // Surface an actionable error state instead of a perpetual "Submitting…";
+        // the marker stays until Back/Retry acknowledges it.
+        const reverted = !!receipt && receipt.status === 0
+        setTxs([
+          {
+            label: opLabel,
+            status: 'error',
+            errorMessage: reverted
+              ? 'Transaction reverted.'
+              : 'Still pending — it may still confirm. Check the explorer or retry.',
+            hash: marker.hash,
+            explorerUrl,
+          },
+        ])
+      })
+      .catch(() => {
+        // Transient RPC failure — leave the submitting state; a later mount re-watches.
+      })
+    return () => {
+      watchCancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [provider, walletAddress])
 
   // Default delegate to the connected wallet address when it becomes available
   // (self-delegate), unless the user has already edited the field.
@@ -339,6 +400,8 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
           label: opLabel,
           sentAt: Date.now(),
         })
+        // Page-owned marker so a remount mid-flight reconstructs this tx's state.
+        setClaimInFlight({ hash, mode, address: startAddress ?? '', sentAt: Date.now() })
         setTxs([{ label: opLabel, status: 'loading', phaseLabel: 'Submitting…', hash, explorerUrl }])
       },
       // Race the direct read provider against the wallet's tx.wait() so the done
@@ -355,6 +418,7 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
 
     if (result.outcome === 'success') {
       setTxs([{ label: opLabel, status: 'done', hash: result.hash, explorerUrl }])
+      clearClaimInFlight()
       setJustClaimed(true)
       // Fast-path the Allocated / RefundClaimed receipt log into the event store
       // and refresh balances.
@@ -725,10 +789,12 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
           txs={txs ?? undefined}
           onDone={() => setStep('done')}
           onBack={() => {
+            clearClaimInFlight()
             setTxs(null)
             setStep('review')
           }}
           onRetry={() => {
+            clearClaimInFlight()
             setTxs(null)
             void runClaim()
           }}

--- a/crowdfund-ui/packages/committer/src/hooks/usePendingTxWatcher.test.ts
+++ b/crowdfund-ui/packages/committer/src/hooks/usePendingTxWatcher.test.ts
@@ -39,7 +39,7 @@ describe('usePendingTxWatcher', () => {
 
     await waitFor(() => expect(result.current[0]?.status).toBe('confirmed'))
     expect(loadPendingTxs()).toEqual([])
-    expect(onResolved).toHaveBeenCalledWith(HASH, 'confirmed')
+    expect(onResolved).toHaveBeenCalledWith(HASH, 'confirmed', 'Commit participation')
   })
 
   it('marks a reverted tx as failed and clears it', async () => {

--- a/crowdfund-ui/packages/committer/src/hooks/usePendingTxWatcher.ts
+++ b/crowdfund-ui/packages/committer/src/hooks/usePendingTxWatcher.ts
@@ -26,7 +26,7 @@ const RESCAN_MS = 4000
 export function usePendingTxWatcher(
   provider: JsonRpcProvider | null,
   chainId: number,
-  onResolved?: (txHash: string, status: WatchedTxStatus) => void,
+  onResolved?: (txHash: string, status: WatchedTxStatus, label: string) => void,
 ): WatchedTx[] {
   const [watched, setWatched] = useState<WatchedTx[]>([])
   // Hashes already being awaited, so a re-scan doesn't double-watch.
@@ -66,7 +66,7 @@ export function usePendingTxWatcher(
               prev.map((w) => (w.txHash === t.txHash ? { ...w, status } : w)),
             )
             removePendingTx(t.txHash)
-            onResolvedRef.current?.(t.txHash, status)
+            onResolvedRef.current?.(t.txHash, status, t.label)
           })
           .catch(() => {
             // Transient RPC failure — drop the watch guard so a later scan retries.

--- a/crowdfund-ui/packages/committer/src/hooks/usePendingTxWatcher.ts
+++ b/crowdfund-ui/packages/committer/src/hooks/usePendingTxWatcher.ts
@@ -3,7 +3,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import type { JsonRpcProvider } from 'ethers'
-import { loadPendingTxs, removePendingTx } from '@/lib/pendingTx'
+import { loadPendingTxs, removePendingTx, PENDING_TX_EVENT } from '@/lib/pendingTx'
 
 export type WatchedTxStatus = 'pending' | 'confirmed' | 'failed'
 
@@ -77,9 +77,14 @@ export function usePendingTxWatcher(
 
     scan()
     const id = setInterval(scan, RESCAN_MS)
+    // Re-scan immediately when a pending tx is saved/removed, so a tx whose
+    // lifetime is shorter than the poll interval (fast local-chain confirms)
+    // still surfaces in the chip instead of slipping between scans.
+    window.addEventListener(PENDING_TX_EVENT, scan)
     return () => {
       cancelled = true
       clearInterval(id)
+      window.removeEventListener(PENDING_TX_EVENT, scan)
     }
   }, [provider, chainId])
 

--- a/crowdfund-ui/packages/committer/src/lib/claimInFlight.ts
+++ b/crowdfund-ui/packages/committer/src/lib/claimInFlight.ts
@@ -1,0 +1,44 @@
+// ABOUTME: sessionStorage marker for an in-flight claim/refund tx, owned by the claim page.
+// ABOUTME: Lets ClaimFlowV2 reconstruct its in-progress (or failed) state after navigating away and back, instead of resetting to the Review form.
+
+/** A claim/refund tx that has been broadcast but whose outcome the claim page
+ *  hasn't yet shown to the user in-page. Kept until the page consumes the
+ *  outcome (success/failure acknowledged) so a remount can re-derive state. */
+export interface ClaimInFlight {
+  hash: string
+  mode: 'arm' | 'refund'
+  /** Connected wallet that submitted it — so a switched wallet doesn't inherit it. */
+  address: string
+  sentAt: number
+}
+
+const KEY = 'armada.crowdfund.claimInFlight'
+
+export function setClaimInFlight(marker: ClaimInFlight): void {
+  try {
+    sessionStorage.setItem(KEY, JSON.stringify(marker))
+  } catch {
+    // best-effort — never break the claim flow on storage failure
+  }
+}
+
+/** The in-flight claim marker, but only if it belongs to `address`. */
+export function getClaimInFlight(address: string | null): ClaimInFlight | null {
+  if (!address) return null
+  try {
+    const raw = sessionStorage.getItem(KEY)
+    if (!raw) return null
+    const marker = JSON.parse(raw) as ClaimInFlight
+    return marker.address?.toLowerCase() === address.toLowerCase() ? marker : null
+  } catch {
+    return null
+  }
+}
+
+export function clearClaimInFlight(): void {
+  try {
+    sessionStorage.removeItem(KEY)
+  } catch {
+    // best-effort — see setClaimInFlight
+  }
+}

--- a/crowdfund-ui/packages/committer/src/lib/pendingTx.ts
+++ b/crowdfund-ui/packages/committer/src/lib/pendingTx.ts
@@ -12,6 +12,18 @@ export interface PendingTx {
 
 const KEY = 'armada.crowdfund.pendingTxs'
 
+/** Dispatched after any pending-tx mutation so a live watcher can re-scan
+ *  immediately instead of waiting for its next poll tick — without this, a tx
+ *  whose lifetime is shorter than the poll interval (e.g. a fast local-chain
+ *  confirmation) is written and removed between scans and never surfaces. */
+export const PENDING_TX_EVENT = 'armada:pendingtx-changed'
+
+function notifyPendingTxChange(): void {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(PENDING_TX_EVENT))
+  }
+}
+
 /** All persisted pending txs. Returns an empty list if storage is missing or malformed. */
 export function loadPendingTxs(): PendingTx[] {
   try {
@@ -31,6 +43,7 @@ function persist(txs: PendingTx[]): void {
     // sessionStorage unavailable / over quota — persistence is best-effort and
     // must never break the tx flow.
   }
+  notifyPendingTxChange()
 }
 
 /** Insert or replace (by txHash) a pending tx. */
@@ -52,4 +65,5 @@ export function clearPendingTxs(): void {
   } catch {
     // ignore — see persist()
   }
+  notifyPendingTxChange()
 }

--- a/crowdfund-ui/packages/committer/src/lib/sendAndWaitTx.ts
+++ b/crowdfund-ui/packages/committer/src/lib/sendAndWaitTx.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Single-step send/wait engine — submits a tx, waits for its receipt, classifies the outcome.
 // ABOUTME: Shared by the multi-step pipeline store and ClaimFlow so both inherit the same tx handling.
 
-import type { TransactionResponse } from 'ethers'
+import type { JsonRpcProvider, TransactionReceipt, TransactionResponse } from 'ethers'
 import type { ReceiptLogLike } from '@armada/crowdfund-shared'
 import { mapRevertToMessage } from '@/lib/revertMessages'
 import { TX_WAIT_TIMEOUT_MS, TX_PENDING_MESSAGE, isTxTimeoutError, isUserRejection } from '@/lib/txWait'
@@ -29,17 +29,37 @@ export interface TxSendResult {
  * @param send Issues the tx (pops the wallet prompt) and resolves to its response.
  * @param onSubmitted Called with the tx hash the moment it is broadcast — used
  *   for two-phase row labels and pending-tx persistence.
+ * @param readProvider Optional direct read provider. When supplied, its
+ *   `waitForTransaction` is raced against the wallet's `tx.wait()` and the first
+ *   confirmation wins — so a slow wallet provider (e.g. MetaMask's lagging poll)
+ *   doesn't keep the UI on "submitting" for seconds after the chain confirmed.
  */
 export async function sendAndWaitTx(
   send: () => Promise<TransactionResponse>,
   onSubmitted?: (hash: string) => void,
+  readProvider?: JsonRpcProvider | null,
 ): Promise<TxSendResult> {
   let hash: string | undefined
   try {
     const tx = await send()
     hash = tx.hash
     onSubmitted?.(hash)
-    const receipt = await tx.wait(1, TX_WAIT_TIMEOUT_MS)
+    // Confirm via the wallet's tx.wait(). When a read provider is supplied, also
+    // race its waitForTransaction and take whichever confirms first. The read
+    // path only accelerates the success case: its timeout resolves to `null`,
+    // which we convert to a rejection so it can't win the race as a fake
+    // receipt; if BOTH paths fail we fall back to the wallet wait's
+    // authoritative error so timeout/revert classification below is unchanged.
+    const walletWait = tx.wait(1, TX_WAIT_TIMEOUT_MS)
+    let receipt: TransactionReceipt | null
+    if (readProvider) {
+      const readWait = readProvider
+        .waitForTransaction(hash, 1, TX_WAIT_TIMEOUT_MS)
+        .then((r) => (r ? r : Promise.reject(new Error('read wait timed out'))))
+      receipt = await Promise.any([walletWait, readWait]).catch(() => walletWait)
+    } else {
+      receipt = await walletWait
+    }
     if (!receipt || receipt.status === 0) {
       return { outcome: 'reverted', hash, errorMessage: 'Transaction reverted' }
     }


### PR DESCRIPTION
Surfaces and recovers claim/refund transactions across navigation, and tightens tx-status timing for all flows. Implements **Level 1** of #339 (the cheap, standalone part); the full `useTxPipeline` migration (Level 2) remains tracked in #339.

### What changed
- **Claim tx in the header chip** — `ClaimFlowV2` now persists its broadcast via `savePendingTx`, so `usePendingTxWatcher` / `LastTxChip` show it cross-page and refresh balances on resolution (previously it appeared only on the claim page's own submit surface).
- **Responsive watcher** — pending-tx mutations dispatch an event the watcher listens for, re-scanning immediately instead of only every 4s, so a fast-confirming tx still shows in the chip.
- **Read-provider confirmation race** — `sendAndWaitTx` gains an optional read provider; claim opts in and races it against the wallet's `tx.wait()`, so the done screen lands when the chain confirms rather than seconds later when the wallet provider catches up. Commit pipeline unchanged.
- **Cross-page failure toast** — the watcher passes the tx label to `onResolved`; a reverted tx now fires an error toast, so a failure that lands while the user is on another page is no longer silent. Covers commit / invite / claim.
- **Claim in-progress / failure recovery** — `ClaimFlowV2` persists a page-owned in-flight marker and, on remount, reconstructs the "Submitting…" state (or the failed outcome with Back/Retry) instead of resetting to the Review form — which looked un-submitted and invited a duplicate claim.

### Scope / risk
- Committer frontend only; the commit/invite tx pipeline behavior is unchanged (the read-provider race is opt-in and not wired into the pipeline).
- Typecheck clean; all 173 committer unit tests pass (watcher + `ClaimFlowV2` suites updated for the new `onResolved` signature and sessionStorage isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
