### PR TITLE
feat(crowdfund): mainnet-readiness for committer, admin, and indexer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ relayer/state/*
 
 # OS
 .DS_Store
+._*
 *.swp
 Thumbs.db
 

--- a/crowdfund-ui/packages/admin/src/config/deployments.ts
+++ b/crowdfund-ui/packages/admin/src/config/deployments.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Loads crowdfund deployment addresses from deployment JSON files.
 // ABOUTME: Fetches from the Vite dev server plugin that serves deployments/.
 
-import { getDeploymentFileName } from './network'
+import { getDeploymentFileName, getHubChainId, assertDeploymentChainId } from './network'
 
 export interface CrowdfundDeployment {
   chainId: number
@@ -38,7 +38,12 @@ export async function loadDeployment(): Promise<CrowdfundDeployment> {
     )
   }
 
-  cachedDeployment = (await response.json()) as CrowdfundDeployment
+  const deployment = (await response.json()) as CrowdfundDeployment
+  // Fail loud if the manifest is for a different chain than this build targets —
+  // otherwise we'd talk to one network's addresses while the wallet expects another.
+  assertDeploymentChainId(deployment.chainId, getHubChainId(), fileName)
+
+  cachedDeployment = deployment
   return cachedDeployment
 }
 

--- a/crowdfund-ui/packages/admin/src/config/network.ts
+++ b/crowdfund-ui/packages/admin/src/config/network.ts
@@ -1,45 +1,17 @@
-// ABOUTME: Network configuration for local (Anvil) and Sepolia modes.
-// ABOUTME: Reads VITE_NETWORK env var to determine active network.
+// ABOUTME: Admin network config — re-exports the shared resolvers so the
+// ABOUTME: logic (local/sepolia/mainnet) lives once in @armada/crowdfund-shared.
 
-export type NetworkMode = 'local' | 'sepolia'
-
-export function getNetworkMode(): NetworkMode {
-  const env = import.meta.env.VITE_NETWORK as string | undefined
-  if (env === 'sepolia') return 'sepolia'
-  return 'local'
-}
-
-export function isLocalMode(): boolean {
-  return getNetworkMode() === 'local'
-}
-
-export function getHubRpcUrl(): string {
-  if (isLocalMode()) return 'http://localhost:8545'
-  return (import.meta.env.VITE_SEPOLIA_RPC as string) || 'https://ethereum-sepolia-rpc.publicnode.com'
-}
-
-/** Ordered list of RPC URLs for fallback. Primary URL first. */
-export function getHubRpcUrls(): string[] {
-  if (isLocalMode()) return ['http://localhost:8545']
-  const primary = (import.meta.env.VITE_SEPOLIA_RPC as string) || 'https://ethereum-sepolia-rpc.publicnode.com'
-  const fallback = (import.meta.env.VITE_SEPOLIA_RPC_FALLBACK as string) || undefined
-  return fallback ? [primary, fallback] : [primary]
-}
-
-export function getHubChainId(): number {
-  return isLocalMode() ? 31337 : 11155111
-}
-
-export function getDeploymentFileName(): string {
-  return isLocalMode() ? 'crowdfund-hub.json' : 'crowdfund-hub-sepolia.json'
-}
-
-export function getPollIntervalMs(): number {
-  return isLocalMode() ? 5_000 : 15_000
-}
-
-/** Block explorer base URL. Returns undefined for local mode (no explorer). */
-export function getExplorerUrl(): string | undefined {
-  if (isLocalMode()) return undefined
-  return 'https://sepolia.etherscan.io'
-}
+export {
+  getNetworkMode,
+  isLocalMode,
+  getHubChainId,
+  getHubNetworkLabel,
+  getHubRpcUrl,
+  getHubRpcUrls,
+  getIndexerUrl,
+  getDeploymentFileName,
+  getPollIntervalMs,
+  getMaxBlockRange,
+  getExplorerUrl,
+} from '@armada/crowdfund-shared'
+export type { NetworkMode } from '@armada/crowdfund-shared'

--- a/crowdfund-ui/packages/admin/src/config/network.ts
+++ b/crowdfund-ui/packages/admin/src/config/network.ts
@@ -13,5 +13,6 @@ export {
   getPollIntervalMs,
   getMaxBlockRange,
   getExplorerUrl,
+  assertDeploymentChainId,
 } from '@armada/crowdfund-shared'
 export type { NetworkMode } from '@armada/crowdfund-shared'

--- a/crowdfund-ui/packages/admin/src/config/validateEnv.test.ts
+++ b/crowdfund-ui/packages/admin/src/config/validateEnv.test.ts
@@ -1,0 +1,68 @@
+// ABOUTME: Unit tests for the admin startup environment validation.
+// ABOUTME: Covers the PROD non-local hard-fail matrix and the dev pass-through.
+import { describe, it, expect } from 'vitest'
+import { validateEnv } from './validateEnv'
+
+const COMPLETE_PROD = {
+  PROD: true,
+  VITE_NETWORK: 'mainnet',
+  VITE_CROWDFUND_PROFILE: 'mainnet',
+  VITE_DEPLOYMENT_INSTANCE: 'launch1',
+}
+
+describe('validateEnv (admin)', () => {
+  it('passes a fully configured production build', () => {
+    expect(validateEnv(COMPLETE_PROD)).toEqual({ ok: true })
+  })
+
+  it('passes any dev build regardless of missing vars', () => {
+    expect(validateEnv({ PROD: false })).toEqual({ ok: true })
+    expect(validateEnv({})).toEqual({ ok: true })
+  })
+
+  it('skips validation for an explicit local PROD build', () => {
+    expect(validateEnv({ PROD: true, VITE_NETWORK: 'local' })).toEqual({ ok: true })
+  })
+
+  it('fails a PROD build with VITE_NETWORK unset', () => {
+    const result = validateEnv({ PROD: true })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes('VITE_NETWORK'))).toBe(true)
+    }
+  })
+
+  it('fails a PROD build with a blank VITE_NETWORK', () => {
+    const result = validateEnv({ PROD: true, VITE_NETWORK: '   ' })
+    expect(result.ok).toBe(false)
+  })
+
+  it('enforces the env on a mainnet build (not just sepolia)', () => {
+    const result = validateEnv({ PROD: true, VITE_NETWORK: 'mainnet', VITE_DEPLOYMENT_INSTANCE: 'launch1' })
+    // profile missing while instance set → must fail
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes('VITE_CROWDFUND_PROFILE'))).toBe(true)
+    }
+  })
+
+  it('requires VITE_CROWDFUND_PROFILE only when a deployment instance is set', () => {
+    const withInstance = validateEnv({ ...COMPLETE_PROD, VITE_CROWDFUND_PROFILE: undefined })
+    expect(withInstance.ok).toBe(false)
+    if (!withInstance.ok) {
+      expect(withInstance.errors.some((e) => e.includes('VITE_CROWDFUND_PROFILE'))).toBe(true)
+    }
+
+    const withoutInstance = validateEnv({
+      ...COMPLETE_PROD,
+      VITE_CROWDFUND_PROFILE: undefined,
+      VITE_DEPLOYMENT_INSTANCE: undefined,
+    })
+    expect(withoutInstance).toEqual({ ok: true })
+  })
+
+  it('does not require WalletConnect or indexer vars (admin uses neither)', () => {
+    // A sepolia build with only VITE_NETWORK set and no instance passes.
+    expect(validateEnv({ PROD: true, VITE_NETWORK: 'sepolia' })).toEqual({ ok: true })
+  })
+})

--- a/crowdfund-ui/packages/admin/src/config/validateEnv.test.ts
+++ b/crowdfund-ui/packages/admin/src/config/validateEnv.test.ts
@@ -65,4 +65,16 @@ describe('validateEnv (admin)', () => {
     // A sepolia build with only VITE_NETWORK set and no instance passes.
     expect(validateEnv({ PROD: true, VITE_NETWORK: 'sepolia' })).toEqual({ ok: true })
   })
+
+  it('rejects a non-mainnet profile on a mainnet build', () => {
+    const result = validateEnv({ PROD: true, VITE_NETWORK: 'mainnet', VITE_CROWDFUND_PROFILE: 'medi' })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes('mainnet must use the "mainnet" profile'))).toBe(true)
+    }
+  })
+
+  it('allows an unset profile on a mainnet build (defaults to mainnet)', () => {
+    expect(validateEnv({ PROD: true, VITE_NETWORK: 'mainnet' })).toEqual({ ok: true })
+  })
 })

--- a/crowdfund-ui/packages/admin/src/config/validateEnv.ts
+++ b/crowdfund-ui/packages/admin/src/config/validateEnv.ts
@@ -48,6 +48,19 @@ export function validateEnv(env: EnvRecord): EnvValidationResult {
         'the UI would apply mainnet sale constants to the deployed instance.',
     )
   }
+  // A non-mainnet profile (e.g. the medi/Sepolia profile) on a mainnet build would
+  // render $1k-scale sale numbers over the real $1.2M sale. Unset is allowed — it
+  // defaults to the mainnet profile.
+  if (
+    network === 'mainnet' &&
+    !missing(env.VITE_CROWDFUND_PROFILE) &&
+    env.VITE_CROWDFUND_PROFILE!.trim() !== 'mainnet'
+  ) {
+    errors.push(
+      `VITE_CROWDFUND_PROFILE is "${env.VITE_CROWDFUND_PROFILE!.trim()}" on a mainnet build — ` +
+        'mainnet must use the "mainnet" profile (or leave it unset, which defaults to mainnet).',
+    )
+  }
 
   return errors.length > 0 ? { ok: false, errors } : { ok: true }
 }

