### PR TITLE
indexer launch hardening: A3 drop, dead-config removal, reorg idempotency, nginx rate limit (#332 #333 #334 #335)

### DIFF
--- a/crowdfund-ui/packages/indexer/src/alerts/rules.test.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/rules.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from 'vitest'
 import {
-  ruleA1, ruleA2, ruleA3, ruleA4, ruleA5, ruleA6, ruleA7, ruleA8,
+  ruleA1, ruleA2, ruleA4, ruleA5, ruleA6, ruleA7, ruleA8,
   ruleA9a, ruleA9b, ruleA10, ruleA11, ruleA12, ruleA13, ruleA17, ruleA18, ruleA19, ruleA20,
   ruleAH1, ruleAH2,
   evaluateAllRules,
@@ -134,30 +134,6 @@ describe('ruleA2 — sale open, not armed', () => {
   })
   it('does not fire before openTimestamp', () => {
     expect(ruleA2(makeContext({ now: OPEN_TS - 1 }))).toEqual([])
-  })
-})
-
-// ============ A3 ============
-describe('ruleA3 — week-1 action after week1Deadline', () => {
-  it('no-ops without event timestamps (current indexer state)', () => {
-    const ctx = makeContext({
-      now: WEEK1_TS + 100,
-      snapshot: {
-        ...makeContext().snapshot,
-        events: [makeEvent('SeedAdded', { seed: '0xs' })],
-      } as never,
-    })
-    expect(ruleA3(ctx)).toEqual([])
-  })
-  it('fires P0 when an event carries a _timestamp beyond week1Deadline', () => {
-    const ctx = makeContext({
-      snapshot: {
-        ...makeContext().snapshot,
-        events: [makeEvent('SeedAdded', { seed: '0xs', _timestamp: WEEK1_TS + 1 })],
-      } as never,
-    })
-    const out = ruleA3(ctx)
-    expect(out[0]).toMatchObject({ id: 'A3', severity: 'P0' })
   })
 })
 

--- a/crowdfund-ui/packages/indexer/src/alerts/rules.ts
+++ b/crowdfund-ui/packages/indexer/src/alerts/rules.ts
@@ -118,37 +118,6 @@ export const ruleA2: AlertRule = (ctx) => {
   }]
 }
 
