### PR TITLE
docs: fix CLAUDE.md file-org/deploy accuracy + reframe README for Armada

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,15 +96,21 @@ When writing new code, follow production security practices even though these le
 | `test/` | Hardhat/Mocha integration tests (TypeScript) |
 | `test-foundry/` | Foundry fuzz, invariant, and Halmos symbolic tests (Solidity) |
 | `scripts/` | Hardhat deployment and utility scripts |
+| `tasks/` | Hardhat CLI tasks (crowdfund, governance operations) |
 | `relayer/` | Node.js relayer service |
-| `usdc-v2-frontend/` | Temporary React frontend |
+| `apps/` | `armada-interface` — user app for shield/unshield/yield/payments (React, Vite); Launch 2 |
 | `crowdfund-ui/` | Crowdfund UIs — committer, admin (React, Vite, Jotai); observer is deprecated as a standalone app |
+| `governance-ui/` | Standalone governance proposal builder (React, Vite); not in npm workspaces |
+| `packages/` | Shared workspace packages — `@armada/ui` design system + showcase |
+| `usdc-v2-frontend/` | Deprecated temporary frontend — superseded by `apps/armada-interface` |
 | `lib/` | Foundry deps (forge-std, halmos) + Railgun SDK helpers |
 | `config/` | Environment configs (local.env, sepolia.env, networks.ts) |
+| `deploy/` | Crowdfund indexer deployment infra (Docker, nginx, backup scripts) |
 | `deployments/` | Generated deployment manifests (Sepolia ones are committed) |
+| `specs/` | Specifications — governance, crowdfund, fee structure, ARM token, operations, monitoring |
+| `docs/` | Operational runbooks (e.g. wind-down redemption) |
 | `_legacy/llm-analysis-2026-02/` | LLM-generated security analysis snapshot (Feb 2026, formerly `audit-reports/`) — historical, predates fee module/governance/July review |
 | `reports/` | Threat models, formal verification notes, analysis reports |
-| `docs/` | Implementation plans and specs |
 | `mcp-server/` | MCP server exposing read-only dev tools for AI coding agents |
 | `_legacy/` | Deprecated earlier approach — do not modify |
 
