### PR TITLE
feat(deploy): mainnet timelock bootstrap mechanics

### DIFF
--- a/config/mainnet.env
+++ b/config/mainnet.env
@@ -94,9 +94,19 @@ export VITE_IRIS_ATTESTATION_BASE_URL=https://iris-api.circle.com/attestations
 # Governance Config
 # ============================================================================
 # Production timelock delay: 2 days (= the Governor's MIN_EXECUTION_DELAY / updateDelay cap).
-# NOTE: the #347 bootstrap profile will deploy at delay 0 and raise to this value as the
-# final timelock op. Until that profile lands, this real delay is used directly.
+# With HARDEN_TIMELOCK on (below), the timelock is deployed at delay 0 and raised to this
+# value as the final bootstrap op (issue #347). This is the post-bootstrap target delay.
 export TIMELOCK_DELAY=172800
+
+# Timelock harden profile (issue #347): deploy at delay 0, deployer temporarily holds
+# PROPOSER/EXECUTOR/CANCELLER to bootstrap all timelock-only wiring, raise the delay to
+# TIMELOCK_DELAY, then renounce every deployer timelock role. Defaults to true on mainnet;
+# set explicitly here for clarity.
+export HARDEN_TIMELOCK=true
+
+# Treasury outflow limits (#348): applied at deploy via initOutflowConfig. The per-token
+# defaults in config/networks.ts are PLACEHOLDERS — override before launch via, e.g.,
+# OUTFLOW_USDC_ABSOLUTE / OUTFLOW_USDC_BPS / OUTFLOW_USDC_WINDOW (and ARM_/ETH_ variants).
 
 # ============================================================================
 # ARM Token Distribution (12M total) — protocol constants, set explicitly

--- a/config/networks.ts
+++ b/config/networks.ts
@@ -44,6 +44,18 @@ export interface RevenueLockBeneficiary {
   label: string;   // human-readable label for deploy logs
 }
 
