### PR TITLE
fix(committer): verify mainnet crowdfund approve target against a trusted anchor (#354)

### DIFF
--- a/crowdfund-ui/packages/committer/src/config/deployments.ts
+++ b/crowdfund-ui/packages/committer/src/config/deployments.ts
@@ -1,7 +1,13 @@
 // ABOUTME: Loads crowdfund deployment addresses from deployment JSON files.
 // ABOUTME: Fetches from the Vite dev server plugin that serves deployments/.
 
-import { getDeploymentFileName, getHubChainId, assertDeploymentChainId } from './network'
+import {
+  getDeploymentFileName,
+  getHubChainId,
+  assertDeploymentChainId,
+  assertExpectedAddress,
+  getExpectedCrowdfundAddress,
+} from './network'
 
 export interface CrowdfundDeployment {
   chainId: number
@@ -45,6 +51,21 @@ export async function loadDeployment(): Promise<CrowdfundDeployment> {
   // Fail loud if the manifest is for a different chain than this build targets —
   // otherwise we'd talk to one network's addresses while the wallet expects another.
   assertDeploymentChainId(deployment.chainId, getHubChainId(), fileName)
+
+  // Verify the crowdfund address (the USDC approve/commit target) against a
+  // trusted value supplied out-of-band via VITE_EXPECTED_CROWDFUND_ADDRESS.
+  // Defends against a compromised/wrong manifest fetched from armada-deployments
+  // redirecting every approval to an attacker address. Required on mainnet (see
+  // validateEnv); on other networks it is checked only when the var is set.
+  const expectedCrowdfund = getExpectedCrowdfundAddress()
+  if (expectedCrowdfund) {
+    assertExpectedAddress(
+      deployment.contracts.crowdfund,
+      expectedCrowdfund,
+      'contracts.crowdfund',
+      fileName,
+    )
+  }
 
   cachedDeployment = deployment
   return cachedDeployment

--- a/crowdfund-ui/packages/committer/src/config/network.ts
+++ b/crowdfund-ui/packages/committer/src/config/network.ts
@@ -15,5 +15,7 @@ export {
   getTxConfirmations,
   getExplorerUrl,
   assertDeploymentChainId,
+  assertExpectedAddress,
+  getExpectedCrowdfundAddress,
 } from '@armada/crowdfund-shared'
 export type { NetworkMode } from '@armada/crowdfund-shared'

--- a/crowdfund-ui/packages/committer/src/config/validateEnv.test.ts
+++ b/crowdfund-ui/packages/committer/src/config/validateEnv.test.ts
@@ -89,6 +89,36 @@ describe('validateEnv', () => {
     }
   })
 
+  it('rejects a malformed VITE_EXPECTED_CROWDFUND_ADDRESS on any network', () => {
+    const mainnet = validateEnv({
+      PROD: true,
+      VITE_NETWORK: 'mainnet',
+      VITE_WALLETCONNECT_PROJECT_ID: 'wc-id',
+      VITE_CROWDFUND_INDEXER_URL: 'https://indexer.example',
+      VITE_EXPECTED_CROWDFUND_ADDRESS: '0x123',
+    })
+    expect(mainnet.ok).toBe(false)
+    if (!mainnet.ok) {
+      expect(mainnet.errors.some((e) => e.includes('not a valid Ethereum address'))).toBe(true)
+    }
+    // Also enforced when opted into on sepolia.
+    const sepolia = validateEnv({ ...COMPLETE_PROD, VITE_EXPECTED_CROWDFUND_ADDRESS: 'nope' })
+    expect(sepolia.ok).toBe(false)
+  })
+
+  it('accepts a lowercase (non-checksummed) VITE_EXPECTED_CROWDFUND_ADDRESS', () => {
+    // Format-only check — a lowercase-entered address must not be rejected.
+    expect(
+      validateEnv({
+        PROD: true,
+        VITE_NETWORK: 'mainnet',
+        VITE_WALLETCONNECT_PROJECT_ID: 'wc-id',
+        VITE_CROWDFUND_INDEXER_URL: 'https://indexer.example',
+        VITE_EXPECTED_CROWDFUND_ADDRESS: '0x52908400098527886e0f7030069857d2e4169ee7',
+      }),
+    ).toEqual({ ok: true })
+  })
+
   it('does not require VITE_EXPECTED_CROWDFUND_ADDRESS on a sepolia build', () => {
     // COMPLETE_PROD is a sepolia build with no expected-address var; must stay green.
     expect(validateEnv(COMPLETE_PROD)).toEqual({ ok: true })

--- a/crowdfund-ui/packages/committer/src/config/validateEnv.test.ts
+++ b/crowdfund-ui/packages/committer/src/config/validateEnv.test.ts
@@ -45,6 +45,7 @@ describe('validateEnv', () => {
         VITE_CROWDFUND_INDEXER_URL: 'https://indexer.example',
         VITE_CROWDFUND_PROFILE: 'mainnet',
         VITE_DEPLOYMENT_INSTANCE: 'launch1',
+        VITE_EXPECTED_CROWDFUND_ADDRESS: '0x52908400098527886E0F7030069857D2E4169EE7',
       }),
     ).toEqual({ ok: true })
   })
@@ -70,7 +71,29 @@ describe('validateEnv', () => {
         VITE_NETWORK: 'mainnet',
         VITE_WALLETCONNECT_PROJECT_ID: 'wc-id',
         VITE_CROWDFUND_INDEXER_URL: 'https://indexer.example',
+        VITE_EXPECTED_CROWDFUND_ADDRESS: '0x52908400098527886E0F7030069857D2E4169EE7',
       }),
+    ).toEqual({ ok: true })
+  })
+
+  it('fails a mainnet build without VITE_EXPECTED_CROWDFUND_ADDRESS', () => {
+    const result = validateEnv({
+      PROD: true,
+      VITE_NETWORK: 'mainnet',
+      VITE_WALLETCONNECT_PROJECT_ID: 'wc-id',
+      VITE_CROWDFUND_INDEXER_URL: 'https://indexer.example',
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes('VITE_EXPECTED_CROWDFUND_ADDRESS'))).toBe(true)
+    }
+  })
+
+  it('does not require VITE_EXPECTED_CROWDFUND_ADDRESS on a sepolia build', () => {
+    // COMPLETE_PROD is a sepolia build with no expected-address var; must stay green.
+    expect(validateEnv(COMPLETE_PROD)).toEqual({ ok: true })
+    expect(
+      validateEnv({ ...COMPLETE_PROD, VITE_EXPECTED_CROWDFUND_ADDRESS: undefined }),
     ).toEqual({ ok: true })
   })
 

