### PR TITLE
fix(privacy-pool): pin CCTP destinationCaller at contract level, remove from external API (#64)

### DIFF
--- a/apps/armada-interface/src/features/shield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/shield-xchain/handler.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Cross-chain shield handler — dual-mode (direct user-wallet submit OR Phase B4 permit-based gasless via GaslessShieldWrapperClient).
 // ABOUTME: Mirrors unshield-xchain but flipped direction: burn on CLIENT → mint on HUB. Hub-side delivery polling identical across both submission modes.
 
-import { encodeFunctionData, pad } from 'viem'
+import { encodeFunctionData } from 'viem'
 import {
   getPublicClient,
   readContract,
@@ -75,7 +75,6 @@ const PRIVACY_POOL_CLIENT_SHIELD_ABI = [
       { name: 'npk', type: 'bytes32' },
       { name: 'encryptedBundle', type: 'bytes32[3]' },
       { name: 'shieldKey', type: 'bytes32' },
-      { name: 'destinationCaller', type: 'bytes32' },
       { name: 'integrator', type: 'address' },
     ],
     outputs: [{ name: 'nonce', type: 'uint64' }],
@@ -336,9 +335,11 @@ async function runDirectSubmit(
     await ctx.upsert(working)
   }
 
-  const { destinationCaller, maxFee, minFinalityThreshold } = await resolveCctpSubmitParams(record)
+  const { maxFee, minFinalityThreshold } = await resolveCctpSubmitParams(record)
 
   // 2. Submit the cross-chain shield on the CLIENT chain via the connected wallet.
+  //    The CCTP destinationCaller is pinned to hubHookRouter by PrivacyPoolClient (issue #64) — not
+  //    passed here.
   const calldata = encodeFunctionData({
     abi: PRIVACY_POOL_CLIENT_SHIELD_ABI,
     functionName: 'crossChainShield',
@@ -349,7 +350,6 @@ async function runDirectSubmit(
       shieldRequest.npk as `0x${string}`,
       shieldRequest.encryptedBundle as readonly [`0x${string}`, `0x${string}`, `0x${string}`],
       shieldRequest.shieldKey as `0x${string}`,
-      destinationCaller,
       ethers.ZeroAddress as `0x${string}`, // integrator: no fee routing for direct user shields
     ],
   })
@@ -434,8 +434,10 @@ async function runGaslessSubmit(
     })
   }
 
-  const { destinationCaller, maxFee, minFinalityThreshold } = await resolveCctpSubmitParams(record)
+  const { maxFee, minFinalityThreshold } = await resolveCctpSubmitParams(record)
 
+  // The CCTP destinationCaller is pinned to hubHookRouter by PrivacyPoolClient (issue #64) — it is no
+  // longer part of the signed CrossChainParams struct.
   const data = buildGaslessCrossChainShieldCalldata({
     user: ownerCaptured as `0x${string}`,
     totalAmount: record.meta.amount,
@@ -456,7 +458,6 @@ async function runGaslessSubmit(
       ],
       shieldKey: shieldRequest.shieldKey as `0x${string}`,
     },
-    destinationCaller,
     integrator: ethers.ZeroAddress as `0x${string}`,
   })
 
@@ -485,23 +486,14 @@ async function runGaslessSubmit(
 
 /**
  * Per-submit CCTP params resolved from the loaded deployment + network mode. Shared across both
- * direct and gasless submit branches so the on-chain inputs (destinationCaller, maxFee,
- * minFinalityThreshold) stay identical regardless of who broadcasts the tx.
+ * direct and gasless submit branches so the on-chain inputs (maxFee, minFinalityThreshold) stay
+ * identical regardless of who broadcasts the tx. The CCTP destinationCaller is no longer resolved
+ * here — PrivacyPoolClient pins it to its configured hubHookRouter at the contract level (issue #64).
  */
 async function resolveCctpSubmitParams(record: TxRecord<'shield-xchain'>): Promise<{
-  destinationCaller: `0x${string}`
   maxFee: bigint
   minFinalityThreshold: number
 }> {
-  // destinationCaller = the HUB's hookRouter, in bytes32 form. Constrains who can call
-  // receiveMessage on the hub MessageTransmitter so only our atomic-delivery path executes.
-  const deployments = await loadDeployments()
-  const hubHookRouter = deployments.hub.contracts.hookRouter
-  const destinationCaller =
-    hubHookRouter && hubHookRouter !== ethers.ZeroAddress
-      ? pad(hubHookRouter as `0x${string}`, { size: 32 })
-      : (`0x${'00'.repeat(32)}` as `0x${string}`)
-
   // maxFee = upper bound CCTP's MessageTransmitter accepts for `feeExecuted`. Iris sets the
   // actual fee (1–1.3 bps depending on chain); we pass 2× the realistic estimate as headroom.
   // Computed locally from amount, no relayer round-trip needed.
@@ -511,7 +503,7 @@ async function resolveCctpSubmitParams(record: TxRecord<'shield-xchain'>): Promi
   // to STANDARD as the safe default. CCTPHookRouter on the hub handles both threshold values.
   const minFinalityThreshold = getNetworkConfig().mode === 'sepolia' ? 1000 : 0
 
-  return { destinationCaller, maxFee, minFinalityThreshold }
+  return { maxFee, minFinalityThreshold }
 }
 
 /**

--- a/apps/armada-interface/src/features/unshield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/handler.ts
@@ -112,7 +112,6 @@ const PRIVACY_POOL_XCHAIN_UNSHIELD_ABI = [
       ] },
       { name: 'destinationDomain', type: 'uint32' },
       { name: 'finalRecipient', type: 'address' },
-      { name: 'destinationCaller', type: 'bytes32' },
       { name: 'maxFee', type: 'uint256' },
     ],
     outputs: [],
@@ -242,7 +241,6 @@ async function runSubmitAndBurn(
     if (!destClientDeployment) {
       throw new Error(`No deployment for destination chain ${record.meta.toChainId}`)
     }
-    const destHookRouter = destClientDeployment.contracts.hookRouter
 
     // Build the Transaction struct (decoded from the SDK's populated transact() calldata). The
     // broadcaster fee must be passed here EXACTLY as it was passed to generateXchainUnshieldProof —
@@ -256,11 +254,8 @@ async function runSubmitAndBurn(
     })
     if (ctx.signal.aborted) throw new Error('cancelled')
 
-    // destinationCaller: bytes32 form of the destination hook router; restricts who can call
-    // receiveMessage on the destination MessageTransmitter (the router atomically delivers).
-    const destinationCaller = destHookRouter && destHookRouter !== ethers.ZeroAddress
-      ? pad(destHookRouter as `0x${string}`, { size: 32 })
-      : `0x${'00'.repeat(32)}` as `0x${string}`
+    // The CCTP destinationCaller is pinned to remoteHookRouters[destinationDomain] by PrivacyPool
+    // (issue #64) — it is not passed here.
 
     // maxFee = upper bound CCTP's MessageTransmitter accepts for `feeExecuted`. Iris sets the
     // actual fee (1–1.3 bps depending on chain); we pass 2× the realistic estimate as headroom.
@@ -273,7 +268,6 @@ async function runSubmitAndBurn(
       txStruct,
       destinationDomain,
       record.meta.recipient as `0x${string}`,
-      destinationCaller,
       maxFee,
     )
   }
@@ -662,7 +656,6 @@ function encodeAtomicCrossChainUnshield(
   transactionStruct: unknown,
   destinationDomain: number,
   finalRecipient: `0x${string}`,
-  destinationCaller: `0x${string}`,
   maxFee: bigint,
 ): `0x${string}` {
   return encodeFunctionData({
@@ -675,7 +668,6 @@ function encodeAtomicCrossChainUnshield(
       transactionStruct as any,
       destinationDomain,
       finalRecipient,
-      destinationCaller,
       maxFee,
     ],
   })

--- a/apps/armada-interface/src/lib/wallet/gasless-cross-chain-shield.test.ts
+++ b/apps/armada-interface/src/lib/wallet/gasless-cross-chain-shield.test.ts
@@ -10,7 +10,6 @@ import {
 
 const USER = '0x1111111111111111111111111111111111111111' as const
 const INTEGRATOR = '0x2222222222222222222222222222222222222222' as const
-const DEST_CALLER = ('0x' + 'cc'.repeat(32)) as `0x${string}`
 
 function baseRequest() {
   return {
@@ -33,7 +32,6 @@ function baseRequest() {
       ] as const,
       shieldKey: ('0x' + '44'.repeat(32)) as `0x${string}`,
     },
-    destinationCaller: DEST_CALLER,
     integrator: INTEGRATOR,
   }
 }
@@ -41,14 +39,14 @@ function baseRequest() {
 describe('buildGaslessCrossChainShieldCalldata', () => {
   it('pins the gaslessCrossChainShield selector', () => {
     // WHY: the relayer's gasless-fee-verifier.ts hardcodes the gaslessCrossChainShield selector
-    // (`0xa608b736`, the first 4 bytes of keccak256("gaslessCrossChainShield((address,uint256,
+    // (`0x742d0b54`, the first 4 bytes of keccak256("gaslessCrossChainShield((address,uint256,
     // uint256,uint256,uint8,bytes32,bytes32),(uint256,uint32,bytes32,bytes32[3],bytes32,
-    // bytes32,address))")). A wrapper-signature refactor (arg reorder, struct rename) would
-    // change the selector and silently produce calldata the relayer rejects as INVALID_DATA.
-    // Hardcoding rather than recomputing so the test fails LOUDLY on drift instead of silently
-    // agreeing with whatever the new shape became.
+    // address))")). A wrapper-signature refactor (arg reorder, struct rename) would change the
+    // selector and silently produce calldata the relayer rejects as INVALID_DATA. Hardcoding
+    // rather than recomputing so the test fails LOUDLY on drift instead of silently agreeing with
+    // whatever the new shape became. (destinationCaller was removed per issue #64 — pinned on-chain.)
     const data = buildGaslessCrossChainShieldCalldata(baseRequest())
-    expect(slice(data, 0, 4)).toBe('0xa608b736')
+    expect(slice(data, 0, 4)).toBe('0x742d0b54')
   })
 
   it('round-trips through viem decoder with all PermitInput + CrossChainParams args intact', () => {
@@ -78,18 +76,14 @@ describe('buildGaslessCrossChainShieldCalldata', () => {
     expect(dest.npk).toBe(input.shieldRequest.npk)
     expect(dest.encryptedBundle).toEqual(input.shieldRequest.encryptedBundle)
     expect(dest.shieldKey).toBe(input.shieldRequest.shieldKey)
-    expect(dest.destinationCaller).toBe(input.destinationCaller)
     expect(dest.integrator).toBe(input.integrator)
   })
 
-  it('zero destinationCaller (any relayer) and standard finality threshold encode cleanly', () => {
-    // WHY: a permissive destinationCaller `0x00…00` IS a legal CCTP input (lets any relayer
-    // call receiveMessage). The default is the hub HookRouter, but local-mode deployments may
-    // not have one configured. Pin that the builder doesn't reject the zero-bytes32 input —
-    // viem treats bytes32 as fixed-size and would throw on a malformed value.
+  it('standard finality threshold (0) encodes cleanly', () => {
+    // WHY: minFinalityThreshold 0 is the STANDARD default (the contract resolves 0 → STANDARD).
+    // Pin that the builder encodes the zero value cleanly rather than rejecting it.
     const input = {
       ...baseRequest(),
-      destinationCaller: ('0x' + '00'.repeat(32)) as `0x${string}`,
       minFinalityThreshold: 0,
     }
     const data = buildGaslessCrossChainShieldCalldata(input)
@@ -98,7 +92,6 @@ describe('buildGaslessCrossChainShieldCalldata', () => {
       data,
     })
     const [, dest] = decoded.args
-    expect(dest.destinationCaller).toBe(input.destinationCaller)
     expect(dest.minFinalityThreshold).toBe(0)
   })
 })

--- a/apps/armada-interface/src/lib/wallet/gasless-cross-chain-shield.ts
+++ b/apps/armada-interface/src/lib/wallet/gasless-cross-chain-shield.ts
@@ -37,7 +37,6 @@ export const GASLESS_CROSS_CHAIN_SHIELD_WRAPPER_ABI = [
           { name: 'npk', type: 'bytes32' },
           { name: 'encryptedBundle', type: 'bytes32[3]' },
           { name: 'shieldKey', type: 'bytes32' },
-          { name: 'destinationCaller', type: 'bytes32' },
           { name: 'integrator', type: 'address' },
         ],
       },
@@ -65,8 +64,6 @@ export interface BuildGaslessCrossChainShieldCalldataInput {
   minFinalityThreshold: number
   /** Built-by-`createShieldRequest()` against the HUB usdc address (commitment lives on hub). */
   shieldRequest: ShieldRequestData
-  /** Hub HookRouter address in bytes32 form — locks destinationCaller; pass `0x00…00` to allow any. */
-  destinationCaller: `0x${string}`
   /** Integrator address for the pool's fee split; address(0) for none. */
   integrator: `0x${string}`
 }