-// A3 — Week-1 action outside week-1 window (P0)
-export const ruleA3: AlertRule = (ctx) => {
-  const out: AlertEvent[] = []
-  for (const e of ctx.snapshot.events) {
-    if (e.type !== 'SeedAdded' && e.type !== 'LaunchTeamInvited') continue
-    // The graph keeps events ordered by block; we cannot trivially derive timestamp
-    // from the event itself, but the indexer guarantees no event past the contract's
-    // own week-1 guard. A week-1 violation would mean a contract or RPC failure.
-    // Use blockNumber as the dedupe seed so each offending event fires once.
-    if (e.blockNumber === 0) continue
-    // Coarse-grained timestamp comparison would require block-timestamp lookups;
-    // the contract's _requireArmLoadedAndPreInviteEnd already enforces this. If a
-    // week-1 event ever appears past week1Deadline, the indexer + chain are
-    // inconsistent — surface it.
-    // For now, A3 is wired but only fires when an indexer extension supplies
-    // event timestamps. Skip when timestamp is unknown.
-    const timestamp = Number((e.args as { _timestamp?: number })._timestamp ?? 0)
-    if (timestamp === 0) continue
-    if (timestamp <= ctx.params.week1Deadline) continue
-    out.push({
-      id: 'A3',
-      severity: 'P0',
-      dedupeKey: `A3:${e.type}:${e.transactionHash}:${e.logIndex}`,
-      title: 'Week-1 action emitted after week-1 deadline',
-      body: `${e.type} emitted at block ${e.blockNumber} after week1Deadline. Investigate immediately.`,
-      runbook: 'OPERATIONS.md §9 failure investigation',
-    })
-  }
-  return out
-}
-
 // A4 — Seed budget thresholds (P2 → P1)
 export const ruleA4: AlertRule = (ctx) => {
   const seedCount = eventsOfType(ctx.snapshot.events, 'SeedAdded').length
@@ -526,7 +495,6 @@ export const ruleAH2: AlertRule = (ctx) => {
 export const ALL_RULES: ReadonlyArray<{ id: string; rule: AlertRule }> = [
   { id: 'A1', rule: ruleA1 },
   { id: 'A2', rule: ruleA2 },
-  { id: 'A3', rule: ruleA3 },
   { id: 'A4', rule: ruleA4 },
   { id: 'A5', rule: ruleA5 },
   { id: 'A6', rule: ruleA6 },

--- a/crowdfund-ui/packages/indexer/src/api/health.test.ts
+++ b/crowdfund-ui/packages/indexer/src/api/health.test.ts
@@ -8,7 +8,6 @@ import type { CursorState } from '../types.js'
 const cursor: CursorState = {
   deployBlock: 100,
   confirmationDepth: 12,
-  overlapWindow: 100,
   chainHead: 150,
   confirmedHead: 138,
   ingestedCursor: 138,

--- a/crowdfund-ui/packages/indexer/src/api/server.test.ts
+++ b/crowdfund-ui/packages/indexer/src/api/server.test.ts
@@ -19,7 +19,6 @@ const contractAddress = '0xF681A7c700420e5CA93f77c8988d3eED02767035'
 const cursor: CursorState = {
   deployBlock: 100,
   confirmationDepth: 12,
-  overlapWindow: 100,
   chainHead: 120,
   confirmedHead: 110,
   ingestedCursor: 110,

--- a/crowdfund-ui/packages/indexer/src/cli/commands.test.ts
+++ b/crowdfund-ui/packages/indexer/src/cli/commands.test.ts
@@ -8,7 +8,6 @@ import type { CursorState, IndexerStoreData, IngestRangeRecord } from '../types.
 const cursor: CursorState = {
   deployBlock: 100,
   confirmationDepth: 12,
-  overlapWindow: 100,
   chainHead: 150,
   confirmedHead: 138,
   ingestedCursor: 138,

--- a/crowdfund-ui/packages/indexer/src/config.test.ts
+++ b/crowdfund-ui/packages/indexer/src/config.test.ts
@@ -7,7 +7,7 @@ import { getInitialCursor, loadIndexerConfig } from './config.js'
 const TOUCHED = [
   'CROWDFUND_CONTRACT_ADDRESS', 'CROWDFUND_CHAIN_ID', 'CROWDFUND_DEPLOY_BLOCK',
   'CROWDFUND_PRIMARY_RPC_URL', 'CROWDFUND_AUDIT_RPC_URL', 'CROWDFUND_CONFIRMATION_DEPTH',
-  'CROWDFUND_OVERLAP_WINDOW', 'CROWDFUND_MAX_BLOCK_RANGE', 'CROWDFUND_INDEXER_PORT',
+  'CROWDFUND_MAX_BLOCK_RANGE', 'CROWDFUND_INDEXER_PORT',
   'CROWDFUND_STALE_AFTER_MS', 'CROWDFUND_REPAIR_MAX_ATTEMPTS', 'CROWDFUND_POLL_ON_START',
   'CROWDFUND_POLL_INTERVAL_MS', 'CROWDFUND_RPC_MAX_RETRIES',
 ]
@@ -40,7 +40,6 @@ describe('loadIndexerConfig', () => {
       primaryRpcUrl: null,
       auditRpcUrl: null,
       confirmationDepth: 12,
-      overlapWindow: 100,
       maxBlockRange: 500,
       port: 3002,
       staleAfterMs: 300_000,

--- a/crowdfund-ui/packages/indexer/src/config.ts
+++ b/crowdfund-ui/packages/indexer/src/config.ts
@@ -11,7 +11,6 @@ export interface IndexerConfig {
   primaryRpcUrl: string | null
   auditRpcUrl: string | null
   confirmationDepth: number
-  overlapWindow: number
   maxBlockRange: number
   port: number
   staleAfterMs: number
@@ -72,7 +71,6 @@ export function getInitialCursor(): CursorState {
   return {
     deployBlock,
     confirmationDepth: readNumberEnv('CROWDFUND_CONFIRMATION_DEPTH', 12),
-    overlapWindow: readNumberEnv('CROWDFUND_OVERLAP_WINDOW', 100),
     chainHead: deployBlock,
     confirmedHead: deployBlock,
     ingestedCursor: deployBlock > 0 ? deployBlock - 1 : 0,
@@ -88,7 +86,6 @@ export function loadIndexerConfig(): IndexerConfig {
     primaryRpcUrl: process.env.CROWDFUND_PRIMARY_RPC_URL ?? null,
     auditRpcUrl: process.env.CROWDFUND_AUDIT_RPC_URL ?? null,
     confirmationDepth: readNumberEnv('CROWDFUND_CONFIRMATION_DEPTH', 12),
-    overlapWindow: readNumberEnv('CROWDFUND_OVERLAP_WINDOW', 100),
     maxBlockRange: readNumberEnv('CROWDFUND_MAX_BLOCK_RANGE', 500),
     port: readNumberEnv('CROWDFUND_INDEXER_PORT', 3002),
     staleAfterMs: readNumberEnv('CROWDFUND_STALE_AFTER_MS', 300_000),

--- a/crowdfund-ui/packages/indexer/src/db/createStore.test.ts
+++ b/crowdfund-ui/packages/indexer/src/db/createStore.test.ts
@@ -15,7 +15,6 @@ const originalGenericDatabaseUrl = process.env.DATABASE_URL
 const cursor: CursorState = {
   deployBlock: 100,
   confirmationDepth: 12,
-  overlapWindow: 100,
   chainHead: 100,
   confirmedHead: 100,
   ingestedCursor: 99,

--- a/crowdfund-ui/packages/indexer/src/db/fileStore.test.ts
+++ b/crowdfund-ui/packages/indexer/src/db/fileStore.test.ts
@@ -13,7 +13,6 @@ const tempDirs: string[] = []
 const cursor: CursorState = {
   deployBlock: 100,
   confirmationDepth: 12,
-  overlapWindow: 100,
   chainHead: 150,
   confirmedHead: 138,
   ingestedCursor: 99,
@@ -180,5 +179,27 @@ describe('FileIndexerStore', () => {
 
     const restored = await store.read()
     expect(restored.rawLogs).toEqual([earlier, replacement])
+  })
+
+  it('does not create a second entry when a reorged copy of the same tx is re-ingested', async () => {
+    const store = await makeStore()
+    const original = {
+      chainId: 11155111,
+      contractAddress: '0xF681A7c700420e5CA93f77c8988d3eED02767035',
+      blockNumber: 120,
+      blockHash: '0x' + '11'.repeat(32),
+      transactionHash: '0x' + '22'.repeat(32),
+      logIndex: 1,
+      topics: ['0x' + '33'.repeat(32)],
+      data: '0x01',
+    }
+    // Same tx re-mined at a new block after a reorg: only blockHash/blockNumber differ.
+    const reorged = { ...original, blockHash: '0x' + 'aa'.repeat(32), blockNumber: 125 }
+
+    await store.upsertRawLogs([original])
+    await store.upsertRawLogs([reorged])
+
+    const restored = await store.read()
+    expect(restored.rawLogs).toEqual([reorged])
   })
 })

--- a/crowdfund-ui/packages/indexer/src/db/fileStore.ts
+++ b/crowdfund-ui/packages/indexer/src/db/fileStore.ts
@@ -3,7 +3,7 @@
 
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
-import { getLogIdentity } from '../ingest/ranges.js'
+import { getLogDedupeKey } from '../ingest/ranges.js'
 import { applyMetaPatch } from './store.js'
 import type { IndexerMeta, IndexerMetaPatch, IndexerStore } from './store.js'
 import type { CursorState, IndexedRawLog, IndexerStoreData, IngestRangeRecord } from '../types.js'
@@ -125,8 +125,8 @@ export class FileIndexerStore implements IndexerStore {
 
   async upsertRawLogs(logs: readonly IndexedRawLog[]): Promise<IndexerStoreData> {
     return this.update((data) => {
-      const records = new Map(data.rawLogs.map((log) => [getLogIdentity(log), log]))
-      for (const log of logs) records.set(getLogIdentity(log), log)
+      const records = new Map(data.rawLogs.map((log) => [getLogDedupeKey(log), log]))
+      for (const log of logs) records.set(getLogDedupeKey(log), log)
       return {
         ...data,
         rawLogs: sortLogs([...records.values()]),

--- a/crowdfund-ui/packages/indexer/src/db/postgresStore.test.ts
+++ b/crowdfund-ui/packages/indexer/src/db/postgresStore.test.ts
@@ -43,12 +43,12 @@ function makeFakePool(rows: { cursor?: unknown[]; metadata?: unknown[]; ranges?:
 }
 
 const initialCursor: CursorState = {
-  deployBlock: 100, confirmationDepth: 12, overlapWindow: 100,
+  deployBlock: 100, confirmationDepth: 12,
   chainHead: 0, confirmedHead: 0, ingestedCursor: 99, verifiedCursor: 99,
 }
 
 const cursorRow = {
-  deploy_block: 100, confirmation_depth: 12, overlap_window: 100,
+  deploy_block: 100, confirmation_depth: 12,
   chain_head: 150, confirmed_head: 138, ingested_cursor: 120, verified_cursor: 110,
 }
 

--- a/crowdfund-ui/packages/indexer/src/db/postgresStore.ts
+++ b/crowdfund-ui/packages/indexer/src/db/postgresStore.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Stores cursors, range verification records, raw logs, and snapshot metadata in durable tables.
 
 import { Pool } from 'pg'
-import { getLogIdentity } from '../ingest/ranges.js'
+import { getLogDedupeKey } from '../ingest/ranges.js'
 import { createEmptyStoreData } from './fileStore.js'
 import type { IndexerMeta, IndexerMetaPatch, IndexerStore } from './store.js'
 import type { CursorState, IndexedRawLog, IndexerStoreData, IngestRangeRecord, IngestRangeStatus } from '../types.js'
@@ -21,7 +21,6 @@ interface DbClient {
 interface CursorRow {
   deploy_block: number
   confirmation_depth: number
-  overlap_window: number
   chain_head: number
   confirmed_head: number
   ingested_cursor: number
@@ -67,7 +66,6 @@ CREATE TABLE IF NOT EXISTS crowdfund_indexer_cursor (
   id boolean PRIMARY KEY DEFAULT true CHECK (id),
   deploy_block integer NOT NULL,
   confirmation_depth integer NOT NULL,
-  overlap_window integer NOT NULL,
   chain_head integer NOT NULL,
   confirmed_head integer NOT NULL,
   ingested_cursor integer NOT NULL,
@@ -148,7 +146,6 @@ function toCursor(row: CursorRow): CursorState {
   return {
     deployBlock: row.deploy_block,
     confirmationDepth: row.confirmation_depth,
-    overlapWindow: row.overlap_window,
     chainHead: row.chain_head,
     confirmedHead: row.confirmed_head,
     ingestedCursor: row.ingested_cursor,
@@ -196,21 +193,20 @@ function rangeKey(range: Pick<IngestRangeRecord, 'fromBlock' | 'toBlock'>): stri
 
 function dedupeLogs(logs: readonly IndexedRawLog[]): IndexedRawLog[] {
   const records = new Map<string, IndexedRawLog>()
-  for (const log of logs) records.set(getLogIdentity(log), log)
+  for (const log of logs) records.set(getLogDedupeKey(log), log)
   return [...records.values()]
 }
 
 async function ensureSeedRows(client: DbClient, initialCursor: CursorState): Promise<void> {
   await client.query(
     `INSERT INTO crowdfund_indexer_cursor (
-      id, deploy_block, confirmation_depth, overlap_window, chain_head, confirmed_head, ingested_cursor, verified_cursor
+      id, deploy_block, confirmation_depth, chain_head, confirmed_head, ingested_cursor, verified_cursor
     )
-    VALUES (true, $1, $2, $3, $4, $5, $6, $7)
+    VALUES (true, $1, $2, $3, $4, $5, $6)
     ON CONFLICT (id) DO NOTHING`,
     [
       initialCursor.deployBlock,
       initialCursor.confirmationDepth,
-      initialCursor.overlapWindow,
       initialCursor.chainHead,
       initialCursor.confirmedHead,
       initialCursor.ingestedCursor,
@@ -227,13 +223,12 @@ async function ensureSeedRows(client: DbClient, initialCursor: CursorState): Pro
 async function upsertCursorRow(client: DbClient, cursor: CursorState): Promise<void> {
   await client.query(
     `INSERT INTO crowdfund_indexer_cursor (
-      id, deploy_block, confirmation_depth, overlap_window, chain_head, confirmed_head, ingested_cursor, verified_cursor
+      id, deploy_block, confirmation_depth, chain_head, confirmed_head, ingested_cursor, verified_cursor
     )
-    VALUES (true, $1, $2, $3, $4, $5, $6, $7)
+    VALUES (true, $1, $2, $3, $4, $5, $6)
     ON CONFLICT (id) DO UPDATE SET
       deploy_block = EXCLUDED.deploy_block,
       confirmation_depth = EXCLUDED.confirmation_depth,
-      overlap_window = EXCLUDED.overlap_window,
       chain_head = EXCLUDED.chain_head,
       confirmed_head = EXCLUDED.confirmed_head,
       ingested_cursor = EXCLUDED.ingested_cursor,
@@ -242,7 +237,6 @@ async function upsertCursorRow(client: DbClient, cursor: CursorState): Promise<v
     [
       cursor.deployBlock,
       cursor.confirmationDepth,
-      cursor.overlapWindow,
       cursor.chainHead,
       cursor.confirmedHead,
       cursor.ingestedCursor,

--- a/crowdfund-ui/packages/indexer/src/ingest/backfill.test.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/backfill.test.ts
@@ -15,7 +15,6 @@ const tempDirs: string[] = []
 const cursor: CursorState = {
   deployBlock: 100,
   confirmationDepth: 2,
-  overlapWindow: 100,
   chainHead: 100,
   confirmedHead: 100,
   ingestedCursor: 99,

--- a/crowdfund-ui/packages/indexer/src/ingest/poller.test.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/poller.test.ts
@@ -15,7 +15,6 @@ const tempDirs: string[] = []
 const cursor: CursorState = {
   deployBlock: 100,
   confirmationDepth: 2,
-  overlapWindow: 100,
   chainHead: 100,
   confirmedHead: 100,
   ingestedCursor: 99,

--- a/crowdfund-ui/packages/indexer/src/ingest/ranges.test.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/ranges.test.ts
@@ -6,6 +6,7 @@ import {
   createRangeDigest,
   findFirstGap,
   getContiguousVerifiedCursor,
+  getLogDedupeKey,
   getLogIdentity,
   getRepairRanges,
 } from './ranges.js'
@@ -54,6 +55,21 @@ describe('range ingestion helpers', () => {
         '0',
       ].join(':'),
     )
+  })
+
+  it('dedupes reorged copies by tx identity while the digest still tracks blockHash', () => {
+    const original = makeLog()
+    // Same tx re-mined at a new block after a reorg: only blockHash/blockNumber differ.
+    const reorged = makeLog({
+      blockHash: '0x' + 'aa'.repeat(32),
+      blockNumber: 10750005,
+    })
+
+    // Store dedup key ignores blockHash/blockNumber, so a re-mined tx cannot double-apply.
+    expect(getLogDedupeKey(original)).toBe(getLogDedupeKey(reorged))
+    // Verification identity keeps blockHash, so the two copies stay distinguishable for
+    // the dual-RPC range digest.
+    expect(getLogIdentity(original)).not.toBe(getLogIdentity(reorged))
   })
 
   it('creates the same digest regardless of input order', () => {

--- a/crowdfund-ui/packages/indexer/src/ingest/ranges.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/ranges.ts
@@ -15,6 +15,21 @@ export function getLogIdentity(log: IndexedRawLog): string {
   ].join(':')
 }
 
+// Store dedup key: mirrors the Postgres crowdfund_indexer_raw_logs primary key
+// (chain_id, contract_address, transaction_hash, log_index). It deliberately excludes
+// blockHash and blockNumber so a reorg that re-mines the same tx at a new block cannot
+// create a second raw-log entry — re-ingestion stays idempotent. getLogIdentity (which
+// keeps blockHash) is retained for createRangeDigest, where a blockHash divergence
+// between two RPCs must still change the digest so reorg divergence is detected.
+export function getLogDedupeKey(log: IndexedRawLog): string {
+  return [
+    log.chainId,
+    log.contractAddress.toLowerCase(),
+    log.transactionHash.toLowerCase(),
+    log.logIndex,
+  ].join(':')
+}
+
 export function createRangeDigest(logs: readonly IndexedRawLog[]): string {
   const hash = createHash('sha256')
   const sorted = [...logs].sort((a, b) => {

--- a/crowdfund-ui/packages/indexer/src/ingest/reconcile.test.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/reconcile.test.ts
@@ -20,7 +20,6 @@ const tempDirs: string[] = []
 const cursor: CursorState = {
   deployBlock: 100,
   confirmationDepth: 12,
-  overlapWindow: 100,
   chainHead: 150,
   confirmedHead: 138,
   ingestedCursor: 99,

--- a/crowdfund-ui/packages/indexer/src/ingest/rpc.test.ts
+++ b/crowdfund-ui/packages/indexer/src/ingest/rpc.test.ts
@@ -15,7 +15,6 @@ const tempDirs: string[] = []
 const cursor: CursorState = {
   deployBlock: 100,
   confirmationDepth: 12,
-  overlapWindow: 100,
   chainHead: 150,
   confirmedHead: 138,
   ingestedCursor: 99,

--- a/crowdfund-ui/packages/indexer/src/snapshots/build.test.ts
+++ b/crowdfund-ui/packages/indexer/src/snapshots/build.test.ts
@@ -16,7 +16,6 @@ function makeStoreData(rawLogs: readonly IndexedRawLog[]): IndexerStoreData {
     cursor: {
       deployBlock: 100,
       confirmationDepth: 12,
-      overlapWindow: 100,
       chainHead: 150,
       confirmedHead: 138,
       ingestedCursor: 120,

--- a/crowdfund-ui/packages/indexer/src/types.ts
+++ b/crowdfund-ui/packages/indexer/src/types.ts
@@ -54,7 +54,6 @@ export interface IngestRangeRecord extends BlockRange {
 export interface CursorState {
   deployBlock: number
   confirmationDepth: number
-  overlapWindow: number
   chainHead: number
   confirmedHead: number
   ingestedCursor: number

--- a/deploy/nginx-indexer.conf
+++ b/deploy/nginx-indexer.conf
@@ -3,6 +3,13 @@
 
 # The indexer sets permissive CORS itself, so no CORS handling is needed here.
 
+# Per-IP request rate limiting (#332). This directive is valid at http context;
+# it works here because sites-enabled/*.conf is included inside nginx's http{} block.
+# The API endpoints (/health, /snapshot, /events) are cheap and cached, so the budget
+# is generous for real users while throttling a request flood. Tune `rate`/`burst` to
+# taste — see CROWDFUND_INDEXER_RUNBOOK.md "Rate limiting".
+limit_req_zone $binary_remote_addr zone=indexer:10m rate=10r/s;
+
 server {
     listen 443 ssl;
     server_name indexer.example.com;            # <-- your hostname
@@ -12,6 +19,10 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/indexer.example.com/privkey.pem;
 
     location / {
+        # Throttle floods; real users stay well under this. 429 on excess (not 503).
+        limit_req zone=indexer burst=20 nodelay;
+        limit_req_status 429;
+
         proxy_pass http://127.0.0.1:3002;       # CROWDFUND_INDEXER_PORT
         proxy_http_version 1.1;
         proxy_set_header Host              $host;

--- a/reports/threat-model-governance-crowdfund.md
+++ b/reports/threat-model-governance-crowdfund.md
@@ -99,3 +99,5 @@
    - Any future redemption frontend must enumerate the token list from `TokenSwept` events / the router, never let the user hand-edit `tokens[]`.
 
    Remaining exposure after mitigations: assets swept *after* a user has redeemed (inherent to sequential pro-rata with permanently locked ARM — addressed only by completing sweeps within the window), and direct callers who ignore the published manifest and router.
+
+9. **Indexer reorg handling:** `CROWDFUND_CONFIRMATION_DEPTH` (default 12) is the stated reorg guarantee — only data at least that many blocks behind the chain head is verified. Reorgs deeper than that are unhandled but acceptable on the Ethereum L1 mainnet hub (chain id 1), where a >12-block reorg implies a consensus/finality failure rather than normal operation. Raw logs are deduped by `(chainId, contract, txHash, logIndex)` — excluding `blockHash` — so a tx re-mined at a new block cannot double-apply (Postgres via its primary key, file store via `getLogDedupeKey`).

--- a/specs/CROWDFUND_INDEXER_RUNBOOK.md
+++ b/specs/CROWDFUND_INDEXER_RUNBOOK.md
@@ -314,6 +314,23 @@ Expected healthy fields:
 
 Two alerts watch the indexer itself (see `MONITORING.md` §8 addendum): **AH1** pages when `status` is `stale` (P2) or `unhealthy` (P1); **AH2** pages when `gapsRequiringIntervention` is non-empty (P1). While the indexer is `stale`/`unhealthy`, the time-based crowdfund alerts (A2/A8/A9a/A9b) are suppressed to avoid false pages off a lagging snapshot.
 
+### Rate limiting
+
+Rate limiting is enforced at the nginx reverse proxy, not in the Node process. The API
+deliberately sets permissive CORS and ships no app-level limiter, so the reverse proxy is
+the single throttling point in front of the public port (`CROWDFUND_INDEXER_PORT`, default
+`3002`).
+
+The chosen limits (in `deploy/nginx-indexer.conf`):
+
+- **10 requests/second per IP** (`limit_req_zone ... rate=10r/s`, keyed on `$binary_remote_addr`).
+- **Burst of 20** with `nodelay`, so short spikes are absorbed rather than queued.
+- **HTTP 429** returned on excess (`limit_req_status 429`), not 503.
+
+The limits are tunable — adjust `rate` and `burst` in the conf and reload nginx. The public
+endpoints (`/health`, `/snapshot`, `/events`) are cheap and cached, so this budget is generous
+for real users while throttling a request flood from a single source.
+
 ---
 
 ## Operator Commands

--- a/specs/CROWDFUND_INDEXER_RUNBOOK.md
+++ b/specs/CROWDFUND_INDEXER_RUNBOOK.md
@@ -28,6 +28,17 @@ Data layers:
 - Snapshots are derived artifacts and can be rebuilt from raw logs.
 - Static snapshots are outage fallback artifacts, published as `snapshot-{block}.json` plus `latest.json`.
 
+### Reorg Handling
+
+`CROWDFUND_CONFIRMATION_DEPTH` (default 12) is the stated reorg guarantee: only data at
+least that many blocks behind the chain head is verified. Reorgs deeper than that are
+unhandled but acceptable on the Ethereum L1 mainnet hub (chain id 1), where a >12-block
+reorg implies a consensus/finality failure rather than normal operation.
+
+Raw logs are deduped by `(chainId, contract, txHash, logIndex)` — excluding `blockHash` —
+so a tx re-mined at a new block cannot double-apply. Postgres enforces this via the
+`crowdfund_indexer_raw_logs` primary key; the file store enforces it via `getLogDedupeKey`.
+
 ---
 
 ## Required Environment
@@ -63,7 +74,6 @@ Cursor and range tuning:
 
 ```bash
 export CROWDFUND_CONFIRMATION_DEPTH=12
-export CROWDFUND_OVERLAP_WINDOW=100
 export CROWDFUND_MAX_BLOCK_RANGE=500
 ```
 
@@ -120,7 +130,6 @@ Cursor and range variables:
 | Variable | Default | Behavior |
 |----------|---------|----------|
 | `CROWDFUND_CONFIRMATION_DEPTH` | `12` | Blocks behind chain head required before data is verified. Lower only for dev. |
-| `CROWDFUND_OVERLAP_WINDOW` | `100` | Stored cursor setting reserved for a future overlap/rescan policy. **Not yet consumed by any code path** — it does not currently provide reorg protection beyond `CROWDFUND_CONFIRMATION_DEPTH`. Tracked for implementation-or-removal (see GitHub issues). |
 | `CROWDFUND_MAX_BLOCK_RANGE` | `500` | Maximum inclusive block range per `eth_getLogs` chunk. |
 
 API and polling variables:
@@ -163,7 +172,7 @@ Alert evaluator variables (used by `evaluate-alerts`; see [`MONITORING.md`](MONI
 | `CROWDFUND_TREASURY_ADDRESS` | required | Treasury address — used to read USDC balance for A13 mismatch detection. |
 | `CROWDFUND_USDC_ADDRESS` | optional | USDC contract — required for A13 (treasury balance). Omit to skip A13. |
 | `CROWDFUND_OPEN_TIMESTAMP` | `0` | Unix seconds when the commitment window opens. Drives A2/A8/A9. |
-| `CROWDFUND_WEEK1_DEADLINE` | `0` | Unix seconds when week-1 ends (openTimestamp + 7 days). Drives A3. |
+| `CROWDFUND_WEEK1_DEADLINE` | `0` | Unix seconds when week-1 ends (openTimestamp + 7 days). Marks the week-1 → weeks-2–3 phase boundary in the monitoring model. |
 | `CROWDFUND_COMMITMENT_DEADLINE` | `0` | Unix seconds when the 3-week window closes (openTimestamp + 21 days). Drives A8/A9. |
 | `CROWDFUND_ALERT_WEBHOOK_P0` | unset | Discord webhook URL for P0 (immediate) alerts. |
 | `CROWDFUND_ALERT_WEBHOOK_P1` | unset | Discord webhook URL for P1 (same-day) alerts. |

--- a/specs/MONITORING.md
+++ b/specs/MONITORING.md
@@ -172,15 +172,11 @@ Post-finalization, track:
 
 ---
 
-### A3 — Week-1 action outside week-1 window
+### A3 — (retired)
 
-| Field | Value |
-|---|---|
-| **Signal** | `SeedAdded` or ROOT-issued `Invited` |
-| **Condition** | Event timestamp after `week1Deadline` |
-| **Severity** | P0 |
-| **Meaning** | Contract or monitoring assumptions broken — this should not be possible |
-| **Runbook** | `OPERATIONS.md` §9 failure investigation; Security Council review |
+A week-1 action (`SeedAdded` / `LaunchTeamInvited`) emitted after the week-1 deadline is
+enforced on-chain by the crowdfund's `_requireArmLoadedAndPreInviteEnd` guard, so no
+off-chain alert covers that condition.
 
 ---
 
@@ -490,7 +486,6 @@ Each alert must include:
 | Alert(s) | `OPERATIONS.md` section |
 |---|---|
 | A1, A2 | §3 Deployment sequence (Steps 4–8) |
-| A3 | §9 Failure scenarios — immediate investigation |
 | A4, A5 | §4 Week-1 cadence; §10 Decision log; §11 Checkpoint 2 |
 | A6 | §4/§5 Monitoring; no automatic action |
 | A7, A8 | §5 Weeks 2–3 cadence; §11 Checkpoint 3 |


### PR DESCRIPTION
Clears the decided indexer launch items (crowdfund/governance hub is Ethereum L1 mainnet, `CONFIRMATION_DEPTH=12`).

## #333 — Drop inert alert A3
A3 only fires when events carry a block timestamp, which the indexer never attaches, so it always returned `[]`. The condition it watched (a week-1 action emitted after the week-1 deadline) is already enforced on-chain by the crowdfund's `_requireArmLoadedAndPreInviteEnd` guard, so no off-chain alert is needed. Removed `ruleA3` + its `ALL_RULES` entry; MONITORING.md A3 section marked retired with the on-chain rationale. Other alert IDs unchanged. (`week1Deadline` param retained — it's a documented campaign phase boundary independent of A3.)

## #334 — Remove unused `CROWDFUND_OVERLAP_WINDOW`
Parsed, stored on the cursor, and documented, but consumed by no code path — it implied reorg protection that didn't exist. Removed from config, `CursorState`, the Postgres cursor schema/INSERT/UPSERT, all test fixtures, and the runbook. Indexer is pre-prod, so no migration.

## #335 — File-store reorg idempotency + documented guarantee
The Postgres store is already reorg-idempotent via `crowdfund_indexer_raw_logs PRIMARY KEY (chain_id, contract_address, transaction_hash, log_index)`. The double-apply in #335 was a **file-store**-only bug. Added `getLogDedupeKey` (keys by `chainId:contract:txHash:logIndex`, excluding blockHash/blockNumber) and switched the file store + in-memory dedup to it, so a tx re-mined at a new block can't create a second entry. `getLogIdentity` (with blockHash) is retained for `createRangeDigest` so dual-RPC reorg divergence is still detected — the verification digest is unchanged. Documented `CONFIRMATION_DEPTH=12` as the stated reorg guarantee (deeper reorgs unhandled but a >12-block L1 reorg implies consensus failure) in the runbook + threat model.

## #332 — Reverse-proxy rate limiting (nginx)
Rate limiting belongs at the reverse proxy, not the Node process (the API sets permissive CORS and ships no app-level limiter by design). Added per-IP `limit_req` to `deploy/nginx-indexer.conf`: `zone=indexer rate=10r/s`, `burst=20 nodelay`, `limit_req_status 429`. Documented the chosen limits in the runbook's new "Rate limiting" subsection. Generous for real users on cheap/cached endpoints (`/health`, `/snapshot`, `/events`); throttles a single-source flood.

## #320 — Runbook re-validation
Re-read `CROWDFUND_INDEXER_RUNBOOK.md` end-to-end against the post-change code: env-var table, defaults, storage-selection logic, CLI commands, and npm scripts all reconciled — **no drift found** (the changes above were self-consistent). Only addition was the rate-limiting subsection.

Also closed #222 separately (decision: steward budget authorized via governance, not at deploy; outflow config already bootstrapped).

## Testing
- Indexer vitest: **161 passed (20 files)**, pristine.
- Typecheck clean.
- nginx changes are config-only (validate with `nginx -t` on the host at deploy time).

Closes #332
Closes #333
Closes #334
Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)