--- a/crowdfund-ui/packages/committer/src/config/validateEnv.ts
+++ b/crowdfund-ui/packages/committer/src/config/validateEnv.ts
@@ -10,6 +10,7 @@ export interface EnvRecord {
   VITE_CROWDFUND_INDEXER_URL?: string
   VITE_CROWDFUND_PROFILE?: string
   VITE_DEPLOYMENT_INSTANCE?: string
+  VITE_EXPECTED_CROWDFUND_ADDRESS?: string
 }
 
 export type EnvValidationResult = { ok: true } | { ok: false; errors: string[] }
@@ -66,6 +67,15 @@ export function validateEnv(env: EnvRecord): EnvValidationResult {
     errors.push(
       `VITE_CROWDFUND_PROFILE is "${env.VITE_CROWDFUND_PROFILE!.trim()}" on a mainnet build — ` +
         'mainnet must use the "mainnet" profile (or leave it unset, which defaults to mainnet).',
+    )
+  }
+  // The crowdfund address is the USDC approve/commit target. On mainnet it must be
+  // pinned to a trusted out-of-band value so the app can reject a compromised/wrong
+  // manifest fetched from armada-deployments; refuse to build without the anchor.
+  if (network === 'mainnet' && missing(env.VITE_EXPECTED_CROWDFUND_ADDRESS)) {
+    errors.push(
+      'VITE_EXPECTED_CROWDFUND_ADDRESS is not set on a mainnet build — the committer cannot ' +
+        'verify the fetched crowdfund (USDC approve target) address against a trusted value.',
     )
   }
 

