### PR TITLE
deploy: nightly indexer backup + restore/rollback procedures (#317)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -54,12 +54,37 @@ reload. It proxies `https://<host>` → `127.0.0.1:3002`.
 
 ## Update / redeploy
 
+Images are commit-tagged, so redeploying is a `.env` bump + `up -d`, and rolling
+back is the same in reverse (see **Rollback** below). Tag the release so the exact
+image can always be rebuilt:
+
 ```bash
 git pull && SHA=$(git rev-parse --short HEAD)
 docker build -f deploy/indexer.Dockerfile -t crowdfund-indexer:$SHA crowdfund-ui
-# bump INDEXER_IMAGE in .env, then:
+git tag "indexer-$(date -u +%Y%m%d)-$SHA" && git push --tags
+# bump INDEXER_IMAGE in .env to crowdfund-indexer:$SHA, then:
 docker compose up -d            # add --profile postgres if used
 ```
+
+Keep the previous image on the host (don't prune it) so a rollback needs no rebuild.
+
+## Rollback
+
+The indexer holds no authoritative state the chain can't replay — snapshots are
+derived and rebuildable from raw logs — so rollback is low-risk.
+
+```bash
+# 1. Point back at the previous image and restart.
+#    (INDEXER_IMAGE=crowdfund-indexer:<previous-sha> in .env)
+docker compose up -d            # add --profile postgres if used
+
+# 2. If a bad build corrupted derived state, rebuild snapshots from raw logs:
+docker compose exec indexer node_modules/.bin/tsx packages/indexer/src/cli/index.ts rebuild-snapshot
+#    …or, if raw data itself is suspect, restore the last good backup (below).
+```
+
+The committer frontend rolls back independently on Netlify — redeploy a previous
+(immutable) deploy from the Netlify UI/CLI. See issue #362 for the mainnet pin.
 
 ## Teardown
 
@@ -72,5 +97,47 @@ docker compose down -v          # also delete data — destructive
 
 State lives in named volumes: `crowdfund-indexer_indexer-data` (file store,
 snapshots, alert dedupe) and `crowdfund-indexer_postgres-data`. Both survive
-`down`/restart. Automated snapshot/restore of these volumes is a planned
-follow-up; for Postgres, `pg_dump`/`psql` per the indexer runbook works today.
+`down`/restart.
+
+### Nightly backup
+
+`backup-indexer.sh` tars the `indexer-data` volume and, when Postgres is running,
+adds a `pg_dump` — with local retention pruning. Run it from the ops dir (where
+`docker-compose.yml` + `.env` live) via cron:
+
+```bash
+cp /path/to/repo/deploy/backup-indexer.sh .
+chmod +x backup-indexer.sh
+# crontab -e  — daily 03:15 UTC:
+15 3 * * *  cd /opt/armada-infra && ./backup-indexer.sh >> backup.log 2>&1
+```
+
+Tunables (env): `BACKUP_DIR` (default `./backups`), `RETENTION_DAYS` (default 14),
+`BACKUP_REMOTE_CMD` (optional off-host copy — a backup on the same VPS does **not**
+survive VPS loss; set this to an `rclone`/`scp` command receiving the file path as
+`$1`, e.g. `export BACKUP_REMOTE_CMD='rclone copy "$1" r2:armada-indexer-backups'`).
+
+### Restore
+
+Stop the stack first so nothing writes during restore:
+
+```bash
+docker compose down                      # keeps volumes
+
+# File store + snapshots (wipe the volume, then unpack the tarball into it):
+docker run --rm -v crowdfund-indexer_indexer-data:/data -v "$PWD/backups":/backup alpine:3 \
+  sh -c 'rm -rf /data/* /data/.[!.]* /data/..?* 2>/dev/null; tar xzf /backup/indexer-data-<STAMP>.tar.gz -C /data'
+
+docker compose up -d                     # add --profile postgres if used
+```
+
+Postgres (restore into a fresh/empty DB — drop & recreate first if it has data):
+
+```bash
+gunzip -c backups/postgres-<STAMP>.sql.gz \
+  | docker compose exec -T postgres sh -c 'psql -U "$POSTGRES_USER" "$POSTGRES_DB"'
+```
+
+Because raw logs are canonical and snapshots are derived, restoring Postgres (or the
+file store) recovers everything; the indexer resumes polling from the restored
+`verifiedCursor`. Verify with `curl -s localhost:3002/health` and the `status` CLI.

--- a/deploy/backup-indexer.sh
+++ b/deploy/backup-indexer.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# ABOUTME: Nightly backup for the crowdfund indexer — tarball of the file-store/snapshot
+# ABOUTME: volume plus a pg_dump when Postgres is running, with local retention pruning.
+set -euo pipefail
+
+# Run this from the ops dir that holds docker-compose.yml + .env (where you deployed).
+# Cron example (daily 03:15 UTC):
+#   15 3 * * *  cd /opt/armada-infra && ./backup-indexer.sh >> backup.log 2>&1
+#
+# Tunables (env vars, all optional):
+#   COMPOSE_PROJECT_NAME  docker compose project name / volume prefix (default: crowdfund-indexer)
+#   BACKUP_DIR            where backups are written (default: ./backups)
+#   RETENTION_DAYS        prune local backups older than this many days (default: 14)
+#   BACKUP_REMOTE_CMD     optional off-host copy command; receives the file path as $1
+#                         (see step 3). A backup on the same VPS does NOT survive VPS loss.
+
+PROJECT="${COMPOSE_PROJECT_NAME:-crowdfund-indexer}"
+BACKUP_DIR="${BACKUP_DIR:-./backups}"
+RETENTION_DAYS="${RETENTION_DAYS:-14}"
+DATA_VOLUME="${PROJECT}_indexer-data"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+
+mkdir -p "$BACKUP_DIR"
+BACKUP_ABS="$(cd "$BACKUP_DIR" && pwd)"
+
+echo "[backup] $STAMP  project=$PROJECT  dir=$BACKUP_ABS  retention=${RETENTION_DAYS}d"
+
+# 1. File-store + snapshots + alert dedupe volume -> tar.gz.
+#    Mounted read-only so a backup can never mutate live data.
+data_out="$BACKUP_ABS/indexer-data-$STAMP.tar.gz"
+docker run --rm \
+  -v "${DATA_VOLUME}:/data:ro" \
+  -v "${BACKUP_ABS}:/backup" \
+  alpine:3 tar czf "/backup/$(basename "$data_out")" -C /data .
+echo "[backup] wrote $data_out ($(du -h "$data_out" | cut -f1))"
+
+# 2. Postgres dump — only when the postgres service is up (file-store deploys skip this).
+#    pg_dump runs inside the container, so POSTGRES_USER/DB come from the container env
+#    and no database credentials are handled by this script.
+pg_out=""
+if docker compose ps --status running --services 2>/dev/null | grep -qx postgres; then
+  pg_out="$BACKUP_ABS/postgres-$STAMP.sql.gz"
+  docker compose exec -T postgres sh -c 'pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB"' | gzip > "$pg_out"
+  echo "[backup] wrote $pg_out ($(du -h "$pg_out" | cut -f1))"
+else
+  echo "[backup] postgres service not running — file store only, skipping pg_dump"
+fi
+
+# 3. Optional off-host copy. A backup on the same box does not survive host loss.
+#    Set BACKUP_REMOTE_CMD to push each fresh file off-box; it receives the path as $1.
+#    Example:  export BACKUP_REMOTE_CMD='rclone copy "$1" r2:armada-indexer-backups'
+if [ -n "${BACKUP_REMOTE_CMD:-}" ]; then
+  for f in "$data_out" "$pg_out"; do
+    [ -n "$f" ] && [ -f "$f" ] || continue
+    echo "[backup] off-host copy: $f"
+    sh -c "$BACKUP_REMOTE_CMD" _ "$f"
+  done
+fi
+
+# 4. Prune local backups older than the retention window.
+find "$BACKUP_ABS" -maxdepth 1 -type f \
+  \( -name 'indexer-data-*.tar.gz' -o -name 'postgres-*.sql.gz' \) \
+  -mtime "+$RETENTION_DAYS" -print -delete | sed 's/^/[backup] pruned /' || true
+
+echo "[backup] done"

--- a/specs/CROWDFUND_INDEXER_RUNBOOK.md
+++ b/specs/CROWDFUND_INDEXER_RUNBOOK.md
@@ -578,6 +578,19 @@ npm run crowdfund:indexer:cli -- status
 npm run crowdfund:indexer:cli -- backfill latest
 ```
 
+### Automated backups (Dockerized deploy)
+
+For the containerized deploy (`deploy/docker-compose.yml`), `deploy/backup-indexer.sh`
+runs nightly via cron: it tars the `indexer-data` volume (file store + snapshots +
+alert dedupe) and, when the `postgres` service is running, adds a `pg_dump`, with local
+retention pruning and an optional off-host copy hook (`BACKUP_REMOTE_CMD`). Set up cron
+and off-host copy per `deploy/README.md` → **Persistence & backups**; the full **Restore**
+and **Rollback** procedures live there too. A backup on the same VPS does not survive VPS
+loss — always configure the off-host copy before launch.
+
+Because raw logs are canonical and snapshots are derived, restoring Postgres (or the file
+store) recovers everything; the indexer resumes from the restored `verifiedCursor`.
+
 Keep database dumps out of git.
 
 ---


### PR DESCRIPTION
Part of the **#317 Deployment Pipeline** umbrella — the indexer backup + restore + rollback slice. No team input required.

> **Stacked on #375** (base is `fix/indexer-launch-hardening` so the runbook is current). GitHub auto-retargets this to `main` when #375 merges.

The Dockerized indexer (`deploy/docker-compose.yml`) already runs with `restart: unless-stopped` (auto-restart) and persists state in named volumes, but backup/restore was an explicit "planned follow-up" in `deploy/README.md`. This fills that gap.

## Changes

- **`deploy/backup-indexer.sh`** (new) — nightly backup: tars the `indexer-data` volume (file store + snapshots + alert dedupe, mounted read-only) and, when the `postgres` service is running, adds a `pg_dump`. Local retention pruning (`RETENTION_DAYS`, default 14) and an optional off-host copy hook (`BACKUP_REMOTE_CMD`). Handles no credentials itself — `pg_dump` runs inside the container using its own env. `bash -n` clean; executable bit set.
- **`deploy/README.md`** — replaced the "planned follow-up" stub with real **Persistence & backups** (cron setup, tunables, off-host guidance), **Restore** (file-store volume + Postgres, step-by-step), and a new **Rollback** section (commit-tagged image swap + `rebuild-snapshot` for corrupted derived state; note that snapshots are rebuildable from raw logs so rollback is low-risk; committer frontend rolls back independently on Netlify — xref #362). `Update / redeploy` now git-tags the release so the exact image can be rebuilt.
- **`specs/CROWDFUND_INDEXER_RUNBOOK.md`** — the existing "Backup Checklist" now points at the automated script + the README restore/rollback procedures (satisfies #317's "restore procedure documented in the indexer runbook").

## Notes / call-outs

- **No systemd unit** — the compose stack's `restart: unless-stopped` already provides auto-restart, so a separate unit would be redundant. Flag if you'd prefer the indexer run under systemd instead of compose.
- **Off-host copy is opt-in but strongly recommended** — a backup on the same VPS doesn't survive VPS loss. The runbook + README both say to configure `BACKUP_REMOTE_CMD` before launch; the actual remote (R2/scp target) is an ops decision.
- Config/docs only — nothing to unit-test. `nginx -t` / a real backup dry-run happen on the host at provisioning time.

Relates to #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)