### PR TITLE
Relayer: reduce testnet RPC request load

### DIFF
--- a/relayer/config.ts
+++ b/relayer/config.ts
@@ -29,8 +29,10 @@ export interface ChainConfig {
    * Relayer-only knobs for the CCTP scan loop. Defaults below come from the chain's
    * characteristics — finality depth (reorg risk), public-RPC range caps, etc.
    *
-   * Per-knob env overrides honour the pattern `RELAYER_<KNOB>_<CHAIN_NAME_UPPER>` (e.g.
-   * `RELAYER_MAX_LOG_RANGE_ETHEREUM_SEPOLIA=200`). When unset, the default for the chain wins.
+   * Per-knob env overrides honour the pattern `RELAYER_<KNOB>_<CHAIN_NAME_UPPER>`, where the
+   * suffix derives from the chain's config `name` ("Hub", "Client A", "Client B" — NOT the
+   * underlying network name). So: `RELAYER_MAX_LOG_RANGE_HUB=200`,
+   * `RELAYER_CONFIRMATION_DEPTH_CLIENT_A=2`, etc. When unset, the default for the chain wins.
    */
   scanner: {
     /**
@@ -80,16 +82,31 @@ function toChainConfig(net: NetChainConfig, env: string): ChainConfig {
     deploymentFile: `${net.deploymentPrefix}${suffix}-v3.json`,
     privacyPoolDeploymentFile: `privacy-pool-${net.deploymentPrefix}${suffix}.json`,
     cctpDomain: net.cctpDomain,
-    scanner: scannerConfigForChain(net.name, env),
+    scanner: scannerConfigForChain(net.name, env, net.chainId),
   };
 }
 
 /**
- * Per-chain scanner defaults. Each value can be overridden by an env var of the form
- * `RELAYER_<KNOB>_<CHAIN>` — e.g. `RELAYER_MAX_LOG_RANGE_ETHEREUM_SEPOLIA=200`. The chain
- * suffix is the chain name uppercased with spaces/dashes → underscores.
+ * Chain-type classification for scanner defaults, keyed by chainId. The config `name` fields
+ * are role labels ("Hub", "Client A", "Client B") that say nothing about the underlying
+ * network, so classification MUST NOT match on names. A chainId absent from every set gets
+ * the conservative fallback defaults below.
  */
-function scannerConfigForChain(chainName: string, env: string): ChainConfig["scanner"] {
+const L1_CHAIN_IDS = new Set([1, 11155111]); // Ethereum mainnet, Ethereum Sepolia
+const BASE_LIKE_CHAIN_IDS = new Set([8453, 84532, 10, 11155420]); // Base, Base Sepolia, OP Mainnet, OP Sepolia
+const ARB_LIKE_CHAIN_IDS = new Set([42161, 421614]); // Arbitrum One, Arbitrum Sepolia
+
+/**
+ * Per-chain scanner defaults. Each value can be overridden by an env var of the form
+ * `RELAYER_<KNOB>_<CHAIN>` — e.g. `RELAYER_MAX_LOG_RANGE_HUB=200`. The chain suffix is the
+ * chain's config `name` ("Hub", "Client A", "Client B") uppercased with spaces/dashes →
+ * underscores: HUB, CLIENT_A, CLIENT_B.
+ */
+export function scannerConfigForChain(
+  chainName: string,
+  env: string,
+  chainId: number,
+): ChainConfig["scanner"] {
   // Anvil has no reorgs and no public-RPC caps — chunking would just slow tests down.
   if (env === "local") {
     return {
@@ -105,9 +122,9 @@ function scannerConfigForChain(chainName: string, env: string): ChainConfig["sca
   //   Ethereum Sepolia: ~12s blocks → 150 blocks ≈ 30 min
   //   Base Sepolia:     ~2s blocks  → 900 blocks ≈ 30 min
   //   Arbitrum Sepolia: ~0.25s      → 7200 blocks ≈ 30 min
-  const isL1 = /ethereum|mainnet|sepolia/i.test(chainName) && !/base|arb|op|optimism/i.test(chainName);
-  const isBaseLike = /base|optimism|op/i.test(chainName);
-  const isArbLike = /arbitrum|arb/i.test(chainName);
+  const isL1 = L1_CHAIN_IDS.has(chainId);
+  const isBaseLike = BASE_LIKE_CHAIN_IDS.has(chainId);
+  const isArbLike = ARB_LIKE_CHAIN_IDS.has(chainId);
 
   const defaultLookback = isL1 ? 150 : isBaseLike ? 900 : isArbLike ? 7_200 : 300;
   const defaultMaxLookback = defaultLookback * 10; // 5 hours of headroom at most

--- a/relayer/lib/static-provider.ts
+++ b/relayer/lib/static-provider.ts
@@ -1,0 +1,20 @@
+// ABOUTME: Constructs ethers JsonRpcProviders pinned to a known chainId (staticNetwork) so
+// ABOUTME: ethers skips per-request eth_chainId re-verification — a material share of RPC quota.
+
+import { ethers } from "ethers";
+
+/**
+ * Create a JsonRpcProvider pinned to `chainId`. Without a static network, ethers v6 re-verifies
+ * the endpoint's chainId alongside request batches; on a long-running poller that overhead is a
+ * significant fraction of total RPC request volume on quota-billed endpoints.
+ *
+ * Pinning is safe here because the relayer's chain set is fixed at boot from config — the
+ * network can never legitimately change mid-process. If an RPC endpoint were misconfigured to
+ * serve a different chain, transactions would fail loudly on chainId mismatch at signing rather
+ * than being silently sent to the wrong network.
+ *
+ * All relayer providers should be constructed through this helper.
+ */
+export function createStaticProvider(rpc: string, chainId: number): ethers.JsonRpcProvider {
+  return new ethers.JsonRpcProvider(rpc, chainId, { staticNetwork: true });
+}

--- a/relayer/modules/cctp-relay.ts
+++ b/relayer/modules/cctp-relay.ts
@@ -18,6 +18,7 @@ import {
 import * as fs from "fs";
 import * as path from "path";
 import { CursorStore } from "../lib/cursor-store";
+import { createStaticProvider } from "../lib/static-provider";
 import { getLogsChunked } from "../lib/get-logs-chunked";
 import { RpcTimeoutError, withTimeout } from "../lib/rpc-utils";
 import { classifyChainHealth, rollupStatus } from "../lib/health-classifier";
@@ -346,7 +347,7 @@ export class CCTPRelayModule {
         }
       }
 
-      const provider = new ethers.JsonRpcProvider(chainConfig.rpc);
+      const provider = createStaticProvider(chainConfig.rpc, chainConfig.chainId);
       const wallet = new ethers.Wallet(accounts.deployer.privateKey, provider);
 
       // Verify connection up-front with the same timeout we'll use during polling.

--- a/relayer/modules/fee-calculator.ts
+++ b/relayer/modules/fee-calculator.ts
@@ -114,11 +114,12 @@ export class FeeCalculator {
    *
    * fee = gasEstimate × gasPrice × (ethPrice / 1e18) × (1 + margin)
    * Result in USDC raw units (6 decimals)
+   *
+   * `gasPrice` is passed in rather than read here: `generateFeeSchedule` prices all seven
+   * operation tiers off a single gas-price reading, so the tiers are mutually consistent
+   * and a schedule regeneration costs one RPC round-trip instead of one per tier.
    */
-  private async calculateFeeForGas(gasEstimate: bigint): Promise<bigint> {
-    const feeData = await this.provider.getFeeData();
-    const gasPrice = feeData.gasPrice || 1_000_000_000n; // Default 1 gwei
-
+  private calculateFeeForGas(gasEstimate: bigint, gasPrice: bigint): bigint {
     // Gas cost in wei
     const gasCostWei = gasEstimate * gasPrice;
 
@@ -161,23 +162,18 @@ export class FeeCalculator {
    * shape narrowing.
    */
   async generateFeeSchedule(): Promise<FeeSchedule> {
-    const [
-      transferFee,
-      unshieldFee,
-      crossContractFee,
-      crossChainShieldFee,
-      crossChainUnshieldFee,
-      shieldFee,
-      shieldXchainFee,
-    ] = await Promise.all([
-      this.calculateFeeForGas(GAS_ESTIMATES.transfer),
-      this.calculateFeeForGas(GAS_ESTIMATES.unshield),
-      this.calculateFeeForGas(GAS_ESTIMATES.crossContract),
-      this.calculateFeeForGas(GAS_ESTIMATES.crossChainShield),
-      this.calculateFeeForGas(GAS_ESTIMATES.crossChainUnshield),
-      this.calculateFeeForGas(GAS_ESTIMATES.shield),
-      this.calculateFeeForGas(GAS_ESTIMATES.shieldXchain),
-    ]);
+    // Single gas-price read per schedule — see calculateFeeForGas doc. getFeeData is the only
+    // RPC call in schedule generation.
+    const feeData = await this.provider.getFeeData();
+    const gasPrice = feeData.gasPrice || 1_000_000_000n; // Default 1 gwei
+
+    const transferFee = this.calculateFeeForGas(GAS_ESTIMATES.transfer, gasPrice);
+    const unshieldFee = this.calculateFeeForGas(GAS_ESTIMATES.unshield, gasPrice);
+    const crossContractFee = this.calculateFeeForGas(GAS_ESTIMATES.crossContract, gasPrice);
+    const crossChainShieldFee = this.calculateFeeForGas(GAS_ESTIMATES.crossChainShield, gasPrice);
+    const crossChainUnshieldFee = this.calculateFeeForGas(GAS_ESTIMATES.crossChainUnshield, gasPrice);
+    const shieldFee = this.calculateFeeForGas(GAS_ESTIMATES.shield, gasPrice);
+    const shieldXchainFee = this.calculateFeeForGas(GAS_ESTIMATES.shieldXchain, gasPrice);
 
     // In fast mode, add CCTP fast transfer fee estimate to cross-chain operations.
     // The fee is proportional to transfer amount, but since we don't know the

--- a/relayer/modules/iris-relay.ts
+++ b/relayer/modules/iris-relay.ts
@@ -28,6 +28,7 @@ import {
 import * as fs from "fs";
 import * as path from "path";
 import { CursorStore } from "../lib/cursor-store";
+import { createStaticProvider } from "../lib/static-provider";
 import { getLogsChunked } from "../lib/get-logs-chunked";
 import { PendingStateStore, type PersistedPendingMessage } from "../lib/pending-state-store";
 import { RpcTimeoutError, withTimeout } from "../lib/rpc-utils";
@@ -453,7 +454,7 @@ export class IrisRelayModule {
         knownRecipients.add(ethers.zeroPadValue(poolAddr, 32).toLowerCase());
       }
 
-      const provider = new ethers.JsonRpcProvider(chainConfig.rpc);
+      const provider = createStaticProvider(chainConfig.rpc, chainConfig.chainId);
       const wallet = new ethers.Wallet(accounts.deployer.privateKey, provider);
 
       // Verify connection up-front with the same timeout we'll use during polling.

--- a/relayer/modules/wallet-manager.ts
+++ b/relayer/modules/wallet-manager.ts
@@ -15,6 +15,7 @@
 
 import { ethers } from "ethers";
 import { accounts, allChains } from "../config";
+import { createStaticProvider } from "../lib/static-provider";
 
 // ============ Types ============
 
@@ -47,7 +48,7 @@ export class WalletManager {
 
   constructor() {
     for (const chain of allChains) {
-      const provider = new ethers.JsonRpcProvider(chain.rpc);
+      const provider = createStaticProvider(chain.rpc, chain.chainId);
       const wallet = new ethers.Wallet(accounts.deployer.privateKey, provider);
       this.chains.set(chain.chainId, { provider, wallet, locked: false });
     }

--- a/relayer/test/config.test.ts
+++ b/relayer/test/config.test.ts
@@ -1,0 +1,87 @@
+// ABOUTME: Unit tests for scannerConfigForChain — pins chainId-based chain-type classification
+// ABOUTME: and the RELAYER_<KNOB>_<NAME> env-override key derivation (HUB, CLIENT_A, CLIENT_B).
+
+import { expect } from "chai";
+import { scannerConfigForChain } from "../config";
+
+describe("scannerConfigForChain", () => {
+  afterEach(() => {
+    // Each test that sets override envs must not leak into the next.
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("RELAYER_")) delete process.env[key];
+    }
+  });
+
+  it("classifies Ethereum Sepolia (hub) as L1: confirmationDepth 6, bootLookback 150", () => {
+    // WHY: chain-type defaults previously matched regexes against the config names ("Hub",
+    // "Client A", ...), which NEVER matched — every chain silently got the fallback defaults,
+    // including confirmationDepth 2 on Ethereum L1 where the design intent is 6 (reorg margin).
+    // This pins classification by chainId so role labels can't break it again.
+    const scanner = scannerConfigForChain("Hub", "sepolia", 11155111);
+    expect(scanner.confirmationDepth).to.equal(6);
+    expect(scanner.bootLookbackBlocks).to.equal(150);
+    expect(scanner.maxBootLookbackBlocks).to.equal(1500);
+    expect(scanner.maxLogRange).to.equal(1000);
+  });
+
+  it("classifies Base Sepolia as base-like: confirmationDepth 2, bootLookback 900", () => {
+    // WHY: ~2s blocks → 900 blocks ≈ 30 min of cold-boot recovery, per the design comment.
+    const scanner = scannerConfigForChain("Client A", "sepolia", 84532);
+    expect(scanner.confirmationDepth).to.equal(2);
+    expect(scanner.bootLookbackBlocks).to.equal(900);
+    expect(scanner.maxBootLookbackBlocks).to.equal(9000);
+  });
+
+  it("classifies Arbitrum Sepolia as arb-like: confirmationDepth 2, bootLookback 7200", () => {
+    // WHY: ~0.25s blocks → 7200 blocks ≈ 30 min. Under the old name-regex bug this chain got
+    // 300 blocks (~75 seconds) of cold-boot recovery — messages sent during any longer relayer
+    // downtime were silently skipped.
+    const scanner = scannerConfigForChain("Client B", "sepolia", 421614);
+    expect(scanner.confirmationDepth).to.equal(2);
+    expect(scanner.bootLookbackBlocks).to.equal(7200);
+    expect(scanner.maxBootLookbackBlocks).to.equal(72000);
+  });
+
+  it("falls back to conservative defaults for an unrecognized chainId", () => {
+    // WHY: a new chain added to config before its chainId is classified must still get sane
+    // scanner behavior (lookback 300 ≈ generic 30 min at 6s blocks, confirmation 2), not a crash.
+    const scanner = scannerConfigForChain("Client B", "sepolia", 99999);
+    expect(scanner.confirmationDepth).to.equal(2);
+    expect(scanner.bootLookbackBlocks).to.equal(300);
+    expect(scanner.maxBootLookbackBlocks).to.equal(3000);
+  });
+
+  it("uses Anvil-tuned values for local env regardless of chainId", () => {
+    // WHY: local Anvil has no reorgs and no RPC range caps — chunking/confirmation-depth would
+    // only slow tests down. The local branch must win before any chainId classification.
+    const scanner = scannerConfigForChain("Hub", "local", 31337);
+    expect(scanner.confirmationDepth).to.equal(0);
+    expect(scanner.maxLogRange).to.equal(10000);
+    expect(scanner.bootLookbackBlocks).to.equal(0);
+  });
+
+  it("honours env overrides keyed by the config name (HUB, CLIENT_A), not the network name", () => {
+    // WHY: operators set RELAYER_<KNOB>_HUB / _CLIENT_A / _CLIENT_B on the VPS. The suffix
+    // derives from the chain's config `name` — this pins the derivation ("Client A" → CLIENT_A)
+    // so a rename of the config labels surfaces as a test failure, not silently ignored envs.
+    process.env.RELAYER_CONFIRMATION_DEPTH_HUB = "3";
+    process.env.RELAYER_MAX_LOG_RANGE_CLIENT_A = "10";
+
+    const hub = scannerConfigForChain("Hub", "sepolia", 11155111);
+    expect(hub.confirmationDepth).to.equal(3);
+
+    const clientA = scannerConfigForChain("Client A", "sepolia", 84532);
+    expect(clientA.maxLogRange).to.equal(10);
+    // Un-overridden knobs keep their chain-type defaults.
+    expect(clientA.bootLookbackBlocks).to.equal(900);
+  });
+
+  it("rejects a non-numeric env override loudly", () => {
+    // WHY: a typo'd override (e.g. "1O0") silently falling back to the default would be a
+    // misconfiguration the operator can't see. Boot-time throw is the visible failure mode.
+    process.env.RELAYER_MAX_LOG_RANGE_HUB = "not-a-number";
+    expect(() => scannerConfigForChain("Hub", "sepolia", 11155111)).to.throw(
+      /RELAYER_MAX_LOG_RANGE_HUB/,
+    );
+  });
+});

--- a/relayer/test/lib/static-provider.test.ts
+++ b/relayer/test/lib/static-provider.test.ts
@@ -1,0 +1,40 @@
+// ABOUTME: Unit tests for the static-network provider factory — pins the property that network
+// ABOUTME: identity resolves locally (no eth_chainId RPC), which is the whole quota-saving point.
+
+import { expect } from "chai";
+import { createStaticProvider } from "../../lib/static-provider";
+
+describe("createStaticProvider", () => {
+  it("resolves getNetwork() from the pinned chainId without any RPC call", async () => {
+    // WHY: the helper exists to stop ethers v6 from re-verifying chainId over RPC alongside
+    // request batches (a large share of RPC quota for a long-running poller). If a regression
+    // dropped the staticNetwork option, getNetwork() would need a live endpoint — this test's
+    // send() override would throw and the URL (port 0) could never connect anyway.
+    const provider = createStaticProvider("http://localhost:0", 11155111);
+    provider.send = async () => {
+      throw new Error("network detection must not hit the RPC endpoint");
+    };
+
+    try {
+      const network = await provider.getNetwork();
+      expect(network.chainId).to.equal(11155111n);
+    } finally {
+      provider.destroy();
+    }
+  });
+
+  it("pins the chainId passed by the caller, per instance", async () => {
+    // WHY: each chain's provider must carry ITS OWN chainId — a copy/paste bug that pinned every
+    // provider to the same network would make ethers sign transactions with the wrong chainId
+    // (EIP-155), which fails at broadcast on every chain but the accidental one.
+    const a = createStaticProvider("http://localhost:0", 84532);
+    const b = createStaticProvider("http://localhost:0", 421614);
+    try {
+      expect((await a.getNetwork()).chainId).to.equal(84532n);
+      expect((await b.getNetwork()).chainId).to.equal(421614n);
+    } finally {
+      a.destroy();
+      b.destroy();
+    }
+  });
+});

--- a/relayer/test/modules/fee-calculator.test.ts
+++ b/relayer/test/modules/fee-calculator.test.ts
@@ -1,0 +1,116 @@
+// ABOUTME: Unit tests for FeeCalculator — pins the one-RPC-read-per-schedule property (quota
+// ABOUTME: guard) plus the fee math invariants: tier proportionality, min-fee floor, TTL caching.
+
+import { expect } from "chai";
+import type { ethers } from "ethers";
+import { FeeCalculator } from "../../modules/fee-calculator";
+
+/** Fake provider that records getFeeData calls and returns a fixed gas price. */
+function stubProvider(gasPrice: bigint): { provider: ethers.JsonRpcProvider; calls: () => number } {
+  let count = 0;
+  const provider = {
+    getFeeData: async () => {
+      count++;
+      return { gasPrice };
+    },
+  } as unknown as ethers.JsonRpcProvider;
+  return { provider, calls: () => count };
+}
+
+const CHAIN_ID = 11155111;
+const BROADCASTER = "0zk-test-address";
+
+describe("FeeCalculator", () => {
+  it("makes exactly one getFeeData call per schedule generation", async () => {
+    // WHY: schedule generation prices seven operation tiers. A regression back to per-tier
+    // getFeeData calls would 7x the RPC cost of every schedule regeneration on every chain —
+    // this is the load-reduction property the fee calculator is built around.
+    const { provider, calls } = stubProvider(2_000_000_000n);
+    const calc = new FeeCalculator(provider, CHAIN_ID, BROADCASTER);
+
+    await calc.generateFeeSchedule();
+    expect(calls()).to.equal(1);
+
+    await calc.generateFeeSchedule();
+    expect(calls()).to.equal(2);
+  });
+
+  it("serves getCurrentFees from cache within the TTL without touching the provider", async () => {
+    // WHY: /fees is polled by frontends; the 5-minute TTL cache is what keeps that polling off
+    // the RPC endpoint. A regression that regenerated per request would multiply RPC load by
+    // the number of /fees hits.
+    const { provider, calls } = stubProvider(2_000_000_000n);
+    const calc = new FeeCalculator(provider, CHAIN_ID, BROADCASTER);
+
+    const first = await calc.getCurrentFees();
+    const second = await calc.getCurrentFees();
+    expect(calls()).to.equal(1);
+    expect(second.cacheId).to.equal(first.cacheId);
+  });
+
+  it("prices all tiers off the same gas reading, proportional to their gas estimates", async () => {
+    // WHY: all seven tiers must be mutually consistent — quoted from one gas-price observation.
+    // If tiers came from different readings (or different formulas), a user comparing quotes
+    // would see incoherent relative pricing, and operator fee accounting couldn't reconcile.
+    // 1000 gwei keeps every tier far above the 0.01 USDC min-fee floor so proportionality is
+    // exact for any configured ETH price ≥ 1.
+    const { provider } = stubProvider(1_000_000_000_000n);
+    const calc = new FeeCalculator(provider, CHAIN_ID, BROADCASTER);
+
+    const { fees } = await calc.generateFeeSchedule();
+    const transfer = BigInt(fees.transfer);
+
+    // Gas estimates: transfer/unshield/crossChainShield/crossChainUnshield 500k,
+    // crossContract 2M (4x), shield 300k (3/5), shieldXchain 400k (4/5).
+    expect(BigInt(fees.unshield)).to.equal(transfer);
+    expect(BigInt(fees.crossChainShield)).to.equal(transfer);
+    expect(BigInt(fees.crossChainUnshield)).to.equal(transfer);
+    expect(BigInt(fees.crossContract)).to.equal(transfer * 4n);
+    expect(BigInt(fees.shield)).to.equal((transfer * 3n) / 5n);
+    expect(BigInt(fees.shieldXchain)).to.equal((transfer * 4n) / 5n);
+  });
+
+  it("enforces the 0.01 USDC minimum fee when gas is effectively free", async () => {
+    // WHY: dust-fee floor. With a 1-wei gas price the formula rounds to zero — the floor is what
+    // prevents publishing a 0-fee schedule that invites free relaying.
+    const { provider } = stubProvider(1n);
+    const calc = new FeeCalculator(provider, CHAIN_ID, BROADCASTER);
+
+    const { fees } = await calc.generateFeeSchedule();
+    for (const fee of Object.values(fees)) {
+      expect(BigInt(fee)).to.equal(10_000n);
+    }
+  });
+
+  it("falls back to 1 gwei when the provider reports no gas price", async () => {
+    // WHY: getFeeData().gasPrice can be null (some RPCs omit it post-EIP-1559). The schedule
+    // must still be generated — a throw here would take down /fees for the whole chain.
+    let count = 0;
+    const provider = {
+      getFeeData: async () => {
+        count++;
+        return { gasPrice: null };
+      },
+    } as unknown as ethers.JsonRpcProvider;
+    const calc = new FeeCalculator(provider, CHAIN_ID, BROADCASTER);
+
+    const schedule = await calc.generateFeeSchedule();
+    expect(count).to.equal(1);
+    // 500k gas x 1 gwei = 5e14 wei; exact fee depends on configured ETH price, but it must be
+    // a positive value at or above the min-fee floor.
+    expect(BigInt(schedule.fees.transfer) >= 10_000n).to.equal(true);
+  });
+
+  it("embeds the chainId in the cacheId", async () => {
+    // WHY: cross-chain quote replay defense — privacy-relay validates cacheId against the
+    // schedule for the request's chainId, and humans grep cacheIds when debugging. A cacheId
+    // without the chainId would make both silently weaker.
+    const { provider } = stubProvider(2_000_000_000n);
+    const calc = new FeeCalculator(provider, CHAIN_ID, BROADCASTER);
+
+    const schedule = await calc.generateFeeSchedule();
+    expect(schedule.cacheId).to.match(new RegExp(`^fee-${CHAIN_ID}-`));
+    expect(schedule.chainId).to.equal(CHAIN_ID);
+    expect(schedule.broadcasterRailgunAddress).to.equal(BROADCASTER);
+  });
+});


### PR DESCRIPTION
## Summary

Cuts the relayer's steady-state RPC request volume on the three testnet chains, and fixes a latent scanner-config bug found while auditing the request paths.

### perf: static network pinning + single gas read (f9093aa)

- **Static network pinning.** New `relayer/lib/static-provider.ts` constructs every provider with `{ staticNetwork: true }` pinned to the config chainId, so ethers v6 stops re-verifying `eth_chainId` alongside request batches — a significant share of total volume for a long-running poller. Adopted in `iris-relay`, `wallet-manager` (fee calculators reuse these providers), and `cctp-relay`.
- **One gas-price read per fee schedule.** `generateFeeSchedule` previously called `getFeeData()` once per operation tier (7×, each ~2 sub-requests). Now a single read prices all seven tiers, which also makes the tiers mutually consistent.

### fix: scanner defaults classified by chainId (efd49e6)

`scannerConfigForChain` matched chain-type regexes (`/ethereum|sepolia/`, `/base/`, `/arbitrum/`) against the config `name` fields — which are always "Hub" / "Client A" / "Client B", so nothing ever matched and every chain silently got fallback defaults. Consequences: Ethereum Sepolia ran `confirmationDepth 2` instead of the intended 6 (thinner reorg margin), and Arbitrum Sepolia got 300 blocks (~75 s) of cold-boot lookback instead of the intended 7200 (~30 min).

Classification now keys off `chainId` sets (L1 / Base-like / Arb-like). Env override key names are unchanged (`RELAYER_<KNOB>_HUB` / `_CLIENT_A` / `_CLIENT_B`); the misleading doc example (`..._ETHEREUM_SEPOLIA`) is corrected.

**Operator notes:**
- ⚠️ Touches `relayer/` — VPS needs pull + restart after merge.
- Hub `confirmationDepth` default rises 2 → 6 (~48 s added detection latency on hub-originated messages, per original design intent). Set `RELAYER_CONFIRMATION_DEPTH_HUB` to override if latency matters more.
- Verify VPS env keys use the `_HUB` / `_CLIENT_A` / `_CLIENT_B` suffixes — network-name-style keys are silently ignored.

## Testing

- `npm run test:relayer`: 125 passing (new suites: `fee-calculator.test.ts`, `static-provider.test.ts`, `config.test.ts`)
- `npm run test:forge`: 737 passing
- `tsc --noEmit`: no errors in `relayer/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)