@@ -146,11 +152,12 @@ Contracts must be deployed in this order (the `npm run setup` script handles thi
 2. Aave mock (hub only)
 3. Governance (hub only) — must precede PrivacyPool (treasury address) and Yield (adapter registry)
 4. PrivacyPool modules (all chains)
-5. Yield contracts (hub only)
-6. Pool linking (hub — connects clients to hub, authorizes adapter in governance registry)
-7. Fee module (hub only) — wires into PrivacyPool + YieldVault; timelock calls use Anvil impersonation locally
-8. Faucets (all chains)
-9. Crowdfund (hub only)
+5. Gasless-shield wrapper (all chains) — permit-based gasless shield path
+6. Yield contracts (hub only)
+7. Pool linking (hub — connects clients to hub, authorizes adapter in governance registry)
+8. Fee module (hub only) — wires into PrivacyPool + YieldVault; timelock calls use Anvil impersonation locally
+9. Faucets (all chains)
+10. Crowdfund (hub only)
 
 If you need to redeploy a single component, understand its dependencies first.
 
@@ -160,6 +167,7 @@ The following are intentional design decisions or inherited code that may look l
 
 - **Railgun internals** (`contracts/railgun/logic/`) — Adapted from Railgun's open-source codebase. Changes break ZK circuit compatibility silently.
 - **Non-standard ERC-4626 vault** (`ArmadaYieldVault`) — Intentionally deviates from the standard. Do not "fix" it to conform.
+- **Frozen Launch 1 interfaces** (`IShieldPauseController`, `IFeeCollector` in `contracts/governance/`) — These are consumed by immutable governance contracts deployed at the crowdfund launch. Once Launch 1 ships, changing their function signatures or semantics breaks the Launch 2 privacy-pool/fee-module integration. Treat as external ABI. See `.context/two-launch-feasibility.md`.
 - **Frontend legacy code** (`usdc-v2-frontend/`) — Residual Namada/Noble/Cosmos code paths are harmless. The frontend is temporary and will be replaced.
 - **Testing mode / verification bypass code** — These POC shortcuts exist in the codebase. Do not remove them (they're tracked), but never enable them without human instruction.
 - **`_legacy/` directory** — Deprecated earlier approach. Do not modify or reference in new code.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
-# Railgun CCTP POC
+# Armada
 
-A proof-of-concept demonstrating **cross-chain privacy with shielded yield** by combining Railgun's ZK-based shielded pool with CCTP-style USDC bridging and DeFi integrations.
+**Cross-chain privacy with shielded yield** — a Railgun-style ZK shielded pool combined with Circle's CCTP for cross-chain USDC bridging and DeFi yield integration.
+
+The project is transitioning from POC to production and ships in two launches:
+
+1. **Crowdfund + Governance** (near-term) — the token sale and on-chain governance stack. Apps live in `crowdfund-ui/` (committer, admin); see `specs/` for the governance, crowdfund, and operations specs.
+2. **Shielded Pool** (later) — the privacy pool, yield vault, fee module, and the `apps/armada-interface` user app. Deploys after the sale via governance proposals.
+
+This README covers the **local privacy-pool + shielded-yield demo**. For the crowdfund/governance apps and their deploy flows, see `CLAUDE.md`, `crowdfund-ui/`, and `specs/`.
 
 ## Quick Start
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 20+
 - [Foundry](https://book.getfoundry.sh/getting-started/installation) (for Anvil local chains)
   ```bash
   curl -L https://foundry.paradigm.xyz | bash
@@ -33,6 +40,8 @@ npm run setup
 npm run armada-relayer
 
 # 6. In a new terminal: start the demo app
+#    (npm run demo runs the deprecated usdc-v2-frontend, retained as the working
+#     local privacy-pool demo until apps/armada-interface's flows are wired for local)
 npm run demo
 
 # 7. Open http://localhost:5173 in your browser
@@ -175,19 +184,21 @@ poc/
 │   │   ├── ArmadaYieldVault.sol
 │   │   ├── ArmadaYieldAdapter.sol
 │   │   └── MockAaveSpoke.sol
+│   ├── governance/         # Governance, treasury, crowdfund, revenue contracts
+│   ├── fees/               # ArmadaFeeModule (volume tiers, integrators)
 │   ├── MockUSDC.sol        # CCTP simulation (burn/mint)
 │   └── Faucet.sol          # Test token faucet
-├── usdc-v2-frontend/       # React demo application
-│   ├── src/
-│   │   ├── hooks/
-│   │   │   ├── useShieldedWallet.ts    # Shielded balance management
-│   │   │   ├── useShieldedYieldTransaction.ts  # Lend/withdraw UX
-│   │   │   └── useYieldRate.ts         # Real-time yield display
-│   │   └── services/
-│   │       └── yield/
-│   │           └── shieldedYieldService.ts  # SDK integration
-├── relayer/                # CCTP message relay service
+├── apps/
+│   └── armada-interface/   # User app — shield/unshield/yield/payments (Launch 2)
+├── crowdfund-ui/           # Crowdfund committer + admin apps (Launch 1)
+├── governance-ui/          # Standalone governance proposal builder
+├── packages/               # Shared workspace packages (@armada/ui design system)
+├── usdc-v2-frontend/       # Deprecated demo frontend — used by `npm run demo`
+├── relayer/                # CCTP message relay + HTTP fee API
 ├── scripts/                # Deployment scripts
+├── tasks/                  # Hardhat CLI tasks (crowdfund, governance)
+├── specs/                  # Specifications (governance, crowdfund, fees, ops)
+├── deploy/                 # Crowdfund indexer deployment infra
 ├── deployments/            # Generated contract addresses
 └── lib/                    # SDK integration modules
 ```


### PR DESCRIPTION
Documentation accuracy pass (Phase E of the repo-organization plan). Fixes drift found during the housekeeping sweep — no code changes.

## CLAUDE.md
- **File Organization table** — added 6 missing root dirs (`apps/`, `deploy/`, `governance-ui/`, `packages/`, `specs/`, `tasks/`); corrected `docs/` (operational runbooks, not "implementation plans and specs" — those live in `specs/`); marked `usdc-v2-frontend/` as deprecated/superseded by `apps/armada-interface`.
- **Deployment Order** — added the missing gasless-shield wrapper step (it's in the `npm run setup` chain between privacy-pool and yield) and renumbered.
- **Do Not Modify Without Discussion** — added the frozen Launch 1 interfaces (`IShieldPauseController`, `IFeeCollector`): once the crowdfund launch ships, changing their signatures breaks Launch 2 integration. Ties to the two-launch feasibility analysis.

## README.md (surgical — technical content left intact)
- Retitled `Railgun CCTP POC` → `Armada`; reframed from "proof-of-concept" to the transitioning-to-production two-launch state, with pointers to the crowdfund/governance apps and `specs/`.
- Node.js 18 → 20 (matches the toolchain).
- Project Structure block: added the app suite (`apps/`, `crowdfund-ui/`, `governance-ui/`, `packages/`), `specs/`, `tasks/`, `deploy/`, governance/fees contracts; marked `usdc-v2-frontend/` deprecated; noted `npm run demo` still runs it as the working local demo.
- Kept all accurate technical content: shield/unshield/yield flows, architecture diagram, cryptography, adaptParams design, troubleshooting.

Verified against the current repo (post-#330/#380 merge): every listed dir exists, the deploy step matches `package.json`, and no stale `audit-reports/` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