+/** Treasury per-token outflow rate-limit parameters (ArmadaTreasuryGov.initOutflowConfig). */
+export interface OutflowParams {
+  /** Rolling window length in seconds (must be >= 1 day). */
+  windowDuration: number;
+  /** Per-window limit as basis points of treasury balance (1..10000). */
+  limitBps: number;
+  /** Absolute per-window cap, in the token's smallest unit. */
+  limitAbsolute: string;
+  /** Immutable minimum the absolute cap can never be reduced below, smallest unit. */
+  floorAbsolute: string;
+}
+
 export interface NetworkConfig {
   env: DeployEnv;
   cctpMode: CCTPMode;
@@ -105,6 +117,22 @@ export interface NetworkConfig {
   windDownRevenueThreshold: string;
   /** CCTP finality mode: "fast" (confirmed, ~8-20s) or "standard" (finalized, ~15-19min) */
   cctpFinalityMode: "fast" | "standard";
+  /**
+   * Timelock harden profile. When true, the deploy bootstraps timelock-only wiring
+   * itself — deploy the timelock with minDelay 0, temporarily grant the deployer
+   * PROPOSER/EXECUTOR/CANCELLER, run all timelock-only setup, raise the delay to its
+   * production value, then renounce all deployer timelock roles. Used for mainnet (and
+   * the Sepolia production-like dry-run, #319). Defaults to true on mainnet, false
+   * elsewhere. See issue #347.
+   */
+  hardenTimelock: boolean;
+  /**
+   * Treasury outflow rate-limit config per token, applied at deploy via
+   * initOutflowConfig so the treasury is protected from launch rather than via a
+   * fragile first governance vote. PLACEHOLDER values — issue #348 tracks the
+   * finalized numbers. Amounts are in each token's smallest unit (USDC 6dp, ARM/ETH 18dp).
+   */
+  outflowConfig: { usdc: OutflowParams; arm: OutflowParams; eth: OutflowParams };
 }
 
 // ============================================================================
@@ -126,6 +154,12 @@ function optionalEnv(key: string, defaultValue: string): string {
 function numEnv(key: string, defaultValue: number): number {
   const value = process.env[key];
   return value ? parseInt(value, 10) : defaultValue;
+}
+
+function boolEnv(key: string, defaultValue: boolean): boolean {
+  const value = process.env[key];
+  if (value === undefined || value === "") return defaultValue;
+  return value === "true" || value === "1";
 }
 
 // ============================================================================
@@ -305,6 +339,31 @@ export function getNetworkConfig(): NetworkConfig {
     windDownDeadline: optionalEnv("WINDDOWN_DEADLINE", "2026-12-31T00:00:00Z"),
     windDownRevenueThreshold: optionalEnv("WINDDOWN_REVENUE_THRESHOLD", "10000"),
     cctpFinalityMode: optionalEnv("CCTP_FINALITY_MODE", "fast") as "fast" | "standard",
+    // Default on for mainnet (safe — can't forget to harden), opt-in elsewhere
+    // (the Sepolia dry-run sets HARDEN_TIMELOCK=true to rehearse the mainnet path).
+    hardenTimelock: boolEnv("HARDEN_TIMELOCK", env === "mainnet"),
+    // PLACEHOLDER outflow limits (#348). Env-overridable per token. Defaults: 1-day
+    // window, 20% of balance, with a generous absolute cap and no immutable floor.
+    outflowConfig: {
+      usdc: {
+        windowDuration: numEnv("OUTFLOW_USDC_WINDOW", 86400),
+        limitBps: numEnv("OUTFLOW_USDC_BPS", 2000),
+        limitAbsolute: optionalEnv("OUTFLOW_USDC_ABSOLUTE", "100000000000"),            // 100,000 USDC (6dp)
+        floorAbsolute: optionalEnv("OUTFLOW_USDC_FLOOR", "0"),
+      },
+      arm: {
+        windowDuration: numEnv("OUTFLOW_ARM_WINDOW", 86400),
+        limitBps: numEnv("OUTFLOW_ARM_BPS", 2000),
+        limitAbsolute: optionalEnv("OUTFLOW_ARM_ABSOLUTE", "500000000000000000000000"), // 500,000 ARM (18dp)
+        floorAbsolute: optionalEnv("OUTFLOW_ARM_FLOOR", "0"),
+      },
+      eth: {
+        windowDuration: numEnv("OUTFLOW_ETH_WINDOW", 86400),
+        limitBps: numEnv("OUTFLOW_ETH_BPS", 2000),
+        limitAbsolute: optionalEnv("OUTFLOW_ETH_ABSOLUTE", "100000000000000000000"),    // 100 ETH (18dp)
+        floorAbsolute: optionalEnv("OUTFLOW_ETH_FLOOR", "0"),
+      },
+    },
   };
 
   return _cachedConfig;

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -377,6 +377,39 @@ async function main() {
     await timelockCall(timelockAddress, call.target, call.calldata, `${call.label}.setWindDownContract()`, nm);
   }
 
+  // 12b. Initialize treasury outflow rate limits (timelock-only). Done at deploy so
+  // the treasury is rate-limited from launch rather than via a fragile first
+  // governance vote. PLACEHOLDER limits — see config.outflowConfig / issue #348.
+  console.log("12b. Initializing treasury outflow limits...");
+  const outflowTokens = [
+    { token: usdcAddress, params: config.outflowConfig.usdc, label: "USDC" },
+    { token: armTokenAddress, params: config.outflowConfig.arm, label: "ARM" },
+    { token: ethers.ZeroAddress, params: config.outflowConfig.eth, label: "ETH" },
+  ];
+  for (const t of outflowTokens) {
+    const calldata = treasury.interface.encodeFunctionData("initOutflowConfig", [
+      t.token, t.params.windowDuration, t.params.limitBps, t.params.limitAbsolute, t.params.floorAbsolute,
+    ]);
+    await timelockCall(timelockAddress, treasuryAddress, calldata, `treasury.initOutflowConfig(${t.label})`, nm);
+  }
+
+  // 12c. Harden: raise the timelock delay to its production value as the FINAL
+  // timelock op. The deploy ran the timelock at minDelay 0 so the bootstrap ops above
+  // executed instantly; after this the real delay is in force (issue #347).
+  //
+  // ORDERING INVARIANT: in a hardened run this script must be the LAST one to perform
+  // any timelock-only op. Step 14 below renounces the deployer's PROPOSER/EXECUTOR
+  // roles, so any later timelock-only wiring (e.g. fee-module setFeeCollector, adapter
+  // authorizeAdapter in the shielded-pool deploy) would revert. The mainnet orchestrator
+  // enforces crowdfund-last ordering for hardened runs; do not harden a full multi-phase
+  // deploy that wires the shielded pool after the crowdfund.
+  const timelock = await ethers.getContractAt("TimelockController", timelockAddress);
+  if (config.hardenTimelock) {
+    console.log(`12c. Raising timelock delay to ${config.timelockDelay}s (harden)...`);
+    const updateDelayCalldata = timelock.interface.encodeFunctionData("updateDelay", [config.timelockDelay]);
+    await timelockCall(timelockAddress, timelockAddress, updateDelayCalldata, "timelock.updateDelay(production)", nm);
+  }
+
   // 13. Update governance manifest with redemption/windDown addresses
   console.log("13. Updating governance manifest...");
   govDeployment.contracts.redemption = redemptionAddress;
@@ -384,9 +417,19 @@ async function main() {
   saveDeployment(govFilename, govDeployment);
   console.log(`   Updated ${govFilename} with redemption + windDown addresses`);
 
-  // 14. Renounce timelock admin (final action — all deployment wiring complete)
-  console.log("14. Renouncing timelock admin...");
-  const timelock = await ethers.getContractAt("TimelockController", timelockAddress);
+  // 14. Renounce deployer timelock roles (final action — all wiring complete).
+  console.log("14. Renouncing timelock roles...");
+  if (config.hardenTimelock) {
+    // Harden: the deployer temporarily held the ops roles to bootstrap timelock-only
+    // wiring above; drop them so no key retains timelock power post-deploy (issue #347).
+    const PROPOSER_ROLE = await timelock.PROPOSER_ROLE();
+    const EXECUTOR_ROLE = await timelock.EXECUTOR_ROLE();
+    const CANCELLER_ROLE = await timelock.CANCELLER_ROLE();
+    await (await timelock.renounceRole(PROPOSER_ROLE, deployer.address, nm.override())).wait();
+    await (await timelock.renounceRole(EXECUTOR_ROLE, deployer.address, nm.override())).wait();
+    await (await timelock.renounceRole(CANCELLER_ROLE, deployer.address, nm.override())).wait();
+    console.log("   Renounced PROPOSER/EXECUTOR/CANCELLER from deployer");
+  }
   const ADMIN_ROLE = await timelock.TIMELOCK_ADMIN_ROLE();
   await (await timelock.renounceRole(ADMIN_ROLE, deployer.address, nm.override())).wait();
   console.log("   Renounced TIMELOCK_ADMIN_ROLE from deployer");

--- a/scripts/deploy_governance.ts
+++ b/scripts/deploy_governance.ts
@@ -88,10 +88,15 @@ async function main() {
   console.log("");
 
   // 1. Deploy TimelockController (needed before ArmadaToken for timelock address)
+  // When hardening (mainnet / sepolia dry-run), deploy at minDelay 0 so the deployer
+  // can run all timelock-only bootstrap ops instantly; deploy_crowdfund raises the
+  // delay to timelockDelay as the final op before renouncing (issue #347).
+  const constructorDelay = config.hardenTimelock ? 0 : timelockDelay;
   console.log("1. Deploying TimelockController...");
+  console.log(`   Initial minDelay: ${constructorDelay}s${config.hardenTimelock ? ` (harden — raised to ${timelockDelay}s post-bootstrap)` : ""}`);
   const TimelockController = await ethers.getContractFactory("TimelockController");
   const timelock = await TimelockController.deploy(
-    timelockDelay, [], [], deployer.address, nm.override()
+    constructorDelay, [], [], deployer.address, nm.override()
   );
   const timelockReceipt = await timelock.deploymentTransaction()!.wait();
   // Record the creation block of the first contract deployed in this script. The
@@ -277,15 +282,19 @@ async function main() {
   await (await timelock.grantRole(CANCELLER_ROLE, governorAddress, nm.override())).wait();
   console.log("   Granted CANCELLER_ROLE to governor (for SC veto)");
 
-  // Testnet only: grant the deployer the operational roles so the deploy + post-deploy ops
-  // pipeline (e.g. authorizing the YieldAdapter via AdapterRegistry) can schedule + execute
-  // timelock actions. The Governor is unusable for ops on testnet (requires ARM tokens,
-  // proposal threshold, quorum, voting period). Anvil covers this via impersonation; mainnet
-  // must NEVER take this branch — adding a mainnet value to DeployEnv must NOT silently
-  // grant operator roles to the deployer. The explicit allowlist below makes that invariant
-  // unmissable. Any future testnet env (goerli, holesky, base-sepolia-hub, …) is opt-in.
+  // Grant the deployer the operational roles (PROPOSER/EXECUTOR/CANCELLER) so the
+  // deploy can drive timelock-only setup directly. Two cases:
+  //   - Testnet ops envs (sepolia): granted and KEPT — the Governor is unusable for
+  //     ops on testnet (needs ARM/quorum/voting), so the deployer stays able to run
+  //     timelock actions post-deploy.
+  //   - Harden envs (mainnet, and the sepolia dry-run): granted TEMPORARILY to
+  //     bootstrap launch wiring, then renounced at the end of deploy_crowdfund so no
+  //     key retains timelock power (issue #347).
+  // A mainnet value in DeployEnv does NOT by itself take this branch — only the
+  // explicit hardenTimelock profile (or the testnet allowlist) does.
   const TESTNET_OPS_ENVS: ReadonlyArray<string> = ["sepolia"];
-  if (TESTNET_OPS_ENVS.includes(config.env)) {
+  const grantDeployerOps = TESTNET_OPS_ENVS.includes(config.env) || config.hardenTimelock;
+  if (grantDeployerOps) {
     const [deployerSigner] = await ethers.getSigners();
     await (await timelock.grantRole(PROPOSER_ROLE, deployerSigner.address, nm.override())).wait();
     console.log(`   Granted PROPOSER_ROLE to deployer (${config.env} ops)`);


### PR DESCRIPTION
Implements the core of #347 — the timelock bootstrap *mechanics*. The mainnet orchestrator is a focused follow-up (see below).

## What
A `hardenTimelock` deploy profile (`HARDEN_TIMELOCK`, default on for mainnet, opt-in elsewhere) that lets the deploy bootstrap all timelock-only wiring itself, then hand off cleanly — no community governance vote required at launch (quorum is unreachable at a base-only sale; see #347).

- **`config/networks.ts`**: `hardenTimelock` flag (`boolEnv`) + per-token treasury `outflowConfig` (PLACEHOLDER values, env-overridable, #348).
- **`deploy_governance.ts`**: when hardening, construct the timelock at `minDelay = 0`; extend the deployer role-grant to harden envs (granted temporarily, vs. kept on testnet ops envs).
- **`deploy_crowdfund.ts`**:
  - 12b — `initOutflowConfig` for USDC/ARM/ETH (all envs; protects the treasury from launch instead of via a fragile first vote).
  - 12c — (harden) raise `updateDelay` to the production value as the **final** timelock op.
  - 14 — (harden) renounce the deployer's PROPOSER/EXECUTOR/CANCELLER, then ADMIN.
- **`config/mainnet.env`**: `HARDEN_TIMELOCK=true` + outflow-placeholder docs.

## Why delay-0→raise
`TimelockController.updateDelay` is `msg.sender == address(this)` (verified, OZ 4.9.6) — it must be scheduled+executed via the timelock. Deploying at `minDelay 0` lets every bootstrap op (wind-down trio, outflow, the delay-raise itself) execute instantly in one run; the raise is last, then roles are renounced (renounce is a direct call, unaffected by the new delay).

## Ordering invariant (documented in code)
In a hardened run, `deploy_crowdfund` must be the **last** script to do any timelock-only op — it renounces the deployer's roles, so later timelock-only wiring (shielded-pool fee/adapter) would revert. The mainnet orchestrator will enforce crowdfund-last; **do not harden a full multi-phase deploy**.

## Scope / follow-up
- **In scope (this PR):** the bootstrap mechanics for the crowdfund-launch sequence (governance + crowdfund), which is #347's scope.
- **Follow-up issue:** the mainnet orchestrator (CCTP-record → governance → crowdfund, crowdfund-last) + the #319 dry-run mechanism + CCTP-record handling. Tracked separately.

## Testing
- Type-clean (changed files); config resolves across envs; **ABI encodes verified** (`initOutflowConfig` `0x74f53e99`, `updateDelay` `0x64d62353`, role getters present); contracts compile.
- The harden path is a **non-local** code path (local `timelockCall` impersonates), so end-to-end validation is the **Sepolia production-like dry-run (#319)** / mainnet-fork — not yet run. Flagging so this isn't mistaken for end-to-end tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)