### PR TITLE
fix(governance): gate windDown setters + assert redemption invariant (security review)

### DIFF
--- a/contracts/governance/RevenueCounter.sol
+++ b/contracts/governance/RevenueCounter.sol
@@ -192,10 +192,10 @@ contract RevenueCounter is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     // ============ Wind-Down ============
 
     /// @notice Register the wind-down contract. One-shot setter; locks after the
-    ///         first non-zero call. Permissionless because the lock + zero-address
-    ///         checks make a misregistration recoverable only via UUPS upgrade.
+    ///         first non-zero call. Owner-only (the owner is the timelock) so it
+    ///         cannot be front-run and bound to a foreign address before wiring.
     /// @param _windDownContract The wind-down contract authorized to call freeze().
-    function setWindDownContract(address _windDownContract) external {
+    function setWindDownContract(address _windDownContract) external onlyOwner {
         require(!windDownContractSet, "RevenueCounter: wind-down already set");
         require(_windDownContract != address(0), "RevenueCounter: zero address");
         windDownContractSet = true;

--- a/contracts/governance/RevenueLock.sol
+++ b/contracts/governance/RevenueLock.sol
@@ -69,6 +69,12 @@ contract RevenueLock {
     ///         See PARAMETER_MANIFEST.md (ship-armada/crowdfund) and issue #225.
     uint256 public immutable MAX_REVENUE_INCREASE_PER_DAY;
 
+    /// @notice Deployer — gates the one-shot windDown setter so it cannot be
+    ///         front-run and permanently bound to a foreign address between this
+    ///         contract's deployment and the deployer wiring it. Mirrors
+    ///         ArmadaToken.tokenDeployer.
+    address public immutable deployer;
+
     // ============ State ============
 
     /// @notice Per-beneficiary total allocation
@@ -173,6 +179,7 @@ contract RevenueLock {
         armToken = IArmadaTokenRevenueLock(_armToken);
         revenueCounter = IRevenueCounterRevenueLock(_revenueCounter);
         MAX_REVENUE_INCREASE_PER_DAY = _maxIncreasePerDay;
+        deployer = msg.sender;
 
         // CRITICAL: lastSyncTimestamp must start at block.timestamp, NOT 0.
         // A zero timestamp would make the first _updateMaxObservedRevenue() see
@@ -336,8 +343,11 @@ contract RevenueLock {
     // ============ Wind-Down ============
 
     /// @notice Register the wind-down contract. One-shot setter; locks after the
-    ///         first non-zero call. Permissionless (no admin on RevenueLock).
+    ///         first non-zero call. Deployer-only so it cannot be front-run and
+    ///         bound to a foreign address (RevenueLock is immutable — a mis-bind is
+    ///         unrecoverable).
     function setWindDownContract(address _windDownContract) external {
+        require(msg.sender == deployer, "RevenueLock: not deployer");
         require(!windDownContractSet, "RevenueLock: wind-down already set");
         require(_windDownContract != address(0), "RevenueLock: zero windDown");
         windDownContractSet = true;

--- a/scripts/deploy_crowdfund.ts
+++ b/scripts/deploy_crowdfund.ts
@@ -323,6 +323,34 @@ async function main() {
   const redemptionAddress = await redemption.getAddress();
   console.log(`   ArmadaRedemption: ${redemptionAddress}`);
 
+  // 9b. Redemption circulating-supply invariant (deploy-time misconfiguration guard).
+  // ArmadaRedemption.circulatingSupply() subtracts revenueLock.lockedAtWindDown() and the
+  // crowdfund unsold-in-contract from circulatingSupplyOf([treasury, redemption]) — both
+  // UNCLAMPED against the running total (only the inner cfBalance-cfStillOwed is clamped).
+  // If the excluded/locked terms ever exceed the base, every redeem() reverts permanently
+  // and the redemption contract has no admin. This asserts correct parameterization at
+  // go-live (security review). It is boundary-exact at deploy (circulating is legitimately
+  // ~0), so compare with <=. A runtime clamp is deferred to a future contract revision.
+  console.log("9b. Asserting redemption circulating-supply invariant...");
+  const revenueLockView = await ethers.getContractAt("RevenueLock", revenueLockAddress);
+  const circBase = await armToken.circulatingSupplyOf([treasuryAddress, redemptionAddress]);
+  const lockedAtWindDown = await revenueLockView.lockedAtWindDown();
+  const cfBalance = await armToken.balanceOf(crowdfundAddress);
+  const cfStillOwed = await crowdfund.armStillOwed();
+  const cfUnsold = cfStillOwed >= cfBalance ? 0n : cfBalance - cfStillOwed;
+  const excludedSum = lockedAtWindDown + cfUnsold;
+  if (excludedSum > circBase) {
+    throw new Error(
+      `Redemption invariant FAILED — excluded terms exceed circulating base:\n` +
+      `  lockedAtWindDown (${ethers.formatUnits(lockedAtWindDown, 18)}) + cfUnsold (${ethers.formatUnits(cfUnsold, 18)}) ` +
+      `= ${ethers.formatUnits(excludedSum, 18)}\n` +
+      `  > circulatingSupplyOf([treasury, redemption]) = ${ethers.formatUnits(circBase, 18)}\n` +
+      `  ArmadaRedemption.circulatingSupply() would underflow and permanently brick redemptions.\n` +
+      `  Check the ARM distribution / RevenueLock allocation parameters.`
+    );
+  }
+  console.log(`   OK: locked+cfUnsold ${ethers.formatUnits(excludedSum, 18)} <= circulating base ${ethers.formatUnits(circBase, 18)}`);
+
   // 10. Deploy ArmadaWindDown (requires redemption address)
   console.log("10. Deploying ArmadaWindDown...");
   const windDownDeadline = Math.floor(new Date(config.windDownDeadline).getTime() / 1000);
@@ -348,34 +376,48 @@ async function main() {
   await (await redemption.setWindDown(windDownAddress, nm.override())).wait();
   console.log(`   redemption.setWindDown(${windDownAddress})`);
 
-  // 11c. Wire wind-down to RevenueCounter and RevenueLock for the trigger-time
-  // freeze hooks (issue #90 fix). Both are permissionless one-shot setters.
-  console.log("11c. Wiring wind-down to RevenueCounter + RevenueLock...");
-  const revenueCounterContract = await ethers.getContractAt("RevenueCounter", revenueCounterAddress);
-  await (await revenueCounterContract.setWindDownContract(windDownAddress, nm.override())).wait();
-  console.log(`   revenueCounter.setWindDownContract(${windDownAddress})`);
+  // 11c. Wire wind-down to RevenueLock — deployer-gated one-shot setter, so a direct
+  // deployer call. RevenueCounter's setter is now owner-gated (owner == timelock) and
+  // is wired via the timelock in step 12 alongside the other timelock-owned contracts.
+  console.log("11c. Wiring wind-down to RevenueLock...");
   const revenueLockContract = await ethers.getContractAt("RevenueLock", revenueLockAddress);
   await (await revenueLockContract.setWindDownContract(windDownAddress, nm.override())).wait();
   console.log(`   revenueLock.setWindDownContract(${windDownAddress})`);
 
-  // 12. Wire wind-down to governor, treasury, and shieldPause (timelock-only calls).
-  // On local: uses Anvil impersonation to execute as the timelock directly.
-  // On non-local: logs the governance proposals needed.
-  console.log("12. Wiring wind-down to governor/treasury/shieldPause (timelock-only)...");
+  // 12. Wire wind-down to the timelock-owned contracts (governor, treasury, shieldPause,
+  // revenueCounter) via the timelock. On local: Anvil impersonation. On non-local: real
+  // schedule + execute (instant under the harden profile's minDelay-0 bootstrap).
+  console.log("12. Wiring wind-down to governor/treasury/shieldPause/revenueCounter (timelock-only)...");
 
   const governorContract = await ethers.getContractAt("ArmadaGovernor", governorAddress);
   const treasury = await ethers.getContractAt("ArmadaTreasuryGov", treasuryAddress);
   const shieldPause = await ethers.getContractAt("ShieldPauseController", shieldPauseAddress);
+  const revenueCounterContract = await ethers.getContractAt("RevenueCounter", revenueCounterAddress);
 
   const windDownCalls = [
     { target: governorAddress, calldata: governorContract.interface.encodeFunctionData("setWindDownContract", [windDownAddress]), label: "governor" },
     { target: treasuryAddress, calldata: treasury.interface.encodeFunctionData("setWindDownContract", [windDownAddress]), label: "treasury" },
     { target: shieldPauseAddress, calldata: shieldPause.interface.encodeFunctionData("setWindDownContract", [windDownAddress]), label: "shieldPause" },
+    { target: revenueCounterAddress, calldata: revenueCounterContract.interface.encodeFunctionData("setWindDownContract", [windDownAddress]), label: "revenueCounter" },
   ];
 
   for (const call of windDownCalls) {
     await timelockCall(timelockAddress, call.target, call.calldata, `${call.label}.setWindDownContract()`, nm);
   }
+
+  // 12a. Verify-after-bind (defense-in-depth). The windDown setters on RevenueLock
+  // (immutable) and RevenueCounter (one-shot) are now caller-gated, so a front-run is
+  // prevented — this read-back catches a wiring bug (wrong address). A mismatch cannot be
+  // repaired in place (one-shot), so abort the deploy.
+  const rlBoundWindDown = await revenueLockContract.windDownContract();
+  const rcBoundWindDown = await revenueCounterContract.windDownContract();
+  if (rlBoundWindDown.toLowerCase() !== windDownAddress.toLowerCase()) {
+    throw new Error(`RevenueLock.windDownContract mis-bound: ${rlBoundWindDown} != expected ${windDownAddress}`);
+  }
+  if (rcBoundWindDown.toLowerCase() !== windDownAddress.toLowerCase()) {
+    throw new Error(`RevenueCounter.windDownContract mis-bound: ${rcBoundWindDown} != expected ${windDownAddress}`);
+  }
+  console.log("   Verified windDown binding on RevenueLock + RevenueCounter");
 
   // 12b. Initialize treasury outflow rate limits (timelock-only). Done at deploy so
   // the treasury is rate-limited from launch rather than via a fragile first

--- a/specs/GOVERNANCE.md
+++ b/specs/GOVERNANCE.md
@@ -689,6 +689,15 @@ Where:
 - **`revenueLock.lockedAtWindDown()`** = `totalAllocation × (10000 − unlockBpsAtWindDown) / 10000`. The locked (unvested) portion. Frozen at wind-down trigger so the value is stable across the redemption window. The vested portion stays in the denominator: beneficiaries can call `release()` and then redeem with no fairness penalty.
 - **`crowdfundUnsoldInContract`** = `ARM.balanceOf(crowdfundContract) − crowdfundContract.armStillOwed()`. The unsold portion still in the crowdfund (will eventually be swept to treasury). Computed dynamically — once the unsold portion is swept via `withdrawUnallocatedArm`, this drops to 0 and the treasury balance subtraction picks it up. Allocated-unclaimed ARM stays in the denominator: participants can call `claim()` and then redeem with no fairness penalty.
 
+**Deployment invariant (no-underflow).** The subtractions run in checked arithmetic, and the `lockedAtWindDown()` and `crowdfundUnsoldInContract` terms are **not** individually bounded against the running total (only the inner `balanceOf(crowdfund) − armStillOwed()` is clamped to avoid a negative). If the excluded/locked terms ever exceed the circulating base, `circulatingSupply()` reverts — and because it is on the hot path of every `redeem()`, redemptions would be **permanently bricked** (the redemption contract has no admin). This cannot be induced at runtime; it can only arise from a **misconfigured ARM distribution** (e.g. a RevenueLock allocation too large relative to supply). The mainnet deploy therefore asserts, at go-live:
+
+```
+revenueLock.lockedAtWindDown() + max(0, ARM.balanceOf(crowdfund) − crowdfund.armStillOwed())
+    ≤ ARM.circulatingSupplyOf([treasury, redemptionContract])
+```
+
+`≤` (not `<`) because circulating is legitimately ~0 at deploy — all ARM sits in the excluded contracts — so the check is boundary-exact at go-live and only loosens as the sale settles and vesting proceeds. Enforced in `scripts/deploy_crowdfund.ts` (step 9b). A runtime clamp on these subtractions is deferred to a future contract revision.
+
 The treasury, redemption contract, RevenueLock, and Crowdfund addresses are **hardcoded** in the redemption contract — no registry, no governance-managed list. The revenue-gated lock mechanism is a one-time launch construct (see REVENUE_LOCK.md §11), so no future lock contracts need to be accounted for. Custom grants post-transfer-unlock are standard treasury transfers, not lock contracts.
 
 Participants can still call `claim()` after wind-down and then redeem. The denominator already accounts for their entitled-unclaimed ARM, so claim timing does not affect payout fairness. As holders redeem, the redemption contract's ARM balance grows and its portion is excluded from the denominator, ensuring correct pro-rata math for sequential redemptions.

--- a/test-foundry/RevenueLock.t.sol
+++ b/test-foundry/RevenueLock.t.sol
@@ -186,6 +186,27 @@ contract RevenueLockTest is Test {
         new RevenueLock(address(armToken), address(revenueCounter), MAX_INCREASE_PER_DAY, b, a);
     }
 
+    // WHY: the one-shot windDown setter was permissionless — anyone could front-run
+    // the deployer and bind it to a foreign address between deploy and wiring. Because
+    // RevenueLock is immutable, a mis-bind is unrecoverable and bricks wind-down. It is
+    // now deployer-gated (the deployer is captured at construction).
+    function test_setWindDownContract_onlyDeployer() public {
+        address windDown = address(0xBEEF);
+
+        // A non-deployer cannot bind it.
+        vm.prank(nonBeneficiary);
+        vm.expectRevert("RevenueLock: not deployer");
+        revenueLock.setWindDownContract(windDown);
+
+        // The deployer (address(this)) can, once.
+        revenueLock.setWindDownContract(windDown);
+        assertEq(revenueLock.windDownContract(), windDown);
+
+        // One-shot: a second bind reverts even from the deployer.
+        vm.expectRevert("RevenueLock: wind-down already set");
+        revenueLock.setWindDownContract(address(0xCAFE));
+    }
+
     function test_constructor_zeroBeneficiaryAddress_reverts() public {
         address[] memory b = new address[](1);
         b[0] = address(0);

--- a/test/revenue_counter.ts
+++ b/test/revenue_counter.ts
@@ -398,6 +398,30 @@ describe("RevenueCounter", function () {
   });
 
   // ============================================================
+  // ============================================================
+  // setWindDownContract access control
+  // ============================================================
+
+  describe("setWindDownContract", function () {
+    // WHY: the one-shot windDown setter was permissionless — anyone could
+    // front-run the deployer and bind it to a foreign address between deploy
+    // and wiring, bricking wind-down. It is now owner-gated (owner == timelock).
+    it("reverts when called by a non-owner", async function () {
+      await expect(
+        revenueCounter.connect(alice).setWindDownContract(bob.address)
+      ).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("allows the owner to bind it once", async function () {
+      await revenueCounter.setWindDownContract(bob.address);
+      expect(await revenueCounter.windDownContract()).to.equal(bob.address);
+      // one-shot: a second call reverts even from the owner
+      await expect(
+        revenueCounter.setWindDownContract(alice.address)
+      ).to.be.revertedWith("RevenueCounter: wind-down already set");
+    });
+  });
+
   // 4. setFeeCollector
   // ============================================================
 

--- a/test/winddown_redemption_integration.ts
+++ b/test/winddown_redemption_integration.ts
@@ -180,7 +180,7 @@ describe("Wind-Down & Redemption Integration", function () {
     await armToken.setWindDownContract(await windDown.getAddress());
 
     // RevenueCounter: set wind-down contract for freeze() at trigger time.
-    await revenueCounter.setWindDownContract(await windDown.getAddress());
+    await revenueCounter.connect(await asTimelock()).setWindDownContract(await windDown.getAddress());
 
     // Redemption: wire wind-down reference (deployer-only one-time setter).
     // ArmadaRedemption reads windDown.triggerTime() to enforce REDEMPTION_DELAY.
@@ -1178,7 +1178,7 @@ describe("Wind-Down Pool Withdraw-Only Mode", function () {
     // Wire governance contracts
     await armToken.setWindDownContract(await windDown.getAddress());
     await redemption.setWindDown(await windDown.getAddress());
-    await revenueCounter.setWindDownContract(await windDown.getAddress());
+    await revenueCounter.connect(await asTimelock()).setWindDownContract(await windDown.getAddress());
 
     const timelockSigner = await asTimelock();
     await governor.connect(timelockSigner).setSecurityCouncil(carol.address);


### PR DESCRIPTION
Two must-do mitigations from the crowdfund/governance security review. **⚠️ Contains frozen-contract changes — see re-review note below.**

## Mitigation 1 — gate the `setWindDownContract` one-shot setters (CONTRACT CHANGE)
`RevenueLock.setWindDownContract` and `RevenueCounter.setWindDownContract` were permissionless one-shot setters. Between the governance and crowdfund deploy phases they sit unbound on a public mempool — a front-run binding them to a foreign address permanently bricks wind-down (`freezeAtWindDown` is gated on the bound address; `ArmadaWindDown._executeWindDown` has no try/catch, so one revert bricks the whole trigger; `RevenueLock` is immutable = unrecoverable).

- **`RevenueLock.sol`** — add a `deployer` immutable (captured at construction) + `require(msg.sender == deployer)`. Mirrors the already-audited `ArmadaToken.tokenDeployer` gate.
- **`RevenueCounter.sol`** — add `onlyOwner` (owner == timelock), matching its three sibling setters.
- **`deploy_crowdfund.ts`** — RevenueCounter's binding moves to the step-12 timelock batch (owner is now enforced); RevenueLock stays a direct deployer call.

Both are strictly *restrictive* (remove an unintended permissionless path, add no new capability), pattern-match existing audited code, and touch no storage layout (immutable / existing `onlyOwner`).

## Mitigation 2 — redemption underflow guard (deploy-script only)
`ArmadaRedemption.circulatingSupply()` subtracts `lockedAtWindDown()` and crowdfund-unsold from `circulatingSupplyOf([treasury, redemption])`, both **unbounded against the running total** (only the inner cf clamp exists). A parameterization error would underflow → every `redeem()` reverts permanently (no admin). Added a deploy-time assertion (step 9b): `lockedAtWindDown + cfUnsold ≤ circulatingSupplyOf([treasury, redemption])` (`≤` — boundary-exact at deploy). Plus a verify-after-bind read-back (step 12a) as defense-in-depth.

## Testing
- New negative-gate tests: `RevenueLock.t.sol` (Foundry, deployer-only) + `revenue_counter.ts` (Hardhat, owner-only + one-shot).
- One test adaptation: `winddown_redemption_integration.ts` binds RevenueCounter via the timelock (matching the new owner-gating).
- Full suites green: Foundry 217 (Revenue/Redemption/WindDown/Governance), Hardhat governance 116 + crowdfund 132.
- **Ran a local `setup:crowdfund` end-to-end** — the 9b invariant passes at the boundary-exact case (`4.2M ≤ 4.2M`) and 12a verify passes.

## ⚠️ Re-review required
This modifies frozen/audited contracts (`RevenueLock`, `RevenueCounter`). The changes are minimal, strictly-restrictive, and pattern-matched to existing audited gates — the ideal profile for a **scoped delta review**, not a full re-audit, but they should not merge without that review. Deployed bytecode now differs from the audited artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)