### PR TITLE
fix(committer): revert-copy mismatches, tx confirmations, claim timeout, invite URL scrub

### DIFF
--- a/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.test.tsx
+++ b/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.test.tsx
@@ -8,7 +8,7 @@ import { createElement, type ReactElement, type ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { JsonRpcProvider } from 'ethers'
 import { ClaimFlowV2, type ClaimFlowV2Props } from './ClaimFlowV2'
-import { clearClaimInFlight } from '@/lib/claimInFlight'
+import { clearClaimInFlight, setClaimInFlight } from '@/lib/claimInFlight'
 import { clearPendingTxs } from '@/lib/pendingTx'
 
 // ClaimFlowV2 reads via react-query — each render gets a fresh client so query
@@ -227,6 +227,30 @@ describe('ClaimFlowV2 read semantics', () => {
     // Phase 2 → refund mode; with no committed USDC, the nothing-to-claim screen.
     expect(await screen.findByText('No refund to claim.')).toBeTruthy()
     expect(alloc).not.toHaveBeenCalled()
+  })
+})
+
+describe('ClaimFlowV2 in-flight watcher', () => {
+  it('surfaces a "still pending" row (not a stuck spinner) when the receipt wait times out', async () => {
+    // Reconstruct an in-flight claim from a persisted marker, then have the read
+    // provider's waitForTransaction reject with an ethers v6 TIMEOUT (its real
+    // timeout semantics — it rejects, it does not resolve null).
+    setClaimInFlight({ hash: '0xpending', mode: 'arm', address: ADDR_A, sentAt: 1 })
+    // Non-zero allocation so the flow lands on the reconstructed submit step
+    // rather than the zero-allocation "nothing to claim" screen.
+    allocationFor = () => Promise.resolve([1_000_000_000_000_000_000n, 0n])
+    const waitForTransaction = vi.fn().mockRejectedValue({ code: 'TIMEOUT', message: 'timeout' })
+    const provider = { waitForTransaction } as unknown as JsonRpcProvider
+
+    renderClaim(<ClaimFlowV2 {...baseProps} provider={provider} walletAddress={ADDR_A} />)
+
+    // The timeout must land on an actionable "still pending" error, not leave the
+    // user parked on "Submitting…" forever.
+    expect(
+      await screen.findByText(/Still pending — it may still confirm/),
+    ).toBeTruthy()
+    // Confirmations + timeout are threaded to the wait call.
+    expect(waitForTransaction).toHaveBeenCalledWith('0xpending', expect.any(Number), expect.any(Number))
   })
 })
 

--- a/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.tsx
+++ b/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.tsx
@@ -24,11 +24,11 @@ import { InformationCircleIcon } from '@heroicons/react/24/solid'
 import { sendAndWaitTx } from '@/lib/sendAndWaitTx'
 import { savePendingTx, removePendingTx } from '@/lib/pendingTx'
 import { setClaimInFlight, getClaimInFlight, clearClaimInFlight } from '@/lib/claimInFlight'
-import { TX_WAIT_TIMEOUT_MS } from '@/lib/txWait'
+import { TX_WAIT_TIMEOUT_MS, isTxTimeoutError } from '@/lib/txWait'
 import { resolveSigner, describeSignerError } from '@/lib/resolveSigner'
 import { isMobileBrowser } from '@/lib/isMobileBrowser'
 import { submitTxViaWagmi } from '@/lib/mobileTxSubmit'
-import { getExplorerUrl, getHubChainId } from '@/config/network'
+import { getExplorerUrl, getHubChainId, getTxConfirmations } from '@/config/network'
 import { useBeforeUnloadGuard } from '@/hooks/useBeforeUnloadGuard'
 import { getHubNetworkLabel } from '@/config/network'
 import styles from './ClaimFlowV2.module.css'
@@ -170,7 +170,7 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
     const opLabel = marker.mode === 'arm' ? 'Claim ARM' : 'Claim USDC refund'
     const explorerUrl = getExplorerUrl()
     provider
