### PR TITLE
fix(committer): block at-cap invitee before the wasted approve on /invite

### DIFF
--- a/crowdfund-ui/packages/committer/src/components/InviteLinkFlowController.tsx
+++ b/crowdfund-ui/packages/committer/src/components/InviteLinkFlowController.tsx
@@ -52,7 +52,7 @@ import { useResetPipelineOnClose } from '@/hooks/useResetPipelineOnClose'
 import { useSelfFill } from '@/hooks/useSelfFill'
 import { useAllowance } from '@/hooks/useAllowance'
 import { useEligibility } from '@/hooks/useEligibility'
-import { effectiveInviteCapUsdc } from '@/lib/inviteCapMath'
+import { effectiveInviteCapUsdc, isAtInviteCap } from '@/lib/inviteCapMath'
 import { useInviteLinks } from '@/hooks/useInviteLinks'
 import { useInviteSlots } from '@/hooks/useInviteSlots'
 
@@ -208,6 +208,14 @@ export function InviteLinkFlowController({ inviteData }: InviteLinkFlowControlle
   // input step and land on the confirmation screen with "fully committed" copy,
   // matching the participate modal, instead of a dead-end input message.
   const isFullyCommitted = existingCommittedUsdc > 0n && existingCommittedUsdc >= effectiveCapUsdc
+  // Every commitWithInvite stacks another invite onto the invitee, which the
+  // contract rejects once they're at the hop's `maxInvitesReceived`. Detect that
+  // up front so an already-maxed re-invitee is blocked before signing a useless
+  // approve, rather than hitting a revert after it. A first-time invitee (0
+  // received) is never at the cap.
+  const maxInvitesReceived =
+    targetHop <= 2 ? HOP_CONFIGS[targetHop as 0 | 1 | 2].maxInvitesReceived : 0
+  const atInviteCap = isAtInviteCap(existingInvitesReceived, maxInvitesReceived)
 
   // Pro-rata ARM for a given new USD commit at the target hop — same math as
   // ParticipateFlowV2's Step3, so all /invite screens show one consistent number.
@@ -542,6 +550,41 @@ export function InviteLinkFlowController({ inviteData }: InviteLinkFlowControlle
         )
 
       case 'commit': {
+        // At the invite-stacking cap for this hop — redeeming would revert
+        // ("max invites received"), since commitWithInvite stacks another invite.
+        // Block before the approve so no gas is wasted; the invitee can still
+        // commit to their existing position via the normal flow.
+        if (atInviteCap) {
+          const hasHeadroom = existingCommittedUsdc < effectiveCapUsdc
+          return (
+            <div className="space-y-4 p-6 text-center">
+              <h2 className="text-lg font-semibold">Invite limit reached</h2>
+              <p className="text-muted-foreground text-sm">
+                You've already accepted the maximum number of invites at {hopLabel(targetHop)}, so
+                this invite link can't be redeemed.
+                {hasHeadroom
+                  ? ' You can still commit to your existing position from My Position.'
+                  : ''}
+              </p>
+              <div className="flex justify-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => navigate('/?view=myposition')}
+                  className="rounded-full border border-border px-4 py-2 text-sm hover:bg-muted"
+                >
+                  View my position
+                </button>
+                <button
+                  type="button"
+                  onClick={() => navigate('/')}
+                  className="rounded-full border border-border px-4 py-2 text-sm hover:bg-muted"
+                >
+                  Back to crowdfund
+                </button>
+              </div>
+            </div>
+          )
+        }
         // No room left to commit — skip straight to the confirmation screen
         // (stepper, What's next, Invite) instead of a dead-end input message.
         if (isFullyCommitted) {

--- a/crowdfund-ui/packages/committer/src/lib/inviteCapMath.test.ts
+++ b/crowdfund-ui/packages/committer/src/lib/inviteCapMath.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Unit tests for the /invite effective-cap math.
 // ABOUTME: (invitesReceived + 1) * perSlotCap — the contract scales the cap on redemption.
 import { describe, it, expect } from 'vitest'
-import { effectiveInviteCapUsdc } from './inviteCapMath'
+import { effectiveInviteCapUsdc, isAtInviteCap } from './inviteCapMath'
 
 const CAP = 1_000n * 10n ** 6n // $1,000 per slot
 
@@ -16,5 +16,27 @@ describe('effectiveInviteCapUsdc', () => {
 
   it('treats negative/garbage invitesReceived as 0 (1x)', () => {
     expect(effectiveInviteCapUsdc(-5, CAP)).toBe(CAP)
+  })
+})
+
+describe('isAtInviteCap', () => {
+  it('is false for a first-time invitee (0 received)', () => {
+    expect(isAtInviteCap(0, 10)).toBe(false)
+  })
+
+  it('is false below the cap', () => {
+    expect(isAtInviteCap(9, 10)).toBe(false)
+  })
+
+  it('is true at the cap (redemption would revert "max invites received")', () => {
+    expect(isAtInviteCap(10, 10)).toBe(true)
+  })
+
+  it('is true above the cap (defensive — stale/over-count reads)', () => {
+    expect(isAtInviteCap(11, 10)).toBe(true)
+  })
+
+  it('never blocks when the cap is unknown / zero (out-of-range hop)', () => {
+    expect(isAtInviteCap(5, 0)).toBe(false)
   })
 })

--- a/crowdfund-ui/packages/committer/src/lib/inviteCapMath.ts
+++ b/crowdfund-ui/packages/committer/src/lib/inviteCapMath.ts
@@ -14,3 +14,19 @@ export function effectiveInviteCapUsdc(
   const multiplier = BigInt(Math.max(0, currentInvitesReceived) + 1)
   return multiplier * perSlotCapUsdc
 }
+
+/**
+ * Whether an invitee is at the invite-stacking cap for a hop. Every
+ * `commitWithInvite` stacks another invite onto the invitee (`invitesReceived`
+ * +1), which the contract rejects once the invitee is already at the hop's
+ * `maxInvitesReceived` ("max invites received"). A first-time invitee has 0
+ * received and is never at the cap. `maxInvitesReceived <= 0` (unknown / no cap,
+ * e.g. an out-of-range hop) is treated as "not at cap" so we never block on a
+ * missing config.
+ */
+export function isAtInviteCap(
+  currentInvitesReceived: number,
+  maxInvitesReceived: number,
+): boolean {
+  return maxInvitesReceived > 0 && currentInvitesReceived >= maxInvitesReceived
+}


### PR DESCRIPTION
Fixes the remaining half of triage finding #9. The revert-copy half already shipped in #355 (`revertMessages` maps `max invites received`); this adds the **pre-check** that avoids the wasted approve entirely.

### Issue
`commitWithInvite` atomically does *invite + commit*. The invite half (`_registerOrStackInvite`) stacks an invite onto the invitee (`invitesReceived + 1`), which the contract rejects once they're at the hop's `maxInvitesReceived` (1 / 10 / 20 for hops 0 / 1 / 2):

```solidity
require(inviteeNode.invitesReceived < hopConfigs[inviteeHop].maxInvitesReceived,
        "ArmadaCrowdfund: max invites received");
```

So an invitee **already at the stacking cap** at the target hop can't redeem *any* invite link there. The controller already had the data (`existingInvitesReceived`, `HOP_CONFIGS[hop].maxInvitesReceived`) but never checked it — an at-cap re-invitee entered an amount, signed a **real USDC `approve` (real gas)**, then hit the revert.

### Fix
- New pure helper `isAtInviteCap(currentInvitesReceived, maxInvitesReceived)` in `inviteCapMath.ts` (`maxInvitesReceived <= 0` ⇒ never blocks, so an out-of-range hop config can't false-positive).
- `InviteLinkFlowController` computes `atInviteCap` from the `existingInvitesReceived` it already reads, and short-circuits the `commit` step to a terminal **"Invite limit reached"** screen *before* the approve — so no gas is wasted. Points the invitee to My Position (they can still commit to their existing position via the normal flow if they have headroom).

### Scope / caveat
Narrow population (already-maxed re-invitees), no funds at risk — a wasted-gas + dead-end UX bug. The invitee's `invitesReceived` is only available from the **event graph** (the contract exposes no getter for received-count), so this is a UX guard, not an authoritative gate: on a cold load before the graph hydrates it could momentarily under-read and not fire — but the contract still enforces the cap and the revert is now clearly messaged (from #355), so the worst case is today's behavior.

### Tests
`inviteCapMath.test.ts` (+5): at/below/above cap, first-timer (0 received), and the unknown-cap guard. The controller has no existing test harness and mocking its full hook tree would be disproportionate for a UX guard, so the decision logic is covered by the helper; the render is a thin conditional branch mirroring the existing `isFullyCommitted` shortcut. 186 committer tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
