### PR TITLE
fix(privacy-pool): authenticate cross-chain source pool (#366)

### DIFF
--- a/contracts/cctp/ICCTPV2.sol
+++ b/contracts/cctp/ICCTPV2.sol
@@ -482,6 +482,16 @@ library BurnMessageV2 {
         require(messageBody.length >= MIN_BURN_MESSAGE_LENGTH, "BurnMessageV2: message too short");
         return uint256(bytes32(messageBody[MAX_FEE_OFFSET:MAX_FEE_OFFSET + 32]));
     }
+
+    /**
+     * @notice Get the messageSender from a burn message
+     * @dev The address that called depositForBurn on the source chain (as bytes32). Distinct from
+     *      the MessageV2 envelope sender, which is the source TokenMessenger.
+     */
+    function getMessageSender(bytes calldata messageBody) internal pure returns (bytes32) {
+        require(messageBody.length >= MIN_BURN_MESSAGE_LENGTH, "BurnMessageV2: message too short");
+        return bytes32(messageBody[MESSAGE_SENDER_OFFSET:MESSAGE_SENDER_OFFSET + 32]);
+    }
 }
 
 // ============================================================================

--- a/contracts/privacy-pool/PrivacyPool.sol
+++ b/contracts/privacy-pool/PrivacyPool.sol
@@ -166,16 +166,16 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
      * @return success Always returns true on success (reverts on failure)
      */
     function handleReceiveFinalizedMessage(
-        uint32,
+        uint32 sourceDomain,
         bytes32 sender,
         uint32 finalityThresholdExecuted,
         bytes calldata messageBody
     ) external override returns (bool) {
         require(msg.sender == hookRouter || msg.sender == tokenMessenger, "PrivacyPool: Unauthorized caller");
         require(finalityThresholdExecuted >= CCTPFinality.STANDARD, "PrivacyPool: Insufficient finality");
-        (sender); // Silence unused variable warning
+        (sender); // envelope sender is the source TokenMessenger; source pool is authenticated in _handleCCTPMessage
 
-        return _handleCCTPMessage(messageBody);
+        return _handleCCTPMessage(sourceDomain, messageBody);
     }
 
     /**
@@ -190,24 +190,25 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
      * @return success Always returns true on success (reverts on failure)
      */
     function handleReceiveUnfinalizedMessage(
-        uint32,
+        uint32 sourceDomain,
         bytes32 sender,
         uint32 finalityThresholdExecuted,
         bytes calldata messageBody
     ) external override returns (bool) {
         require(msg.sender == hookRouter || msg.sender == tokenMessenger, "PrivacyPool: Unauthorized caller");
         require(finalityThresholdExecuted >= CCTPFinality.FAST, "PrivacyPool: Finality below minimum");
-        (sender); // Silence unused variable warning
+        (sender); // envelope sender is the source TokenMessenger; source pool is authenticated in _handleCCTPMessage
 
-        return _handleCCTPMessage(messageBody);
+        return _handleCCTPMessage(sourceDomain, messageBody);
     }
 
     /**
      * @notice Shared CCTP message processing logic for both finalized and unfinalized paths
+     * @param sourceDomain CCTP domain the message originated from (from the MessageV2 envelope)
      * @param messageBody BurnMessageV2 encoded message containing hookData
      * @return success Always returns true on success (reverts on failure)
      */