--- a/crowdfund-ui/packages/admin/src/config/validateEnv.ts
+++ b/crowdfund-ui/packages/admin/src/config/validateEnv.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Startup environment validation for the committer.
+// ABOUTME: Startup environment validation for the admin app.
 // ABOUTME: Hard-fails production builds that are missing critical VITE_* config.
 
 /** The subset of the Vite env we validate. All fields optional so the pure
@@ -6,8 +6,6 @@
 export interface EnvRecord {
   PROD?: boolean
   VITE_NETWORK?: string
-  VITE_WALLETCONNECT_PROJECT_ID?: string
-  VITE_CROWDFUND_INDEXER_URL?: string
   VITE_CROWDFUND_PROFILE?: string
   VITE_DEPLOYMENT_INSTANCE?: string
 }
@@ -23,8 +21,13 @@ function missing(value?: string): boolean {
  *
  * Enforces for any non-local PROD build (sepolia, mainnet, or an unset network —
  * unset is itself a misconfiguration we want to surface loudly rather than let
- * silently fall back to a local/localhost config). Dev builds always pass: they
- * default to local and tolerate absent vars.
+ * silently fall back). Dev builds always pass: they default to local and tolerate
+ * absent vars.
+ *
+ * The admin app uses a plain `window.ethereum` wallet (no WalletConnect) and reads
+ * events over RPC (no indexer), so — unlike the committer — it requires neither
+ * VITE_WALLETCONNECT_PROJECT_ID nor VITE_CROWDFUND_INDEXER_URL. It does consume the
+ * profile-driven CROWDFUND_CONSTANTS, so the instance/profile pairing still matters.
  */
 export function validateEnv(env: EnvRecord): EnvValidationResult {
   const isProd = env.PROD === true
@@ -38,16 +41,6 @@ export function validateEnv(env: EnvRecord): EnvValidationResult {
 
   if (missing(network)) {
     errors.push('VITE_NETWORK is not set (expected "sepolia" or "mainnet" for production).')
-  }
-  if (missing(env.VITE_WALLETCONNECT_PROJECT_ID)) {
-    errors.push(
-      'VITE_WALLETCONNECT_PROJECT_ID is not set — wallet connection will not work.',
-    )
-  }
-  if (missing(env.VITE_CROWDFUND_INDEXER_URL)) {
-    errors.push(
-      'VITE_CROWDFUND_INDEXER_URL is not set — no event indexer is configured.',
-    )
   }
   if (!missing(env.VITE_DEPLOYMENT_INSTANCE) && missing(env.VITE_CROWDFUND_PROFILE)) {
     errors.push(

--- a/crowdfund-ui/packages/admin/src/hooks/useWallet.ts
+++ b/crowdfund-ui/packages/admin/src/hooks/useWallet.ts
@@ -3,7 +3,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { BrowserProvider, JsonRpcSigner } from 'ethers'
-import { getHubChainId, isLocalMode, getHubRpcUrl } from '@/config/network'
+import { getHubChainId, getNetworkMode, getHubRpcUrl, getExplorerUrl } from '@/config/network'
 
 export interface UseWalletResult {
   address: string | null
@@ -27,14 +27,18 @@ async function ensureCorrectChain(ethereum: any, expectedChainId: number): Promi
   } catch (err: any) {
     // Error 4902: chain not yet added to wallet — add it then retry
     if (err?.code === 4902) {
+      const mode = getNetworkMode()
+      const chainName =
+        mode === 'local' ? 'Anvil (Local)' : mode === 'mainnet' ? 'Ethereum' : 'Sepolia'
+      const explorerUrl = getExplorerUrl()
       await ethereum.request({
         method: 'wallet_addEthereumChain',
         params: [{
           chainId: hexChainId,
-          chainName: isLocalMode() ? 'Anvil (Local)' : 'Sepolia',
+          chainName,
           nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
           rpcUrls: [getHubRpcUrl()],
-          ...(isLocalMode() ? {} : { blockExplorerUrls: ['https://sepolia.etherscan.io'] }),
+          ...(explorerUrl ? { blockExplorerUrls: [explorerUrl] } : {}),
         }],
       })
     } else {

--- a/crowdfund-ui/packages/admin/src/main.tsx
+++ b/crowdfund-ui/packages/admin/src/main.tsx
@@ -7,19 +7,46 @@ import { Toaster } from 'sonner'
 import { MotionConfig } from 'framer-motion'
 import { App } from '@/App'
 import { initSentry, SentryErrorBoundary } from '@/lib/sentry'
+import { validateEnv } from '@/config/validateEnv'
 import './index.css'
 
 initSentry()
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <SentryErrorBoundary fallback={<div className="p-6">An unexpected error occurred. The team has been notified.</div>}>
-      <JotaiProvider>
-        <MotionConfig reducedMotion="user">
-          <App />
-        </MotionConfig>
-        <Toaster richColors position="bottom-right" />
-      </JotaiProvider>
-    </SentryErrorBoundary>
-  </StrictMode>,
-)
+const root = createRoot(document.getElementById('root')!)
+
+// Refuse to boot a misconfigured production build. Rendering a styled error
+// screen (rather than a blank page or a silently-wrong app) makes the missing
+// config obvious to whoever deployed it.
+const envCheck = validateEnv(import.meta.env)
+if (!envCheck.ok) {
+  root.render(
+    <StrictMode>
+      <div className="min-h-screen bg-background text-foreground flex items-center justify-center p-6">
+        <div className="max-w-md space-y-4 text-center">
+          <h1 className="text-destructive text-xl font-semibold">Configuration error</h1>
+          <p className="text-muted-foreground">
+            This deployment is missing required configuration and cannot start safely.
+          </p>
+          <ul className="space-y-1 text-left text-sm text-muted-foreground">
+            {envCheck.errors.map((message) => (
+              <li key={message}>• {message}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </StrictMode>,
+  )
+} else {
+  root.render(
+    <StrictMode>
+      <SentryErrorBoundary fallback={<div className="p-6">An unexpected error occurred. The team has been notified.</div>}>
+        <JotaiProvider>
+          <MotionConfig reducedMotion="user">
+            <App />
+          </MotionConfig>
+          <Toaster richColors position="bottom-right" />
+        </JotaiProvider>
+      </SentryErrorBoundary>
+    </StrictMode>,
+  )
+}

--- a/crowdfund-ui/packages/committer/src/config/deployments.ts
+++ b/crowdfund-ui/packages/committer/src/config/deployments.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Loads crowdfund deployment addresses from deployment JSON files.
 // ABOUTME: Fetches from the Vite dev server plugin that serves deployments/.
 
-import { getDeploymentFileName } from './network'
+import { getDeploymentFileName, getHubChainId, assertDeploymentChainId } from './network'
 
 export interface CrowdfundDeployment {
   chainId: number
@@ -41,7 +41,12 @@ export async function loadDeployment(): Promise<CrowdfundDeployment> {
     )
   }
 
-  cachedDeployment = (await response.json()) as CrowdfundDeployment
+  const deployment = (await response.json()) as CrowdfundDeployment
+  // Fail loud if the manifest is for a different chain than this build targets —
+  // otherwise we'd talk to one network's addresses while the wallet expects another.
+  assertDeploymentChainId(deployment.chainId, getHubChainId(), fileName)
+
+  cachedDeployment = deployment
   return cachedDeployment
 }
 

--- a/crowdfund-ui/packages/committer/src/config/network.ts
+++ b/crowdfund-ui/packages/committer/src/config/network.ts
@@ -12,6 +12,7 @@ export {
   getDeploymentFileName,
   getPollIntervalMs,
   getMaxBlockRange,
+  getTxConfirmations,
   getExplorerUrl,
   assertDeploymentChainId,
 } from '@armada/crowdfund-shared'

--- a/crowdfund-ui/packages/committer/src/config/network.ts
+++ b/crowdfund-ui/packages/committer/src/config/network.ts
@@ -1,97 +1,17 @@
-// ABOUTME: Network configuration for local (Anvil) and Sepolia modes.
-// ABOUTME: Reads VITE_NETWORK env var to determine active network.
+// ABOUTME: Committer network config — re-exports the shared resolvers so the
+// ABOUTME: logic (local/sepolia/mainnet) lives once in @armada/crowdfund-shared.
 
-export type NetworkMode = 'local' | 'sepolia'
-
-export function getNetworkMode(): NetworkMode {
-  const env = import.meta.env.VITE_NETWORK as string | undefined
-  if (env === 'sepolia') return 'sepolia'
-  if (env === 'local') return 'local'
-  // No explicit network. A production bundle must never silently fall back to
-  // local (which points at localhost:8545) — default unset to sepolia in PROD.
-  // (Startup validateEnv() hard-fails such a build before render anyway.)
-  // Dev keeps the local default.
-  return import.meta.env.PROD ? 'sepolia' : 'local'
-}
-
-export function isLocalMode(): boolean {
-  return getNetworkMode() === 'local'
-}
-
-export function getHubRpcUrl(): string {
-  if (isLocalMode()) return 'http://localhost:8545'
-  return (import.meta.env.VITE_SEPOLIA_RPC as string) || 'https://ethereum-sepolia-rpc.publicnode.com'
-}
-
-/** Ordered list of RPC URLs for fallback. Primary URL first. */
-export function getHubRpcUrls(): string[] {
-  if (isLocalMode()) return ['http://localhost:8545']
-  const primary = (import.meta.env.VITE_SEPOLIA_RPC as string) || 'https://ethereum-sepolia-rpc.publicnode.com'
-  const fallback = (import.meta.env.VITE_SEPOLIA_RPC_FALLBACK as string) || undefined
-  return fallback ? [primary, fallback] : [primary]
-}
-
-export function getIndexerUrl(): string | null {
-  if (isLocalMode()) return null
-  return (import.meta.env.VITE_CROWDFUND_INDEXER_URL as string | undefined) ?? null
-}
-
-export function getHubChainId(): number {
-  return isLocalMode() ? 31337 : 11155111
-}
-
-/**
- * Human-readable name of the deployment's chain, derived from the chain id so
- * it stays correct across environments (testnet today, mainnet later) without
- * hardcoding a network into UI copy.
- */
-export function getHubNetworkLabel(): string {
-  switch (getHubChainId()) {
-    case 1:
-      return 'Ethereum'
-    case 11155111:
-      return 'Sepolia'
-    case 31337:
-      return 'the local network'
-    default:
-      return 'the correct network'
-  }
-}
-
-/**
- * Returns the path (relative to the Vite serveDeployments middleware) of the
- * crowdfund deployment manifest to load.
- *
- * Local mode → `crowdfund-hub.json` (written by `npm run setup`).
- * Sepolia + `VITE_DEPLOYMENT_INSTANCE=<name>` → mirrored path under
- *   `instances/<name>/sepolia/crowdfund.json`, populated by
- *   `npm run fetch-deployment -- <name>` from the armada-deployments repo.
- * Sepolia, no instance set → legacy `crowdfund-hub-sepolia.json` (whatever the
- *   local `deployments/` folder currently holds — overwritten by `setup:sepolia`).
- */
-export function getDeploymentFileName(): string {
-  if (isLocalMode()) return 'crowdfund-hub.json'
-  const instance = (import.meta.env.VITE_DEPLOYMENT_INSTANCE as string | undefined)?.trim()
-  if (instance) return `instances/${instance}/sepolia/crowdfund.json`
-  return 'crowdfund-hub-sepolia.json'
-}
-
-export function getPollIntervalMs(): number {
-  return isLocalMode() ? 5_000 : 15_000
-}
-
-/**
- * Max blocks per eth_getLogs request. Local Anvil is tiny so 10 is plenty;
- * Sepolia public RPCs (publicnode) handle far larger ranges, so use a wide
- * range to keep cold-start backfills from taking thousands of requests.
- * fetchLogs halves this on a range-too-large error, so an over-estimate is safe.
- */
-export function getMaxBlockRange(): number {
-  return isLocalMode() ? 10 : 2_000
-}
-
-/** Block explorer base URL. Returns undefined for local mode (no explorer). */
-export function getExplorerUrl(): string | undefined {
-  if (isLocalMode()) return undefined
-  return 'https://sepolia.etherscan.io'
-}
+export {
+  getNetworkMode,
+  isLocalMode,
+  getHubChainId,
+  getHubNetworkLabel,
+  getHubRpcUrl,
+  getHubRpcUrls,
+  getIndexerUrl,
+  getDeploymentFileName,
+  getPollIntervalMs,
+  getMaxBlockRange,
+  getExplorerUrl,
+} from '@armada/crowdfund-shared'
+export type { NetworkMode } from '@armada/crowdfund-shared'

--- a/crowdfund-ui/packages/committer/src/config/network.ts
+++ b/crowdfund-ui/packages/committer/src/config/network.ts
@@ -13,5 +13,6 @@ export {
   getPollIntervalMs,
   getMaxBlockRange,
   getExplorerUrl,
+  assertDeploymentChainId,
 } from '@armada/crowdfund-shared'
 export type { NetworkMode } from '@armada/crowdfund-shared'

--- a/crowdfund-ui/packages/committer/src/config/validateEnv.test.ts
+++ b/crowdfund-ui/packages/committer/src/config/validateEnv.test.ts
@@ -49,6 +49,31 @@ describe('validateEnv', () => {
     ).toEqual({ ok: true })
   })
 
+  it('rejects a non-mainnet profile on a mainnet build', () => {
+    const result = validateEnv({
+      PROD: true,
+      VITE_NETWORK: 'mainnet',
+      VITE_WALLETCONNECT_PROJECT_ID: 'wc-id',
+      VITE_CROWDFUND_INDEXER_URL: 'https://indexer.example',
+      VITE_CROWDFUND_PROFILE: 'medi',
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes('mainnet must use the "mainnet" profile'))).toBe(true)
+    }
+  })
+
+  it('allows an unset profile on a mainnet build (defaults to mainnet)', () => {
+    expect(
+      validateEnv({
+        PROD: true,
+        VITE_NETWORK: 'mainnet',
+        VITE_WALLETCONNECT_PROJECT_ID: 'wc-id',
+        VITE_CROWDFUND_INDEXER_URL: 'https://indexer.example',
+      }),
+    ).toEqual({ ok: true })
+  })
+
   it('fails a PROD build with VITE_NETWORK unset', () => {
     const result = validateEnv({ PROD: true })
     expect(result.ok).toBe(false)

--- a/crowdfund-ui/packages/committer/src/config/validateEnv.test.ts
+++ b/crowdfund-ui/packages/committer/src/config/validateEnv.test.ts
@@ -22,8 +22,31 @@ describe('validateEnv', () => {
     expect(validateEnv({})).toEqual({ ok: true })
   })
 
-  it('skips validation for an explicit non-sepolia PROD build', () => {
+  it('skips validation only for an explicit local PROD build', () => {
     expect(validateEnv({ PROD: true, VITE_NETWORK: 'local' })).toEqual({ ok: true })
+  })
+
+  it('enforces a mainnet PROD build, not just sepolia (H4)', () => {
+    // mainnet was previously skipped; a mainnet build missing WalletConnect/indexer must fail.
+    const result = validateEnv({ PROD: true, VITE_NETWORK: 'mainnet' })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes('VITE_WALLETCONNECT_PROJECT_ID'))).toBe(true)
+      expect(result.errors.some((e) => e.includes('VITE_CROWDFUND_INDEXER_URL'))).toBe(true)
+    }
+  })
+
+  it('passes a fully configured mainnet production build', () => {
+    expect(
+      validateEnv({
+        PROD: true,
+        VITE_NETWORK: 'mainnet',
+        VITE_WALLETCONNECT_PROJECT_ID: 'wc-id',
+        VITE_CROWDFUND_INDEXER_URL: 'https://indexer.example',
+        VITE_CROWDFUND_PROFILE: 'mainnet',
+        VITE_DEPLOYMENT_INSTANCE: 'launch1',
+      }),
+    ).toEqual({ ok: true })
   })
 
   it('fails a PROD build with VITE_NETWORK unset', () => {

--- a/crowdfund-ui/packages/committer/src/config/validateEnv.ts
+++ b/crowdfund-ui/packages/committer/src/config/validateEnv.ts
@@ -55,6 +55,19 @@ export function validateEnv(env: EnvRecord): EnvValidationResult {
         'the UI would apply mainnet sale constants to the deployed instance.',
     )
   }
+  // A non-mainnet profile (e.g. the medi/Sepolia profile) on a mainnet build would
+  // render $1k-scale sale numbers over the real $1.2M sale. Unset is allowed — it
+  // defaults to the mainnet profile.
+  if (
+    network === 'mainnet' &&
+    !missing(env.VITE_CROWDFUND_PROFILE) &&
+    env.VITE_CROWDFUND_PROFILE!.trim() !== 'mainnet'
+  ) {
+    errors.push(
+      `VITE_CROWDFUND_PROFILE is "${env.VITE_CROWDFUND_PROFILE!.trim()}" on a mainnet build — ` +
+        'mainnet must use the "mainnet" profile (or leave it unset, which defaults to mainnet).',
+    )
+  }
 
   return errors.length > 0 ? { ok: false, errors } : { ok: true }
 }

--- a/crowdfund-ui/packages/committer/src/config/wagmi.ts
+++ b/crowdfund-ui/packages/committer/src/config/wagmi.ts
@@ -3,8 +3,8 @@
 
 import { getDefaultConfig } from '@rainbow-me/rainbowkit'
 import { http, fallback } from 'wagmi'
-import { sepolia, hardhat } from 'wagmi/chains'
-import { getHubRpcUrls, getHubChainId, isLocalMode } from './network'
+import { mainnet, sepolia, hardhat } from 'wagmi/chains'
+import { getHubRpcUrls, getHubChainId, getNetworkMode } from './network'
 
 // Define the local Anvil chain — uses wagmi's hardhat chain as a base,
 // but overrides the RPC URL to match our local config.
@@ -18,7 +18,10 @@ const anvilChain = {
 } as const
 
 const hubChainId = getHubChainId()
-const chains = isLocalMode() ? [anvilChain] : [sepolia]
+// Register only the active hub chain so the wallet prompts to the right network.
+const mode = getNetworkMode()
+const hubChain = mode === 'local' ? anvilChain : mode === 'mainnet' ? mainnet : sepolia
+const chains = [hubChain]
 const rpcUrls = getHubRpcUrls()
 
 // In dev, fall back to a placeholder project id so the app boots without a

--- a/crowdfund-ui/packages/committer/src/hooks/useInviteLinks.ts
+++ b/crowdfund-ui/packages/committer/src/hooks/useInviteLinks.ts
@@ -18,7 +18,7 @@ import {
   effectiveTimestamp,
   classifyStoredLinks,
 } from '@/lib/inviteLinks'
-import { getHubChainId } from '@/config/network'
+import { getHubChainId, getTxConfirmations } from '@/config/network'
 import { TX_WAIT_TIMEOUT_MS, isUserRejection } from '@/lib/txWait'
 import { mapRevertToMessage } from '@/lib/revertMessages'
 
@@ -170,7 +170,7 @@ export function useInviteLinks(
     try {
       const crowdfund = new Contract(crowdfundAddress, CROWDFUND_ABI_FRAGMENTS, signer)
       const tx = await crowdfund.revokeInviteNonce(nonce)
-      const receipt = await tx.wait(1, TX_WAIT_TIMEOUT_MS)
+      const receipt = await tx.wait(getTxConfirmations(), TX_WAIT_TIMEOUT_MS)
       if (!receipt || receipt.status === 0) return false
       await updateInviteLinkStatus(address.toLowerCase(), nonce, 'revoked')
       await refreshLinks()

--- a/crowdfund-ui/packages/committer/src/hooks/useInviteSlots.ts
+++ b/crowdfund-ui/packages/committer/src/hooks/useInviteSlots.ts
@@ -8,7 +8,7 @@ import { type StoredInviteLink } from '@/lib/inviteLinks'
 import { buildSlotRows } from '@/lib/slotRows'
 import { TX_WAIT_TIMEOUT_MS, TX_PENDING_MESSAGE, isTxTimeoutError } from '@/lib/txWait'
 import { mapRevertToMessage } from '@/lib/revertMessages'
-import { getHubNetworkLabel } from '@/config/network'
+import { getHubNetworkLabel, getTxConfirmations } from '@/config/network'
 import {
   CROWDFUND_ABI_FRAGMENTS,
   HOP_CONFIGS,
@@ -214,7 +214,7 @@ function useHopSection(args: {
       try {
         const crowdfund = new Contract(crowdfundAddress, CROWDFUND_ABI_FRAGMENTS, signer)
         const tx = await crowdfund.invite(invitee, hop)
-        const receipt = await tx.wait(1, TX_WAIT_TIMEOUT_MS)
+        const receipt = await tx.wait(getTxConfirmations(), TX_WAIT_TIMEOUT_MS)
         if (!receipt || receipt.status === 0) {
           throw new Error('Transaction reverted')
         }

--- a/crowdfund-ui/packages/committer/src/lib/inviteLinks.ts
+++ b/crowdfund-ui/packages/committer/src/lib/inviteLinks.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Pure functions for invite link lifecycle — no React dependency.
 
 import { tryGetChecksumAddress } from '@armada/crowdfund-shared'
+import { getHubChainId } from '@/config/network'
 
 /** Max hop index in the URL — matches `HOP_CONFIGS.length - 1`. Anything
  * outside this band can't represent a real inviter so we reject pre-contract. */
@@ -102,14 +103,22 @@ export function decodeInviteUrl(searchParams: URLSearchParams): InviteLinkData |
   return { inviter, fromHop, nonce, deadline, signature }
 }
 
-// IndexedDB helpers
-const DB_NAME = 'armada-invite-links'
+// IndexedDB helpers. The database is namespaced per chain id so invite links
+// created on one network (e.g. a Sepolia test instance) never surface in the UI on
+// another (e.g. mainnet): an invite's EIP-712 signature carries the chain id in its
+// domain separator and fails validation cross-chain, so a stale link would only
+// confuse. Each chain gets its own isolated database.
+const DB_NAME_PREFIX = 'armada-invite-links'
 const STORE_NAME = 'links'
 const DB_VERSION = 1
 
+function dbName(): string {
+  return `${DB_NAME_PREFIX}-${getHubChainId()}`
+}
+
 function openDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, DB_VERSION)
+    const request = indexedDB.open(dbName(), DB_VERSION)
     request.onupgradeneeded = () => {
       const db = request.result
       if (!db.objectStoreNames.contains(STORE_NAME)) {

--- a/crowdfund-ui/packages/committer/src/lib/mobileTxSubmit.test.ts
+++ b/crowdfund-ui/packages/committer/src/lib/mobileTxSubmit.test.ts
@@ -13,7 +13,7 @@ vi.mock('wagmi/actions', () => ({
 }))
 
 vi.mock('@/config/wagmi', () => ({ wagmiConfig: { __testConfig: true } }))
-vi.mock('@/config/network', () => ({ getHubChainId: () => 11155111 }))
+vi.mock('@/config/network', () => ({ getHubChainId: () => 11155111, getTxConfirmations: () => 1 }))
 
 import { submitTxViaWagmi } from './mobileTxSubmit'
 

--- a/crowdfund-ui/packages/committer/src/lib/mobileTxSubmit.ts
+++ b/crowdfund-ui/packages/committer/src/lib/mobileTxSubmit.ts
@@ -4,7 +4,7 @@
 import { sendTransaction, waitForTransactionReceipt } from 'wagmi/actions'
 import type { Contract, TransactionResponse } from 'ethers'
 import type { ReceiptLogLike } from '@armada/crowdfund-shared'
-import { getHubChainId } from '@/config/network'
+import { getHubChainId, getTxConfirmations } from '@/config/network'
 import { TX_WAIT_TIMEOUT_MS } from './txWait'
 
 /** viem raises a named `WaitForTransactionReceiptTimeoutError` on receipt timeout. */
@@ -43,7 +43,7 @@ export async function submitTxViaWagmi(
 
   const response = {
     hash,
-    wait: async (confirmations: number = 1, timeoutMs: number = TX_WAIT_TIMEOUT_MS) => {
+    wait: async (confirmations: number = getTxConfirmations(), timeoutMs: number = TX_WAIT_TIMEOUT_MS) => {
       try {
         const receipt = await waitForTransactionReceipt(wagmiConfig, {
           hash,

--- a/crowdfund-ui/packages/committer/src/lib/mobileTxSubmit.ts
+++ b/crowdfund-ui/packages/committer/src/lib/mobileTxSubmit.ts
@@ -43,11 +43,11 @@ export async function submitTxViaWagmi(
 
   const response = {
     hash,
-    wait: async (_confirmations?: number, timeoutMs: number = TX_WAIT_TIMEOUT_MS) => {
+    wait: async (confirmations: number = 1, timeoutMs: number = TX_WAIT_TIMEOUT_MS) => {
       try {
         const receipt = await waitForTransactionReceipt(wagmiConfig, {
           hash,
-          confirmations: 1,
+          confirmations,
           timeout: timeoutMs,
         })
         return {

--- a/crowdfund-ui/packages/committer/src/lib/sendAndWaitTx.ts
+++ b/crowdfund-ui/packages/committer/src/lib/sendAndWaitTx.ts
@@ -5,6 +5,7 @@ import type { JsonRpcProvider, TransactionReceipt, TransactionResponse } from 'e
 import type { ReceiptLogLike } from '@armada/crowdfund-shared'
 import { mapRevertToMessage } from '@/lib/revertMessages'
 import { TX_WAIT_TIMEOUT_MS, TX_PENDING_MESSAGE, isTxTimeoutError, isUserRejection } from '@/lib/txWait'
+import { getTxConfirmations } from '@/config/network'
 
 export type TxOutcome = 'success' | 'reverted' | 'timeout' | 'rejected' | 'error'
 
@@ -50,11 +51,14 @@ export async function sendAndWaitTx(
     // which we convert to a rejection so it can't win the race as a fake
     // receipt; if BOTH paths fail we fall back to the wallet wait's
     // authoritative error so timeout/revert classification below is unchanged.
-    const walletWait = tx.wait(1, TX_WAIT_TIMEOUT_MS)
+    // Deeper on mainnet (see confirmationsForMode) so a 1-block reorg can't show a
+    // dropped tx as confirmed; 1 on local/testnet keeps those instant.
+    const confirmations = getTxConfirmations()
+    const walletWait = tx.wait(confirmations, TX_WAIT_TIMEOUT_MS)
     let receipt: TransactionReceipt | null
     if (readProvider) {
       const readWait = readProvider
-        .waitForTransaction(hash, 1, TX_WAIT_TIMEOUT_MS)
+        .waitForTransaction(hash, confirmations, TX_WAIT_TIMEOUT_MS)
         .then((r) => (r ? r : Promise.reject(new Error('read wait timed out'))))
       receipt = await Promise.any([walletWait, readWait]).catch(() => walletWait)
     } else {

--- a/crowdfund-ui/packages/indexer/src/alerts/rules.test.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/rules.test.ts
@@ -404,6 +404,7 @@ describe('time-gated rules', () => {
       totalCommitted: HOP0_CAP,
       perHop: new Map(),
       displayInviter: 'armada',
+      allInviters: [],
       allocatedArm: null,
       refundUsdc: 1_000_000n, // refundable
       allocatedPerHop: new Map(),

--- a/crowdfund-ui/packages/indexer/src/cli/index.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/index.ts
@@ -3,7 +3,7 @@
 
 import { join } from 'node:path'
 import { JsonRpcProvider } from 'ethers'
-import { getInitialCursor, readBooleanEnv, readNumberEnv, readRequiredEnv } from '../config.js'
+import { getInitialCursor, readBooleanEnv, readNumberEnv, readRequiredEnv, readRequiredNumberEnv } from '../config.js'
 import { createIndexerStore } from '../db/createStore.js'
 import type { IndexerStore } from '../db/store.js'
 import type { IngestRangeRecord } from '../types.js'
@@ -59,7 +59,7 @@ async function runCommand(args: ParsedCliArgs, store: IndexerStore): Promise<voi
       )
     }
     const config = {
-      chainId: readNumberEnv('CROWDFUND_CHAIN_ID', 11155111),
+      chainId: readRequiredNumberEnv('CROWDFUND_CHAIN_ID'),
       contractAddress: readRequiredEnv('CROWDFUND_CONTRACT_ADDRESS'),
       providerName: 'primary',
     }
@@ -146,7 +146,7 @@ async function runCommand(args: ParsedCliArgs, store: IndexerStore): Promise<voi
   }
 
   if (args.command === 'rebuild-snapshot' || args.command === 'publish-snapshot') {
-    const chainId = readNumberEnv('CROWDFUND_CHAIN_ID', 11155111)
+    const chainId = readRequiredNumberEnv('CROWDFUND_CHAIN_ID')
     const contractAddress = readRequiredEnv('CROWDFUND_CONTRACT_ADDRESS')
 
     const snapshotData = { ...data, rawLogs: await store.readLogs(data.cursor.verifiedCursor) }
@@ -216,7 +216,7 @@ async function runCommand(args: ParsedCliArgs, store: IndexerStore): Promise<voi
 
   if (args.command === 'evaluate-alerts') {
     const params: CrowdfundParams = {
-      chainId: readNumberEnv('CROWDFUND_CHAIN_ID', 11155111),
+      chainId: readRequiredNumberEnv('CROWDFUND_CHAIN_ID'),
       contractAddress: readRequiredEnv('CROWDFUND_CONTRACT_ADDRESS'),
       treasuryAddress: readRequiredEnv('CROWDFUND_TREASURY_ADDRESS'),
       openTimestamp: readNumberEnv('CROWDFUND_OPEN_TIMESTAMP', 0),

--- a/crowdfund-ui/packages/indexer/src/config.test.ts
+++ b/crowdfund-ui/packages/indexer/src/config.test.ts
@@ -29,7 +29,8 @@ afterEach(() => {
 })
 
 describe('loadIndexerConfig', () => {
-  it('applies documented defaults when only the contract address is set', () => {
+  it('applies documented defaults when chain id + contract address are set', () => {
+    process.env.CROWDFUND_CHAIN_ID = '11155111'
     process.env.CROWDFUND_CONTRACT_ADDRESS = '0xabc'
     const config = loadIndexerConfig()
     expect(config).toMatchObject({
@@ -63,11 +64,18 @@ describe('loadIndexerConfig', () => {
     expect(config.staleAfterMs).toBe(120_000)
   })
 
+  it('throws when the required chain id is missing', () => {
+    process.env.CROWDFUND_CONTRACT_ADDRESS = '0xabc'
+    expect(() => loadIndexerConfig()).toThrow('CROWDFUND_CHAIN_ID')
+  })
+
   it('throws when the required contract address is missing', () => {
+    process.env.CROWDFUND_CHAIN_ID = '11155111'
     expect(() => loadIndexerConfig()).toThrow('CROWDFUND_CONTRACT_ADDRESS')
   })
 
   it('rejects an invalid numeric variable', () => {
+    process.env.CROWDFUND_CHAIN_ID = '11155111'
     process.env.CROWDFUND_CONTRACT_ADDRESS = '0xabc'
     process.env.CROWDFUND_MAX_BLOCK_RANGE = '-5'
     expect(() => loadIndexerConfig()).toThrow('CROWDFUND_MAX_BLOCK_RANGE')

--- a/crowdfund-ui/packages/indexer/src/config.ts
+++ b/crowdfund-ui/packages/indexer/src/config.ts
@@ -46,6 +46,19 @@ export function readNumberEnv(name: string, fallback: number): number {
   return parsed
 }
 
+/** Like readNumberEnv but with no fallback — for values where a wrong default is
+ *  dangerous (e.g. CROWDFUND_CHAIN_ID: silently defaulting to a testnet chain id
+ *  would let a mainnet box index/label itself as the wrong network). */
+export function readRequiredNumberEnv(name: string): number {
+  const raw = process.env[name]
+  if (!raw) throw new Error(`Missing required environment variable: ${name}`)
+  const parsed = Number(raw)
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid numeric environment variable: ${name}`)
+  }
+  return parsed
+}
+
 export function readBooleanEnv(name: string, fallback: boolean): boolean {
   const value = process.env[name]
   if (!value) return fallback
@@ -69,7 +82,7 @@ export function getInitialCursor(): CursorState {
 
 export function loadIndexerConfig(): IndexerConfig {
   return {
-    chainId: readNumberEnv('CROWDFUND_CHAIN_ID', 11155111),
+    chainId: readRequiredNumberEnv('CROWDFUND_CHAIN_ID'),
     contractAddress: readRequiredEnv('CROWDFUND_CONTRACT_ADDRESS'),
     deployBlock: readNumberEnv('CROWDFUND_DEPLOY_BLOCK', 0),
     primaryRpcUrl: process.env.CROWDFUND_PRIMARY_RPC_URL ?? null,

--- a/crowdfund-ui/packages/shared/src/index.ts
+++ b/crowdfund-ui/packages/shared/src/index.ts
@@ -74,6 +74,7 @@ export {
   resolveDeploymentFileName,
   pollIntervalForMode,
   maxBlockRangeForMode,
+  confirmationsForMode,
   explorerUrlForMode,
   assertDeploymentChainId,
   getNetworkMode,
@@ -86,6 +87,7 @@ export {
   getDeploymentFileName,
   getPollIntervalMs,
   getMaxBlockRange,
+  getTxConfirmations,
   getExplorerUrl,
 } from './lib/network.js'
 export type { NetworkMode, NetworkEnv } from './lib/network.js'

--- a/crowdfund-ui/packages/shared/src/index.ts
+++ b/crowdfund-ui/packages/shared/src/index.ts
@@ -75,6 +75,7 @@ export {
   pollIntervalForMode,
   maxBlockRangeForMode,
   explorerUrlForMode,
+  assertDeploymentChainId,
   getNetworkMode,
   isLocalMode,
   getHubChainId,

--- a/crowdfund-ui/packages/shared/src/index.ts
+++ b/crowdfund-ui/packages/shared/src/index.ts
@@ -64,6 +64,31 @@ export type {
   ComputeSelfFillOptions,
 } from './lib/selfFillPlan.js'
 
+export {
+  resolveNetworkMode,
+  isLocalNetwork,
+  chainIdForMode,
+  networkLabelForChainId,
+  resolveHubRpcUrls,
+  resolveIndexerUrl,
+  resolveDeploymentFileName,
+  pollIntervalForMode,
+  maxBlockRangeForMode,
+  explorerUrlForMode,
+  getNetworkMode,
+  isLocalMode,
+  getHubChainId,
+  getHubNetworkLabel,
+  getHubRpcUrl,
+  getHubRpcUrls,
+  getIndexerUrl,
+  getDeploymentFileName,
+  getPollIntervalMs,
+  getMaxBlockRange,
+  getExplorerUrl,
+} from './lib/network.js'
+export type { NetworkMode, NetworkEnv } from './lib/network.js'
+
 export { createProvider, fetchLogs, getBlockTimestamp } from './lib/rpc.js'
 export {
   aggregate3,

--- a/crowdfund-ui/packages/shared/src/lib/network.test.ts
+++ b/crowdfund-ui/packages/shared/src/lib/network.test.ts
@@ -12,6 +12,7 @@ import {
   resolveDeploymentFileName,
   pollIntervalForMode,
   maxBlockRangeForMode,
+  confirmationsForMode,
   explorerUrlForMode,
   assertDeploymentChainId,
   type NetworkEnv,
@@ -183,6 +184,12 @@ describe('poll interval / block range / explorer', () => {
   it('uses a small block range locally and a wide one on live networks', () => {
     expect(maxBlockRangeForMode('local')).toBe(10)
     expect(maxBlockRangeForMode('mainnet')).toBe(2_000)
+  })
+
+  it('waits deeper for confirmations on mainnet than local/testnet', () => {
+    expect(confirmationsForMode('local')).toBe(1)
+    expect(confirmationsForMode('sepolia')).toBe(1)
+    expect(confirmationsForMode('mainnet')).toBe(2)
   })
 
   it('maps each mode to its explorer (none for local)', () => {

--- a/crowdfund-ui/packages/shared/src/lib/network.test.ts
+++ b/crowdfund-ui/packages/shared/src/lib/network.test.ts
@@ -13,6 +13,7 @@ import {
   pollIntervalForMode,
   maxBlockRangeForMode,
   explorerUrlForMode,
+  assertDeploymentChainId,
   type NetworkEnv,
 } from './network.js'
 
@@ -157,6 +158,18 @@ describe('resolveDeploymentFileName', () => {
   it('falls back to the legacy per-mode file when no instance is set', () => {
     expect(resolveDeploymentFileName({ VITE_NETWORK: 'sepolia' })).toBe('crowdfund-hub-sepolia.json')
     expect(resolveDeploymentFileName({ VITE_NETWORK: 'mainnet' })).toBe('crowdfund-hub-mainnet.json')
+  })
+})
+
+describe('assertDeploymentChainId', () => {
+  it('passes when the manifest matches the build target', () => {
+    expect(() => assertDeploymentChainId(1, 1, 'crowdfund.json')).not.toThrow()
+  })
+
+  it('throws a descriptive error on mismatch', () => {
+    expect(() => assertDeploymentChainId(11155111, 1, 'crowdfund-hub-mainnet.json')).toThrow(
+      /chain mismatch.*11155111.*chain 1/,
+    )
   })
 })
 

--- a/crowdfund-ui/packages/shared/src/lib/network.test.ts
+++ b/crowdfund-ui/packages/shared/src/lib/network.test.ts
@@ -1,0 +1,180 @@
+// ABOUTME: Tests for the shared network resolvers — mode, chain id, RPC, explorer,
+// ABOUTME: indexer, manifest path across local / sepolia / mainnet and env precedence.
+
+import { describe, it, expect } from 'vitest'
+import {
+  resolveNetworkMode,
+  isLocalNetwork,
+  chainIdForMode,
+  networkLabelForChainId,
+  resolveHubRpcUrls,
+  resolveIndexerUrl,
+  resolveDeploymentFileName,
+  pollIntervalForMode,
+  maxBlockRangeForMode,
+  explorerUrlForMode,
+  type NetworkEnv,
+} from './network.js'
+
+describe('resolveNetworkMode', () => {
+  it('honours explicit VITE_NETWORK', () => {
+    expect(resolveNetworkMode({ VITE_NETWORK: 'mainnet' })).toBe('mainnet')
+    expect(resolveNetworkMode({ VITE_NETWORK: 'sepolia' })).toBe('sepolia')
+    expect(resolveNetworkMode({ VITE_NETWORK: 'local' })).toBe('local')
+  })
+
+  it('trims whitespace around the value', () => {
+    expect(resolveNetworkMode({ VITE_NETWORK: '  mainnet  ' })).toBe('mainnet')
+  })
+
+  it('defaults to local in dev when unset', () => {
+    expect(resolveNetworkMode({})).toBe('local')
+    expect(resolveNetworkMode({ PROD: false })).toBe('local')
+    expect(resolveNetworkMode({ VITE_NETWORK: '   ' })).toBe('local')
+  })
+
+  it('defaults to sepolia in PROD when unset — never local, never mainnet', () => {
+    expect(resolveNetworkMode({ PROD: true })).toBe('sepolia')
+    expect(resolveNetworkMode({ PROD: true, VITE_NETWORK: '' })).toBe('sepolia')
+  })
+
+  it('treats an unrecognised value as unset (falls through to the default)', () => {
+    expect(resolveNetworkMode({ VITE_NETWORK: 'goerli' })).toBe('local')
+    expect(resolveNetworkMode({ VITE_NETWORK: 'goerli', PROD: true })).toBe('sepolia')
+  })
+})
+
+describe('chainIdForMode / isLocalNetwork', () => {
+  it('maps each mode to its chain id', () => {
+    expect(chainIdForMode('local')).toBe(31337)
+    expect(chainIdForMode('sepolia')).toBe(11155111)
+    expect(chainIdForMode('mainnet')).toBe(1)
+  })
+
+  it('identifies local', () => {
+    expect(isLocalNetwork('local')).toBe(true)
+    expect(isLocalNetwork('sepolia')).toBe(false)
+    expect(isLocalNetwork('mainnet')).toBe(false)
+  })
+})
+
+describe('networkLabelForChainId', () => {
+  it('labels known chains', () => {
+    expect(networkLabelForChainId(1)).toBe('Ethereum')
+    expect(networkLabelForChainId(11155111)).toBe('Sepolia')
+    expect(networkLabelForChainId(31337)).toBe('the local network')
+  })
+
+  it('falls back for unknown chains', () => {
+    expect(networkLabelForChainId(8453)).toBe('the correct network')
+  })
+})
+
+describe('resolveHubRpcUrls', () => {
+  it('returns localhost for local mode', () => {
+    expect(resolveHubRpcUrls({ VITE_NETWORK: 'local' })).toEqual(['http://localhost:8545'])
+  })
+
+  it('prefers VITE_HUB_RPC and appends the fallback when present', () => {
+    const env: NetworkEnv = {
+      VITE_NETWORK: 'mainnet',
+      VITE_HUB_RPC: 'https://primary.example',
+      VITE_HUB_RPC_FALLBACK: 'https://fallback.example',
+    }
+    expect(resolveHubRpcUrls(env)).toEqual(['https://primary.example', 'https://fallback.example'])
+  })
+
+  it('omits the fallback when only the primary is set', () => {
+    expect(resolveHubRpcUrls({ VITE_NETWORK: 'mainnet', VITE_HUB_RPC: 'https://primary.example' }))
+      .toEqual(['https://primary.example'])
+  })
+
+  it('falls back to the legacy VITE_SEPOLIA_RPC names in sepolia mode', () => {
+    const env: NetworkEnv = {
+      VITE_NETWORK: 'sepolia',
+      VITE_SEPOLIA_RPC: 'https://legacy-primary.example',
+      VITE_SEPOLIA_RPC_FALLBACK: 'https://legacy-fallback.example',
+    }
+    expect(resolveHubRpcUrls(env)).toEqual([
+      'https://legacy-primary.example',
+      'https://legacy-fallback.example',
+    ])
+  })
+
+  it('lets VITE_HUB_RPC win over the legacy name in sepolia mode', () => {
+    const env: NetworkEnv = {
+      VITE_NETWORK: 'sepolia',
+      VITE_HUB_RPC: 'https://new.example',
+      VITE_SEPOLIA_RPC: 'https://legacy.example',
+    }
+    expect(resolveHubRpcUrls(env)).toEqual(['https://new.example'])
+  })
+
+  it('does NOT read the legacy sepolia name on mainnet (wrong-chain guard)', () => {
+    const env: NetworkEnv = { VITE_NETWORK: 'mainnet', VITE_SEPOLIA_RPC: 'https://sepolia.example' }
+    // Falls through to the mainnet default, never the sepolia URL.
+    expect(resolveHubRpcUrls(env)).toEqual(['https://ethereum-rpc.publicnode.com'])
+  })
+
+  it('uses the per-network public default when no env URL is set', () => {
+    expect(resolveHubRpcUrls({ VITE_NETWORK: 'sepolia' }))
+      .toEqual(['https://ethereum-sepolia-rpc.publicnode.com'])
+    expect(resolveHubRpcUrls({ VITE_NETWORK: 'mainnet' }))
+      .toEqual(['https://ethereum-rpc.publicnode.com'])
+  })
+})
+
+describe('resolveIndexerUrl', () => {
+  it('is null in local mode regardless of env', () => {
+    expect(resolveIndexerUrl({ VITE_NETWORK: 'local', VITE_CROWDFUND_INDEXER_URL: 'https://x' }))
+      .toBeNull()
+  })
+
+  it('returns the configured URL on non-local networks, else null', () => {
+    expect(resolveIndexerUrl({ VITE_NETWORK: 'mainnet', VITE_CROWDFUND_INDEXER_URL: 'https://api' }))
+      .toBe('https://api')
+    expect(resolveIndexerUrl({ VITE_NETWORK: 'mainnet' })).toBeNull()
+  })
+})
+
+describe('resolveDeploymentFileName', () => {
+  it('uses the unsuffixed file in local mode', () => {
+    expect(resolveDeploymentFileName({ VITE_NETWORK: 'local' })).toBe('crowdfund-hub.json')
+  })
+
+  it('builds an instance path scoped by mode when an instance is set', () => {
+    expect(resolveDeploymentFileName({ VITE_NETWORK: 'mainnet', VITE_DEPLOYMENT_INSTANCE: 'launch1' }))
+      .toBe('instances/launch1/mainnet/crowdfund.json')
+    expect(resolveDeploymentFileName({ VITE_NETWORK: 'sepolia', VITE_DEPLOYMENT_INSTANCE: 'medi2' }))
+      .toBe('instances/medi2/sepolia/crowdfund.json')
+  })
+
+  it('trims the instance name', () => {
+    expect(resolveDeploymentFileName({ VITE_NETWORK: 'mainnet', VITE_DEPLOYMENT_INSTANCE: '  launch1  ' }))
+      .toBe('instances/launch1/mainnet/crowdfund.json')
+  })
+
+  it('falls back to the legacy per-mode file when no instance is set', () => {
+    expect(resolveDeploymentFileName({ VITE_NETWORK: 'sepolia' })).toBe('crowdfund-hub-sepolia.json')
+    expect(resolveDeploymentFileName({ VITE_NETWORK: 'mainnet' })).toBe('crowdfund-hub-mainnet.json')
+  })
+})
+
+describe('poll interval / block range / explorer', () => {
+  it('polls faster on local than on live networks', () => {
+    expect(pollIntervalForMode('local')).toBe(5_000)
+    expect(pollIntervalForMode('sepolia')).toBe(15_000)
+    expect(pollIntervalForMode('mainnet')).toBe(15_000)
+  })
+
+  it('uses a small block range locally and a wide one on live networks', () => {
+    expect(maxBlockRangeForMode('local')).toBe(10)
+    expect(maxBlockRangeForMode('mainnet')).toBe(2_000)
+  })
+
+  it('maps each mode to its explorer (none for local)', () => {
+    expect(explorerUrlForMode('mainnet')).toBe('https://etherscan.io')
+    expect(explorerUrlForMode('sepolia')).toBe('https://sepolia.etherscan.io')
+    expect(explorerUrlForMode('local')).toBeUndefined()
+  })
+})

--- a/crowdfund-ui/packages/shared/src/lib/network.ts
+++ b/crowdfund-ui/packages/shared/src/lib/network.ts
@@ -129,6 +129,17 @@ export function maxBlockRangeForMode(mode: NetworkMode): number {
 }
 
 /**
+ * Confirmations to await before treating a transaction as terminally successful.
+ * Deeper on mainnet so a single-block reorg can't surface a dropped tx as
+ * confirmed (showing "done" for a commit that never landed). Instant local chains
+ * and the low-stakes testnet stay at 1. Keep this small enough that
+ * confirmations × ~12s stays well within the tx-wait timeout.
+ */
+export function confirmationsForMode(mode: NetworkMode): number {
+  return mode === 'mainnet' ? 2 : 1
+}
+
+/**
  * Guard a loaded deployment manifest against the build's target chain. Throws on
  * mismatch so a build can never silently use one network's contract addresses on
  * another (e.g. a mainnet site accidentally fed a Sepolia manifest) — the wallet
@@ -205,6 +216,10 @@ export function getPollIntervalMs(): number {
 
 export function getMaxBlockRange(): number {
   return maxBlockRangeForMode(getNetworkMode())
+}
+
+export function getTxConfirmations(): number {
+  return confirmationsForMode(getNetworkMode())
 }
 
 export function getExplorerUrl(): string | undefined {

--- a/crowdfund-ui/packages/shared/src/lib/network.ts
+++ b/crowdfund-ui/packages/shared/src/lib/network.ts
@@ -1,0 +1,193 @@
+// ABOUTME: Shared network configuration for local (Anvil), Sepolia, and mainnet.
+// ABOUTME: Pure resolvers (testable) + import.meta.env wrappers used by the apps.
+
+export type NetworkMode = 'local' | 'sepolia' | 'mainnet'
+
+/** The subset of Vite env the network resolvers read. All optional so the pure
+ *  resolvers can be exercised with plain records in tests. */
+export interface NetworkEnv {
+  PROD?: boolean
+  VITE_NETWORK?: string
+  /** Canonical hub RPC for the active non-local network (mainnet or sepolia). */
+  VITE_HUB_RPC?: string
+  VITE_HUB_RPC_FALLBACK?: string
+  /** Legacy Sepolia-specific RPC names. Read only in sepolia mode for backward
+   *  compatibility with deploys configured before the VITE_HUB_RPC rename. */
+  VITE_SEPOLIA_RPC?: string
+  VITE_SEPOLIA_RPC_FALLBACK?: string
+  VITE_CROWDFUND_INDEXER_URL?: string
+  VITE_DEPLOYMENT_INSTANCE?: string
+}
+
+// Default public RPCs, used only when no env-configured URL is present. A money
+// app should set a dedicated provider (see VITE_HUB_RPC); these are last-resort
+// fallbacks so a missing env var degrades to a working endpoint rather than none.
+const DEFAULT_SEPOLIA_RPC = 'https://ethereum-sepolia-rpc.publicnode.com'
+const DEFAULT_MAINNET_RPC = 'https://ethereum-rpc.publicnode.com'
+
+const CHAIN_ID: Record<NetworkMode, number> = {
+  local: 31337,
+  sepolia: 11155111,
+  mainnet: 1,
+}
+
+/**
+ * Resolve the active network mode from the env.
+ *
+ * Explicit `VITE_NETWORK` wins. When unset, dev defaults to local; a production
+ * bundle defaults to sepolia — never local (which points at localhost:8545) and
+ * never mainnet (which must be an explicit, deliberate opt-in). A PROD build with
+ * an unset/blank network is itself a misconfiguration that the apps' startup
+ * validation surfaces loudly.
+ */
+export function resolveNetworkMode(env: NetworkEnv): NetworkMode {
+  const value = env.VITE_NETWORK?.trim()
+  if (value === 'mainnet') return 'mainnet'
+  if (value === 'sepolia') return 'sepolia'
+  if (value === 'local') return 'local'
+  return env.PROD ? 'sepolia' : 'local'
+}
+
+export function isLocalNetwork(mode: NetworkMode): boolean {
+  return mode === 'local'
+}
+
+export function chainIdForMode(mode: NetworkMode): number {
+  return CHAIN_ID[mode]
+}
+
+/**
+ * Human-readable name of the deployment's chain, derived from the chain id so it
+ * stays correct across environments without hardcoding a network into UI copy.
+ */
+export function networkLabelForChainId(chainId: number): string {
+  switch (chainId) {
+    case 1:
+      return 'Ethereum'
+    case 11155111:
+      return 'Sepolia'
+    case 31337:
+      return 'the local network'
+    default:
+      return 'the correct network'
+  }
+}
+
+/** Ordered list of RPC URLs for fallback. Primary URL first. */
+export function resolveHubRpcUrls(env: NetworkEnv): string[] {
+  const mode = resolveNetworkMode(env)
+  if (mode === 'local') return ['http://localhost:8545']
+
+  // VITE_HUB_RPC is the canonical name. In sepolia mode we also honour the legacy
+  // VITE_SEPOLIA_RPC names so deploys configured before the rename keep working;
+  // we deliberately do NOT read those on mainnet (a sepolia URL on mainnet would
+  // silently target the wrong chain).
+  const legacyPrimary = mode === 'sepolia' ? env.VITE_SEPOLIA_RPC : undefined
+  const legacyFallback = mode === 'sepolia' ? env.VITE_SEPOLIA_RPC_FALLBACK : undefined
+  const defaultRpc = mode === 'mainnet' ? DEFAULT_MAINNET_RPC : DEFAULT_SEPOLIA_RPC
+
+  const primary = env.VITE_HUB_RPC || legacyPrimary || defaultRpc
+  const fallback = env.VITE_HUB_RPC_FALLBACK || legacyFallback || undefined
+  return fallback ? [primary, fallback] : [primary]
+}
+
+export function resolveIndexerUrl(env: NetworkEnv): string | null {
+  if (resolveNetworkMode(env) === 'local') return null
+  return env.VITE_CROWDFUND_INDEXER_URL ?? null
+}
+
+/**
+ * Path (relative to the apps' deployment-manifest middleware) of the crowdfund
+ * deployment manifest to load.
+ *
+ * Local → `crowdfund-hub.json`.
+ * Non-local + `VITE_DEPLOYMENT_INSTANCE=<name>` → mirrored path under
+ *   `instances/<name>/<mode>/crowdfund.json` (mode is `sepolia` or `mainnet`),
+ *   populated by `npm run fetch-deployment` from the armada-deployments repo.
+ * Non-local, no instance → legacy `crowdfund-hub-<mode>.json`.
+ */
+export function resolveDeploymentFileName(env: NetworkEnv): string {
+  const mode = resolveNetworkMode(env)
+  if (mode === 'local') return 'crowdfund-hub.json'
+  const instance = env.VITE_DEPLOYMENT_INSTANCE?.trim()
+  if (instance) return `instances/${instance}/${mode}/crowdfund.json`
+  return `crowdfund-hub-${mode}.json`
+}
+
+export function pollIntervalForMode(mode: NetworkMode): number {
+  return mode === 'local' ? 5_000 : 15_000
+}
+
+/**
+ * Max blocks per eth_getLogs request. Local Anvil is tiny so 10 is plenty; public
+ * RPCs handle far larger ranges, so use a wide range to keep cold-start backfills
+ * from taking thousands of requests. fetchLogs halves this on a range-too-large
+ * error, so an over-estimate is safe.
+ */
+export function maxBlockRangeForMode(mode: NetworkMode): number {
+  return mode === 'local' ? 10 : 2_000
+}
+
+/** Block explorer base URL. Returns undefined for local mode (no explorer). */
+export function explorerUrlForMode(mode: NetworkMode): string | undefined {
+  switch (mode) {
+    case 'mainnet':
+      return 'https://etherscan.io'
+    case 'sepolia':
+      return 'https://sepolia.etherscan.io'
+    case 'local':
+      return undefined
+  }
+}
+
+// --- import.meta.env wrappers -------------------------------------------------
+// These read the live Vite env. Each app's bundler statically replaces
+// import.meta.env at build, so the resolvers above stay pure and unit-testable.
+
+function env(): NetworkEnv {
+  return import.meta.env as unknown as NetworkEnv
+}
+
+export function getNetworkMode(): NetworkMode {
+  return resolveNetworkMode(env())
+}
+
+export function isLocalMode(): boolean {
+  return isLocalNetwork(getNetworkMode())
+}
+
+export function getHubChainId(): number {
+  return chainIdForMode(getNetworkMode())
+}
+
+export function getHubNetworkLabel(): string {
+  return networkLabelForChainId(getHubChainId())
+}
+
+export function getHubRpcUrl(): string {
+  return resolveHubRpcUrls(env())[0]
+}
+
+export function getHubRpcUrls(): string[] {
+  return resolveHubRpcUrls(env())
+}
+
+export function getIndexerUrl(): string | null {
+  return resolveIndexerUrl(env())
+}
+
+export function getDeploymentFileName(): string {
+  return resolveDeploymentFileName(env())
+}
+
+export function getPollIntervalMs(): number {
+  return pollIntervalForMode(getNetworkMode())
+}
+
+export function getMaxBlockRange(): number {
+  return maxBlockRangeForMode(getNetworkMode())
+}
+
+export function getExplorerUrl(): string | undefined {
+  return explorerUrlForMode(getNetworkMode())
+}

--- a/crowdfund-ui/packages/shared/src/lib/network.ts
+++ b/crowdfund-ui/packages/shared/src/lib/network.ts
@@ -128,6 +128,25 @@ export function maxBlockRangeForMode(mode: NetworkMode): number {
   return mode === 'local' ? 10 : 2_000
 }
 
+/**
+ * Guard a loaded deployment manifest against the build's target chain. Throws on
+ * mismatch so a build can never silently use one network's contract addresses on
+ * another (e.g. a mainnet site accidentally fed a Sepolia manifest) — the wallet
+ * would expect chain X while the app talked to chain-Y addresses.
+ */
+export function assertDeploymentChainId(
+  manifestChainId: number,
+  expectedChainId: number,
+  source: string,
+): void {
+  if (manifestChainId !== expectedChainId) {
+    throw new Error(
+      `Deployment chain mismatch: ${source} is for chain ${manifestChainId}, but this ` +
+        `build targets chain ${expectedChainId}. Check VITE_NETWORK / VITE_DEPLOYMENT_INSTANCE.`,
+    )
+  }
+}
+
 /** Block explorer base URL. Returns undefined for local mode (no explorer). */
 export function explorerUrlForMode(mode: NetworkMode): string | undefined {
   switch (mode) {

--- a/deploy/indexer.env.template
+++ b/deploy/indexer.env.template
@@ -8,12 +8,19 @@ INDEXER_IMAGE=crowdfund-indexer:latest
 CROWDFUND_ALERT_INTERVAL_SECONDS=60
 
 # --- Crowdfund target --------------------------------------------------------
+# Chain the indexer ingests: 11155111 = Sepolia, 1 = Ethereum mainnet. MUST match
+# the network of CROWDFUND_CONTRACT_ADDRESS below — a mismatch silently indexes the
+# wrong chain. Set it explicitly on every deploy (the service falls back to Sepolia
+# when unset, so a mainnet box that forgets this would index as Sepolia).
 CROWDFUND_CHAIN_ID=11155111
 CROWDFUND_CONTRACT_ADDRESS=
 CROWDFUND_TREASURY_ADDRESS=
 CROWDFUND_USDC_ADDRESS=
 CROWDFUND_DEPLOY_BLOCK=0
-# Primary ingestion RPC (required) + independent audit RPC (recommended).
+# Primary ingestion RPC (required) + independent audit RPC (recommended). On mainnet
+# use a dedicated provider (e.g. Alchemy/Infura), NOT a public node — the indexer
+# polls continuously and public endpoints rate-limit. Use two different providers so
+# the audit cross-check stays independent of the ingestion RPC.
 CROWDFUND_PRIMARY_RPC_URL=
 CROWDFUND_AUDIT_RPC_URL=
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,47 +1,59 @@
 # Netlify build config — committer app deploy.
 #
-# Env vars set in the Netlify UI (not committed) — all of the following matter,
-# not just the instance:
-#   VITE_WALLETCONNECT_PROJECT_ID  required — WalletConnect modal is dead without it
-#   DEPLOYMENT_INSTANCE            optional override; defaults to "medi2".
-#                                  The build script re-exports it as
-#                                  VITE_DEPLOYMENT_INSTANCE so the bundled
-#                                  committer reads the matching instance file
-#                                  at runtime.
-#   VITE_CROWDFUND_INDEXER_URL     REQUIRED — indexer API base URL for the active
-#                                  instance (e.g. https://api.knowable.run).
-#                                  Without it every visitor falls back to a slow
-#                                  cold-start RPC backfill; the bundle's startup
-#                                  env validation hard-fails a PROD build at
-#                                  runtime when it is missing.
-#   VITE_SENTRY_DSN                error monitoring DSN; if unset, Sentry is a
-#                                  silent no-op (and the root error fallback
-#                                  stops claiming "the team has been notified").
+# ONE committed config serves TWO independent Netlify sites (sepolia + mainnet).
+# Each site selects its network purely through per-site env vars set in the Netlify
+# UI; the defaults below reproduce today's Sepolia (medi2) build, so a site that
+# sets none of the network vars still builds the Sepolia committer unchanged.
+#
+# Per-site env vars (Netlify UI → Site settings → Environment variables):
+#   NETWORK                 armada-deployments top-level folder: "testnet" (default)
+#                           or "mainnet" — which repo folder the manifest is fetched from.
+#   VITE_NETWORK            app network mode: "sepolia" (default) or "mainnet". Switches
+#                           chain id, explorer, hub RPC, manifest chain subdir, poll
+#                           interval. Startup validateEnv hard-fails a blank PROD value.
+#   VITE_CROWDFUND_PROFILE  sale-parameter profile: "medi" (default, ~$1k Sepolia) or
+#                           "mainnet" ($1.2M sale, $15k hop caps). MUST match the
+#                           instance's scale or the UI misrepresents the sale.
+#   DEPLOYMENT_INSTANCE     named armada-deployments instance; defaults to "medi2".
+#                           Re-exported as VITE_DEPLOYMENT_INSTANCE for the runtime.
+#   VITE_HUB_RPC            dedicated hub RPC URL (+ optional VITE_HUB_RPC_FALLBACK).
+#                           Strongly recommended on mainnet; without it the app falls
+#                           back to a public node. (Legacy VITE_SEPOLIA_RPC still works
+#                           on the Sepolia site.)
+#   VITE_WALLETCONNECT_PROJECT_ID  required — WalletConnect modal is dead without it.
+#   VITE_CROWDFUND_INDEXER_URL     required — indexer API base URL for the active
+#                                  instance (e.g. https://api.knowable.run). Startup
+#                                  validateEnv hard-fails a PROD build when it is missing.
+#   VITE_SENTRY_DSN                error monitoring DSN; silent no-op if unset.
 #   VITE_SENTRY_RELEASE            release tag used to group events.
 #   VITE_SENTRY_ENVIRONMENT        deploy environment, e.g. "production".
-#   SENTRY_AUTH_TOKEN              build-time only — lets the Sentry Vite plugin
-#                                  upload and then DELETE sourcemaps. If unset the
-#                                  plugin no-ops and .map files would ship
-#                                  publicly in dist/.
+#   SENTRY_AUTH_TOKEN              build-time only — lets the Sentry Vite plugin upload
+#                                  and then delete sourcemaps.
 
 [build]
   base    = "."
   publish = "crowdfund-ui/packages/committer/dist"
-  # Build flow:
-  #   1. Pick the deployment instance (defaults to medi2).
-  #   2. Fetch the crowdfund manifest from the armada-deployments repo into
-  #      the committer's public/api/deployments/instances/<name>/sepolia/
-  #      so the production build serves it under the same path the dev server's
-  #      serveDeployments() plugin exposes.
+  # Build flow (all network selection comes from per-site env — see header):
+  #   1. Resolve network/profile/instance. Defaults reproduce the Sepolia medi2
+  #      build exactly, so the existing site needs no env changes.
+  #   2. Fetch the manifest from armada-deployments at
+  #      <NETWORK>/<instance>/<VITE_NETWORK>/crowdfund.json into the committer's
+  #      public/api/deployments/instances/<name>/<VITE_NETWORK>/ so the prod build
+  #      serves it under the same path the dev server's serveDeployments() exposes.
   #   3. Install workspace deps with --legacy-peer-deps (Railgun SDK peer-dep conflict).
   #   4. Build the committer.
+  # TODO: confirm the armada-deployments mainnet layout matches
+  # `mainnet/<instance>/mainnet/crowdfund.json` once the mainnet instance is published.
   command = """
+    NETWORK="${NETWORK:-testnet}" && \
+    export VITE_NETWORK="${VITE_NETWORK:-sepolia}" && \
+    export VITE_CROWDFUND_PROFILE="${VITE_CROWDFUND_PROFILE:-medi}" && \
     INSTANCE="${DEPLOYMENT_INSTANCE:-medi2}" && \
     export VITE_DEPLOYMENT_INSTANCE="${INSTANCE}" && \
-    BASE="https://raw.githubusercontent.com/ship-armada/armada-deployments/main/testnet/${INSTANCE}" && \
-    echo "Fetching crowdfund deployment manifest for instance: ${INSTANCE}" && \
-    mkdir -p "crowdfund-ui/packages/committer/public/api/deployments/instances/${INSTANCE}/sepolia" && \
-    curl -sfL -o "crowdfund-ui/packages/committer/public/api/deployments/instances/${INSTANCE}/sepolia/crowdfund.json" "${BASE}/sepolia/crowdfund.json" && \
+    BASE="https://raw.githubusercontent.com/ship-armada/armada-deployments/main/${NETWORK}/${INSTANCE}" && \
+    echo "Fetching ${NETWORK}/${INSTANCE} (VITE_NETWORK=${VITE_NETWORK}, profile=${VITE_CROWDFUND_PROFILE})" && \
+    mkdir -p "crowdfund-ui/packages/committer/public/api/deployments/instances/${INSTANCE}/${VITE_NETWORK}" && \
+    curl -sfL -o "crowdfund-ui/packages/committer/public/api/deployments/instances/${INSTANCE}/${VITE_NETWORK}/crowdfund.json" "${BASE}/${VITE_NETWORK}/crowdfund.json" && \
     rm -rf node_modules package-lock.json && \
     npm install --legacy-peer-deps && \
     npm run build --workspace=@armada/crowdfund-committer
@@ -54,15 +66,10 @@
   # Sourcemap generation over the main chunk pushes V8 past the default heap
   # limit and the build dies with "Reached heap limit" (exit 134). Raise it.
   NODE_OPTIONS = "--max-old-space-size=4096"
-  # Switches all network-dependent decisions in the app (manifest path,
-  # hub RPC, chain ID 11155111, sepolia.etherscan, 15s poll). VITE_WALLETCONNECT_PROJECT_ID
-  # and VITE_DEPLOYMENT_INSTANCE are set via the Netlify UI as deploy-context env vars.
-  VITE_NETWORK = "sepolia"
-  # Sale-parameter profile. MUST match the deployed instance's scale: the
-  # medi-family Sepolia instances are ~$1k-scale and use the "medi" profile.
-  # Without this, constants.ts defaults to mainnet ($1.2M sale, $15k hop caps)
-  # and the UI grossly misrepresents the contract.
-  VITE_CROWDFUND_PROFILE = "medi"
+  # NOTE: VITE_NETWORK and VITE_CROWDFUND_PROFILE are intentionally NOT set here.
+  # They are per-site env vars (see header) so this one committed config can serve
+  # both the Sepolia and mainnet sites; the build command supplies Sepolia defaults
+  # (sepolia / medi) when a site leaves them unset.
 
 # SPA fallback — react-router serves /invite?... and other dynamic paths.
 [[redirects]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -182,6 +182,7 @@
         "@rainbow-me/rainbowkit": "^2.2.10",
         "@sentry/react": "^8.55.0",
         "@tanstack/react-query": "^5.96.0",
+        "@web3icons/react": "^4.1.17",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "ethers": "^6.15.0",

--- a/scripts/fetch-deployment.ts
+++ b/scripts/fetch-deployment.ts
@@ -1,11 +1,17 @@
 // ABOUTME: Fetches a named deployment instance from the armada-deployments repo into deployments/instances/.
-// ABOUTME: Usage: npm run fetch-deployment -- <instance> [--ref <git-ref>]
+// ABOUTME: Usage: npm run fetch-deployment -- <instance> [--network testnet|mainnet] [--ref <git-ref>]
 
 import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 const REPO_BASE = 'https://raw.githubusercontent.com/ship-armada/armada-deployments'
 const DEFAULT_REF = 'main'
+// Top-level folder in the armada-deployments repo. Defaults to `testnet` so the
+// existing `npm run fetch-deployment -- <instance>` flow is unchanged; mainnet
+// instances live under `mainnet/` and are reached with `--network mainnet`.
+const DEFAULT_NETWORK = 'testnet'
+const NETWORKS = ['testnet', 'mainnet'] as const
+type Network = (typeof NETWORKS)[number]
 const PROJECT_ROOT = path.resolve(__dirname, '..')
 const OUT_ROOT = path.join(PROJECT_ROOT, 'deployments', 'instances')
 
@@ -19,15 +25,23 @@ interface DeploymentManifest {
   chains: Record<string, { chainId: number; role: string; artifacts: string[] }>
 }
 
-function parseArgs(argv: string[]): { instance: string; ref: string } {
+function parseArgs(argv: string[]): { instance: string; ref: string; network: Network } {
   const positional: string[] = []
   let ref = DEFAULT_REF
+  let network: Network = DEFAULT_NETWORK
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
     if (arg === '--ref') {
       const next = argv[i + 1]
       if (!next) throw new Error('--ref requires a value (commit SHA, tag, or branch name)')
       ref = next
+      i++
+    } else if (arg === '--network') {
+      const next = argv[i + 1]
+      if (!next || !NETWORKS.includes(next as Network)) {
+        throw new Error(`--network requires one of: ${NETWORKS.join(', ')}`)
+      }
+      network = next as Network
       i++
     } else if (arg.startsWith('--')) {
       throw new Error(`Unknown flag: ${arg}`)
@@ -38,7 +52,7 @@ function parseArgs(argv: string[]): { instance: string; ref: string } {
   if (positional.length !== 1) {
     throw new Error('Expected exactly one positional argument: <instance>')
   }
-  return { instance: positional[0], ref }
+  return { instance: positional[0], ref, network }
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -58,8 +72,8 @@ async function fetchText(url: string): Promise<string> {
 }
 
 async function main() {
-  const { instance, ref } = parseArgs(process.argv.slice(2))
-  const base = `${REPO_BASE}/${ref}/testnet/${instance}`
+  const { instance, ref, network } = parseArgs(process.argv.slice(2))
+  const base = `${REPO_BASE}/${ref}/${network}/${instance}`
   const outDir = path.join(OUT_ROOT, instance)
 
   console.log(`Fetching deployment instance '${instance}' from ${base}`)


### PR DESCRIPTION
Makes the crowdfund committer, admin, and indexer deployable against Ethereum mainnet, without changing local/sepolia behavior. **Frontend + indexer code only** — contract deploy, hosting, and RPC provisioning remain under #317 / #319.

## Changes
**Mainnet network mode** — shared `network.ts` now owns `NetworkMode = local|sepolia|mainnet` with mainnet chain id (1), `etherscan.io`, `VITE_HUB_RPC` (+ sepolia-only legacy `VITE_SEPOLIA_RPC` fallback), and the `instances/<name>/<mode>/crowdfund.json` manifest path. Committer + admin `config/network.ts` delegate to it (logic deduped); each wallet layer registers the mainnet chain. PROD-unset stays sepolia — mainnet is explicit opt-in. (`3b74dc3`)

**Build / deploy** — `netlify.toml` parameterized so one config serves two independent sites (sepolia + mainnet) via per-site env, Sepolia byte-identical (`12cfd29`); `fetch-deployment.ts` gained `--network testnet|mainnet`, default `testnet` (`3e98d31`).

**Fail-loud config** — startup `validateEnv` on committer + admin (`2e3e2aa`); indexer requires `CROWDFUND_CHAIN_ID`, no silent testnet default (`87e5a02`); indexer env template clarified for mainnet + dedicated RPC (`521b631`).

**Hardening** — wrong-chain deployment-manifest guard (`d12e3ab`); committer waits 2 confirmations on mainnet to avoid showing false success on a reorg, the crowdfund analog of #336 (`5f73c77`); per-chain invite-link IndexedDB so testnet links don't bleed into mainnet (`9e7c1af`).

**Housekeeping** — gitignore macOS AppleDouble + lockfile sync (`fa543b0`); indexer test-fixture fix so `tsc -b` is clean (`2ce817e`).

## Testing
- Suites green: shared 297, committer 173, admin 86, indexer 161.
- `tsc` clean across all four crowdfund-ui packages.
- Production builds verified (committer + admin).
- Sepolia/local behavior unchanged (verified by build simulation + tests).

## Not included (tracked in #317 / #319)
Mainnet contract deploy + `config/mainnet.env`; mainnet `armada-deployments` instance (confirm `mainnet/<instance>/mainnet/crowdfund.json` layout); indexer instance provisioning; committer/admin hosting + admin access control; dedicated RPC provisioning; CSP hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)