### PR TITLE
fix(privacy-pool): cap shield fee at 10% (#230) + drop EOA from cross-chain shield event (#65)

### DIFF
--- a/contracts/privacy-pool/PrivacyPool.sol
+++ b/contracts/privacy-pool/PrivacyPool.sol
@@ -34,6 +34,10 @@ import "../railgun/logic/Snark.sol";
 contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
     using SafeERC20 for IERC20;
 
+    /// @notice Maximum settable shield fee in basis points (10%), matching ArmadaFeeModule.MAX_BPS.
+    /// @dev Bounds setShieldFee so a single mis-proposal cannot brick shields by consuming all deposited value.
+    uint256 public constant MAX_SHIELD_FEE_BPS = 1000;
+
     // ══════════════════════════════════════════════════════════════════════════
     // INITIALIZATION
     // ══════════════════════════════════════════════════════════════════════════
@@ -278,7 +282,7 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
      */
     function setShieldFee(uint120 _feeBps) external override {
         require(msg.sender == owner, "PrivacyPool: Only owner");
-        require(_feeBps <= 10000, "PrivacyPool: Fee too high");
+        require(_feeBps <= MAX_SHIELD_FEE_BPS, "PrivacyPool: Fee too high");
         shieldFee = _feeBps;
     }
 

--- a/contracts/privacy-pool/PrivacyPoolClient.sol
+++ b/contracts/privacy-pool/PrivacyPoolClient.sol
@@ -146,7 +146,7 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
         // Encode shield payload and execute CCTP burn in helper (avoids stack-too-deep)
         _executeCCTPShield(amount, maxFee, minFinalityThreshold, npk, encryptedBundle, shieldKey, destinationCaller, integrator);
 
-        emit CrossChainShieldInitiated(msg.sender, amount, npk, 0);
+        emit CrossChainShieldInitiated(amount, npk, 0);
 
         return 0;
     }

--- a/contracts/privacy-pool/interfaces/IPrivacyPoolClient.sol
+++ b/contracts/privacy-pool/interfaces/IPrivacyPoolClient.sol
@@ -15,13 +15,13 @@ interface IPrivacyPoolClient is IMessageHandlerV2 {
 
     /**
      * @notice Emitted when a cross-chain shield is initiated
-     * @param sender Address that initiated the shield
+     * @dev The initiating EOA is intentionally omitted so this event does not broadcast an
+     *      indexed, filterable EOA -> NPK link (matches Railgun's Shield-event convention).
      * @param amount Amount of USDC being shielded
      * @param npk Note public key
      * @param nonce CCTP message nonce
      */
     event CrossChainShieldInitiated(
-        address indexed sender,
         uint256 amount,
         bytes32 indexed npk,
         uint64 nonce

--- a/test/privacy_pool_adversarial.ts
+++ b/test/privacy_pool_adversarial.ts
@@ -597,9 +597,12 @@ describe("Privacy Pool Adversarial", function () {
       expect(await privacyPoolClient.hubDomain()).to.equal(DOMAINS.hub);
     });
 
-    it("setShieldFee rejects fee > 10000 bps", async function () {
+    // WHY: The shield fee is capped at MAX_SHIELD_FEE_BPS (1000 = 10%) so a single
+    // owner/governance mis-proposal cannot brick shields by consuming all deposited
+    // value. Just over the cap must revert.
+    it("setShieldFee rejects fee > MAX_SHIELD_FEE_BPS (1000 bps)", async function () {
       await expect(
-        privacyPool.setShieldFee(10001)
+        privacyPool.setShieldFee(1001)
       ).to.be.revertedWith("PrivacyPool: Fee too high");
     });
   });
@@ -647,9 +650,10 @@ describe("Privacy Pool Adversarial", function () {
       ).to.be.revertedWith("ShieldModule: Invalid npk");
     });
 
-    it("shield fee boundary: exactly 10000 bps accepted", async function () {
-      // 10000 bps = 100% fee (edge case)
-      await privacyPool.setShieldFee(10000);
+    // WHY: The cap is inclusive — exactly MAX_SHIELD_FEE_BPS (1000 = 10%) is the
+    // highest fee governance can set and must be accepted.
+    it("shield fee boundary: exactly 1000 bps (10%) accepted", async function () {
+      await privacyPool.setShieldFee(1000);
       // Reset to normal after
       await privacyPool.setShieldFee(50);
     });

--- a/test/privacy_pool_integration.ts
+++ b/test/privacy_pool_integration.ts
@@ -399,6 +399,15 @@ describe("Privacy Pool Integration", function () {
       });
       expect(event).to.not.be.undefined;
 
+      // WHY: CrossChainShieldInitiated must NOT emit the initiating EOA — doing so would
+      // broadcast an indexed, filterable EOA -> NPK link (see issue #65). Assert the event
+      // carries only (amount, npk, nonce) and has no `sender` field.
+      const parsedEvent = privacyPoolClient.interface.parseLog(event as any);
+      expect(parsedEvent?.args.sender).to.be.undefined;
+      expect(parsedEvent?.args.amount).to.equal(SHIELD_AMOUNT);
+      expect(parsedEvent?.args.npk).to.equal(npk);
+      expect(parsedEvent?.args.length).to.equal(3);
+
       // Verify USDC was burned on client
       const aliceBalance = await clientUsdc.balanceOf(aliceAddress);
       expect(aliceBalance).to.equal(0);


### PR DESCRIPTION
Two small, independent privacy-pool hardening fixes.

## #230 — Tighten shield fee cap (100% → 10%)
`PrivacyPool.setShieldFee` only required `_feeBps <= 10000` (100%). A single owner/governance mis-proposal could set it to 100% and effectively brick shields by consuming all deposited value. Introduces `MAX_SHIELD_FEE_BPS = 1000` (10%, matching `ArmadaFeeModule.MAX_BPS`) and enforces it.

**Scope correction:** the issue claimed a `setUnshieldFee()` also needed capping — there is no such setter on PrivacyPool (`unshieldFee` is a dead storage var; the Railgun path already caps at 50%). So this touches shield only. Current deployed fee is 50 bps, well under the new cap — no migration concern.

## #65 — Drop initiating EOA from `CrossChainShieldInitiated`
The event emitted `address indexed sender` alongside `npk`, broadcasting an indexed, filterable EOA → NPK link on the client chain. Railgun's `Shield` event does not volunteer this. Removed `sender`; event now carries `(amount, npk, nonce)`. The link is still recoverable from calldata — this only stops us publishing it in an indexed, queryable form. No relayer/frontend code parses this event (only one integration test, updated here).

## Tests
- `privacy_pool_adversarial.ts`: cap tests retargeted to the 1000 bps boundary (reject 1001, accept 1000).
- `privacy_pool_integration.ts`: asserts the event has no `sender` field and carries exactly `(amount, npk, nonce)`.
- Full runs green: Hardhat adversarial (58) + integration (8); Foundry full suite (759).

🤖 Generated with [Claude Code](https://claude.com/claude-code)