### PR TITLE
fix(deploy): record contract-creation block as manifest deployBlock

### DIFF
--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -156,9 +156,14 @@ async function main() {
   const crowdfund = await ArmadaCrowdfund.deploy(
     usdcAddress, armTokenAddress, treasuryAddress, launchTeamAddress, securityCouncilAddress, openTimestamp, nm.override()
   );
-  await crowdfund.deploymentTransaction()!.wait();
+  const crowdfundReceipt = await crowdfund.deploymentTransaction()!.wait();
+  // Record the contract-creation block (not an end-of-script block number). The
+  // indexer and frontends backfill events from this block; capturing it here —
+  // before the multi-minute post-deploy wiring runs — ensures early events like
+  // ArmLoaded are not skipped (issue #324).
+  const crowdfundDeployBlock = crowdfundReceipt!.blockNumber;
   const crowdfundAddress = await crowdfund.getAddress();
-  console.log(`   ArmadaCrowdfund: ${crowdfundAddress}`);
+  console.log(`   ArmadaCrowdfund: ${crowdfundAddress} (block ${crowdfundDeployBlock})`);
 
   // 4. Set transfer whitelist (one-shot — must happen before any ARM transfers)
   // Per ARM token spec §5: crowdfund, treasury, revenueLock.
@@ -387,11 +392,10 @@ async function main() {
   console.log("   Renounced TIMELOCK_ADMIN_ROLE from deployer");
 
   // Save deployment
-  const currentBlock = await ethers.provider.getBlockNumber();
   const deployment: CrowdfundDeployment = {
     chainId,
     deployer: deployer.address,
-    deployBlock: currentBlock,
+    deployBlock: crowdfundDeployBlock,
     contracts: {
       armToken: armTokenAddress,
       usdc: usdcAddress,

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -93,9 +93,15 @@ async function main() {
   const timelock = await TimelockController.deploy(
     timelockDelay, [], [], deployer.address, nm.override()
   );
-  await timelock.deploymentTransaction()!.wait();
+  const timelockReceipt = await timelock.deploymentTransaction()!.wait();
+  // Record the creation block of the first contract deployed in this script. The
+  // governance manifest covers many contracts; using the earliest creation block
+  // as the manifest deployBlock guarantees event backfill starts before any
+  // governance contract's first event, rather than at an end-of-script block
+  // number tens of blocks past contract creation (issue #324).
+  const governanceDeployBlock = timelockReceipt!.blockNumber;
   const timelockAddress = await timelock.getAddress();
-  console.log(`   TimelockController: ${timelockAddress}`);
+  console.log(`   TimelockController: ${timelockAddress} (block ${governanceDeployBlock})`);
 
   // 2. Deploy ArmadaToken (needs timelock address for addToWhitelist gating)
   console.log("2. Deploying ArmadaToken...");
@@ -326,11 +332,10 @@ async function main() {
   console.log("15-16. Wind-down wiring + admin renounce: DEFERRED (completed by deploy_crowdfund.ts)");
 
   // Save deployment
-  const currentBlock = await ethers.provider.getBlockNumber();
   const deployment: GovernanceDeployment = {
     chainId,
     deployer: deployer.address,
-    deployBlock: currentBlock,
+    deployBlock: governanceDeployBlock,
     contracts: {
       timelockController: timelockAddress,
       armToken: armTokenAddress,

--- a/scripts/deploy_revenue_lock_cohort.ts
+++ b/scripts/deploy_revenue_lock_cohort.ts
@@ -148,9 +148,12 @@ async function main() {
     amountArray,
     nm.override(),
   );
-  await lock.deploymentTransaction()!.wait();
+  const lockReceipt = await lock.deploymentTransaction()!.wait();
+  // Record the contract-creation block (not an end-of-script block number) so
+  // event backfill starts at the RevenueLock's first block (issue #324).
+  const lockDeployBlock = lockReceipt!.blockNumber;
   const lockAddress = await lock.getAddress();
-  console.log(`  RevenueLock deployed: ${lockAddress}`);
+  console.log(`  RevenueLock deployed: ${lockAddress} (block ${lockDeployBlock})`);
 
   // Verify read-back
   const onchainTotal = await lock.totalAllocation();
@@ -161,11 +164,10 @@ async function main() {
   }
 
   // Save manifest
-  const currentBlock = await ethers.provider.getBlockNumber();
   const manifest: CohortDeployment = {
     chainId,
     deployer: deployer.address,
-    deployBlock: currentBlock,
+    deployBlock: lockDeployBlock,
     cohortName,
     contracts: {
       revenueLock: lockAddress,


### PR DESCRIPTION
Closes #324.

## Problem
`deploy_crowdfund.ts`, `deploy_governance.ts`, and `deploy_revenue_lock_cohort.ts` set the manifest `deployBlock` to `getBlockNumber()` at the **end** of the script. The script runs for minutes after contract creation (post-deploy wiring + timelock round-trips), so the recorded block lands tens of blocks past actual creation — and past early events like `ArmLoaded`. The indexer and frontends use `deployBlock` as their event-backfill start, so those early events get silently skipped (surfaced on medi3-Sepolia: A1 alert never fired, ~30 min to diagnose).

## Change
Capture the creation block from the deployment receipt (`receipt.blockNumber`), mirroring the existing pattern in `deploy_privacy_pool.ts`:
- **crowdfund** — the crowdfund contract's creation block.
- **governance** — the first contract deployed (TimelockController). The manifest spans many contracts; the earliest creation block guarantees backfill starts before any governance event.
- **revenue-lock cohort** — the RevenueLock's creation block (same bug, folded in).

Removed the now-unused end-of-script `getBlockNumber()` call in each.

## Side effects
- New value is strictly **lower** than before — consumers use `deployBlock` only as a backfill start, so this can only capture more, never miss; events are keyed by tx/log identity (no double-apply), and nothing exists before creation. Cost is a few dozen empty blocks scanned.
- **Existing committed manifests are not retroactively changed** — this only affects future deploys. The medi* instances in `armada-deployments` are likewise untouched.
- No orphaned imports; no test asserts on these scripts' `deployBlock`.

## Testing
`node_modules` wasn't available in the workspace, so no local `tsc`/test run — the change is a localized, type-safe mirror of the privacy-pool pattern. Please confirm via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)