### PR TITLE
docs(privacy-pool): document intentional module immutability (#79)

### DIFF
--- a/.claude/ARCHITECTURE_NOTES.md
+++ b/.claude/ARCHITECTURE_NOTES.md
@@ -247,3 +247,15 @@ Preventing double-spends across chains is the hard part. Options:
 - Nullifier synchronization strategy for cross-chain
 - Yield distribution mechanism details
 - Circuit proving system choice (Groth16 vs Plonk/Halo2)
+
+---
+
+## PrivacyPool Module Immutability (Design Decision)
+
+**Decision:** The PrivacyPool's four modules — `shieldModule`, `transactModule`, `merkleModule`, `verifierModule` — are **immutable by design**. They are assigned once in `PrivacyPool.initialize()` and there is deliberately **no setter** for any of them. This is intentional, not an oversight (resolves issue #79).
+
+**Rationale.** Each of the four modules holds either **fund custody** (`ShieldModule`, `TransactModule`) or **proof/tree logic** (`VerifierModule`, `MerkleModule`). A swappable module would let whoever controls the pool owner redirect user funds or install logic that accepts forged proofs — reintroducing exactly the trust assumption that issue #55 rejected. Keeping the modules fixed means the custody and verification codepaths are pinned at deploy time and cannot be re-pointed at malicious code.
+
+**Mutable surface.** The values that are genuinely safe to change already have owner-gated setters on `PrivacyPool`: shield fee, privileged shield callers, hook router / remote hook routers, remote pools, fee module, shield-pause controller, default finality threshold (treasury is set once at init and is immutable thereafter). Configuration is mutable; the core custody/verification modules are not.
+
+**Known nuance (not a contradiction).** The `VerifierModule` *contract* is immutable, but its verification **keys** remain owner-settable via `setVerificationKey` — a deliberate operational need for circuit/key upgrades. Module immutability alone therefore does not fully protect proof verification: a compromised owner key could install a bad verifying key. That key-custody risk is tracked separately in issue #349 (PrivacyPool owner is a permanent deployer EOA) and is out of scope for the module-immutability decision.

--- a/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
+++ b/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
@@ -38,6 +38,16 @@ abstract contract PrivacyPoolStorage {
     // MODULE ADDRESSES
     // ══════════════════════════════════════════════════════════════════════════
 
+    /// @dev The four module addresses below are set once in initialize() and are INTENTIONALLY
+    ///      IMMUTABLE — there is deliberately no setter for any of them. Each module holds fund
+    ///      custody (Shield/Transact) or proof/tree logic (Verifier/Merkle); a swappable module
+    ///      would let the owner redirect funds or accept forged proofs, reintroducing the trust
+    ///      assumption rejected in issue #55. Mutable configuration lives in the setters on
+    ///      PrivacyPool (fees, treasury, privileged callers, hook routers, fee module, pause
+    ///      controller). NOTE: the VerifierModule contract is immutable, but its verification KEYS
+    ///      remain owner-settable via setVerificationKey (needed for circuit/key upgrades) — that
+    ///      key-custody risk is tracked separately in issue #349. See .claude/ARCHITECTURE_NOTES.md.
+
     /// @notice Address of ShieldModule implementation
     address public shieldModule;
 


### PR DESCRIPTION
Closes #79.

#79 asked whether PrivacyPool's immutable modules are intentional. They are — this documents the decision; no behavior change.

Verified: `shieldModule`/`transactModule`/`merkleModule`/`verifierModule` are assigned only in `initialize()` with **no setters**. Every existing setter is for a safe-to-change config value.

## Changes (docs only)
- `.claude/ARCHITECTURE_NOTES.md` — new "PrivacyPool Module Immutability (Design Decision)" section: rationale (custody/verification modules must not be swappable — the trust assumption #55 rejected), the mutable config surface, and the honest nuance that `setVerificationKey` keeps the verifier's **keys** owner-settable (key-custody risk tracked in #349).
- `PrivacyPoolStorage.sol` — NatSpec anchor on the four module fields pointing to that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)