--- a/crowdfund-ui/packages/committer/src/config/validateEnv.ts
+++ b/crowdfund-ui/packages/committer/src/config/validateEnv.ts
@@ -78,6 +78,18 @@ export function validateEnv(env: EnvRecord): EnvValidationResult {
         'verify the fetched crowdfund (USDC approve target) address against a trusted value.',
     )
   }
+  // If an expected address is supplied (any network), it must be a well-formed
+  // 20-byte hex address. Catch a typo here at startup rather than deferring to the
+  // manifest-load-time getAddress() in assertExpectedAddress. Format-only (no EIP-55
+  // checksum) so a lowercase-entered value is accepted.
+  if (
+    !missing(env.VITE_EXPECTED_CROWDFUND_ADDRESS) &&
+    !/^0x[0-9a-fA-F]{40}$/.test(env.VITE_EXPECTED_CROWDFUND_ADDRESS!.trim())
+  ) {
+    errors.push(
+      'VITE_EXPECTED_CROWDFUND_ADDRESS is not a valid Ethereum address (expected 0x + 40 hex chars).',
+    )
+  }
 
   return errors.length > 0 ? { ok: false, errors } : { ok: true }
 }

--- a/crowdfund-ui/packages/shared/src/index.ts
+++ b/crowdfund-ui/packages/shared/src/index.ts
@@ -77,6 +77,7 @@ export {
   confirmationsForMode,
   explorerUrlForMode,
   assertDeploymentChainId,
+  assertExpectedAddress,
   getNetworkMode,
   isLocalMode,
   getHubChainId,
@@ -89,6 +90,7 @@ export {
   getMaxBlockRange,
   getTxConfirmations,
   getExplorerUrl,
+  getExpectedCrowdfundAddress,
 } from './lib/network.js'
 export type { NetworkMode, NetworkEnv } from './lib/network.js'
 

--- a/crowdfund-ui/packages/shared/src/lib/network.test.ts
+++ b/crowdfund-ui/packages/shared/src/lib/network.test.ts
@@ -15,6 +15,7 @@ import {
   confirmationsForMode,
   explorerUrlForMode,
   assertDeploymentChainId,
+  assertExpectedAddress,
   type NetworkEnv,
 } from './network.js'
 
@@ -171,6 +172,40 @@ describe('assertDeploymentChainId', () => {
     expect(() => assertDeploymentChainId(11155111, 1, 'crowdfund-hub-mainnet.json')).toThrow(
       /chain mismatch.*11155111.*chain 1/,
     )
+  })
+})
+
+describe('assertExpectedAddress', () => {
+  // A valid checksummed address and the same address in different casings.
+  const CHECKSUMMED = '0x52908400098527886E0F7030069857D2E4169EE7'
+  const LOWER = CHECKSUMMED.toLowerCase()
+  const OTHER = '0x8617E340B3D01FA5F11F306F4090FD50E238070D'
+
+  it('passes when both sides are the same address regardless of casing', () => {
+    expect(() =>
+      assertExpectedAddress(LOWER, CHECKSUMMED, 'contracts.crowdfund', 'crowdfund.json'),
+    ).not.toThrow()
+    expect(() =>
+      assertExpectedAddress(CHECKSUMMED, LOWER, 'contracts.crowdfund', 'crowdfund.json'),
+    ).not.toThrow()
+  })
+
+  it('throws a supply-chain warning when the addresses differ', () => {
+    expect(() =>
+      assertExpectedAddress(OTHER, CHECKSUMMED, 'contracts.crowdfund', 'crowdfund.json'),
+    ).toThrow(/Address integrity check failed.*contracts\.crowdfund.*supply-chain/s)
+  })
+
+  it('throws on a malformed actual address', () => {
+    expect(() =>
+      assertExpectedAddress('not-an-address', CHECKSUMMED, 'contracts.crowdfund', 'crowdfund.json'),
+    ).toThrow(/malformed address/)
+  })
+
+  it('throws on a malformed expected address', () => {
+    expect(() =>
+      assertExpectedAddress(CHECKSUMMED, '0x123', 'contracts.crowdfund', 'crowdfund.json'),
+    ).toThrow(/malformed address/)
   })
 })
 