-      .waitForTransaction(marker.hash, 1, TX_WAIT_TIMEOUT_MS)
+      .waitForTransaction(marker.hash, getTxConfirmations(), TX_WAIT_TIMEOUT_MS)
       .then((receipt) => {
         if (watchCancelled) return
         if (receipt && receipt.status === 1) {
@@ -181,24 +181,37 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
           setStep('done')
           return
         }
-        // status 0 = reverted; null = our wait window elapsed (still pending).
-        // Surface an actionable error state instead of a perpetual "Submitting…";
-        // the marker stays until Back/Retry acknowledges it.
-        const reverted = !!receipt && receipt.status === 0
+        // status 0 = reverted. A wait-window timeout does NOT resolve here — ethers
+        // v6 rejects it with a TIMEOUT error (handled in .catch below) rather than
+        // resolving null. Surface an actionable error instead of a perpetual
+        // "Submitting…"; the marker stays until Back/Retry acknowledges it.
         setTxs([
           {
             label: opLabel,
             status: 'error',
-            errorMessage: reverted
-              ? 'Transaction reverted.'
-              : 'Still pending — it may still confirm. Check the explorer or retry.',
+            errorMessage: 'Transaction reverted.',
             hash: marker.hash,
             explorerUrl,
           },
         ])
       })
