### PR TITLE
fix(committer): prevent duplicate commit broadcast on retry (double USDC pull)

### DIFF
--- a/crowdfund-ui/packages/committer/src/hooks/useTxPipeline.test.ts
+++ b/crowdfund-ui/packages/committer/src/hooks/useTxPipeline.test.ts
@@ -3,7 +3,8 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { createStore } from 'jotai'
-import { loadPendingTxs, clearPendingTxs } from '@/lib/pendingTx'
+import { loadPendingTxs, removePendingTx, clearPendingTxs } from '@/lib/pendingTx'
+import { TX_PENDING_MESSAGE } from '@/lib/txWait'
 import {
   runTxPipeline,
   setPipelineAttached,
@@ -216,6 +217,61 @@ describe('tx pipeline store', () => {
     applyWatchedTxResult(store, '0xcommit', 'reverted')
     expect(getPipelineState(store, A).rows[0].status).toBe('error')
     expect(getPipelineState(store, A).rows[0].errorMessage).toBe('Transaction reverted')
+  })
+
+  it('does not re-broadcast a timed-out row while its tx is still pending (no double-send)', async () => {
+    // send broadcasts (hash known) but the receipt wait times out; the pending
+    // entry is deliberately kept so the row can still confirm out-of-band.
+    const a = makeStep('commit', () => Promise.reject({ code: 'TIMEOUT' }))
+    runTxPipeline(store, { address: A, steps: [a.step] })
+
+    await waitFor(() => getPipelineState(store, A).phase === 'error')
+    expect(a.send).toHaveBeenCalledOnce()
+    expect(loadPendingTxs().some((t) => t.txHash === '0xcommit')).toBe(true)
+
+    // Retry while the original tx is still pending must NOT send a duplicate.
+    retryTxPipeline(store, A)
+    await flush()
+    expect(a.send).toHaveBeenCalledOnce()
+    // The guard restores an actionable error row (Retry still offered) — not a
+    // stuck spinner.
+    const row = getPipelineState(store, A).rows[0]
+    expect(row.status).toBe('error')
+    expect(row.errorMessage).toBe(TX_PENDING_MESSAGE)
+    expect(getPipelineState(store, A).phase).toBe('error')
+
+    // When the watcher finally confirms the original tx, the pipeline completes —
+    // still exactly one send.
+    removePendingTx('0xcommit')
+    applyWatchedTxResult(store, '0xcommit', 'confirmed')
+    expect(getPipelineState(store, A).rows[0].status).toBe('done')
+    expect(getPipelineState(store, A).phase).toBe('success')
+    expect(a.send).toHaveBeenCalledOnce()
+  })
+
+  it('advances past a watcher-confirmed middle row so retry continues, never re-sending it', async () => {
+    const a = makeStep('approve', () => Promise.resolve({ status: 1, logs: [] }))
+    const b = makeStep('commit1', () => Promise.reject({ code: 'TIMEOUT' }))
+    const c = makeStep('commit2', () => Promise.resolve({ status: 1, logs: [] }))
+
+    runTxPipeline(store, { address: A, steps: [a.step, b.step, c.step] })
+    await waitFor(() => getPipelineState(store, A).phase === 'error')
+    expect(a.send).toHaveBeenCalledOnce()
+    expect(b.send).toHaveBeenCalledOnce()
+    expect(c.send).not.toHaveBeenCalled()
+
+    // The watcher confirms the timed-out commit1 (mirrors production order: the
+    // pending entry is cleared before the resolution callback runs).
+    removePendingTx('0xcommit1')
+    applyWatchedTxResult(store, '0xcommit1', 'confirmed')
+    expect(getPipelineState(store, A).rows[1].status).toBe('done')
+
+    // Retry continues from commit2 — commit1 is never re-sent.
+    retryTxPipeline(store, A)
+    await waitFor(() => getPipelineState(store, A).phase === 'success')
+    expect(b.send).toHaveBeenCalledOnce()
+    expect(c.send).toHaveBeenCalledOnce()
+    expect(getPipelineState(store, A).rows.map((r) => r.status)).toEqual(['done', 'done', 'done'])
   })
 
   it('retry resumes from the failed row and keeps earlier successes', async () => {

--- a/crowdfund-ui/packages/committer/src/hooks/useTxPipeline.ts
+++ b/crowdfund-ui/packages/committer/src/hooks/useTxPipeline.ts
@@ -6,7 +6,8 @@ import { atom, useAtomValue, useStore } from 'jotai'
 import type { TransactionResponse } from 'ethers'
 import type { ReceiptLogLike, Step4Transaction } from '@armada/crowdfund-shared'
 import { sendAndWaitTx } from '@/lib/sendAndWaitTx'
-import { savePendingTx, removePendingTx } from '@/lib/pendingTx'
+import { savePendingTx, removePendingTx, loadPendingTxs } from '@/lib/pendingTx'
+import { TX_PENDING_MESSAGE } from '@/lib/txWait'
 import { getHubChainId, getExplorerUrl } from '@/config/network'
 
 /** One transaction in a pipeline: a labelled wallet send plus optional follow-ups. */
@@ -14,9 +15,13 @@ export interface TxStep {
   label: string
   /** Issues the tx (pops the wallet prompt). */
   send: () => Promise<TransactionResponse>
-  /** Receipt logs on success — e.g. ingest commit events into the graph store. */
+  /** Receipt logs on success — e.g. ingest commit events into the graph store.
+   *  Skipped when a step is confirmed out-of-band by the pending-tx watcher (only
+   *  the drive() path calls it) — must not be load-bearing for a later send. */
   onReceipt?: (logs: readonly ReceiptLogLike[]) => void
-  /** Side effect after this step confirms, before the next send (e.g. refresh allowance). */
+  /** Side effect after this step confirms, before the next send (e.g. refresh
+   *  allowance). Like onReceipt, skipped on watcher-confirmed steps — must not
+   *  gate the correctness of a later send. */
   after?: () => Promise<void>
 }
 
@@ -112,6 +117,14 @@ async function drive(store: Store, address: string): Promise<void> {
   rec.running = true
   try {
     while (rec.cursor < rec.steps.length) {
+      // Skip any row already completed out-of-band (e.g. confirmed by the
+      // background watcher while this step sat timed-out). Keeps the cursor
+      // self-healing so a resumed/retried pipeline never re-sends — or stomps —
+      // a done row, independent of the watcher's remove/resolve ordering.
+      if (readState(store, address).rows[rec.cursor]?.status === 'done') {
+        rec.cursor += 1
+        continue
+      }
       // Decision point before each send — never prompt the wallet without UI.
       if (rec.aborted) {
         setPhase(store, address, 'aborted')
@@ -123,6 +136,30 @@ async function drive(store: Store, address: string): Promise<void> {
       }
       const i = rec.cursor
       const step = rec.steps[i]
+
+      // Idempotency guard: if a prior attempt already broadcast this step and
+      // that tx is still unresolved (persisted pending), do NOT broadcast a
+      // duplicate. The contract accepts over-cap commits, so a second commit on
+      // a fresh nonce would pull USDC twice. The pending-tx watcher owns resolving
+      // this hash and resumes the pipeline via applyWatchedTxResult once it lands.
+      // TODO: recovering a genuinely dropped/replaced tx needs same-nonce,
+      // gas-bumped resubmission — until then, in-tab recovery is a page reload (a
+      // fresh flow's rows carry no hash, so the guard can't block it) or speeding
+      // up / cancelling the tx in the wallet.
+      const existingRow = readState(store, address).rows[i]
+      if (existingRow?.hash && loadPendingTxs().some((t) => t.txHash === existingRow.hash)) {
+        setRow(store, address, i, {
+          status: 'error',
+          phaseLabel: undefined,
+          hash: existingRow.hash,
+          explorerUrl: getExplorerUrl(),
+          errorMessage: TX_PENDING_MESSAGE,
+          errorDetails: `Transaction hash: ${existingRow.hash}`,
+        })
+        setPhase(store, address, 'error')
+        return
+      }
+
       // Phase 1: waiting for the wallet to confirm (no hash yet).
       setRow(store, address, i, {
         label: step.label,
@@ -148,9 +185,12 @@ async function drive(store: Store, address: string): Promise<void> {
           sentAt: Date.now(),
         })
       })
-      // A resolved tx no longer needs watching; a timed-out one may still
-      // confirm, so it stays persisted for the post-timeout watcher (3.4).
-      if (result.hash && result.outcome !== 'timeout') {
+      // A tx that definitively resolved no longer needs watching: `success` is
+      // done, and `reverted` changed no state (safe to re-send on retry). A
+      // `timeout` or `error` with a broadcast hash may still be in the mempool —
+      // keep it persisted so the post-timeout watcher resolves it AND the
+      // idempotency guard above blocks a duplicate re-send until it does.
+      if (result.hash && (result.outcome === 'success' || result.outcome === 'reverted')) {
         removePendingTx(result.hash)
       }
       if (result.outcome === 'success') {
@@ -268,11 +308,9 @@ export function retryTxPipeline(store: Store, address: string): void {
   if (readState(store, address).phase !== 'error') return
   rec.aborted = false
   rec.attached = true
-  setRow(store, address, rec.cursor, {
-    status: 'loading',
-    errorMessage: undefined,
-    errorDetails: undefined,
-  })
+  // Don't pre-set the cursor row here: drive() skips any watcher-confirmed `done`
+  // row (so retry never stomps it), sets the target row to `loading` on the send
+  // path, or restores an actionable `error` row if the idempotency guard fires.
   setPhase(store, address, 'running')
   void drive(store, address)
 }
@@ -299,6 +337,12 @@ export function applyWatchedTxResult(
         errorMessage: undefined,
         errorDetails: undefined,
       })
+      // Reconcile the engine cursor so a resumed/retried pipeline continues past
+      // this row instead of re-sending it. The record may be gone (a reset /
+      // account-switch abort / clear raced this resolution) — null-guard it; the
+      // row mutation above is render-only and safe without a record.
+      const rec = records.get(address)
+      if (rec && rec.cursor <= idx) rec.cursor = idx + 1
       if (readState(store, address).rows.every((r) => r.status === 'done')) {
         setPhase(store, address, 'success')
       }


### PR DESCRIPTION
Fixes triage finding #1: a pipeline could broadcast a **second** transaction for a commit step whose first tx was still unresolved, and because `ArmadaCrowdfund.commit()` accepts over-cap deposits (no revert), both would mine — **pulling the user's USDC twice**. Entirely client-side idempotency; no contract change.

### Root cause (two re-send paths in `useTxPipeline.ts`)
- **Retry while in-flight:** on a 120s receipt timeout, `drive()` left the row `error`, kept the pending hash persisted, and left `rec.cursor` on that step. `retryTxPipeline` re-entered `drive()` at the same cursor and called `step.send()` again → a fresh-nonce duplicate.
- **Retry after out-of-band confirm:** `applyWatchedTxResult` flipped the row to `done` but never advanced `rec.cursor`, so with a later step still pending, Retry re-sent the already-confirmed step.

### The invariant enforced
A pipeline step broadcasts **at most one** transaction. Retry/resume may continue the pipeline but never re-broadcasts a step whose tx is unresolved or already confirmed.

### Changes (all in `useTxPipeline.ts`)
1. **Idempotency guard in `drive()`** — before sending a step, if its row already has a `hash` still present in `loadPendingTxs()`, do not re-send; restore an actionable `error` row (`TX_PENDING_MESSAGE`, Retry still offered) and stop. The pending-tx watcher owns resolving that hash and resumes the pipeline once it lands.
2. **Done-row skip in `drive()`** — skip any row already `status: 'done'` (advance the cursor). Makes the cursor self-healing so retry/resume can never re-send or stomp a watcher-confirmed row, independent of the watcher's remove/resolve ordering. Let me also slim `retryTxPipeline` (it no longer pre-sets the row, which removes the stomp risk at the source).
3. **Cursor reconcile in `applyWatchedTxResult`** — on confirm, advance `rec.cursor` past the row (null-guarded — a reset/abort/clear can race the resolution).
4. **Pending-store rule** — remove the persisted pending tx only on `success`/`reverted` (definitively resolved / no state change), keep it on `timeout`/`error` so the guard covers an errored-with-hash tx that may still be in the mempool.

### Deliberately deferred (documented `TODO`)
Recovering a genuinely **dropped/replaced** tx needs same-nonce, gas-bumped resubmission (a replacement can't double-spend) — a larger, wallet-dependent change. Until then, in-tab recovery from a stuck-pending guard is a **page reload** (a fresh flow's rows carry no hash, so the guard can't block new commits) or speeding up / cancelling the tx in the wallet. This is strictly safer than today, which double-sends.

### Tests (`useTxPipeline.test.ts`)
- Timeout → Retry does **not** re-broadcast while pending (`send` count stays 1); guard leaves an actionable error row; watcher-confirm then completes to `success` — still one send.
- Multi-step: middle step times out → watcher confirms it → cursor advances → Retry continues to the **next** step, never re-sending the confirmed one.
- Existing regression stays green: a genuinely **reverted** step (no state change) still re-sends on Retry.

183 committer tests pass; typecheck clean.

### Follow-up context
Design refinements in this PR (done-row skip, guard-restores-error, null-guard, `onReceipt`/`after` asymmetry doc, TODO wording) came from a second review pass on the plan. Remaining open triage items (#4, #5, #7, rest of #9) are separate, deferred work; #2/#3/CSP were deferred by decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