--- a/crowdfund-ui/packages/shared/src/lib/network.ts
+++ b/crowdfund-ui/packages/shared/src/lib/network.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Shared network configuration for local (Anvil), Sepolia, and mainnet.
 // ABOUTME: Pure resolvers (testable) + import.meta.env wrappers used by the apps.
 
+import { getAddress } from 'ethers'
+
 export type NetworkMode = 'local' | 'sepolia' | 'mainnet'
 
 /** The subset of Vite env the network resolvers read. All optional so the pure
@@ -17,6 +19,10 @@ export interface NetworkEnv {
   VITE_SEPOLIA_RPC_FALLBACK?: string
   VITE_CROWDFUND_INDEXER_URL?: string
   VITE_DEPLOYMENT_INSTANCE?: string
+  /** Trusted crowdfund address supplied out-of-band from the mainnet deploy
+   *  output. Used to verify the fetched manifest's crowdfund (USDC approve/commit
+   *  target) address against a value that does not come from armada-deployments. */
+  VITE_EXPECTED_CROWDFUND_ADDRESS?: string
 }
 
 // Default public RPCs, used only when no env-configured URL is present. A money
@@ -158,6 +164,34 @@ export function assertDeploymentChainId(
   }
 }
 
+/**
+ * Guard a loaded deployment manifest's critical address against an out-of-band
+ * expected value. Defends against a compromised/wrong manifest (supply-chain gap
+ * on the armada-deployments fetch) redirecting the USDC approve/commit target.
+ * Case/checksum-insensitive. Throws on mismatch or a malformed input.
+ */
+export function assertExpectedAddress(
+  actual: string,
+  expected: string,
+  field: string,
+  source: string,
+): void {
+  let a: string
+  let e: string
+  try {
+    a = getAddress(actual)
+    e = getAddress(expected)
+  } catch {
+    throw new Error(`Address integrity check failed for ${field} in ${source}: malformed address`)
+  }
+  if (a !== e) {
+    throw new Error(
+      `Address integrity check failed: ${field} in ${source} is ${a}, but this build expects ${e}. ` +
+        `Refusing to load — possible supply-chain tampering of the deployment manifest.`,
+    )
+  }
+}
+
 /** Block explorer base URL. Returns undefined for local mode (no explorer). */
 export function explorerUrlForMode(mode: NetworkMode): string | undefined {
   switch (mode) {
@@ -224,4 +258,8 @@ export function getTxConfirmations(): number {
 
 export function getExplorerUrl(): string | undefined {
   return explorerUrlForMode(getNetworkMode())
+}
+
+export function getExpectedCrowdfundAddress(): string | undefined {
+  return env().VITE_EXPECTED_CROWDFUND_ADDRESS?.trim() || undefined
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,6 +16,18 @@
 #                           instance's scale or the UI misrepresents the sale.
 #   DEPLOYMENT_INSTANCE     named armada-deployments instance; defaults to "medi2".
 #                           Re-exported as VITE_DEPLOYMENT_INSTANCE for the runtime.
+#   DEPLOYMENT_REF          git ref of ship-armada/armada-deployments to fetch the
+#                           manifest from. Pins the fetch to an immutable point so a
+#                           later push to `main` cannot change what ships after review.
+#                           MUST be a full commit SHA on the mainnet site; defaults to
+#                           "main" (unpinned) for Sepolia, which is low-stakes.
+#   VITE_EXPECTED_CROWDFUND_ADDRESS  trusted crowdfund contract address, supplied
+#                           out-of-band from the mainnet deploy output (NOT from
+#                           armada-deployments). The build fails if the fetched
+#                           manifest's crowdfund address does not match it, and the
+#                           runtime refuses to load a mismatching manifest. REQUIRED on
+#                           mainnet (validateEnv hard-fails without it); optional on
+#                           Sepolia (checked only when set).
 #   VITE_HUB_RPC            dedicated hub RPC URL (+ optional VITE_HUB_RPC_FALLBACK).
 #                           Strongly recommended on mainnet; without it the app falls
 #                           back to a public node. (Legacy VITE_SEPOLIA_RPC still works
@@ -50,10 +62,13 @@
     export VITE_CROWDFUND_PROFILE="${VITE_CROWDFUND_PROFILE:-medi}" && \
     INSTANCE="${DEPLOYMENT_INSTANCE:-medi2}" && \
     export VITE_DEPLOYMENT_INSTANCE="${INSTANCE}" && \
-    BASE="https://raw.githubusercontent.com/ship-armada/armada-deployments/main/${NETWORK}/${INSTANCE}" && \
-    echo "Fetching ${NETWORK}/${INSTANCE} (VITE_NETWORK=${VITE_NETWORK}, profile=${VITE_CROWDFUND_PROFILE})" && \
+    REF="${DEPLOYMENT_REF:-main}" && \
+    BASE="https://raw.githubusercontent.com/ship-armada/armada-deployments/${REF}/${NETWORK}/${INSTANCE}" && \
+    echo "Fetching ${NETWORK}/${INSTANCE}@${REF} (VITE_NETWORK=${VITE_NETWORK}, profile=${VITE_CROWDFUND_PROFILE})" && \
     mkdir -p "crowdfund-ui/packages/committer/public/api/deployments/instances/${INSTANCE}/${VITE_NETWORK}" && \
-    curl -sfL -o "crowdfund-ui/packages/committer/public/api/deployments/instances/${INSTANCE}/${VITE_NETWORK}/crowdfund.json" "${BASE}/${VITE_NETWORK}/crowdfund.json" && \
+    export CF_MANIFEST_PATH="crowdfund-ui/packages/committer/public/api/deployments/instances/${INSTANCE}/${VITE_NETWORK}/crowdfund.json" && \
+    curl -sfL -o "${CF_MANIFEST_PATH}" "${BASE}/${VITE_NETWORK}/crowdfund.json" && \
+    node -e "const fs=require('fs');const p=process.env.CF_MANIFEST_PATH;const exp=process.env.VITE_EXPECTED_CROWDFUND_ADDRESS;if(exp){const d=JSON.parse(fs.readFileSync(p,'utf8'));const got=(d.contracts&&d.contracts.crowdfund||'').toLowerCase();if(got!==exp.toLowerCase()){console.error('FATAL: fetched crowdfund '+got+' != expected '+exp.toLowerCase());process.exit(1);}console.log('crowdfund address verified against VITE_EXPECTED_CROWDFUND_ADDRESS');}else{console.log('VITE_EXPECTED_CROWDFUND_ADDRESS unset — skipping build-time address check');}" && \
     rm -rf node_modules package-lock.json && \
     npm install --legacy-peer-deps && \
     npm run build --workspace=@armada/crowdfund-committer

--- a/netlify.toml
+++ b/netlify.toml
@@ -19,8 +19,10 @@
 #   DEPLOYMENT_REF          git ref of ship-armada/armada-deployments to fetch the
 #                           manifest from. Pins the fetch to an immutable point so a
 #                           later push to `main` cannot change what ships after review.
-#                           MUST be a full commit SHA on the mainnet site; defaults to
-#                           "main" (unpinned) for Sepolia, which is low-stakes.
+#                           MUST be a full 40-char commit SHA on the mainnet site —
+#                           the build hard-fails otherwise (a branch ref would defeat
+#                           the pin). Defaults to "main" (unpinned) for Sepolia, which
+#                           is low-stakes.
 #   VITE_EXPECTED_CROWDFUND_ADDRESS  trusted crowdfund contract address, supplied
 #                           out-of-band from the mainnet deploy output (NOT from
 #                           armada-deployments). The build fails if the fetched
@@ -63,6 +65,7 @@
     INSTANCE="${DEPLOYMENT_INSTANCE:-medi2}" && \
     export VITE_DEPLOYMENT_INSTANCE="${INSTANCE}" && \
     REF="${DEPLOYMENT_REF:-main}" && \
+    if [ "${VITE_NETWORK}" = "mainnet" ] && ! echo "${REF}" | grep -Eq '^[0-9a-f]{40}$'; then echo "FATAL: DEPLOYMENT_REF must be a full 40-char commit SHA on mainnet (got: ${REF}) — pinning to a branch defeats the supply-chain guard"; exit 1; fi && \
     BASE="https://raw.githubusercontent.com/ship-armada/armada-deployments/${REF}/${NETWORK}/${INSTANCE}" && \
     echo "Fetching ${NETWORK}/${INSTANCE}@${REF} (VITE_NETWORK=${VITE_NETWORK}, profile=${VITE_CROWDFUND_PROFILE})" && \
     mkdir -p "crowdfund-ui/packages/committer/public/api/deployments/instances/${INSTANCE}/${VITE_NETWORK}" && \

--- a/specs/OPERATIONS.md
+++ b/specs/OPERATIONS.md
@@ -83,6 +83,7 @@ Complete every item before calling the deploy script. Sign off with initials and
 |---|---|
 | Observer URL is live and loading events | ☐ |
 | Committer URL is live and wallet connection works | ☐ |
+| Committer `DEPLOYMENT_REF` (commit SHA) and `VITE_EXPECTED_CROWDFUND_ADDRESS` set on the mainnet Netlify site (see §3 Step 8) | ☐ |
 | RPC fallback providers configured and tested | ☐ |
 | Monitoring alerts configured (see §8) | ☐ |
 | Security Council members confirmed reachable | ☐ |
@@ -147,9 +148,9 @@ Record: `contract_address = [address]`, `deploy_tx = [hash]`, `block = [number]`
 
 Record: `loadArm_tx = [hash]`
 
-> **If `loadArm()` was called before `openTimestamp`:** Stop here. Verify observer shows ARMED / PRE-OPEN. Do not proceed to Steps 6, 7, or 9 until `block.timestamp ≥ openTimestamp`. The contract is armed but commitments will revert and `addSeed()` / `launchTeamInvite()` may also revert until the week-1 window is active.
+> **If `loadArm()` was called before `openTimestamp`:** Stop here. Verify observer shows ARMED / PRE-OPEN. Do not proceed to Steps 6, 7, or 10 until `block.timestamp ≥ openTimestamp`. The contract is armed but commitments will revert and `addSeed()` / `launchTeamInvite()` may also revert until the week-1 window is active. (Step 8, the committer integrity-anchor config, is not gated by `openTimestamp` and may be done now.)
 
-> **At or after `openTimestamp`:** Continue to Steps 6, 7, 8, and 9 in order.
+> **At or after `openTimestamp`:** Continue to Steps 6, 7, 8, 9, and 10 in order.
 
 ### Step 6: Add initial seeds
 
@@ -163,19 +164,36 @@ See §4 (Week-1 operating cadence) for the full seed addition procedure. The fir
 
 See §4 for the launch-team invite procedure.
 
-### Step 8: Verify observer and committer
+### Step 8: Configure the committer's supply-chain integrity anchor (Netlify env)
+
+The mainnet committer fetches its contract addresses (including the `crowdfund`
+address every user grants a USDC `approve()` to) from the `ship-armada/armada-deployments`
+repo at build time. Two per-site Netlify env vars pin and verify that fetch so a
+later push to the deployments repo cannot silently redirect the approve target.
+This step may be performed as soon as the contract address (Step 1) and the
+published manifest exist — it does not depend on `openTimestamp`.
+
+| | |
+|---|---|
+| **Actor** | Deployer / ops |
+| **Action** | 1. Capture the deployed `crowdfund` address from the Step 1 deploy output. 2. Publish the deployment manifest to `armada-deployments` and record the resulting **commit SHA**. 3. In the mainnet committer Netlify site env (Site settings → Environment variables), set `DEPLOYMENT_REF=<that commit SHA>` (a full SHA, not a branch) and `VITE_EXPECTED_CROWDFUND_ADDRESS=<deployed crowdfund address>`. 4. Trigger a committer redeploy. |
+| **Preconditions** | Step 1 complete (crowdfund address known); manifest published to `armada-deployments` |
+| **On-chain confirmation** | Build log prints `crowdfund address verified against VITE_EXPECTED_CROWDFUND_ADDRESS`; the app loads without an address-integrity error |
+| **Fallback** | If the build fails with `FATAL: fetched crowdfund … != expected …`, the pinned manifest's crowdfund address does not match the trusted value — do NOT override the check; confirm the correct manifest/SHA and the correct expected address before redeploying. A mainnet build also hard-fails `validateEnv` if `VITE_EXPECTED_CROWDFUND_ADDRESS` is unset. |
+
+### Step 9: Verify observer and committer
 
 | | |
 |---|---|
 | **Actor** | Deployer or ops |
 | **Action** | Load observer; confirm `ArmLoaded` and any `SeedAdded` events appear; confirm stats banner shows correct state. If `block.timestamp < openTimestamp`: observer should show "ARMED / PRE-OPEN" (or equivalent) — not "OPEN". Commitments will start working once the open timestamp is reached. If `block.timestamp ≥ openTimestamp`: observer should show "OPEN" with correct countdown. Test wallet connection on committer. |
-| **Preconditions** | Pre-open path: Step 5 complete. Open path: Steps 5–7 complete. |
+| **Preconditions** | Pre-open path: Steps 5 and 8 complete. Open path: Steps 5–8 complete. |
 | **On-chain confirmation** | Observer reflects correct state (pre-open or open) and correct hop-0 count |
 | **Fallback** | If observer not loading: check RPC provider; check contract address in observer config |
 
-### Step 9: Announce sale open
+### Step 10: Announce sale open
 
-**Do not announce until Step 8 confirms observer shows OPEN (not merely ARMED / PRE-OPEN).** Publish observer and committer URLs. Send participant communications.
+**Do not announce until Step 9 confirms observer shows OPEN (not merely ARMED / PRE-OPEN).** Publish observer and committer URLs. Send participant communications.
 
 ---
 


### PR DESCRIPTION
Closes #354.

## Problem
The mainnet committer fetches its contract addresses — including the `crowdfund` address every user grants a USDC `approve()` to — at Netlify build time from the **unpinned `main`** of `ship-armada/armada-deployments` via plain `curl`, with no integrity check. Anyone with push access to that repo's `main` could redirect every mainnet USDC approval to an attacker address. Runtime validation was chain-id-only, satisfied by any manifest carrying the right `chainId`.

## Fix — two independent defenses
**1. Pin the source** (`netlify.toml`): build fetch uses a new `DEPLOYMENT_REF` (defaults to `main`) so the mainnet site pins to a commit SHA; a later push to `main` can't change what ships. Sepolia unaffected.

**2. Verify the value** (build-time + runtime):
- Build-time Node check fails the build if the fetched `crowdfund` address ≠ `VITE_EXPECTED_CROWDFUND_ADDRESS`; skips when unset.
- New pure `assertExpectedAddress()` in `shared/network.ts` (checksum-insensitive via `ethers.getAddress`) called at runtime in `deployments.ts` after the chain-id guard.
- `validateEnv` hard-fails a mainnet PROD build when `VITE_EXPECTED_CROWDFUND_ADDRESS` is unset, so the anchor can never be silently absent.

The expected address is supplied out-of-band from the deploy output — **not** sourced from armada-deployments — so it also defends against a bad manifest at the pinned SHA.

## Scope
Committer + shared only. No admin/indexer, no CSP, no `fetch-deployment.ts`, no new deps (ethers already in `shared`). Sepolia builds/runs unchanged with no new env vars. No addresses/keys committed (only a public EIP-55 test vector in unit tests).

## Tests
Shared 302/302, committer 195/195; both packages typecheck clean. New: `assertExpectedAddress` cases (match across casings / mismatch / malformed) and validateEnv mainnet-required / sepolia-not-required cases.

## Docs
`netlify.toml` header documents `DEPLOYMENT_REF` + `VITE_EXPECTED_CROWDFUND_ADDRESS`; `OPERATIONS.md` gains a post-deploy step (new §3 Step 8, renumbered 9/10) and a pre-launch checklist row.

## ⚠️ Deploy-time action required
The **mainnet committer Netlify site must have `DEPLOYMENT_REF=<commit SHA>` and `VITE_EXPECTED_CROWDFUND_ADDRESS=<deployed crowdfund address>` set before its next deploy** — otherwise the mainnet build will intentionally fail `validateEnv`. These are per-site env vars set at deploy time (see OPERATIONS §3 Step 8); they inherently land after the mainnet deploy exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)