-      .catch(() => {
-        // Transient RPC failure — leave the submitting state; a later mount re-watches.
+      .catch((err) => {
+        if (watchCancelled) return
+        // ethers v6 rejects a `waitForTransaction` timeout with code 'TIMEOUT'. The
+        // tx may still confirm later, so show a "still pending" error row instead of
+        // stranding the user on "Submitting…". Any other rejection is a transient RPC
+        // failure — leave the submitting state and let a later mount re-watch.
+        if (isTxTimeoutError(err)) {
+          setTxs([
+            {
+              label: opLabel,
+              status: 'error',
+              errorMessage: 'Still pending — it may still confirm. Check the explorer or retry.',
+              hash: marker.hash,
+              explorerUrl,
+            },
+          ])
+        }
       })
     return () => {
       watchCancelled = true

--- a/crowdfund-ui/packages/committer/src/components/InviteLandingPage.test.tsx
+++ b/crowdfund-ui/packages/committer/src/components/InviteLandingPage.test.tsx
@@ -1,10 +1,25 @@
 // ABOUTME: Tests for the /invite landing page footer — "Not ready to participate yet?" nav + social links.
 // ABOUTME: Uses the malformed-link branch so the on-chain pre-check (deployment/provider) never runs.
 
-import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
-import { describe, it, expect } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
 import { InviteLandingPage } from './InviteLandingPage'
+
+// A valid-format invite link reaches the on-chain pre-check, which awaits
+// loadDeployment() first — rejecting it short-circuits the pre-check silently
+// (it's caught) so no network I/O runs in the test. The URL-scrub effect is
+// independent of the pre-check, so it still fires.
+vi.mock('@/config/deployments', () => ({
+  loadDeployment: () => Promise.reject(new Error('no network in test')),
+}))
+
+// Surfaces the current router location's query string so a test can assert the
+// signed invite params were scrubbed out of the URL.
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="location-search">{location.search}</div>
+}
 
 describe('InviteLandingPage footer', () => {
   it('shows the "not ready" nav + social links on a malformed invite link', () => {
@@ -25,5 +40,26 @@ describe('InviteLandingPage footer', () => {
     const x = screen.getByRole('link', { name: 'Armada on X' })
     expect(x).toHaveAttribute('href', 'https://x.com/ship_armada')
     expect(x).toHaveAttribute('target', '_blank')
+  })
+})
+
+describe('InviteLandingPage URL scrub', () => {
+  it('strips the signed invite params from the URL after capturing them', async () => {
+    // Valid-format link: EIP-55 checksummed inviter + canonical 65-byte sig.
+    const inviter = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
+    const sig = '0x' + '1'.repeat(130)
+    const link = `/invite?inviter=${inviter}&fromHop=0&nonce=1&deadline=9999999999&sig=${sig}`
+
+    render(
+      <MemoryRouter initialEntries={[link]}>
+        <InviteLandingPage />
+        <LocationProbe />
+      </MemoryRouter>,
+    )
+
+    // The bearer signature must not linger in the address bar / history entry.
+    await waitFor(() =>
+      expect(screen.getByTestId('location-search').textContent).toBe(''),
+    )
   })
 })

--- a/crowdfund-ui/packages/committer/src/components/InviteLandingPage.tsx
+++ b/crowdfund-ui/packages/committer/src/components/InviteLandingPage.tsx
@@ -49,7 +49,7 @@ function parseHopVariant(fromHop: number): HopVariant {
 }
 
 export function InviteLandingPage() {
-  const [searchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
   const [joined, setJoined] = useState(false)
   const [preCheckError, setPreCheckError] = useState<PreCheckError | null>(null)
@@ -61,10 +61,20 @@ export function InviteLandingPage() {
   const [windowEndSec, setWindowEndSec] = useState<number | null>(null)
   const [blockTimestampSec, setBlockTimestampSec] = useState<number | null>(null)
 
-  const inviteData = useMemo<InviteLinkData | null>(
-    () => decodeInviteUrl(searchParams),
-    [searchParams],
-  )
+  // Capture the invite once, on mount, so the flow no longer depends on the query
+  // string — that lets the effect below strip the signed link out of the URL
+  // without tearing the landing card / commit flow down.
+  const [inviteData] = useState<InviteLinkData | null>(() => decodeInviteUrl(searchParams))
+
+  // The invite signature is a single-use bearer credential (the invitee isn't
+  // bound in the signed struct), so an un-redeemed link left in the address bar or
+  // browser history is a live token on a shared or synced machine. Once it's been
+  // captured above, scrub the query params from the URL. `inviteData` is held in
+  // state, so the InviteLinkFlowController (which reads its props, not the URL)
+  // keeps working after the query is gone.
+  useEffect(() => {
+    if (inviteData) setSearchParams(new URLSearchParams(), { replace: true })
+  }, [inviteData, setSearchParams])
 
   const hopVariant = useMemo(
     () => (inviteData ? parseHopVariant(inviteData.fromHop) : 'hop-1'),

--- a/crowdfund-ui/packages/committer/src/hooks/usePendingTxWatcher.test.ts
+++ b/crowdfund-ui/packages/committer/src/hooks/usePendingTxWatcher.test.ts
@@ -42,6 +42,19 @@ describe('usePendingTxWatcher', () => {
     expect(onResolved).toHaveBeenCalledWith(HASH, 'confirmed', 'Commit participation')
   })
 
+  it('waits with the configured confirmation count (reorg safety)', async () => {
+    seed()
+    const waitForTransaction = vi.fn().mockResolvedValue({ status: 1 })
+    const provider = makeProvider(waitForTransaction)
+
+    const { result } = renderHook(() => usePendingTxWatcher(provider, CHAIN, undefined))
+
+    await waitFor(() => expect(result.current[0]?.status).toBe('confirmed'))
+    // Confirmations are threaded through (not left to ethers' default of 1) so a
+    // mainnet build can require >1 confirmation before treating a tx as landed.
+    expect(waitForTransaction).toHaveBeenCalledWith(HASH, expect.any(Number))
+  })
+
   it('marks a reverted tx as failed and clears it', async () => {
     seed()
     const provider = makeProvider(vi.fn().mockResolvedValue({ status: 0 }))

--- a/crowdfund-ui/packages/committer/src/hooks/usePendingTxWatcher.ts
+++ b/crowdfund-ui/packages/committer/src/hooks/usePendingTxWatcher.ts
@@ -4,6 +4,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { JsonRpcProvider } from 'ethers'
 import { loadPendingTxs, removePendingTx, PENDING_TX_EVENT } from '@/lib/pendingTx'
+import { getTxConfirmations } from '@/config/network'
 
 export type WatchedTxStatus = 'pending' | 'confirmed' | 'failed'
 
@@ -58,7 +59,7 @@ export function usePendingTxWatcher(
         if (watchingRef.current.has(t.txHash)) continue
         watchingRef.current.add(t.txHash)
         provider
-          .waitForTransaction(t.txHash)
+          .waitForTransaction(t.txHash, getTxConfirmations())
           .then((receipt) => {
             if (cancelled) return
             const status: WatchedTxStatus = receipt && receipt.status === 1 ? 'confirmed' : 'failed'

--- a/crowdfund-ui/packages/committer/src/lib/revertMessages.test.ts
+++ b/crowdfund-ui/packages/committer/src/lib/revertMessages.test.ts
@@ -37,12 +37,35 @@ describe('mapRevertToMessage', () => {
     expect(mapRevertToMessage(new Error('claim expired'))).toBe('The 3-year claim deadline has passed.')
   })
 
-  it('maps refundMode', () => {
-    expect(mapRevertToMessage(new Error('refundMode'))).toBe('No ARM allocations (refund mode). Use Claim Refund instead.')
+  it('maps the contract "sale in refund mode" string', () => {
+    expect(mapRevertToMessage(new Error('ArmadaCrowdfund: sale in refund mode'))).toBe(
+      'No ARM allocations (refund mode). Use Claim Refund instead.',
+    )
   })
 
   it('maps invalid signature', () => {
     expect(mapRevertToMessage(new Error('invalid signature'))).toBe('This invite link has an invalid signature.')
+  })
+
+  it('maps the contract "invalid invite signature" string', () => {
+    expect(mapRevertToMessage(new Error('ArmadaCrowdfund: invalid invite signature'))).toBe(
+      'This invite link has an invalid signature.',
+    )
+  })
+
+  it('maps max invites received', () => {
+    expect(mapRevertToMessage(new Error('ArmadaCrowdfund: max invites received'))).toBe(
+      "You've already accepted the maximum number of invites for this hop.",
+    )
+  })
+
+  it('maps "not active window" without being shadowed by "not active"', () => {
+    expect(mapRevertToMessage(new Error('ArmadaCrowdfund: not active window'))).toBe(
+      'Commitment window is not open.',
+    )
+    expect(mapRevertToMessage(new Error('ArmadaCrowdfund: not active'))).toBe(
+      'Crowdfund is not in the active phase.',
+    )
   })
 
   it('maps nonce consumed', () => {

--- a/crowdfund-ui/packages/committer/src/lib/revertMessages.ts
+++ b/crowdfund-ui/packages/committer/src/lib/revertMessages.ts
@@ -9,15 +9,17 @@ const REVERT_MAP: [RegExp, string][] = [
   [/cancelled/i, 'This crowdfund has been cancelled.'],
   [/already finalized/i, 'This crowdfund has already been finalized.'],
   [/ARM not loaded/i, 'The crowdfund has not opened yet.'],
-  [/not active/i, 'Crowdfund is not in the active phase.'],
+  // `not active window` must precede `not active` — the latter is a substring of
+  // the former, so the general pattern would otherwise shadow the window-specific one.
   [/not active window/i, 'Commitment window is not open.'],
+  [/not active/i, 'Crowdfund is not in the active phase.'],
   [/below minimum/i, 'Amount is below the minimum commitment.'],
   [/not whitelisted/i, 'You are not invited to this hop level.'],
   [/invalid hop/i, 'You are not invited to this hop level.'],
   [/already claimed/i, 'You have already claimed this.'],
   [/claim expired/i, 'The 3-year claim deadline has passed.'],
-  [/refundMode/i, 'No ARM allocations (refund mode). Use Claim Refund instead.'],
-  [/invalid signature/i, 'This invite link has an invalid signature.'],
+  [/refund mode/i, 'No ARM allocations (refund mode). Use Claim Refund instead.'],
+  [/invalid( invite)? signature/i, 'This invite link has an invalid signature.'],
   [/nonce already used/i, 'This invite link has already been used.'],
   [/nonce consumed/i, 'This invite link has already been used.'],
   [/nonce revoked/i, 'This invite link has been revoked.'],
@@ -28,6 +30,7 @@ const REVERT_MAP: [RegExp, string][] = [
   [/invite expired/i, 'This invite link has expired.'],
   [/invite limit reached/i, 'The inviter has no remaining invite slots.'],
   [/already whitelisted/i, 'This address is already invited.'],
+  [/max invites received/i, "You've already accepted the maximum number of invites for this hop."],
   [/max hop reached/i, 'You are already at the deepest hop level.'],
   // OpenZeppelin ERC20 (USDC) revert strings.
   [/insufficient allowance/i, 'USDC approval is too low — approve and retry.'],


### PR DESCRIPTION
Batches four low-risk, self-contained fixes surfaced by the pre-mainnet committer review (`.context/COMMITTER_REVIEW_TRIAGE.md`). No changes to the commit/money state machine; each reuses existing helpers or is copy/config only. All 181 committer tests pass; typecheck clean.

### 1. Revert-message mismatches — copy quality (triage #9 + housekeeping)
`revertMessages.ts` had patterns that never matched the real `ArmadaCrowdfund.sol` strings, so users saw generic "Transaction failed" instead of specific copy:
- `/refundMode/` → `/refund mode/` (contract emits `"sale in refund mode"`).
- `/invalid signature/` → `/invalid( invite)? signature/` (contract emits `"invalid invite signature"`; still matches the bare form).
- Reordered `/not active window/` **before** `/not active/` — the latter is a substring and was shadowing the window-specific message.
- Added `/max invites received/` (was unmapped) — an at-cap invitee redemption now gets clear copy instead of a generic-failure retry loop.

Deliberately **kept** the genuinely-unused-but-harmless patterns (`/deadline passed/`, `/nonce consumed/`, etc.). Nothing emits those exact strings, so they cause no *wrong* message; removing them only churns intent-documenting tests for zero functional gain.

### 2. Recovery watchers confirm at the configured depth (triage housekeeping)
`usePendingTxWatcher` and `ClaimFlowV2`'s remount watcher called `waitForTransaction` with ethers' default of 1 confirmation, while `sendAndWaitTx` deliberately uses `getTxConfirmations()` (2 on mainnet) for reorg safety. Threaded `getTxConfirmations()` into both.

### 3. ClaimFlowV2 remount watcher: ethers-v6 timeout handling (triage #6)
The watcher assumed `waitForTransaction(hash, confs, timeout)` resolves `null` on timeout; ethers v6 **rejects** with `code: 'TIMEOUT'`, so the "still pending → retry" branch was dead code and the rejection was swallowed by an empty `.catch()` — parking the user on a permanent "Submitting…" spinner. Now routes the timeout through the existing `isTxTimeoutError` helper (already used correctly by `txWait.ts`/`sendAndWaitTx`) to show an actionable "still pending" row. No funds at risk (on-chain `claimed` guard); this only fixes the stuck-spinner UX.

### 4. Scrub the invite signature from the URL after capture (triage #8)
The single-use bearer invite signature (invitee not bound in the signed struct) lingered in `location.search` and browser history with no scrub. `InviteLandingPage` now captures the invite into state once, then `replace`s the query out of the URL. The `InviteLinkFlowController` reads its props (not the URL), so redemption is unaffected. (`Referrer-Policy: no-referrer` is already set in `netlify.toml`, so this closes the address-bar / history-entry residue specifically.)

### Not included / follow-ups
- **Finding #3** (mainnet approval-target addresses fetched from unpinned `armada-deployments@main`) — tracked in #354; blocked on finalized mainnet addresses.
- Findings #1, #2, #4, #5, #7 remain open (money-path state machine, product decision, or claim-gating work) — deferred as deliberate, non-trivial changes.

### Tests
Extended the existing suites for each change: `revertMessages.test.ts` (4 new cases + fixed the now-invalid `refundMode` case), `usePendingTxWatcher.test.ts` (confirmations threaded), `ClaimFlowV2.test.tsx` (timeout → "still pending", not a stuck spinner), `InviteLandingPage.test.tsx` (URL scrubbed after capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
