### PR TITLE
fix(armada-interface): realign native-gas display table to real gasUsed (#331)

### DIFF
--- a/apps/armada-interface/src/hooks/useNativeGasEstimate.ts
+++ b/apps/armada-interface/src/hooks/useNativeGasEstimate.ts
@@ -9,17 +9,23 @@ import type { TxKind } from '@/lib/tx/types'
 export type { NativeGasEstimate }
 
 /**
- * Gas units per flow for fee tooltip display. The five same-chain / yield flows are set from measured
- * Sepolia `gasUsed` plus ~10-15% headroom (see issue #331). The two -xchain flows are unmeasured and
- * kept at their prior conservative estimates.
- * TODO(#331): set shield-xchain / unshield-xchain from real Sepolia gasUsed once measured
- * (relayer-side re-tune tracked in ship-armada/armada-relayer#16).
+ * Gas units per flow for fee tooltip display (wallet-submit path — the tx the user actually signs).
+ * The five same-chain / yield flows are set from measured Sepolia `gasUsed` + ~10-15% headroom (#331).
+ * The two -xchain rows are derived from local gas profiling (test/privacy_pool_gas.ts) corrected to
+ * Sepolia. Note `gasUsed` is protocol-deterministic, so local == Sepolia for identical code/state; the
+ * only correction is the ~380k Groth16 verify that the profiling test skips under setTestingMode
+ * (calibrated from the transact/unshield local-vs-Sepolia deltas: +356k / +402k).
+ *   - unshield-xchain signs atomicCrossChainUnshield (real ZK proof + CCTP burn). Local ~902k + the
+ *     ~380k verify + CCTP burn + headroom => ~1.5M. Sits just above unshield-local (1.4M), as expected.
+ *   - shield-xchain signs only the client-side crossChainShield (USDC pull + CCTP burn, NO proof), so
+ *     the verify correction does not apply. Local ~177k; 600k is retained as a conservative ceiling
+ *     covering real Circle CCTP overhead. A Sepolia one-shot would let us tighten it.
  */
 const GAS_UNITS: Partial<Record<TxKind, bigint>> = {
   shield: 1_000_000n,
   'shield-xchain': 600_000n,
   'unshield-local': 1_400_000n,
-  'unshield-xchain': 650_000n,
+  'unshield-xchain': 1_500_000n,
   'transfer-shielded': 1_300_000n,
   'yield-deposit': 2_000_000n,
   'yield-withdraw': 2_000_000n,

--- a/apps/armada-interface/src/hooks/useNativeGasEstimate.ts
+++ b/apps/armada-interface/src/hooks/useNativeGasEstimate.ts
@@ -8,15 +8,21 @@ import type { TxKind } from '@/lib/tx/types'
 
 export type { NativeGasEstimate }
 
-/** Conservative gas units per flow for fee tooltip display. */
+/**
+ * Gas units per flow for fee tooltip display. The five same-chain / yield flows are set from measured
+ * Sepolia `gasUsed` plus ~10-15% headroom (see issue #331). The two -xchain flows are unmeasured and
+ * kept at their prior conservative estimates.
+ * TODO(#331): set shield-xchain / unshield-xchain from real Sepolia gasUsed once measured
+ * (relayer-side re-tune tracked in ship-armada/armada-relayer#16).
+ */
 const GAS_UNITS: Partial<Record<TxKind, bigint>> = {
-  shield: 450_000n,
+  shield: 1_000_000n,
   'shield-xchain': 600_000n,
-  'unshield-local': 550_000n,
+  'unshield-local': 1_400_000n,
   'unshield-xchain': 650_000n,
-  'transfer-shielded': 550_000n,
-  'yield-deposit': 500_000n,
-  'yield-withdraw': 500_000n,
+  'transfer-shielded': 1_300_000n,
+  'yield-deposit': 2_000_000n,
+  'yield-withdraw': 2_000_000n,
 }
 
 export function useNativeGasEstimate(


### PR DESCRIPTION
Fixes #331 (frontend half — the relayer half moved to ship-armada/armada-relayer#16).

## What
`useNativeGasEstimate`'s `GAS_UNITS` table (display-only estimate for the wallet-submit path — the tx the user signs) was out of sync with real on-chain gas. All seven rows now carry justified values.

### Five same-chain / yield rows — from measured Sepolia `gasUsed` + ~10-15% headroom
| flow | before | after | real gasUsed |
|---|--:|--:|--:|
| `shield` | 450k | 1,000,000 | 881,402 |
| `unshield-local` | 550k | 1,400,000 | 1,214,560 |
| `transfer-shielded` | 550k | 1,300,000 | 1,136,646 |
| `yield-deposit` | 500k | 2,000,000 | 1,929,731 |
| `yield-withdraw` | 500k | 2,000,000 | 1,925,927 |

### Two cross-chain rows — derived from local profiling, corrected to Sepolia
`gasUsed` is protocol-deterministic (local == Sepolia for identical code/state). The only correction needed is the **~380k Groth16 verify** that `test/privacy_pool_gas.ts` skips under `setTestingMode` — calibrated from the transact/unshield local-vs-Sepolia deltas (+356k / +402k).

| flow | before | after | basis |
|---|--:|--:|---|
| `unshield-xchain` | 650k | **1,500,000** | signs `atomicCrossChainUnshield` (real ZK proof + CCTP burn). Local ~902k + ~380k verify + CCTP + headroom. Was a ~2.3× under-estimate. |
| `shield-xchain` | 600k | **600k (kept)** | signs only client-side `crossChainShield` (USDC pull + CCTP burn, **no proof** → no verify correction). Local ~177k; 600k is a conservative ceiling over real Circle CCTP overhead. |

A Sepolia one-shot of `crossChainShield` would let us tighten `shield-xchain`, but it is already safely conservative (over-, not under-estimated).

## Notes
- Frontend-only; independent of the relayer re-tune (separate repo/deploy). This table is the wallet-submit native-gas estimate, driven by real on-chain gas, not the relayer.
- Constants-only recalibration, no logic change. `npm run typecheck --workspace=@armada/interface` passes. The hook has no existing test harness; a constant-value assertion would be tautological, so none added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)