### PR TITLE
fix(committer): assert hub chain on every desktop write (no wrong-chain "success")

### DIFF
--- a/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.tsx
+++ b/crowdfund-ui/packages/committer/src/components/ClaimFlowV2.tsx
@@ -26,8 +26,7 @@ import { savePendingTx, removePendingTx } from '@/lib/pendingTx'
 import { setClaimInFlight, getClaimInFlight, clearClaimInFlight } from '@/lib/claimInFlight'
 import { TX_WAIT_TIMEOUT_MS, isTxTimeoutError } from '@/lib/txWait'
 import { resolveSigner, describeSignerError } from '@/lib/resolveSigner'
-import { isMobileBrowser } from '@/lib/isMobileBrowser'
-import { submitTxViaWagmi } from '@/lib/mobileTxSubmit'
+import { submitWrite } from '@/lib/submitWrite'
 import { getExplorerUrl, getHubChainId, getTxConfirmations } from '@/config/network'
 import { useBeforeUnloadGuard } from '@/hooks/useBeforeUnloadGuard'
 import { getHubNetworkLabel } from '@/config/network'
@@ -392,15 +391,12 @@ export function ClaimFlowV2(props: ClaimFlowV2Props) {
     const result = await sendAndWaitTx(
       () => {
         const crowdfund = new Contract(crowdfundAddress, CROWDFUND_ABI_FRAGMENTS, activeSigner)
-        // Mobile: submit via wagmi so MetaMask Mobile surfaces the request (the
-        // ethers signer transport doesn't trigger the WC redirect). Desktop keeps
-        // the ethers path unchanged.
-        if (isMobileBrowser()) {
-          return mode === 'arm'
-            ? submitTxViaWagmi(crowdfund, 'claim', [delegateAddress!])
-            : submitTxViaWagmi(crowdfund, 'claimRefund', [])
-        }
-        return mode === 'arm' ? crowdfund.claim(delegateAddress!) : crowdfund.claimRefund()
+        // submitWrite routes mobile through wagmi (so MetaMask Mobile surfaces the
+        // request) and desktop through ethers after asserting the wallet is on the
+        // hub chain.
+        return mode === 'arm'
+          ? submitWrite(crowdfund, 'claim', [delegateAddress!], activeSigner)
+          : submitWrite(crowdfund, 'claimRefund', [], activeSigner)
       },
       (hash) => {
         // Persist the broadcast so the header tx chip (via usePendingTxWatcher)

--- a/crowdfund-ui/packages/committer/src/components/InviteLinkFlowController.tsx
+++ b/crowdfund-ui/packages/committer/src/components/InviteLinkFlowController.tsx
@@ -43,8 +43,7 @@ import { loadDeployment } from '@/config/deployments'
 import type { CrowdfundDeployment } from '@/config/deployments'
 import type { InviteLinkData } from '@/lib/inviteLinks'
 import { resolveSigner, describeSignerError } from '@/lib/resolveSigner'
-import { isMobileBrowser } from '@/lib/isMobileBrowser'
-import { submitTxViaWagmi } from '@/lib/mobileTxSubmit'
+import { submitWrite } from '@/lib/submitWrite'
 import { useWallet } from '@/hooks/useWallet'
 import { useBeforeUnloadGuard } from '@/hooks/useBeforeUnloadGuard'
 import { useTxPipeline, type TxStep } from '@/hooks/useTxPipeline'
@@ -332,9 +331,7 @@ export function InviteLinkFlowController({ inviteData }: InviteLinkFlowControlle
         label: `Approve ${formatUsdc(amountBig)} USDC`,
         send: () => {
           const usdc = new Contract(deployment!.contracts.usdc, ERC20_ABI_FRAGMENTS, activeSigner)
-          return isMobileBrowser()
-            ? submitTxViaWagmi(usdc, 'approve', [deployment!.contracts.crowdfund, amountBig])
-            : usdc.approve(deployment!.contracts.crowdfund, amountBig)
+          return submitWrite(usdc, 'approve', [deployment!.contracts.crowdfund, amountBig], activeSigner)
         },
         // Re-read allowance so a retry's skip-approval decision sees the real value.
         after: allowanceState.refresh,
@@ -356,9 +353,7 @@ export function InviteLinkFlowController({ inviteData }: InviteLinkFlowControlle
           inviteData.signature,
           amountBig,
         ] as const
-        return isMobileBrowser()
-          ? submitTxViaWagmi(crowdfund, 'commitWithInvite', commitArgs)
-          : crowdfund.commitWithInvite(...commitArgs)
+        return submitWrite(crowdfund, 'commitWithInvite', commitArgs, activeSigner)
       },
       // Fast-path the Invited + Committed events into the graph so the user has a
       // recognized hop position the moment we hit Step5.

--- a/crowdfund-ui/packages/committer/src/components/ParticipateFlowV2.tsx
+++ b/crowdfund-ui/packages/committer/src/components/ParticipateFlowV2.tsx
@@ -34,8 +34,7 @@ import {
 import { FooterSocials } from '@/components/FooterSocials'
 import { getHubNetworkLabel } from '@/config/network'
 import { resolveSigner, describeSignerError } from '@/lib/resolveSigner'
-import { isMobileBrowser } from '@/lib/isMobileBrowser'
-import { submitTxViaWagmi } from '@/lib/mobileTxSubmit'
+import { submitWrite } from '@/lib/submitWrite'
 import { useTxPipeline, type TxStep } from '@/hooks/useTxPipeline'
 import { useSelfFill } from '@/hooks/useSelfFill'
 import { useResetPipelineOnClose } from '@/hooks/useResetPipelineOnClose'
@@ -410,9 +409,7 @@ export function ParticipateFlowV2({
         label: `Approve ${formatUsdc(totalBig)} USDC`,
         send: () => {
           const usdc = new Contract(usdcAddress!, ERC20_ABI_FRAGMENTS, activeSigner)
-          return isMobileBrowser()
-            ? submitTxViaWagmi(usdc, 'approve', [crowdfundAddress!, totalBig])
-            : usdc.approve(crowdfundAddress!, totalBig)
+          return submitWrite(usdc, 'approve', [crowdfundAddress!, totalBig], activeSigner)
         },
         // Re-read allowance so the next attempt's skip-approval decision is real.
         after: refreshAllowance,
@@ -428,9 +425,7 @@ export function ParticipateFlowV2({
           : 'Commit participation',
         send: () => {
           const crowdfund = new Contract(crowdfundAddress!, CROWDFUND_ABI_FRAGMENTS, activeSigner)
-          return isMobileBrowser()
-            ? submitTxViaWagmi(crowdfund, 'commit', [p.hop, amountBig])
-            : crowdfund.commit(p.hop, amountBig)
+          return submitWrite(crowdfund, 'commit', [p.hop, amountBig], activeSigner)
         },
         onReceipt: (logs) => onReceiptLogs?.(logs),
       })

--- a/crowdfund-ui/packages/committer/src/lib/revertMessages.test.ts
+++ b/crowdfund-ui/packages/committer/src/lib/revertMessages.test.ts
@@ -9,6 +9,12 @@ describe('mapRevertToMessage', () => {
     expect(mapRevertToMessage(new Error('user rejected transaction'))).toBe('Transaction rejected by user')
   })
 
+  it('maps the submitWrite wrong-network guard error', () => {
+    expect(mapRevertToMessage(new Error('Wrong network — switch to Ethereum and retry.'))).toBe(
+      'Wrong network — switch to the hub chain in your wallet and retry.',
+    )
+  })
+
   it('maps deadline passed', () => {
     expect(mapRevertToMessage(new Error('deadline passed'))).toBe('The commitment deadline has passed.')
   })

--- a/crowdfund-ui/packages/committer/src/lib/revertMessages.ts
+++ b/crowdfund-ui/packages/committer/src/lib/revertMessages.ts
@@ -4,6 +4,9 @@
 /** Known contract revert reasons → user-facing messages */
 const REVERT_MAP: [RegExp, string][] = [
   [/user rejected/i, 'Transaction rejected by user'],
+  // Pre-broadcast guard from submitWrite/assertHubChain: the wallet is on a
+  // non-hub chain. Keep this above the generic patterns so the message survives.
+  [/wrong network/i, 'Wrong network — switch to the hub chain in your wallet and retry.'],
   [/insufficient funds/i, 'Insufficient funds for gas'],
   [/deadline passed/i, 'The commitment deadline has passed.'],
   [/cancelled/i, 'This crowdfund has been cancelled.'],

--- a/crowdfund-ui/packages/committer/src/lib/selfFillSteps.ts
+++ b/crowdfund-ui/packages/committer/src/lib/selfFillSteps.ts
@@ -10,8 +10,7 @@ import {
   type ReceiptLogLike,
   type SelfFillPlan,
 } from '@armada/crowdfund-shared'
-import { isMobileBrowser } from '@/lib/isMobileBrowser'
-import { submitTxViaWagmi } from '@/lib/mobileTxSubmit'
+import { submitWrite } from '@/lib/submitWrite'
 import type { TxStep } from '@/hooks/useTxPipeline'
 
 export interface BuildSelfFillStepsParams {
@@ -51,9 +50,7 @@ export function buildSelfFillSteps({
       label: `Approve ${formatUsdc(plan.newCommitUsdc)} USDC`,
       send: () => {
         const usdc = new Contract(usdcAddress, ERC20_ABI_FRAGMENTS, signer)
-        return isMobileBrowser()
-          ? submitTxViaWagmi(usdc, 'approve', [crowdfundAddress, plan.newCommitUsdc])
-          : usdc.approve(crowdfundAddress, plan.newCommitUsdc)
+        return submitWrite(usdc, 'approve', [crowdfundAddress, plan.newCommitUsdc], signer)
       },
       // Re-read allowance so the multicall step's view of approval is real.
       after: refreshAllowance,
@@ -64,10 +61,7 @@ export function buildSelfFillSteps({
   const calls = encodeSelfFillCalls(crowdfund.interface, selfAddress, plan)
   steps.push({
     label: `Self-invite & commit · ${plan.totalInvites} invites + ${plan.commits.length} commits`,
-    send: () =>
-      isMobileBrowser()
-        ? submitTxViaWagmi(crowdfund, 'multicall', [calls])
-        : crowdfund.multicall(calls),
+    send: () => submitWrite(crowdfund, 'multicall', [calls], signer),
     onReceipt: (logs) => onReceiptLogs?.(logs),
     after: refreshAllowance,
   })

--- a/crowdfund-ui/packages/committer/src/lib/submitWrite.test.ts
+++ b/crowdfund-ui/packages/committer/src/lib/submitWrite.test.ts
@@ -1,0 +1,102 @@
+// ABOUTME: Tests for submitWrite / assertHubChain — the mobile/desktop send split + live hub-chain assertion.
+// ABOUTME: Verifies a desktop send on the wrong chain is blocked (never broadcast), and mobile routes to wagmi unasserted.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Contract, Signer } from 'ethers'
+
+let mobile = false
+vi.mock('@/lib/isMobileBrowser', () => ({ isMobileBrowser: () => mobile }))
+
+const mockWagmiSubmit = vi.fn()
+vi.mock('@/lib/mobileTxSubmit', () => ({
+  submitTxViaWagmi: (...args: unknown[]) => mockWagmiSubmit(...args),
+}))
+
+// Hub chain = 1 for the tests.
+vi.mock('@/config/network', () => ({
+  getHubChainId: () => 1,
+  getHubNetworkLabel: () => 'Ethereum',
+}))
+
+import { submitWrite, assertHubChain, isWrongChainError } from './submitWrite'
+
+/** A signer whose live `eth_chainId` resolves to `chainIdHex` (or no `send` when null). */
+function signerOnChain(chainIdHex: string | null): Signer {
+  const provider = chainIdHex == null ? {} : { send: vi.fn().mockResolvedValue(chainIdHex) }
+  return { provider } as unknown as Signer
+}
+
+/** A contract whose dynamic `contract[method](...)` access records (method, ...args). */
+function contractWith(record: (...args: unknown[]) => unknown): Contract {
+  return new Proxy(
+    {},
+    { get: (_t, prop: string) => (...args: unknown[]) => record(prop, ...args) },
+  ) as unknown as Contract
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mobile = false
+})
+
+describe('submitWrite (desktop)', () => {
+  it('asserts the hub chain, then calls the ethers method', async () => {
+    const method = vi.fn().mockResolvedValue({ hash: '0xabc' })
+    const signer = signerOnChain('0x1') // live chain = hub
+    const res = await submitWrite(contractWith(method), 'commit', [1, 100n], signer)
+
+    expect(method).toHaveBeenCalledWith('commit', 1, 100n)
+    expect(res).toEqual({ hash: '0xabc' })
+    expect(mockWagmiSubmit).not.toHaveBeenCalled()
+  })
+
+  it('throws WRONG_CHAIN and never broadcasts when the wallet is on the wrong chain', async () => {
+    const method = vi.fn()
+    const signer = signerOnChain('0xaa36a7') // Sepolia, not the hub
+    await expect(submitWrite(contractWith(method), 'commit', [1], signer)).rejects.toMatchObject({
+      code: 'WRONG_CHAIN',
+    })
+    // Critically: the send never fired, so no duplicate/wrong-chain tx is broadcast.
+    expect(method).not.toHaveBeenCalled()
+  })
+
+  it('proceeds (non-blocking) when the live chain cannot be queried', async () => {
+    const method = vi.fn().mockResolvedValue({ hash: '0xok' })
+    const signer = signerOnChain(null) // provider has no `send`
+    await submitWrite(contractWith(method), 'commit', [1], signer)
+    expect(method).toHaveBeenCalled()
+  })
+})
+
+describe('submitWrite (mobile)', () => {
+  it('routes to wagmi without a chain assertion', async () => {
+    mobile = true
+    mockWagmiSubmit.mockResolvedValue({ hash: '0xmobile' })
+    const method = vi.fn()
+    const send = vi.fn()
+    const signer = { provider: { send } } as unknown as Signer
+
+    const res = await submitWrite(contractWith(method), 'commit', [1], signer)
+
+    expect(mockWagmiSubmit).toHaveBeenCalledWith(expect.anything(), 'commit', [1])
+    expect(send).not.toHaveBeenCalled() // no eth_chainId assertion on mobile (wagmi pins it)
+    expect(method).not.toHaveBeenCalled()
+    expect(res).toEqual({ hash: '0xmobile' })
+  })
+})
+
+describe('assertHubChain / isWrongChainError', () => {
+  it('resolves on the hub chain', async () => {
+    await expect(assertHubChain(signerOnChain('0x1'))).resolves.toBeUndefined()
+  })
+
+  it('throws a WRONG_CHAIN error off the hub chain', async () => {
+    await expect(assertHubChain(signerOnChain('0x5'))).rejects.toMatchObject({ code: 'WRONG_CHAIN' })
+  })
+
+  it('isWrongChainError matches only the guard error', () => {
+    expect(isWrongChainError(Object.assign(new Error('x'), { code: 'WRONG_CHAIN' }))).toBe(true)
+    expect(isWrongChainError(new Error('x'))).toBe(false)
+    expect(isWrongChainError(null)).toBe(false)
+  })
+})

--- a/crowdfund-ui/packages/committer/src/lib/submitWrite.ts
+++ b/crowdfund-ui/packages/committer/src/lib/submitWrite.ts
@@ -1,0 +1,70 @@
+// ABOUTME: Unified contract-write submit — mobile via wagmi (chain-pinned), desktop via ethers after a live hub-chain assertion.
+// ABOUTME: Centralizes the mobile/desktop split so no write path can broadcast to the wrong chain when the wallet switches networks mid-flow.
+
+import type { Contract, Signer, TransactionResponse } from 'ethers'
+import { isMobileBrowser } from '@/lib/isMobileBrowser'
+import { submitTxViaWagmi } from '@/lib/mobileTxSubmit'
+import { getHubChainId, getHubNetworkLabel } from '@/config/network'
+
+/** Distinguish the wrong-chain guard error so callers/copy can special-case it. */
+export function isWrongChainError(err: unknown): boolean {
+  return (err as { code?: unknown } | null)?.code === 'WRONG_CHAIN'
+}
+
+/**
+ * Assert the wallet's LIVE chain is the hub chain before a desktop ethers send.
+ *
+ * The desktop ethers path — unlike the mobile wagmi path, which pins `chainId`
+ * on `sendTransaction` — broadcasts to whatever chain the injected wallet is
+ * currently on, and the pipeline doesn't re-check the chain between steps. If the
+ * user switched networks mid-flow, a send to the crowdfund address on the wrong
+ * chain can return a status-1 receipt (no code at that address ⇒ no revert) and be
+ * shown as a successful commit while nothing landed on the hub.
+ *
+ * We read the live chain via a direct `eth_chainId` request rather than
+ * `provider.getNetwork()`: the wagmi→ethers `BrowserProvider` is built with a
+ * STATIC network (see `wagmiAdapter`), so `getNetwork()` returns the
+ * construction-time chain and would miss a live switch. A provider that can't be
+ * queried is left un-asserted (non-blocking) so we never wedge a legitimate send.
+ */
+export async function assertHubChain(signer: Signer): Promise<void> {
+  const provider = signer.provider as
+    | { send?: (method: string, params: unknown[]) => Promise<unknown> }
+    | null
+  if (!provider?.send) return
+  const hex = (await provider.send('eth_chainId', [])) as string
+  const live = Number.parseInt(hex, 16)
+  if (Number.isFinite(live) && live !== getHubChainId()) {
+    throw Object.assign(
+      new Error(`Wrong network — switch to ${getHubNetworkLabel()} and retry.`),
+      { code: 'WRONG_CHAIN' as const },
+    )
+  }
+}
+
+/**
+ * Submit a contract write. Mobile routes through wagmi's `sendTransaction`
+ * (chain-pinned, and it triggers the WalletConnect app redirect); desktop goes
+ * through the ethers signer after asserting the wallet is on the hub chain.
+ * Returns an ethers-`TransactionResponse`-shaped object either way, so the shared
+ * send/wait engine (`sendAndWaitTx`) is unchanged.
+ */
+export async function submitWrite(
+  contract: Contract,
+  method: string,
+  args: readonly unknown[],
+  signer: Signer,
+): Promise<TransactionResponse> {
+  if (isMobileBrowser()) {
+    return submitTxViaWagmi(contract, method, args)
+  }
+  await assertHubChain(signer)
+  // Dynamic method call — ethers' Contract Proxy resolves `contract[method]` to
+  // the write method (same as the direct `contract.commit(...)` call this
+  // replaced), so it works on a real Contract and on plain-object test doubles.
+  const write = (contract as unknown as Record<
+    string,
+    (...a: unknown[]) => Promise<TransactionResponse>
+  >)[method]
+  return write(...args)
+}


### PR DESCRIPTION
Fixes triage finding #7. Desktop wallet writes weren't chain-pinned: a mid-flow network switch could broadcast a commit to the crowdfund address on the wrong chain and — if that address is codeless there (status-1 receipt, no revert) — be shown as a **successful commit while nothing landed on the hub.**

### Root cause
Every write splits mobile vs. desktop. **Mobile** pins the chain (`submitTxViaWagmi` → `sendTransaction({ chainId })`); **desktop** goes through a raw ethers `JsonRpcSigner` with no assertion, and the pipeline never re-checks the chain between steps (`useTxPipeline` aborts on address change only, `App.tsx:404-406`). `sendAndWaitTx` classifies any status-1 receipt as `success`.

### Fix — assert the LIVE hub chain before each desktop send
New `submitWrite(contract, method, args, signer)` helper centralizes the mobile/desktop split (previously duplicated across 8 call sites) and, on desktop, calls `assertHubChain(signer)` first:

- Reads the **live** chain via a direct `eth_chainId` request, **not** `provider.getNetwork()` — the wagmi→ethers `BrowserProvider` is built with a *static* network (`wagmiAdapter`), so `getNetwork()` returns the construction-time chain and would miss a live switch. (Same approach `useMobileChainReconciliation` already uses.)
- On a mismatch it throws a `WRONG_CHAIN` error **before** broadcast (no hash), so `sendAndWaitTx` surfaces it as an actionable error row — never a false success. Added a `revertMessages` pattern so the copy reads "switch to the hub chain and retry."
- A provider that can't be queried is left un-asserted (non-blocking) so a legitimate send is never wedged.

Because the assertion runs per-send, it's immune to a switch that happens *between* pipeline steps — no race, unlike an effect-based abort.

Wired into all desktop write paths: `ParticipateFlowV2` (approve + commit), `ClaimFlowV2` (claim + claimRefund), `InviteLinkFlowController` (approve + commitWithInvite), and `selfFillSteps` (approve + multicall). Mobile behavior is unchanged (still routed through wagmi, which already pins the chain).

### Severity
LOW — no theft, and the full false-success outcome needs a confluence (mid-flow switch + stale hook signer reused rather than the already-chain-pinned `resolveSigner` fallback + codeless address on the destination chain + a wallet that doesn't reject the mismatch). But it's a real correctness/trust gap on the money path, and the fix also DRYs the previously-duplicated send split.

### Tests
New `submitWrite.test.ts` (+7): desktop on the hub chain sends; desktop on the wrong chain throws `WRONG_CHAIN` and **never broadcasts**; unqueryable provider is non-blocking; mobile routes to wagmi with no assertion; plus `assertHubChain`/`isWrongChainError` units. `revertMessages` (+1) covers the new copy. 189 committer tests pass; typecheck clean.

### Context
Final engineering item from the pre-mainnet committer review (`.context/COMMITTER_REVIEW_TRIAGE.md`). Independent of the other open review PRs (#357 #358 #359).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
