### PR TITLE
fix(committer): gate claim surface on authoritative state (refund cold-load, ARM deadline)

### DIFF
--- a/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.test.tsx
+++ b/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.test.tsx
@@ -23,6 +23,8 @@ function renderClaim(ui: ReactElement) {
 // Per-test read implementations, driven by the connected address.
 let claimedFor: (addr: string) => Promise<boolean>
 let allocationFor: (addr: string) => Promise<[bigint, bigint]>
+// Raw per-hop commitment (phase-2 refund path reads getCommitment per hop).
+let commitmentFor: (addr: string, hop: number) => Promise<bigint>
 let claimImpl: () => Promise<unknown>
 // Captures the delegate argument passed to the on-chain `claim(delegate)` call.
 let lastClaimDelegate: string | undefined
@@ -35,6 +37,7 @@ vi.mock('ethers', async (importOriginal) => {
       return {
         claimed: (addr: string) => claimedFor(addr),
         computeAllocation: (addr: string) => allocationFor(addr),
+        getCommitment: (addr: string, hop: number) => commitmentFor(addr, hop),
         claim: (delegate: string) => {
           lastClaimDelegate = delegate
           return claimImpl()
@@ -74,6 +77,7 @@ beforeEach(() => {
   clearPendingTxs()
   claimedFor = () => Promise.resolve(false)
   allocationFor = () => Promise.resolve([0n, 0n])
+  commitmentFor = () => Promise.resolve(0n)
   claimImpl = () => Promise.resolve({ hash: '0xclaim', wait: () => Promise.resolve({ status: 1, logs: [] }) })
   lastClaimDelegate = undefined
 })
@@ -251,6 +255,72 @@ describe('ClaimFlowV2 in-flight watcher', () => {
     ).toBeTruthy()
     // Confirmations + timeout are threaded to the wait call.
     expect(waitForTransaction).toHaveBeenCalledWith('0xpending', expect.any(Number), expect.any(Number))
+  })
+})
+
+describe('ClaimFlowV2 refund gate (contract-authoritative)', () => {
+  it('shows the on-chain refund even when the indexer total lags on a cold load (phase 2)', async () => {
+    // Cancelled sale: the event-graph total is still 0 (cold load / lagging
+    // indexer), but the contract reports a real commitment via getCommitment.
+    commitmentFor = (_addr, hop) => Promise.resolve(hop === 0 ? 500_000_000n : 0n) // 500 USDC at hop 0
+
+    renderClaim(<ClaimFlowV2 {...baseProps} phase={2} totalCommitted={0n} walletAddress={ADDR_A} />)
+
+    // The refund review renders from the contract amount — never the false
+    // "No refund to claim." terminal screen the graph total would have produced.
+    expect(await screen.findByText('Claim your refund')).toBeTruthy()
+    expect(screen.queryByText('No refund to claim.')).toBeNull()
+  })
+
+  it('still shows "No refund to claim" when the address genuinely committed nothing (phase 2)', async () => {
+    commitmentFor = () => Promise.resolve(0n)
+
+    renderClaim(<ClaimFlowV2 {...baseProps} phase={2} totalCommitted={0n} walletAddress={ADDR_A} />)
+
+    expect(await screen.findByText('No refund to claim.')).toBeTruthy()
+  })
+})
+
+describe('ClaimFlowV2 ARM claim deadline', () => {
+  const PAST = { claimDeadline: 1_000, blockTimestamp: 2_000 }
+
+  it('gates the ARM claim past the deadline instead of showing phantom ARM', async () => {
+    allocationFor = () => Promise.resolve([1_000_000_000_000_000_000n, 0n]) // 1 ARM, no refund
+
+    renderClaim(<ClaimFlowV2 {...baseProps} {...PAST} walletAddress={ADDR_A} />)
+
+    expect(await screen.findByText('ARM claim window closed')).toBeTruthy()
+    expect(screen.getByText(/nothing left to claim/i)).toBeTruthy()
+    // No phantom "in your wallet" ARM copy, and no claim action (nothing to claim).
+    expect(screen.queryByText(/in your wallet/)).toBeNull()
+    expect(screen.queryByRole('button', { name: /Claim/ })).toBeNull()
+  })
+
+  it('offers the USDC refund claim past the deadline when there is an over-cap refund', async () => {
+    allocationFor = () => Promise.resolve([1_000_000_000_000_000_000n, 250_000_000n]) // ARM forfeited, 250 USDC refund
+
+    renderClaim(<ClaimFlowV2 {...baseProps} {...PAST} signer={{} as never} walletAddress={ADDR_A} />)
+
+    expect(await screen.findByText('ARM claim window closed')).toBeTruthy()
+    // The refund is claimable; ARM is not offered.
+    const refundBtn = screen.getByRole('button', { name: /Claim .*refund/ })
+    expect(refundBtn).toBeTruthy()
+    expect(screen.queryByText(/in your wallet/)).toBeNull()
+
+    // Claiming past the deadline succeeds without a delegate (contract skips it).
+    fireEvent.click(refundBtn)
+    await waitFor(() => expect(lastClaimDelegate).toBeDefined())
+  })
+
+  it('done screen past the deadline never asserts ARM landed', async () => {
+    claimedFor = () => Promise.resolve(true) // already claimed, revisited after the deadline
+    allocationFor = () => Promise.resolve([1_000_000_000_000_000_000n, 0n])
+
+    renderClaim(<ClaimFlowV2 {...baseProps} {...PAST} walletAddress={ADDR_A} />)
+
+    expect(await screen.findByText('Claim complete.')).toBeTruthy()
+    expect(screen.queryByText(/in your wallet/)).toBeNull()
+    expect(screen.queryByText('ARM claimed.')).toBeNull()
   })
 })
 

--- a/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.tsx
+++ b/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.tsx
@@ -10,6 +10,7 @@ import {
   type Step4Transaction,
   CROWDFUND_ABI_FRAGMENTS,
   CROWDFUND_CONSTANTS,
+  HOP_CONFIGS,
   formatArm,
   formatUsdc,
   formatCountdown,
@@ -89,7 +90,6 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
     crowdfundAddress,
     phase,
     refundMode,
-    totalCommitted,
     claimAvailable,
     claimCountdownSeconds,
     onGoToMyPosition,
@@ -159,6 +159,14 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
   // Phase 0 with refundMode (cappedDemand < min) → refund. Otherwise → ARM.
   // This mirrors v1 ClaimTab's mode derivation.
   const mode: ClaimMode = phase === 2 || refundMode ? 'refund' : 'arm'
+
+  // Past the ARM claim deadline, `claim()` still succeeds but transfers ZERO ARM
+  // (the allocation is forfeited on-chain) — only the over-cap USDC refund, if
+  // any, still moves. Gate the ARM path so the UI never walks the user into a
+  // claim showing ARM numbers it won't deliver. Refund-mode sales have no ARM and
+  // no deadline, so this only applies to the ARM path.
+  const armClaimWindowClosed =
+    mode === 'arm' && props.claimDeadline > 0 && props.blockTimestamp > props.claimDeadline
 
   // Watch a reconstructed in-flight claim (from the marker) to its outcome.
   // Pure observation via the read provider — it never re-sends, so there's no
@@ -302,15 +310,25 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
     retry: false,
     queryFn: async () => {
       const contract = new Contract(crowdfundAddress!, CROWDFUND_ABI_FRAGMENTS, provider!)
-      const [claimedRes, allocRes] = await Promise.allSettled([
+      const [claimedRes, allocRes, committedRes] = await Promise.allSettled([
         contract.claimed(walletAddress) as Promise<boolean>,
         phase === 1
           ? (contract.computeAllocation(walletAddress) as Promise<[bigint, bigint]>)
+          : Promise.resolve(null),
+        // A cancelled sale (phase 2) can't `computeAllocation` (it reverts), so sum
+        // the raw per-hop commitments. This makes the refund gate + amount
+        // contract-authoritative rather than indexer-derived — the indexer lags on
+        // a cold load and would otherwise flash a false "no refund to claim".
+        phase === 2
+          ? Promise.all(
+              HOP_CONFIGS.map((_, h) => contract.getCommitment(walletAddress, h) as Promise<bigint>),
+            )
           : Promise.resolve(null),
       ])
       const hasClaimed = claimedRes.status === 'fulfilled' ? claimedRes.value : false
       let armAmount = 0n
       let refundAmount = 0n
+      let committedTotal = 0n
       let readError = false
       if (phase === 1) {
         if (allocRes.status === 'fulfilled' && allocRes.value) {
@@ -320,11 +338,24 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
           readError = true
         }
       }
-      return { hasClaimed, armAmount, refundAmount, readError }
+      if (phase === 2) {
+        if (committedRes.status === 'fulfilled' && committedRes.value) {
+          committedTotal = committedRes.value.reduce((sum, c) => sum + c, 0n)
+        } else if (committedRes.status === 'rejected') {
+          readError = true
+        }
+      }
+      return { hasClaimed, armAmount, refundAmount, committedTotal, readError }
     },
   })
 
-  const reads = claimQuery.data ?? { hasClaimed: false, armAmount: 0n, refundAmount: 0n, readError: false }
+  const reads = claimQuery.data ?? {
+    hasClaimed: false,
+    armAmount: 0n,
+    refundAmount: 0n,
+    committedTotal: 0n,
+    readError: false,
+  }
   const hasClaimed = reads.hasClaimed || justClaimed
   const armAmount = reads.armAmount
   const refundAmount = reads.refundAmount
@@ -333,11 +364,19 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
   // so the gate states render). An account switch re-keys the query → loading.
   const loading = claimReadsEnabled && claimQuery.isPending
 
+  // Contract-authoritative USDC the user can claim back on the refund path: a
+  // cancelled sale (phase 2) refunds the full raw commitment (summed above); a
+  // finalized refund-mode sale returns it as `computeAllocation`'s refund. Using
+  // this instead of the indexer-derived `totalCommitted` fixes both the false
+  // "no refund" flash on a cold load and the over-cap understatement (claimRefund
+  // returns the raw deposit, which the capped graph value understates).
+  const refundClaimable = phase === 2 ? reads.committedTotal : refundAmount
+
   // What the user actually gets back.
   const armDisplay = useMemo(() => formatArm(armAmount), [armAmount])
   const refundDisplay = useMemo(
-    () => formatUsdc(mode === 'refund' ? totalCommitted : refundAmount),
-    [mode, totalCommitted, refundAmount],
+    () => formatUsdc(mode === 'refund' ? refundClaimable : refundAmount),
+    [mode, refundClaimable, refundAmount],
   )
 
   // Submit the claim/refund transaction through the shared single-step engine,
@@ -345,7 +384,9 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
   // handling. Updates `txs` so Step4Approve renders controlled status.
   const runClaim = async () => {
     if (runningRef.current) return
-    const opLabel = mode === 'arm' ? 'Claim ARM' : 'Claim USDC refund'
+    // Past the deadline the ARM path claims only the USDC refund — label it honestly.
+    const opLabel =
+      mode === 'arm' && !armClaimWindowClosed ? 'Claim ARM' : 'Claim USDC refund'
     if (!crowdfundAddress) {
       // Surface an error row instead of bailing into Step4's neutral state.
       setTxs([
@@ -357,7 +398,10 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
     // handleDelegateChange (from ENS resolution or a direct 0x… entry). Fall
     // back to checksumming the raw input as a defense-in-depth backstop.
     const delegateAddress = resolvedDelegate || tryGetChecksumAddress(delegate)
-    if (mode === 'arm' && (!delegateAddress || delegateAddress === ZeroAddress)) {
+    // Past the ARM claim deadline the contract skips delegation entirely (ARM is
+    // forfeited), so no delegate is required — the claim returns only the USDC
+    // refund. Don't block that refund-only claim on delegate validation.
+    if (mode === 'arm' && !armClaimWindowClosed && (!delegateAddress || delegateAddress === ZeroAddress)) {
       setTxs([
         { label: opLabel, status: 'error', errorMessage: 'Enter a valid delegate address.' },
       ])
@@ -533,6 +577,7 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
     return (
       <DoneScreen
         mode={mode}
+        armForfeited={armClaimWindowClosed}
         armDisplay={armDisplay}
         refundDisplay={refundDisplay}
         refundAmount={refundAmount}
@@ -624,7 +669,7 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
   // different wallet). Renders in the same shell as the DoneScreen so the
   // terminal state is visually consistent with a successful claim.
   const armNothing = mode === 'arm' && armAmount === 0n && refundAmount === 0n
-  const refundNothing = mode === 'refund' && totalCommitted === 0n
+  const refundNothing = mode === 'refund' && refundClaimable === 0n
   if (armNothing || refundNothing) {
     return (
       <NothingToClaimScreen
@@ -638,6 +683,47 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
   }
 
   // ── Active flow ─────────────────────────────────────────────────
+
+  // Past the ARM claim deadline: ARM is forfeited on-chain. Offer only the USDC
+  // refund (if any) rather than the normal ARM review, which would show ARM
+  // numbers the claim won't deliver. Gated on `step === 'review'` so the submit /
+  // done screens still render once a refund claim is in flight.
+  if (step === 'review' && armClaimWindowClosed) {
+    const hasRefund = refundAmount > 0n
+    return (
+      <CardShell title="ARM claim window closed">
+        <p className={styles.gateBody}>
+          The window to claim your ARM allocation has closed, so the ARM is forfeited.
+          {hasRefund
+            ? ` You can still claim your USDC refund of ${formatUsdc(refundAmount)} from over-cap commitments.`
+            : ' There is nothing left to claim.'}
+        </p>
+        <div className={styles.gateActions}>
+          {hasRefund && (
+            <ArmadaButton
+              variant="gradient"
+              size="md"
+              label={`Claim ${formatUsdc(refundAmount)} refund`}
+              showIcon={false}
+              disabled={submitting}
+              onClick={() => {
+                setTxs(null)
+                setStep('submit')
+                void runClaim()
+              }}
+            />
+          )}
+          <ArmadaButton
+            variant="secondary"
+            size="md"
+            label="Back to crowdfund"
+            showIcon={false}
+            onClick={onGoToNetwork}
+          />
+        </div>
+      </CardShell>
+    )
+  }
 
   if (step === 'review') {
     const delegateValid = delegateEns === 'resolved' && resolvedDelegate !== ''
@@ -820,6 +906,7 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
   return (
     <DoneScreen
       mode={mode}
+      armForfeited={armClaimWindowClosed}
       armDisplay={armDisplay}
       refundDisplay={refundDisplay}
       refundAmount={refundAmount}
@@ -941,6 +1028,7 @@ function NothingToClaimScreen({
 
 function DoneScreen({
   mode,
+  armForfeited,
   armDisplay,
   refundDisplay,
   refundAmount,
@@ -948,6 +1036,12 @@ function DoneScreen({
   onGoToNetwork,
 }: {
   mode: ClaimMode
+  /** The ARM claim deadline has passed — `claim()` delivered no ARM (forfeited),
+   *  only the USDC refund (if any). Suppresses the "ARM is in your wallet" copy.
+   *  Stays neutral rather than asserting "forfeited": a user who claimed in time
+   *  but revisits after the deadline is also `hasClaimed`, and `claimed` alone
+   *  can't tell us which. */
+  armForfeited: boolean
   armDisplay: string
   refundDisplay: string
   /** Over-cap USDC refund delivered by the ARM `claim()` call. Used to swap in
@@ -961,27 +1055,36 @@ function DoneScreen({
   // from the user's perspective, and "You already claimed" reads like an
   // error. Past-tense success copy works for both cases.
   const armHasRefund = mode === 'arm' && refundAmount > 0n
-  const headline = mode === 'arm' ? 'ARM claimed.' : 'Refund claimed.'
-  const subline =
-    mode === 'arm' ? (
-      armHasRefund ? (
-        <>
-          {armDisplay} is in your wallet.
-          <br />
-          {refundDisplay} USDC refund returned too.
-        </>
-      ) : (
-        <>
-          {armDisplay} is in your wallet.
-          <br />
-          Your delegate now holds your governance voting power.
-        </>
-      )
+  const armForfeitedPath = mode === 'arm' && armForfeited
+  const headline =
+    mode === 'arm' ? (armForfeited ? 'Claim complete.' : 'ARM claimed.') : 'Refund claimed.'
+  const subline = armForfeitedPath ? (
+    // Past the deadline: never assert ARM landed. Show the refund if there was one.
+    armHasRefund ? (
+      <>{refundDisplay} USDC refund returned to your wallet.</>
     ) : (
-      <>{refundDisplay} returned to your wallet.</>
+      <>Your claim has settled on-chain.</>
     )
-  const nextText =
-    mode === 'arm'
+  ) : mode === 'arm' ? (
+    armHasRefund ? (
+      <>
+        {armDisplay} is in your wallet.
+        <br />
+        {refundDisplay} USDC refund returned too.
+      </>
+    ) : (
+      <>
+        {armDisplay} is in your wallet.
+        <br />
+        Your delegate now holds your governance voting power.
+      </>
+    )
+  ) : (
+    <>{refundDisplay} returned to your wallet.</>
+  )
+  const nextText = armForfeitedPath
+    ? 'ARM is delivered only when claimed within the claim window; any USDC refund settles regardless. View your position to confirm your balances, or head back to the crowdfund.'
+    : mode === 'arm'
       ? armHasRefund
         ? 'Both transfers are already settled on-chain. View your position to confirm balances, or head back to the crowdfund to see how the rest of the fleet finalized.'
         : 'Your ARM is settled on-chain and your delegate is active. View your position to confirm the balance, or head back to the crowdfund.'


### PR DESCRIPTION
Fixes triage findings #4 and #5 — two claim-surface bugs where the UI asserts something the contract won't do. Both are display/gating (no funds move incorrectly), and both are fixed by gating on **contract-authoritative** state. Entirely in `ClaimFlowV2.tsx`; no App.tsx changes. 186 committer tests pass; typecheck clean.

### #4 — Refund page showed "No refund to claim" to users who did commit
The refund gate keyed on the **event-graph** `totalCommitted`, so a cold load of `/?view=claim` on a cancelled sale with a lagging indexer showed a confident terminal "you didn't commit any USDC" until events hydrated.

- Extended the existing claim read query: for a **cancelled sale (phase 2)**, sum `getCommitment(addr, h)` across the 3 hops → contract-authoritative `committedTotal`. (Finalized refund-mode already has the figure in `computeAllocation`'s refund.)
- The refund **gate** and **amount** now use `refundClaimable = phase === 2 ? committedTotal : refundAmount`. The existing `if (loading)` gate covers the read window, so the false terminal screen can't flash — no new `eventsLoading` prop needed.
- This also fixes the over-cap **display understatement**: `claimRefund` returns the raw deposit, which the capped graph value understated.

### #5 — Claim ignored `claimDeadline`; showed "ARM in your wallet" while paying zero ARM
Past the deadline, `claim()` still succeeds, permanently sets `claimed = true`, forfeits the ARM, and transfers only any USDC refund — but the UI showed the full ARM allocation as delivered.

- New `armClaimWindowClosed` gate (both values already props): past the deadline the ARM review is replaced with an honest **"ARM claim window closed"** screen, and `DoneScreen` uses **neutral** copy (refund figure if any + "ARM is delivered only when claimed within the claim window") — never "X ARM is in your wallet." Neutral rather than "forfeited" because a user who claimed *in time* and revisits *after* the deadline is also `hasClaimed`, and `claimed` alone can't distinguish them.
- **Doesn't strand the refund (chosen: option B):** an over-cap depositor past the deadline still has a claimable USDC refund, and `claim()` (not `claimRefund()`) is the only path to it in a finalized sale. So the gate offers a **"Claim $X refund"** action when `refundAmount > 0`, with the delegate requirement relaxed (the contract doesn't require a delegate past the deadline — no delegation happens).

Near-term likelihood of #5 is low (mainnet claim deadline is ~3 years out), but the outcome is permanent and irreversible when hit.

### Tests (`ClaimFlowV2.test.tsx`, +5)
- #4: phase-2 cold load with a lagging graph total but a real on-chain commitment → refund review renders (not the false terminal); genuinely-zero commitment still shows "No refund to claim."
- #5: past-deadline ARM claim → "ARM claim window closed" gate, no phantom ARM; with an over-cap refund → a "Claim refund" action that submits without a delegate; already-claimed-past-deadline done screen never asserts ARM landed.

### Context
Third PR from the pre-mainnet committer review (`.context/COMMITTER_REVIEW_TRIAGE.md`), after #355 (batch) and #357 (#1 double-send). Remaining: #7 (desktop chain-pin), the pre-check half of #9; tracked #3 / issue #354. #2 / CSP deferred by decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