@@ -106,7 +103,6 @@ export function buildGaslessCrossChainShieldCalldata(
           `0x${string}`,
         ],
         shieldKey: input.shieldRequest.shieldKey,
-        destinationCaller: input.destinationCaller,
         integrator: input.integrator,
       },
     ],

--- a/contracts/GaslessShieldWrapperClient.sol
+++ b/contracts/GaslessShieldWrapperClient.sol
@@ -40,7 +40,7 @@ contract GaslessShieldWrapperClient {
      * @dev `destHash` is `keccak256(abi.encode(dest))` — the digest of the `CrossChainParams`
      *      the wrapper executed. Lets the user verify off-chain that the relayer honored the
      *      cross-chain destination they signed against (npk, ciphertext, finality, maxFee,
-     *      integrator, destinationCaller, …). Symmetric with the hub wrapper's
+     *      integrator, …). Symmetric with the hub wrapper's
      *      `shieldRequestHash`.
      */
     event GaslessShield(
@@ -118,13 +118,14 @@ contract GaslessShieldWrapperClient {
     }
 
     /// @dev CCTP V2 cross-chain shield destination args, grouped for stack-shallow reasons.
+    /// @dev The CCTP destinationCaller is not included: PrivacyPoolClient pins it to its configured
+    ///      hubHookRouter at the contract level, so it is neither caller- nor signer-supplied.
     struct CrossChainParams {
         uint256 maxFee;
         uint32 minFinalityThreshold;
         bytes32 npk;
         bytes32[3] encryptedBundle;
         bytes32 shieldKey;
-        bytes32 destinationCaller;
         address integrator;
     }
 
@@ -191,7 +192,6 @@ contract GaslessShieldWrapperClient {
             dest.npk,
             dest.encryptedBundle,
             dest.shieldKey,
-            dest.destinationCaller,
             dest.integrator
         );
 

--- a/contracts/privacy-pool/PrivacyPool.sol
+++ b/contracts/privacy-pool/PrivacyPool.sol
@@ -128,23 +128,23 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
      * @param _transaction Transaction with unshield proof
      * @param destinationDomain Target client chain's CCTP domain
      * @param finalRecipient Address to receive USDC on client chain
-     * @param destinationCaller Address allowed to call receiveMessage on Client (bytes32).
-     *        Use bytes32(0) to allow any relayer, or specify a relayer address for MEV protection.
      * @param maxFee Maximum CCTP relayer fee in USDC raw units (deducted from burn amount at protocol level, 0 = no fee)
      * @return nonce CCTP message nonce
+     * @dev The CCTP destinationCaller is pinned at the contract level to remoteHookRouters[destinationDomain]
+     *      (see setRemoteHookRouter) — it is not caller-supplied, so a burn can only be delivered through
+     *      the destination chain's CCTPHookRouter.
      */
     function atomicCrossChainUnshield(
         Transaction calldata _transaction,
         uint32 destinationDomain,
         address finalRecipient,
-        bytes32 destinationCaller,
         uint256 maxFee
     ) external override returns (uint64) {
         bytes memory result = _delegatecall(
             transactModule,
             abi.encodeCall(
                 ITransactModule.atomicCrossChainUnshield,
-                (_transaction, destinationDomain, finalRecipient, destinationCaller, maxFee)
+                (_transaction, destinationDomain, finalRecipient, maxFee)
             )
         );
         return abi.decode(result, (uint64));
@@ -270,6 +270,19 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
         require(msg.sender == owner, "PrivacyPool: Only owner");
         remotePools[domain] = poolAddress;
         emit RemotePoolSet(domain, poolAddress);
+    }
+
+    /**
+     * @notice Set the CCTP hook router on a remote (destination) domain
+     * @dev Pinned as the CCTP destinationCaller for outbound unshield burns to that domain, so the
+     *      message can only be delivered through that chain's CCTPHookRouter (which fires the mint hook).
+     * @param domain CCTP domain ID of the remote chain
+     * @param routerAddress Address of the remote CCTPHookRouter (as bytes32)
+     */
+    function setRemoteHookRouter(uint32 domain, bytes32 routerAddress) external override {
+        require(msg.sender == owner, "PrivacyPool: Only owner");
+        remoteHookRouters[domain] = routerAddress;
+        emit RemoteHookRouterSet(domain, routerAddress);
     }
 
     /**

--- a/contracts/privacy-pool/PrivacyPoolClient.sol
+++ b/contracts/privacy-pool/PrivacyPoolClient.sol
@@ -53,6 +53,12 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
     /// @notice CCTP Hook Router address (authorized to call handleReceiveFinalizedMessage)
     address public override hookRouter;
 
+    /// @notice Hub chain's CCTP Hook Router address, as bytes32.
+    /// @dev Pinned as the CCTP destinationCaller for outbound shield burns, so the message can only be
+    ///      delivered through the Hub's CCTPHookRouter (which fires the mint hook). Removes the
+    ///      caller-supplied destinationCaller footgun — bytes32(0) would let a third party strand funds.
+    bytes32 public override hubHookRouter;
+
     /// @notice Default finality threshold for outbound CCTP burns (STANDARD=2000, FAST=1000)
     /// @dev Used as fallback when user passes 0 to crossChainShield
     uint32 public defaultFinalityThreshold;
@@ -117,10 +123,11 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
      * @param npk Note public key (recipient's key for claiming the note)
      * @param encryptedBundle Encrypted note data [3 x bytes32]
      * @param shieldKey Shield key for decryption by recipient
-     * @param destinationCaller Address allowed to call receiveMessage on Hub (bytes32).
-     *        Use bytes32(0) to allow any relayer, or specify a relayer address for MEV protection.
      * @param integrator Integrator address for fee split (address(0) for no integrator)
      * @return nonce CCTP message nonce
+     * @dev The CCTP destinationCaller is pinned to hubHookRouter (not caller-supplied), so the burn can
+     *      only be delivered through the Hub's CCTPHookRouter — a caller cannot leave it bytes32(0) and
+     *      let a third party call receiveMessage directly and strand the funds.
      */
     function crossChainShield(
         uint256 amount,
@@ -129,12 +136,12 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
         bytes32 npk,
         bytes32[3] calldata encryptedBundle,
         bytes32 shieldKey,
-        bytes32 destinationCaller,
         address integrator
     ) external override returns (uint64) {
         require(amount > 0, "PrivacyPoolClient: Amount must be > 0");
         require(maxFee < amount, "PrivacyPoolClient: Fee exceeds amount");
         require(hubPool != bytes32(0), "PrivacyPoolClient: Hub not configured");
+        require(hubHookRouter != bytes32(0), "PrivacyPoolClient: Hook router not configured");
 
         // Transfer USDC from user to this contract
         IERC20(usdc).safeTransferFrom(msg.sender, address(this), amount);
@@ -144,7 +151,7 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
         IERC20(usdc).safeApprove(tokenMessenger, amount);
 
         // Encode shield payload and execute CCTP burn in helper (avoids stack-too-deep)
-        _executeCCTPShield(amount, maxFee, minFinalityThreshold, npk, encryptedBundle, shieldKey, destinationCaller, integrator);
+        _executeCCTPShield(amount, maxFee, minFinalityThreshold, npk, encryptedBundle, shieldKey, integrator);
 
         emit CrossChainShieldInitiated(amount, npk, 0);
 
@@ -270,7 +277,6 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
         bytes32 npk,
         bytes32[3] calldata encryptedBundle,
         bytes32 shieldKey,
-        bytes32 destinationCaller,
         address integrator
     ) internal {
         bytes memory hookData = CCTPPayloadLib.encodeShield(ShieldData({
@@ -281,12 +287,14 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
             integrator: integrator
         }));
 
+        // destinationCaller is pinned to the Hub's hook router (validated non-zero in crossChainShield)
+        // so the message can only be delivered via the Hub's CCTPHookRouter.
         ITokenMessengerV2(tokenMessenger).depositForBurnWithHook(
             amount,
             hubDomain,
             hubPool,
             usdc,
-            destinationCaller,
+            hubHookRouter,
             maxFee,
             _resolveFinality(minFinalityThreshold),
             hookData
@@ -337,6 +345,18 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
     function setHookRouter(address _hookRouter) external override {
         require(msg.sender == owner, "PrivacyPoolClient: Only owner");
         hookRouter = _hookRouter;
+    }
+
+    /**
+     * @notice Set the Hub chain's CCTP hook router (as bytes32)
+     * @dev Pinned as the CCTP destinationCaller for outbound shield burns, so a shield can only be
+     *      delivered through the Hub's CCTPHookRouter. Must be set before crossChainShield can be used.
+     * @param _hubHookRouter Hub CCTPHookRouter address (as bytes32)
+     */
+    function setHubHookRouter(bytes32 _hubHookRouter) external override {
+        require(msg.sender == owner, "PrivacyPoolClient: Only owner");
+        hubHookRouter = _hubHookRouter;
+        emit HubHookRouterSet(_hubHookRouter);
     }
 
     /**

--- a/contracts/privacy-pool/interfaces/IPrivacyPool.sol
+++ b/contracts/privacy-pool/interfaces/IPrivacyPool.sol
@@ -16,6 +16,7 @@ interface IPrivacyPool is IMessageHandlerV2 {
 
     /// @notice Emitted when a remote pool address is configured
     event RemotePoolSet(uint32 indexed domain, bytes32 poolAddress);
+    event RemoteHookRouterSet(uint32 indexed domain, bytes32 routerAddress);
 
     /// @notice Emitted when testing mode is changed
     event TestingModeSet(bool enabled);
@@ -81,16 +82,15 @@ interface IPrivacyPool is IMessageHandlerV2 {
      * @param _transaction Transaction with unshield proof
      * @param destinationDomain Target client chain's CCTP domain
      * @param finalRecipient Address to receive USDC on client chain
-     * @param destinationCaller Address allowed to call receiveMessage on Client (bytes32).
-     *        Use bytes32(0) to allow any relayer, or specify a relayer address for MEV protection.
      * @param maxFee Maximum CCTP relayer fee in USDC raw units (deducted from burn amount at protocol level, 0 = no fee)
      * @return nonce CCTP message nonce
+     * @dev The CCTP destinationCaller is pinned to remoteHookRouters[destinationDomain] at the contract
+     *      level (see setRemoteHookRouter) — it is not caller-supplied.
      */
     function atomicCrossChainUnshield(
         Transaction calldata _transaction,
         uint32 destinationDomain,
         address finalRecipient,
-        bytes32 destinationCaller,
         uint256 maxFee
     ) external returns (uint64 nonce);
 
@@ -104,6 +104,14 @@ interface IPrivacyPool is IMessageHandlerV2 {
      * @param poolAddress Address of the remote contract (as bytes32)
      */
     function setRemotePool(uint32 domain, bytes32 poolAddress) external;
+
+    /**
+     * @notice Set the CCTP hook router on a remote (destination) domain, pinned as the outbound
+     *         unshield destinationCaller for that domain
+     * @param domain CCTP domain ID of the remote chain
+     * @param routerAddress Address of the remote CCTPHookRouter (as bytes32)
+     */
+    function setRemoteHookRouter(uint32 domain, bytes32 routerAddress) external;
 
     /**
      * @notice Set a verification key for a circuit configuration

--- a/contracts/privacy-pool/interfaces/IPrivacyPoolClient.sol
+++ b/contracts/privacy-pool/interfaces/IPrivacyPoolClient.sol
@@ -47,6 +47,9 @@ interface IPrivacyPoolClient is IMessageHandlerV2 {
     /// @notice Emitted when default finality threshold is changed
     event DefaultFinalityThresholdSet(uint32 threshold);
 
+    /// @notice Emitted when the Hub CCTP hook router is set
+    event HubHookRouterSet(bytes32 hubHookRouter);
+
     // ══════════════════════════════════════════════════════════════════════════
     // INITIALIZATION
     // ══════════════════════════════════════════════════════════════════════════
@@ -85,10 +88,10 @@ interface IPrivacyPoolClient is IMessageHandlerV2 {
      * @param npk Note public key
      * @param encryptedBundle Encrypted note data [3 x bytes32]
      * @param shieldKey Shield key for decryption
-     * @param destinationCaller Address allowed to call receiveMessage on Hub (bytes32).
-     *        Use bytes32(0) to allow any relayer, or specify a relayer address for MEV protection.
      * @param integrator Integrator address for fee split (address(0) for no integrator)
      * @return nonce CCTP message nonce
+     * @dev The CCTP destinationCaller is pinned to hubHookRouter at the contract level (see
+     *      setHubHookRouter) — it is not caller-supplied.
      */
     function crossChainShield(
         uint256 amount,
@@ -97,7 +100,6 @@ interface IPrivacyPoolClient is IMessageHandlerV2 {
         bytes32 npk,
         bytes32[3] calldata encryptedBundle,
         bytes32 shieldKey,
-        bytes32 destinationCaller,
         address integrator
     ) external returns (uint64 nonce);
 
@@ -117,6 +119,12 @@ interface IPrivacyPoolClient is IMessageHandlerV2 {
      * @param _hookRouter Address of the CCTPHookRouter contract
      */
     function setHookRouter(address _hookRouter) external;
+
+    /**
+     * @notice Set the Hub chain's CCTP hook router (as bytes32), pinned as the outbound shield destinationCaller
+     * @param _hubHookRouter Hub CCTPHookRouter address (as bytes32)
+     */
+    function setHubHookRouter(bytes32 _hubHookRouter) external;
 
     /**
      * @notice Set the default finality threshold for outbound CCTP burns
@@ -151,4 +159,7 @@ interface IPrivacyPoolClient is IMessageHandlerV2 {
 
     /// @notice CCTP Hook Router address
     function hookRouter() external view returns (address);
+
+    /// @notice Hub chain's CCTP hook router (as bytes32), pinned as the outbound shield destinationCaller
+    function hubHookRouter() external view returns (bytes32);
 }

--- a/contracts/privacy-pool/interfaces/ITransactModule.sol
+++ b/contracts/privacy-pool/interfaces/ITransactModule.sol
@@ -71,16 +71,15 @@ interface ITransactModule {
      * @param _transaction Transaction with unshield proof
      * @param destinationDomain Client chain's CCTP domain
      * @param finalRecipient Address to receive USDC on client chain
-     * @param destinationCaller Address allowed to call receiveMessage on Client (bytes32).
-     *        Use bytes32(0) to allow any relayer, or specify a relayer address for MEV protection.
      * @param maxFee Maximum CCTP relayer fee in USDC raw units (deducted from burn amount at protocol level, 0 = no fee)
      * @return nonce CCTP message nonce for tracking
+     * @dev The CCTP destinationCaller is pinned to remoteHookRouters[destinationDomain] at the contract
+     *      level — it is not caller-supplied.
      */
     function atomicCrossChainUnshield(
         Transaction calldata _transaction,
         uint32 destinationDomain,
         address finalRecipient,
-        bytes32 destinationCaller,
         uint256 maxFee
     ) external returns (uint64 nonce);
 }

--- a/contracts/privacy-pool/modules/TransactModule.sol
+++ b/contracts/privacy-pool/modules/TransactModule.sol
@@ -107,15 +107,15 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
      * @param _transaction Transaction with unshield proof
      * @param destinationDomain Client chain's CCTP domain
      * @param finalRecipient Address to receive USDC on client chain
-     * @param destinationCaller Address allowed to call receiveMessage on Client (bytes32).
-     *        Use bytes32(0) to allow any relayer, or specify a relayer address for MEV protection.
      * @return nonce CCTP message nonce for tracking
+     * @dev The CCTP destinationCaller is pinned to remoteHookRouters[destinationDomain] (not
+     *      caller-supplied), so the burn can only be delivered through the destination chain's
+     *      CCTPHookRouter — a caller cannot leave it bytes32(0) and let a third party strand the funds.
      */
     function atomicCrossChainUnshield(
         Transaction calldata _transaction,
         uint32 destinationDomain,
         address finalRecipient,
-        bytes32 destinationCaller,
         uint256 maxFee
     ) external override onlyDelegatecall returns (uint64 nonce) {
         // Post-wind-down SC emergency pause: block ALL operations including unshields.
@@ -128,7 +128,7 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
         _processAtomicUnshieldTransaction(_transaction);
 
         // Execute the CCTP burn and return nonce
-        nonce = _executeCCTPBurn(_transaction, destinationDomain, finalRecipient, destinationCaller, maxFee);
+        nonce = _executeCCTPBurn(_transaction, destinationDomain, finalRecipient, maxFee);
     }
 
     /**
@@ -146,6 +146,10 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
             "TransactModule: Must include unshield"
         );
         require(remotePools[destinationDomain] != bytes32(0), "TransactModule: Unknown destination");
+        require(
+            remoteHookRouters[destinationDomain] != bytes32(0),
+            "TransactModule: Hook router not configured"
+        );
 
         // Validate the transaction proof
         (bool valid, string memory reason) = _validateTransaction(_transaction);
@@ -186,7 +190,6 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
         Transaction calldata _transaction,
         uint32 destinationDomain,
         address finalRecipient,
-        bytes32 destinationCaller,
         uint256 maxFee
     ) internal returns (uint64 nonce) {
         // Unshield is free per spec — the full preimage value is bridged.
@@ -211,12 +214,14 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
             ? defaultFinalityThreshold
             : CCTPFinality.STANDARD;
 
+        // destinationCaller is pinned to the destination chain's hook router (validated non-zero in
+        // _validateAtomicUnshieldInputs) so the message can only be delivered via its CCTPHookRouter.
         ITokenMessengerV2(tokenMessenger).depositForBurnWithHook(
             base,
             destinationDomain,
             remotePools[destinationDomain],
             usdc,
-            destinationCaller,
+            remoteHookRouters[destinationDomain],
             maxFee,
             finality,
             hookData

--- a/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
+++ b/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
@@ -177,11 +177,18 @@ abstract contract PrivacyPoolStorage {
     /// @dev When address(0), ShieldModule falls back to the flat shieldFee calculation.
     address public feeModule;
 
+    /// @notice CCTP hook router on each remote (destination) domain, as bytes32.
+    /// @dev Used as the CCTP `destinationCaller` for outbound unshield burns so the message can only be
+    ///      delivered through that chain's CCTPHookRouter (which fires the mint hook). Pinning this at the
+    ///      contract level removes the caller-supplied `destinationCaller` footgun: bytes32(0) would let
+    ///      any third party call receiveMessage directly, skip the hook, and strand the funds.
+    mapping(uint32 => bytes32) public remoteHookRouters;
+
     // ══════════════════════════════════════════════════════════════════════════
     // RESERVED FOR FUTURE USE
     // ══════════════════════════════════════════════════════════════════════════
 
     /// @dev Reserved storage slots for future upgrades
     ///      When adding new state variables above, decrement this gap
-    uint256[46] private __gap;
+    uint256[45] private __gap;
 }

--- a/relayer/lib/transact-shape.ts
+++ b/relayer/lib/transact-shape.ts
@@ -31,13 +31,13 @@ export const LEND_AND_SHIELD_SELECTOR = "0xf2987ad1";
 export const REDEEM_AND_SHIELD_SELECTOR = "0x0793b70e";
 
 /**
- * PrivacyPool.atomicCrossChainUnshield(Transaction, uint32, address, bytes32, uint256) — A5
- * cross-chain unshield. The Transaction struct burns shielded USDC into the pool's own EOA and
- * the surrounding wrapper args drive the CCTP burn-and-mint to a different chain. Same
- * single-Transaction-in-arg-0 shape as the yield wrappers, so the synthetic-transact rewrite
- * applies here too.
+ * PrivacyPool.atomicCrossChainUnshield(Transaction, uint32, address, uint256) — A5 cross-chain
+ * unshield. The Transaction struct burns shielded USDC into the pool's own EOA and the surrounding
+ * wrapper args drive the CCTP burn-and-mint to a different chain. Same single-Transaction-in-arg-0
+ * shape as the yield wrappers, so the synthetic-transact rewrite applies here too. The CCTP
+ * destinationCaller is pinned on-chain (issue #64), so it is no longer a call argument.
  */
-export const ATOMIC_CROSS_CHAIN_UNSHIELD_SELECTOR = "0xe484d408";
+export const ATOMIC_CROSS_CHAIN_UNSHIELD_SELECTOR = "0xb8843aaa";
 
 /** The wrappers that need synthetic-transact re-encoding before the SDK helper can decode. */
 export const WRAPPER_SELECTORS: ReadonlySet<string> = new Set([
@@ -102,5 +102,5 @@ export const TRANSACT_ABI: readonly string[] = [
 export const WRAPPER_ABIS: readonly string[] = [
   `function lendAndShield(${TRANSACTION_STRUCT} _transaction, bytes32 _npk, ${SHIELD_CIPHERTEXT_STRUCT} _shieldCiphertext)`,
   `function redeemAndShield(${TRANSACTION_STRUCT} _transaction, bytes32 _npk, ${SHIELD_CIPHERTEXT_STRUCT} _shieldCiphertext)`,
-  `function atomicCrossChainUnshield(${TRANSACTION_STRUCT} _transaction, uint32 destinationDomain, address finalRecipient, bytes32 destinationCaller, uint256 maxFee)`,
+  `function atomicCrossChainUnshield(${TRANSACTION_STRUCT} _transaction, uint32 destinationDomain, address finalRecipient, uint256 maxFee)`,
 ];

--- a/relayer/modules/gasless-fee-verifier.ts
+++ b/relayer/modules/gasless-fee-verifier.ts
@@ -39,12 +39,13 @@ export const GASLESS_SHIELD_SELECTOR = ethers.id(
 ).slice(0, 10);
 
 /**
- * Client wrapper entry: `gaslessCrossChainShield((address,uint256,uint256,uint256,uint8,bytes32,bytes32),(uint256,uint32,bytes32,bytes32[3],bytes32,bytes32,address))`.
+ * Client wrapper entry: `gaslessCrossChainShield((address,uint256,uint256,uint256,uint8,bytes32,bytes32),(uint256,uint32,bytes32,bytes32[3],bytes32,address))`.
  *
- * Same pinning rationale as above.
+ * Same pinning rationale as above. (destinationCaller was removed from CrossChainParams per issue
+ * #64 — PrivacyPoolClient pins it to hubHookRouter on-chain.)
  */
 export const GASLESS_CROSS_CHAIN_SHIELD_SELECTOR = ethers.id(
-  "gaslessCrossChainShield((address,uint256,uint256,uint256,uint8,bytes32,bytes32),(uint256,uint32,bytes32,bytes32[3],bytes32,bytes32,address))",
+  "gaslessCrossChainShield((address,uint256,uint256,uint256,uint8,bytes32,bytes32),(uint256,uint32,bytes32,bytes32[3],bytes32,address))",
 ).slice(0, 10);
 
 const GASLESS_SHIELD_ABI = [
@@ -52,7 +53,7 @@ const GASLESS_SHIELD_ABI = [
 ];
 
 const GASLESS_CROSS_CHAIN_SHIELD_ABI = [
-  "function gaslessCrossChainShield((address user, uint256 totalAmount, uint256 fee, uint256 deadline, uint8 v, bytes32 r, bytes32 s) permitInput, (uint256 maxFee, uint32 minFinalityThreshold, bytes32 npk, bytes32[3] encryptedBundle, bytes32 shieldKey, bytes32 destinationCaller, address integrator) dest)",
+  "function gaslessCrossChainShield((address user, uint256 totalAmount, uint256 fee, uint256 deadline, uint8 v, bytes32 r, bytes32 s) permitInput, (uint256 maxFee, uint32 minFinalityThreshold, bytes32 npk, bytes32[3] encryptedBundle, bytes32 shieldKey, address integrator) dest)",
 ];
 
 /** Interfaces hoisted to module scope — built once instead of per /relay request. */

--- a/relayer/test/modules/broadcaster-fee-verifier.test.ts
+++ b/relayer/test/modules/broadcaster-fee-verifier.test.ts
@@ -120,7 +120,6 @@ function encodeWrapperCalldata(
       emptyTransaction(),
       0, // destinationDomain (uint32)
       ethers.ZeroAddress, // finalRecipient
-      "0x" + "00".repeat(32), // destinationCaller (bytes32)
       0n, // maxFee (uint256)
     ]);
   }

--- a/relayer/test/modules/gasless-fee-verifier.test.ts
+++ b/relayer/test/modules/gasless-fee-verifier.test.ts
@@ -38,7 +38,7 @@ const HUB_IFACE = new ethers.Interface([
 ]);
 
 const CLIENT_IFACE = new ethers.Interface([
-  "function gaslessCrossChainShield((address user, uint256 totalAmount, uint256 fee, uint256 deadline, uint8 v, bytes32 r, bytes32 s) permitInput, (uint256 maxFee, uint32 minFinalityThreshold, bytes32 npk, bytes32[3] encryptedBundle, bytes32 shieldKey, bytes32 destinationCaller, address integrator) dest)",
+  "function gaslessCrossChainShield((address user, uint256 totalAmount, uint256 fee, uint256 deadline, uint8 v, bytes32 r, bytes32 s) permitInput, (uint256 maxFee, uint32 minFinalityThreshold, bytes32 npk, bytes32[3] encryptedBundle, bytes32 shieldKey, address integrator) dest)",
 ]);
 
 function encodeHubShield(fee: bigint): string {
@@ -85,7 +85,6 @@ function encodeClientShield(fee: bigint): string {
       "0x" + "24".repeat(32), // npk
       ["0x" + "00".repeat(32), "0x" + "00".repeat(32), "0x" + "00".repeat(32)], // encryptedBundle
       "0x" + "00".repeat(32), // shieldKey
-      "0x" + "00".repeat(32), // destinationCaller
       "0x" + "26".repeat(20), // integrator
     ],
   ]);
@@ -111,7 +110,7 @@ describe("verifyGaslessFee", () => {
     // ABLOWED_SELECTORS table.
     const expected = ethers
       .id(
-        "gaslessCrossChainShield((address,uint256,uint256,uint256,uint8,bytes32,bytes32),(uint256,uint32,bytes32,bytes32[3],bytes32,bytes32,address))",
+        "gaslessCrossChainShield((address,uint256,uint256,uint256,uint8,bytes32,bytes32),(uint256,uint32,bytes32,bytes32[3],bytes32,address))",
       )
       .slice(0, 10);
     expect(GASLESS_CROSS_CHAIN_SHIELD_SELECTOR).to.equal(expected);

--- a/scripts/link_privacy_pool.ts
+++ b/scripts/link_privacy_pool.ts
@@ -108,6 +108,17 @@ async function main() {
     await setRemoteTx.wait();
     console.log(`  Remote pool set for domain ${clientConfig.domain}`);
 
+    // Set the client's hook router on Hub — pinned as the CCTP destinationCaller for Hub->client
+    // unshield burns, so a burn to this domain can only be delivered via the client's CCTPHookRouter.
+    if (clientDeployment.contracts.hookRouter) {
+      const clientHookRouterBytes32 = ethers.zeroPadValue(clientDeployment.contracts.hookRouter, 32);
+      console.log(`  Setting remote hook router on Hub...`);
+      await (await privacyPool.setRemoteHookRouter(clientConfig.domain, clientHookRouterBytes32, nm.override())).wait();
+      console.log(`  Remote hook router set for domain ${clientConfig.domain}`);
+    } else {
+      console.log(`  Warning: ${clientConfig.name} has no hookRouter — remoteHookRouter NOT set (unshields to this domain will revert)`);
+    }
+
     // In mock mode, we need to configure TokenMessenger cross-references
     // In real CCTP mode, Circle manages this - skip
     if (!isCCTPReal()) {
@@ -157,13 +168,27 @@ async function main() {
 
     const clientPoolContract = new ethers.Contract(
       clientDeployment.contracts.privacyPoolClient,
-      ["function setHookRouter(address _hookRouter) external"],
+      [
+        "function setHookRouter(address _hookRouter) external",
+        "function setHubHookRouter(bytes32 _hubHookRouter) external",
+      ],
       clientSigner
     );
 
     console.log(`Setting hookRouter on ${clientConfig.name} PrivacyPoolClient...`);
     await (await clientPoolContract.setHookRouter(clientDeployment.contracts.hookRouter)).wait();
     console.log(`  hookRouter set to: ${clientDeployment.contracts.hookRouter}`);
+
+    // Pin the Hub's hook router as the CCTP destinationCaller for client->Hub shield burns, so a
+    // shield can only be delivered via the Hub's CCTPHookRouter.
+    if (hubHookRouterAddress) {
+      const hubHookRouterBytes32 = ethers.zeroPadValue(hubHookRouterAddress, 32);
+      console.log(`Setting hubHookRouter on ${clientConfig.name} PrivacyPoolClient...`);
+      await (await clientPoolContract.setHubHookRouter(hubHookRouterBytes32)).wait();
+      console.log(`  hubHookRouter set to: ${hubHookRouterAddress}`);
+    } else {
+      console.log(`  Warning: Hub has no hookRouter — hubHookRouter NOT set (shields from ${clientConfig.name} will revert)`);
+    }
     console.log("");
   }
 

--- a/scripts/test_sepolia.ts
+++ b/scripts/test_sepolia.ts
@@ -56,7 +56,7 @@ const PRIVACY_POOL_CLIENT_ABI = [
   "function localDomain() view returns (uint32)",
   "function hubDomain() view returns (uint32)",
   "function hubPool() view returns (bytes32)",
-  "function crossChainShield(uint256 amount, uint256 maxFee, bytes32 npk, bytes32[3] encryptedBundle, bytes32 shieldKey, bytes32 destinationCaller) external returns (uint64)",
+  "function crossChainShield(uint256 amount, uint256 maxFee, uint32 minFinalityThreshold, bytes32 npk, bytes32[3] encryptedBundle, bytes32 shieldKey, address integrator) external returns (uint64)",
 ];
 
 // ============================================================================
@@ -454,13 +454,13 @@ async function testCrossChainShield(config: ReturnType<typeof getNetworkConfig>,
   const shieldTx = await client.crossChainShield(
     amount,
     MAX_FEE,
+    0, // minFinalityThreshold: 0 → contract resolves to STANDARD
     npk,
     encryptedBundle,
     shieldKey,
-    ethers.ZeroHash, // any relayer can relay
+    ethers.ZeroAddress, // integrator: none
     fees2
-  ,
-  ethers.ZeroAddress);
+  );
   info(`Tx: ${shieldTx.hash}`);
   const receipt = await waitForTx(shieldTx);
   passed(`Cross-chain shield initiated in block ${receipt.blockNumber}`);

--- a/test-foundry/OnlyDelegatecall.t.sol
+++ b/test-foundry/OnlyDelegatecall.t.sol
@@ -103,7 +103,7 @@ contract OnlyDelegatecallTest is Test {
         });
 
         vm.expectRevert(bytes(EXPECTED_REVERT));
-        transactModule.atomicCrossChainUnshield(txn, 1, address(1), bytes32(0), 0);
+        transactModule.atomicCrossChainUnshield(txn, 1, address(1), 0);
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/test-foundry/TransactModuleWindDown.t.sol
+++ b/test-foundry/TransactModuleWindDown.t.sol
@@ -209,7 +209,7 @@ contract TransactModuleWindDownTest is Test {
 
         Transaction memory tx0 = _buildMinimalTransaction(UnshieldType.NORMAL);
 
-        try pool.atomicCrossChainUnshield(tx0, 1, address(0xBEEF), bytes32(0), 0) {
+        try pool.atomicCrossChainUnshield(tx0, 1, address(0xBEEF), 0) {
             // Success — guard didn't block
         } catch Error(string memory reason) {
             assertTrue(

--- a/test-foundry/gasless/GaslessShieldWrapperClient.t.sol
+++ b/test-foundry/gasless/GaslessShieldWrapperClient.t.sol
@@ -21,7 +21,6 @@ contract MockPrivacyPoolClient {
     uint32 public lastMinFinalityThreshold;
     bytes32 public lastNpk;
     bytes32 public lastShieldKey;
-    bytes32 public lastDestinationCaller;
     address public lastIntegrator;
     uint256 public callCount;
 
@@ -36,7 +35,6 @@ contract MockPrivacyPoolClient {
         bytes32 npk,
         bytes32[3] calldata /* encryptedBundle */,
         bytes32 shieldKey,
-        bytes32 destinationCaller,
         address integrator
     ) external returns (uint64) {
         // Mirror the real client: pull amount from msg.sender (the wrapper).
@@ -54,7 +52,6 @@ contract MockPrivacyPoolClient {
         lastMinFinalityThreshold = minFinalityThreshold;
         lastNpk = npk;
         lastShieldKey = shieldKey;
-        lastDestinationCaller = destinationCaller;
         lastIntegrator = integrator;
         callCount++;
         return stubNonce;
@@ -140,7 +137,6 @@ contract GaslessShieldWrapperClientTest is Test {
             npk: bytes32(uint256(0xBEEF)),
             encryptedBundle: [bytes32(0), bytes32(0), bytes32(0)],
             shieldKey: bytes32(0),
-            destinationCaller: bytes32(0),
             integrator: integrator
         });
     }
@@ -179,7 +175,7 @@ contract GaslessShieldWrapperClientTest is Test {
         // WHY: symmetric with the hub wrapper's shieldRequestHash test. The event surfaces
         // keccak256(abi.encode(dest)) so the user can verify off-chain that the relayer honoured
         // the cross-chain destination they signed against (npk, ciphertext, finality, maxFee,
-        // integrator, destinationCaller, …). A refactor that changed the hash shape (e.g.
+        // integrator, …). A refactor that changed the hash shape (e.g.
         // hashed individual fields, used encodePacked) would silently break that primitive.
         // Pin the exact digest shape.
         uint256 totalAmount = 6 * ONE_USDC;

--- a/test/fast_finality.ts
+++ b/test/fast_finality.ts
@@ -217,6 +217,11 @@ describe("CCTP V2 Fast Finality", function () {
     await privacyPool.setHookRouter(await hubHookRouter.getAddress());
     await privacyPoolClient.setHookRouter(await clientHookRouter.getAddress());
 
+    // Pin the destination hook routers on-chain (destinationCaller is no longer
+    // a per-call parameter — the router is fixed by the operator).
+    await privacyPoolClient.setHubHookRouter(ethers.zeroPadValue(await hubHookRouter.getAddress(), 32));
+    await privacyPool.setRemoteHookRouter(DOMAINS.client, ethers.zeroPadValue(await clientHookRouter.getAddress(), 32));
+
     await hubMessageTransmitter.connect(relayer).setRelayer(await hubHookRouter.getAddress());
     await clientMessageTransmitter.connect(relayer).setRelayer(await clientHookRouter.getAddress());
   }
@@ -349,9 +354,7 @@ describe("CCTP V2 Fast Finality", function () {
         params.npk,
         params.encryptedBundle,
         params.shieldKey,
-        ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -370,9 +373,7 @@ describe("CCTP V2 Fast Finality", function () {
         params.npk,
         params.encryptedBundle,
         params.shieldKey,
-        ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -394,9 +395,7 @@ describe("CCTP V2 Fast Finality", function () {
         params.npk,
         params.encryptedBundle,
         params.shieldKey,
-        ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -424,6 +423,7 @@ describe("CCTP V2 Fast Finality", function () {
         deployerAddress
       );
       await freshClient.setHookRouter(await clientHookRouter.getAddress());
+      await freshClient.setHubHookRouter(ethers.zeroPadValue(await hubHookRouter.getAddress(), 32));
 
       await clientUsdc.mint(aliceAddress, SHIELD_AMOUNT);
       await clientUsdc.connect(alice).approve(freshClientAddress, SHIELD_AMOUNT);
@@ -436,9 +436,7 @@ describe("CCTP V2 Fast Finality", function () {
         params.npk,
         params.encryptedBundle,
         params.shieldKey,
-        ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -458,9 +456,7 @@ describe("CCTP V2 Fast Finality", function () {
           params.npk,
           params.encryptedBundle,
           params.shieldKey,
-          ethers.ZeroHash
-        ,
-        ethers.ZeroAddress)
+          ethers.ZeroAddress)
       ).to.be.revertedWith("PrivacyPoolClient: Invalid finality threshold");
     });
 
@@ -476,9 +472,7 @@ describe("CCTP V2 Fast Finality", function () {
           params.npk,
           params.encryptedBundle,
           params.shieldKey,
-          ethers.ZeroHash
-        ,
-        ethers.ZeroAddress)
+          ethers.ZeroAddress)
       ).to.be.revertedWith("PrivacyPoolClient: Invalid finality threshold");
     });
   });
@@ -505,9 +499,7 @@ describe("CCTP V2 Fast Finality", function () {
         params.npk,
         params.encryptedBundle,
         params.shieldKey,
-        ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -534,9 +526,7 @@ describe("CCTP V2 Fast Finality", function () {
         params.npk,
         params.encryptedBundle,
         params.shieldKey,
-        ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -569,9 +559,7 @@ describe("CCTP V2 Fast Finality", function () {
         params.npk,
         params.encryptedBundle,
         params.shieldKey,
-        ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -651,9 +639,7 @@ describe("CCTP V2 Fast Finality", function () {
         params.npk,
         params.encryptedBundle,
         params.shieldKey,
-        ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -674,9 +660,7 @@ describe("CCTP V2 Fast Finality", function () {
         params.npk,
         params.encryptedBundle,
         params.shieldKey,
-        ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -710,9 +694,7 @@ describe("CCTP V2 Fast Finality", function () {
         params.npk,
         params.encryptedBundle,
         params.shieldKey,
-        ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -734,9 +716,7 @@ describe("CCTP V2 Fast Finality", function () {
         params.npk,
         params.encryptedBundle,
         params.shieldKey,
-        ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 
@@ -763,9 +743,7 @@ describe("CCTP V2 Fast Finality", function () {
         params.npk,
         params.encryptedBundle,
         params.shieldKey,
-        ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
       const encodedMessage = extractMessageSent(receipt, clientMessageTransmitter);
 

--- a/test/fee_module_integration.ts
+++ b/test/fee_module_integration.ts
@@ -247,6 +247,8 @@ describe("Fee Module Integration", function () {
 
     await privacyPool.setHookRouter(await hubHookRouter.getAddress());
     await privacyPoolClient.setHookRouter(await clientHookRouter.getAddress());
+    await privacyPoolClient.setHubHookRouter(ethers.zeroPadValue(await hubHookRouter.getAddress(), 32));
+    await privacyPool.setRemoteHookRouter(DOMAINS.client, ethers.zeroPadValue(await clientHookRouter.getAddress(), 32));
     await hubMessageTransmitter.connect(relayer).setRelayer(await hubHookRouter.getAddress());
     await clientMessageTransmitter.connect(relayer).setRelayer(await clientHookRouter.getAddress());
 
@@ -395,7 +397,6 @@ describe("Fee Module Integration", function () {
         npk,
         encryptedBundle,
         shieldKey,
-        ethers.ZeroHash,
         ethers.ZeroAddress  // no integrator
       );
       const receipt = await tx.wait();

--- a/test/privacy_pool_adversarial.ts
+++ b/test/privacy_pool_adversarial.ts
@@ -152,6 +152,13 @@ describe("Privacy Pool Adversarial", function () {
 
     // Link deployments
     await privacyPool.setRemotePool(DOMAINS.client, ethers.zeroPadValue(clientAddress, 32));
+
+    // Pin the CCTP destinationCaller (issue #64). These tests do not relay through a CCTPHookRouter,
+    // so the pinned value only needs to be non-zero for the shield/unshield paths to pass their
+    // "hook router configured" guard; the relayer address is used as a stand-in.
+    const hookRouterStandIn = ethers.zeroPadValue(await relayer.getAddress(), 32);
+    await privacyPoolClient.setHubHookRouter(hookRouterStandIn);
+    await privacyPool.setRemoteHookRouter(DOMAINS.client, hookRouterStandIn);
     await hubTokenMessenger.setRemoteTokenMessenger(DOMAINS.client, ethers.zeroPadValue(await clientTokenMessenger.getAddress(), 32));
     await clientTokenMessenger.setRemoteTokenMessenger(DOMAINS.hub, ethers.zeroPadValue(await hubTokenMessenger.getAddress(), 32));
   });
@@ -485,7 +492,7 @@ describe("Privacy Pool Adversarial", function () {
       });
 
       await privacyPool.atomicCrossChainUnshield(
-        tx, DOMAINS.client, bobAddress, ethers.ZeroHash, 0
+        tx, DOMAINS.client, bobAddress, 0
       );
 
       // Verify nullifier is spent
@@ -532,7 +539,7 @@ describe("Privacy Pool Adversarial", function () {
       await expect(
         privacyPool
           .connect(attacker)
-          .atomicCrossChainUnshield(buildTx(), DOMAINS.client, attackerAddress, ethers.ZeroHash, 0)
+          .atomicCrossChainUnshield(buildTx(), DOMAINS.client, attackerAddress, 0)
       )
         .to.emit(poolAsTransact, "CrossChainUnshieldInitiated")
         .withArgs(DOMAINS.client, attackerAddress, unshieldAmount, 0);
@@ -544,7 +551,7 @@ describe("Privacy Pool Adversarial", function () {
       await expect(
         privacyPool
           .connect(bob)
-          .atomicCrossChainUnshield(buildTx(), DOMAINS.client, bobAddress, ethers.ZeroHash, 0)
+          .atomicCrossChainUnshield(buildTx(), DOMAINS.client, bobAddress, 0)
       ).to.be.revertedWith("TransactModule: Note already spent");
     });
   });
@@ -699,7 +706,7 @@ describe("Privacy Pool Adversarial", function () {
       });
 
       await expect(
-        privacyPool.atomicCrossChainUnshield(tx, DOMAINS.hub, bobAddress, ethers.ZeroHash, 0)
+        privacyPool.atomicCrossChainUnshield(tx, DOMAINS.hub, bobAddress, 0)
       ).to.be.revertedWith("TransactModule: Use local unshield");
     });
 
@@ -723,7 +730,7 @@ describe("Privacy Pool Adversarial", function () {
       });
 
       await expect(
-        privacyPool.atomicCrossChainUnshield(tx, 999, bobAddress, ethers.ZeroHash, 0)
+        privacyPool.atomicCrossChainUnshield(tx, 999, bobAddress, 0)
       ).to.be.revertedWith("TransactModule: Unknown destination");
     });
 
@@ -747,7 +754,7 @@ describe("Privacy Pool Adversarial", function () {
       });
 
       await expect(
-        privacyPool.atomicCrossChainUnshield(tx, DOMAINS.client, ethers.ZeroAddress, ethers.ZeroHash, 0)
+        privacyPool.atomicCrossChainUnshield(tx, DOMAINS.client, ethers.ZeroAddress, 0)
       ).to.be.revertedWith("TransactModule: Invalid recipient");
     });
 
@@ -763,7 +770,7 @@ describe("Privacy Pool Adversarial", function () {
       });
 
       await expect(
-        privacyPool.atomicCrossChainUnshield(tx, DOMAINS.client, bobAddress, ethers.ZeroHash, 0)
+        privacyPool.atomicCrossChainUnshield(tx, DOMAINS.client, bobAddress, 0)
       ).to.be.revertedWith("TransactModule: Must include unshield");
     });
 
@@ -789,7 +796,7 @@ describe("Privacy Pool Adversarial", function () {
       // maxFee = 100 USDC >> base amount of ~10 USDC
       await expect(
         privacyPool.atomicCrossChainUnshield(
-          tx, DOMAINS.client, bobAddress, ethers.ZeroHash, ethers.parseUnits("100", 6)
+          tx, DOMAINS.client, bobAddress, ethers.parseUnits("100", 6)
         )
       ).to.be.revertedWith("TransactModule: maxFee exceeds base");
     });
@@ -946,9 +953,7 @@ describe("Privacy Pool Adversarial", function () {
         privacyPoolClient.connect(alice).crossChainShield(
           0, 0, 0, validNpk(),
           [ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash],
-          ethers.ZeroHash, ethers.ZeroHash
-        ,
-        ethers.ZeroAddress)
+          ethers.ZeroHash, ethers.ZeroAddress)
       ).to.be.revertedWith("PrivacyPoolClient: Amount must be > 0");
     });
 
@@ -958,9 +963,7 @@ describe("Privacy Pool Adversarial", function () {
         privacyPoolClient.connect(alice).crossChainShield(
           amount, amount, 0, validNpk(),
           [ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash],
-          ethers.ZeroHash, ethers.ZeroHash
-        ,
-        ethers.ZeroAddress)
+          ethers.ZeroHash, ethers.ZeroAddress)
       ).to.be.revertedWith("PrivacyPoolClient: Fee exceeds amount");
     });
 
@@ -985,9 +988,7 @@ describe("Privacy Pool Adversarial", function () {
         freshClient.connect(alice).crossChainShield(
           amount, 0, 0, validNpk(),
           [ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash],
-          ethers.ZeroHash, ethers.ZeroHash
-        ,
-        ethers.ZeroAddress)
+          ethers.ZeroHash, ethers.ZeroAddress)
       ).to.be.revertedWith("PrivacyPoolClient: Hub not configured");
     });
   });

--- a/test/privacy_pool_gas.ts
+++ b/test/privacy_pool_gas.ts
@@ -154,6 +154,12 @@ describe("Privacy Pool Gas Profiling", function () {
     await privacyPool.setRemotePool(DOMAINS.client, ethers.zeroPadValue(clientAddress, 32));
     await hubTokenMessenger.setRemoteTokenMessenger(DOMAINS.client, ethers.zeroPadValue(await clientTokenMessenger.getAddress(), 32));
     await clientTokenMessenger.setRemoteTokenMessenger(DOMAINS.hub, ethers.zeroPadValue(await hubTokenMessenger.getAddress(), 32));
+
+    // Pin the CCTP destinationCaller (issue #64). This gas benchmark relays by calling
+    // receiveMessage directly from `relayer` (no CCTPHookRouter), so the pinned destinationCaller
+    // must equal the relayer for the mock's `destinationCaller == msg.sender` check to pass.
+    await privacyPoolClient.setHubHookRouter(ethers.zeroPadValue(relayerAddress, 32));
+    await privacyPool.setRemoteHookRouter(DOMAINS.client, ethers.zeroPadValue(relayerAddress, 32));
   });
 
   // ═══════════════════════════════════════════════════════════════════
@@ -367,9 +373,7 @@ describe("Privacy Pool Gas Profiling", function () {
       const shieldKey = ethers.keccak256(ethers.toUtf8Bytes("cctp-key"));
 
       const tx = await privacyPoolClient.connect(alice).crossChainShield(
-        amount, 0, 0, npk, encBundle, shieldKey, ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        amount, 0, 0, npk, encBundle, shieldKey, ethers.ZeroAddress);
       const receipt = await tx.wait();
       recordGas("crossChainShield (client-side)", Number(receipt!.gasUsed));
 
@@ -431,7 +435,6 @@ describe("Privacy Pool Gas Profiling", function () {
         txData,
         DOMAINS.client,
         bobAddr,
-        ethers.ZeroHash,
         0 // maxFee
       );
       const receipt = await tx.wait();

--- a/test/privacy_pool_hardening.ts
+++ b/test/privacy_pool_hardening.ts
@@ -161,6 +161,10 @@ describe("Privacy Pool Integration Hardening", function () {
     await privacyPool.setHookRouter(await hubHookRouter.getAddress());
     await privacyPoolClient.setHookRouter(await clientHookRouter.getAddress());
 
+    // Pin the destinationCaller (hook router) on-chain for cross-chain shield/unshield
+    await privacyPoolClient.setHubHookRouter(ethers.zeroPadValue(await hubHookRouter.getAddress(), 32));
+    await privacyPool.setRemoteHookRouter(DOMAINS.client, ethers.zeroPadValue(await clientHookRouter.getAddress(), 32));
+
     // Set mock MessageTransmitter relayer to hookRouter (so hookRouter can call receiveMessage)
     await hubMessageTransmitter.connect(relayer).setRelayer(await hubHookRouter.getAddress());
     await clientMessageTransmitter.connect(relayer).setRelayer(await clientHookRouter.getAddress());
@@ -442,9 +446,8 @@ describe("Privacy Pool Integration Hardening", function () {
       const shieldKey = ethers.keccak256(ethers.toUtf8Bytes("rt-key"));
 
       const clientTx = await privacyPoolClient.connect(alice).crossChainShield(
-        SHIELD_AMOUNT, 0, 0, npk, encBundle, shieldKey, ethers.ZeroHash
-      ,
-      ethers.ZeroAddress);
+        SHIELD_AMOUNT, 0, 0, npk, encBundle, shieldKey, ethers.ZeroAddress
+      );
       const clientReceipt = await clientTx.wait();
 
       // Step 2: Relay to Hub — extract full MessageV2 from MessageSent(bytes) event
@@ -490,7 +493,7 @@ describe("Privacy Pool Integration Hardening", function () {
       });
 
       const unshieldTx = await privacyPool.atomicCrossChainUnshield(
-        unshieldTxData, DOMAINS.client, bobAddress, ethers.ZeroHash, 0
+        unshieldTxData, DOMAINS.client, bobAddress, 0
       );
       const unshieldReceipt = await unshieldTx.wait();
 

--- a/test/privacy_pool_integration.ts
+++ b/test/privacy_pool_integration.ts
@@ -270,6 +270,11 @@ describe("Privacy Pool Integration", function () {
     await privacyPool.setHookRouter(await hubHookRouter.getAddress());
     await privacyPoolClient.setHookRouter(await clientHookRouter.getAddress());
 
+    // Pin the CCTP destinationCaller (hook router) on-chain (#64). The
+    // destinationCaller arg is no longer passed per-call; it is fixed here.
+    await privacyPoolClient.setHubHookRouter(ethers.zeroPadValue(await hubHookRouter.getAddress(), 32));
+    await privacyPool.setRemoteHookRouter(DOMAINS.client, ethers.zeroPadValue(await clientHookRouter.getAddress(), 32));
+
     // Set mock MessageTransmitter relayer to hookRouter
     // (so hookRouter can call receiveMessage on mock)
     // setRelayer() requires msg.sender == current relayer
@@ -376,7 +381,6 @@ describe("Privacy Pool Integration", function () {
       const shieldKey = ethers.keccak256(ethers.toUtf8Bytes("shield-key"));
 
       // Execute cross-chain shield
-      // Use bytes32(0) for destinationCaller to allow any relayer
       const tx = await privacyPoolClient.connect(alice).crossChainShield(
         SHIELD_AMOUNT,
         0,               // maxFee = 0 (no CCTP fee for this test)
@@ -384,9 +388,7 @@ describe("Privacy Pool Integration", function () {
         npk,
         encryptedBundle,
         shieldKey,
-        ethers.ZeroHash  // destinationCaller = 0 (any relayer can submit)
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
 
       // Check event was emitted
@@ -439,9 +441,7 @@ describe("Privacy Pool Integration", function () {
         npk,
         encryptedBundle,
         shieldKey,
-        ethers.ZeroHash  // destinationCaller = 0 (any relayer)
-      ,
-      ethers.ZeroAddress);
+        ethers.ZeroAddress);
       const receipt = await tx.wait();
 
       // Extract MessageSent(bytes) event — contains the full encoded MessageV2
@@ -597,9 +597,6 @@ describe("Privacy Pool Integration", function () {
         },
       };
 
-      // Set destinationCaller = relayer address (bytes32)
-      const destinationCaller = ethers.ZeroHash; // Allow any relayer
-
       // Record balances before
       const recipientBalanceBefore = await clientUsdc.balanceOf(bobAddress);
       const clientHookRouterAddress = await clientHookRouter.getAddress();
@@ -610,7 +607,6 @@ describe("Privacy Pool Integration", function () {
         transaction,
         DOMAINS.client,
         bobAddress,         // finalRecipient on client chain
-        destinationCaller,
         MAX_FEE,
       );
       const receipt = await tx.wait();
@@ -672,7 +668,7 @@ describe("Privacy Pool Integration", function () {
       ];
       const shieldKey = ethers.keccak256(ethers.toUtf8Bytes("src-auth-key"));
       const tx = await privacyPoolClient.connect(alice).crossChainShield(
-        SRC_AUTH_AMOUNT, 0, 0, npk, encryptedBundle, shieldKey, ethers.ZeroHash, ethers.ZeroAddress,
+        SRC_AUTH_AMOUNT, 0, 0, npk, encryptedBundle, shieldKey, ethers.ZeroAddress,
       );
       const receipt = await tx.wait();
       for (const log of receipt!.logs) {


### PR DESCRIPTION
Fixes #64.

## Problem
`crossChainShield` (client) and `atomicCrossChainUnshield` (hub) took `destinationCaller` as a caller-supplied CCTP argument. `receiveMessage` enforces `destinationCaller == 0 || == msg.sender`, and in `relayWithHook` the caller is the **CCTPHookRouter** — so the *only* valid value is the destination hook router. Any other value breaks delivery, and `bytes32(0)` lets a third party call `receiveMessage` directly, skip the mint hook, and **strand the burned funds**. (The code comments claiming "specify a relayer for MEV protection" were wrong — no such value works.)

## Fix — pin it on-chain, delete the parameter
- **Client:** new `hubHookRouter` (bytes32) + owner setter `setHubHookRouter`; `crossChainShield` uses it as the burn's `destinationCaller` and reverts if unset. Parameter removed from the signature.
- **Hub:** new `remoteHookRouters[domain]` mapping (appended before the storage `__gap`, gap 46→45) + owner setter `setRemoteHookRouter`; `atomicCrossChainUnshield` / `TransactModule` use `remoteHookRouters[destinationDomain]` and revert if unset. Parameter removed.
- **Gasless path:** `destinationCaller` removed from `GaslessShieldWrapperClient.CrossChainParams` (it was part of the `keccak256(abi.encode(dest))` signed digest). Since there are no public deployments, the signed-struct change lands atomically across signer + verifier + contract — no migration.

`destinationCaller` still exists in the CCTP **wire format** (now always the hook router); the relayer's message-parsing/allowlist is unchanged and still accepts it.

## Blast radius (all updated in-PR)
Contracts (5) + 3 interfaces + gasless wrapper · deploy linking (`link_privacy_pool.ts` now registers both routers) · frontend (`shield-xchain`/`unshield-xchain` handlers, gasless signer + its test — new selector `0x742d0b54`) · relayer (`transact-shape.ts` selector `0xe484d408`→`0xb8843aaa`, `gasless-fee-verifier.ts`, tests) · `test_sepolia.ts` (also realigned to the current signature) · ~34 Hardhat call sites + 3 Foundry tests + new router wiring in every cross-chain test setup.

## Security note
This closes the direct-`receiveMessage`-bypass stranding class (finding #1 in #64, and the only real residual from the closed #64-adjacent #367). Complementary to #364/#378, which bind the *recipient/params* into the proof — a different surface. Impact on those tracked separately (see issue updates).

## Tests
All green: **Foundry 759** · **Hardhat 120** (integration, adversarial, hardening, fee-module, fast_finality, gas) · **relayer 32** · **frontend 21 + typecheck**. Added: revert-on-unset-router coverage via the existing cross-chain suites; gas profile confirms `crossChainShield` unchanged (~178k).

## Deploy note
Requires re-running `link_privacy_pool.ts` (registers `hubHookRouter` on each client + `remoteHookRouters` on the hub) — folded into `npm run setup`. Relayer + frontend redeploy needed (ABIs/selectors changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)