### PR TITLE
fix(crowdfund): make launch team address configurable in deploy script

### DIFF
--- a/config/networks.ts
+++ b/config/networks.ts
@@ -90,6 +90,10 @@ export interface NetworkConfig {
   revenueLockBeneficiaries: RevenueLockBeneficiary[];
   /** Security council address for crowdfund cancel authority. Required for non-local. */
   securityCouncilAddress: string;
+  /** Launch team address — issues crowdfund seeds and direct invites during the
+   *  window. Kept separate from the deployer to limit deployer-key exposure once
+   *  the deployer's privileges are renounced post-deploy. Required for non-local. */
+  launchTeamAddress: string;
   /** Crowdfund open delay in seconds from deployment time. Default 600 (10 minutes) —
    *  an operational buffer that lets the post-deploy verification checklist complete
    *  before commits can flow. Production deploys should set this explicitly via
@@ -283,6 +287,7 @@ export function getNetworkConfig(): NetworkConfig {
     },
     revenueLockBeneficiaries,
     securityCouncilAddress: optionalEnv("SECURITY_COUNCIL_ADDRESS", ""),
+    launchTeamAddress: optionalEnv("LAUNCH_TEAM_ADDRESS", ""),
     crowdfundOpenDelay: numEnv("CROWDFUND_OPEN_DELAY", 600),
     windDownDeadline: optionalEnv("WINDDOWN_DEADLINE", "2026-12-31T00:00:00Z"),
     windDownRevenueThreshold: optionalEnv("WINDDOWN_REVENUE_THRESHOLD", "10000"),

--- a/config/sepolia.env
+++ b/config/sepolia.env
@@ -128,6 +128,15 @@ export CROWDFUND_OPEN_DELAY=600
 export SECURITY_COUNCIL_ADDRESS=0xf9d211b55bfa4DB270A94BA4fD3e4eDCB8355CA4
 
 # ============================================================================
+# Launch Team (required — must differ from deployer)
+# ============================================================================
+# The launch team issues crowdfund seeds and direct invites during the window.
+# Kept separate from the deployer so the deployer key can be fully retired after
+# deployment without leaving launch-team powers attached to it (issue #218).
+# Set this to the operator-controlled launch-team key before deploying.
+# export LAUNCH_TEAM_ADDRESS=0x...
+
+# ============================================================================
 # WalletConnect Config (required for WalletConnect wallet support on Sepolia)
 # ============================================================================
 # Get a free project ID from https://cloud.walletconnect.com

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -136,10 +136,25 @@ async function main() {
   if (securityCouncilAddress.toLowerCase() === deployer.address.toLowerCase()) {
     throw new Error("Security council address must differ from deployer address");
   }
-  console.log(`   Launch team: ${deployer.address}`);
+  // Launch team: config-driven for non-local (a separate key limits deployer
+  // exposure during the crowdfund window — see issue #218), deployer fallback
+  // for local. When explicitly configured it must differ from the deployer.
+  let launchTeamAddress: string;
+  if (config.launchTeamAddress) {
+    launchTeamAddress = config.launchTeamAddress;
+    rejectAnvilAddresses([launchTeamAddress], "Launch team");
+    if (launchTeamAddress.toLowerCase() === deployer.address.toLowerCase()) {
+      throw new Error("Launch team address must differ from deployer address");
+    }
+  } else if (isLocal()) {
+    launchTeamAddress = deployer.address;
+  } else {
+    throw new Error("LAUNCH_TEAM_ADDRESS is required for non-local deployments");
+  }
+  console.log(`   Launch team: ${launchTeamAddress}`);
   console.log(`   Security council: ${securityCouncilAddress}`);
   const crowdfund = await ArmadaCrowdfund.deploy(
-    usdcAddress, armTokenAddress, treasuryAddress, deployer.address, securityCouncilAddress, openTimestamp, nm.override()
+    usdcAddress, armTokenAddress, treasuryAddress, launchTeamAddress, securityCouncilAddress, openTimestamp, nm.override()
   );
   await crowdfund.deploymentTransaction()!.wait();
   const crowdfundAddress = await crowdfund.getAddress();


### PR DESCRIPTION
Closes #218.

## Problem
`deploy_crowdfund.ts` hardcoded `deployer.address` as the crowdfund launch team. The deployer is a privileged key that is retired post-deploy (removed from the ARM whitelist, governor deployer cleared, timelock admin renounced). Using it as launch team keeps it operationally hot — with seed/invite powers — for the entire crowdfund window.

## Change
- `config/networks.ts` — new `launchTeamAddress` field on `NetworkConfig`, read from `LAUNCH_TEAM_ADDRESS` (mirrors `securityCouncilAddress`).
- `scripts/deploy_crowdfund.ts` — resolve launch team **config-driven for non-local, deployer fallback for local**; reject Anvil keys and reject equality with the deployer when explicitly set; pass it to the constructor.
- `config/sepolia.env` — documented `LAUNCH_TEAM_ADDRESS` template.

## Behavior
- **Local**: unset → falls back to `deployer.address`, byte-identical to prior behavior. `npm run setup` and local tests unaffected.
- **Non-local**: `LAUNCH_TEAM_ADDRESS` is **required** (fail-loud), matching the security council's resolution and this script's "halt on misconfig" posture.

## Operator action required
The next sepolia/mainnet deploy will halt until `LAUNCH_TEAM_ADDRESS` is set in the env. Set it to an operator-controlled key separate from the deployer.

## Testing
Local deploy path is behavior-identical (no logic change for `isLocal()`), so no test impact expected. Run `npm run test:crowdfund` after install / in CI to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)