-    function _handleCCTPMessage(bytes calldata messageBody) internal returns (bool) {
+    function _handleCCTPMessage(uint32 sourceDomain, bytes calldata messageBody) internal returns (bool) {
         // Decode the BurnMessageV2 to get amount, feeExecuted, and hookData
         (
             uint256 grossAmount,
@@ -224,6 +225,19 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
 
         // Route based on message type
         if (payload.messageType == MessageType.SHIELD) {
+            // Authenticate the source pool: the burn message's messageSender is the address that
+            // called depositForBurn on the source chain (i.e. the remote PrivacyPoolClient), which
+            // must match the configured remote pool for this domain. The handler's envelope `sender`
+            // is the source TokenMessenger, not the pool, so it cannot be used here. This is a
+            // defense-in-depth backstop on top of CCTP's attestation and rejects shields from
+            // unconfigured domains or arbitrary source contracts.
+            bytes32 sourcePool = remotePools[sourceDomain];
+            require(sourcePool != bytes32(0), "PrivacyPool: unconfigured source domain");
+            require(
+                BurnMessageV2.getMessageSender(messageBody) == sourcePool,
+                "PrivacyPool: untrusted source pool"
+            );
+
             // Cross-chain shield from Client
             ShieldData memory shieldData = CCTPPayloadLib.decodeShieldData(payload.data);
 

--- a/contracts/privacy-pool/PrivacyPoolClient.sol
+++ b/contracts/privacy-pool/PrivacyPoolClient.sol
@@ -234,6 +234,16 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
 
         // Route based on message type
         if (payload.messageType == MessageType.UNSHIELD) {
+            // Authenticate the source pool: the burn message's messageSender is the address that
+            // called depositForBurn on the Hub (i.e. the Hub PrivacyPool), which must match the
+            // configured hubPool. The envelope sender is the Hub TokenMessenger, not the pool, so it
+            // cannot be used here. The handlers already enforce remoteDomain == hubDomain. This is a
+            // defense-in-depth backstop on top of CCTP's attestation.
+            require(
+                BurnMessageV2.getMessageSender(messageBody) == hubPool,
+                "PrivacyPoolClient: untrusted source pool"
+            );
+
             // Cross-chain unshield from Hub
             UnshieldData memory unshieldData = CCTPPayloadLib.decodeUnshieldData(payload.data);
 

--- a/test/privacy_pool_integration.ts
+++ b/test/privacy_pool_integration.ts
@@ -635,6 +635,112 @@ describe("Privacy Pool Integration", function () {
     });
   });
 
+  describe("Cross-Chain Source Pool Authentication (#366)", function () {
+    // WHY: The CCTP receive handlers must authenticate the *source pool* — the burn message's
+    // messageSender (the depositForBurn caller on the source chain), NOT the envelope sender (which is
+    // the source TokenMessenger). Without this, cross-chain shield/unshield authenticity rests entirely
+    // on Circle's attestation with no on-chain backstop, and shields from unconfigured domains or
+    // arbitrary source contracts are accepted. Legitimate flows are covered by the tests above; these
+    // exercise the rejection paths.
+    const SRC_AUTH_AMOUNT = ethers.parseUnits("10", 6);
+    const SNARK_SCALAR_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
+    const clientBytes32 = () => ethers.zeroPadValue(clientAddress, 32);
+
+    // Produce a genuine cross-chain shield message from the client pool. Its burn messageSender is the
+    // client pool (the depositForBurn caller), so a correctly-configured hub accepts it — each test then
+    // flips the hub's remotePools config to trip the auth revert while relaying this same message.
+    async function buildClientShieldMessage(): Promise<string> {
+      await clientUsdc.mint(aliceAddress, SRC_AUTH_AMOUNT);
+      await clientUsdc.connect(alice).approve(clientAddress, SRC_AUTH_AMOUNT);
+      const npk = ethers.zeroPadValue(
+        ethers.toBeHex(BigInt(ethers.keccak256(ethers.toUtf8Bytes("src-auth-npk"))) % SNARK_SCALAR_FIELD),
+        32,
+      );
+      const encryptedBundle: [string, string, string] = [
+        ethers.keccak256(ethers.toUtf8Bytes("enc1")),
+        ethers.keccak256(ethers.toUtf8Bytes("enc2")),
+        ethers.keccak256(ethers.toUtf8Bytes("enc3")),
+      ];
+      const shieldKey = ethers.keccak256(ethers.toUtf8Bytes("src-auth-key"));
+      const tx = await privacyPoolClient.connect(alice).crossChainShield(
+        SRC_AUTH_AMOUNT, 0, 0, npk, encryptedBundle, shieldKey, ethers.ZeroHash, ethers.ZeroAddress,
+      );
+      const receipt = await tx.wait();
+      for (const log of receipt!.logs) {
+        try {
+          const parsed = clientMessageTransmitter.interface.parseLog(log);
+          if (parsed?.name === "MessageSent") return parsed.args.message;
+        } catch {
+          // Not from this contract
+        }
+      }
+      throw new Error("MessageSent event not found");
+    }
+
+    afterEach(async function () {
+      // Restore the correct remote pool so later tests are unaffected.
+      await privacyPool.setRemotePool(DOMAINS.client, clientBytes32());
+    });
+
+    // WHY: The hub must not accept cross-chain shields from a domain with no configured remote pool.
+    it("hub rejects cross-chain shield from an unconfigured source domain", async function () {
+      const message = await buildClientShieldMessage();
+      await privacyPool.setRemotePool(DOMAINS.client, ethers.ZeroHash); // deauthorize the domain
+      await expect(
+        hubHookRouter.connect(relayer).relayWithHook(message, "0x"),
+      ).to.be.revertedWith("PrivacyPool: unconfigured source domain");
+    });
+
+    // WHY: Core #366 defense — even a CCTP-delivered shield must originate from our deployed client
+    // pool. Configuring a different remote pool makes the legit client-pool messageSender no longer
+    // match, so the shield is rejected.
+    it("hub rejects cross-chain shield from an untrusted source pool", async function () {
+      const message = await buildClientShieldMessage();
+      await privacyPool.setRemotePool(DOMAINS.client, ethers.zeroPadValue(bobAddress, 32)); // wrong pool
+      await expect(
+        hubHookRouter.connect(relayer).relayWithHook(message, "0x"),
+      ).to.be.revertedWith("PrivacyPool: untrusted source pool");
+    });
+
+    // WHY: Client mirror — an unshield whose burn messageSender is not the configured hubPool must be
+    // rejected. Crafted directly (the source-pool check fires before any payout, so no proof/USDC is
+    // needed); the client TokenMessenger is impersonated so the caller check passes.
+    it("client rejects cross-chain unshield from an untrusted source pool", async function () {
+      const coder = ethers.AbiCoder.defaultAbiCoder();
+      // CCTPPayload{ messageType: UNSHIELD(1), data: "0x" } — data unused, the auth check reverts first.
+      const hookData = coder.encode(["tuple(uint8 messageType, bytes data)"], [[1, "0x"]]);
+      // BurnMessageV2 with messageSender = bob (NOT the hubPool).
+      const messageBody = ethers.solidityPacked(
+        ["uint32", "bytes32", "bytes32", "uint256", "bytes32", "uint256", "uint256", "uint256", "bytes"],
+        [
+          1,                                                    // version
+          ethers.zeroPadValue(await clientUsdc.getAddress(), 32), // burnToken
+          ethers.zeroPadValue(clientAddress, 32),               // mintRecipient
+          SRC_AUTH_AMOUNT,                                      // amount
+          ethers.zeroPadValue(bobAddress, 32),                 // messageSender (untrusted)
+          0,                                                   // maxFee
+          0,                                                   // feeExecuted
+          0,                                                   // expirationBlock
+          hookData,
+        ],
+      );
+
+      const tmAddress = await clientTokenMessenger.getAddress();
+      // Fund via setBalance — the mock TokenMessenger has no receive()/fallback to accept a transfer.
+      await ethers.provider.send("hardhat_setBalance", [tmAddress, "0x56BC75E2D63100000"]); // 100 ETH
+      const tmSigner = await ethers.getImpersonatedSigner(tmAddress);
+
+      await expect(
+        privacyPoolClient.connect(tmSigner).handleReceiveFinalizedMessage(
+          DOMAINS.hub,      // remoteDomain (matches hubDomain)
+          ethers.ZeroHash,  // envelope sender (unused for auth)
+          2000,             // finalityThresholdExecuted = STANDARD
+          messageBody,
+        ),
+      ).to.be.revertedWith("PrivacyPoolClient: untrusted source pool");
+    });
+  });
+
   describe("Verification Keys", function () {
     it("should have verification keys loaded", async function () {
       // Check that verification keys are set for common circuit configurations


### PR DESCRIPTION
Fixes #366.

## Problem
The CCTP receive handlers authenticated only `msg.sender == hookRouter || tokenMessenger` and discarded the source `sender`/`sourceDomain`. The `remotePools` mapping was written by `setRemotePool` but **never read** in the receive path, so there was no on-chain guarantee a cross-chain shield originated from a legitimate remote pool — authenticity rested entirely on Circle's attestation, and the hub accepted shields from unconfigured domains.

## ⚠️ Deviation from the issue's suggested fix (important)
The issue recommended `require(sender == remotePools[sourceDomain])` using the handler's `sender` argument. **That is incorrect and would revert every legitimate cross-chain shield.** There are two distinct sender fields in CCTP V2:

| Field | Value | Source |
|---|---|---|
| MessageV2 envelope `sender` (the handler's `sender` arg) | source **TokenMessenger** | `MockCCTPV2.sol:364` sets it to `tokenMessenger` |
| BurnMessage body `messageSender` (offset 100) | the `depositForBurn` caller = source **pool** | `MockCCTPV2.sol:159` sets it to `msg.sender` |

`remotePools` stores **pool** addresses, so the correct anchor is the **burn body `messageSender`**, not the envelope `sender`. Verified against the mock and proven by tests: legitimate shield/unshield e2e flows still pass, which they would not under the issue's literal check.

## Fix
- Add `BurnMessageV2.getMessageSender(messageBody)` accessor (offset 100).
- **Hub** (`PrivacyPool`): thread the envelope `sourceDomain` into `_handleCCTPMessage`; in the SHIELD branch require `remotePools[sourceDomain] != 0` and `messageSender == remotePools[sourceDomain]`.
- **Client** (`PrivacyPoolClient`): in the UNSHIELD branch require `messageSender == hubPool` (handlers already enforce `remoteDomain == hubDomain`).

Defense-in-depth on top of the attestation; also makes `remotePools` registration meaningful.

## Tests (`test/privacy_pool_integration.ts` — new "Cross-Chain Source Pool Authentication" block)
- hub rejects shield from an **unconfigured source domain**
- hub rejects shield from an **untrusted source pool**
- client rejects unshield from an **untrusted source pool**

Legitimate cross-chain shield + unshield e2e tests (unchanged) still pass — the proof the corrected anchor is right. Full runs green: Foundry (759), Hardhat integration (11) + adversarial (58).

🤖 Generated with [Claude Code](https://claude.com/claude-code)