### PR TITLE
fix(privacy-pool): per-tx uniqueNonce for cross-chain unshield delivery matching (#287)

### DIFF
--- a/apps/armada-interface/src/features/unshield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/handler.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Same handler covers Withdraw modal (destination ≠ hub) and Send-External tab (destination ≠ hub) — same contract path, different UI entry.
 
 import { ethers } from 'ethers'
-import { encodeFunctionData, pad } from 'viem'
+import { encodeFunctionData, keccak256, toBytes } from 'viem'
 import { getPublicClient, sendTransaction } from 'wagmi/actions'
 import { asTxError, waitForReceiptOrFail } from '@/lib/tx/receipt'
 import { simulateOrThrow } from '@/lib/tx/simulate'
@@ -113,10 +113,21 @@ const PRIVACY_POOL_XCHAIN_UNSHIELD_ABI = [
       { name: 'destinationDomain', type: 'uint32' },
       { name: 'finalRecipient', type: 'address' },
       { name: 'maxFee', type: 'uint256' },
+      { name: 'uniqueNonce', type: 'bytes32' },
     ],
     outputs: [],
   },
 ] as const
+
+/**
+ * Per-transaction CCTP delivery marker (issue #287). Derived deterministically from the record's ulid
+ * so submit-time calldata and scan-time matching compute the identical value with no persisted/threaded
+ * state, and two same-recipient unshields get distinct markers. Echoed into the CCTP hookData's
+ * `UnshieldData.uniqueNonce`; the destination-scan predicate searches `messageBody` for it.
+ */
+function deliveryNonce(recordId: string): `0x${string}` {
+  return keccak256(toBytes(recordId))
+}
 
 /**
  * Stage map for `unshield-xchain` (A5 — relayer-mediated hub burn):
@@ -269,6 +280,7 @@ async function runSubmitAndBurn(
       destinationDomain,
       record.meta.recipient as `0x${string}`,
       maxFee,
+      deliveryNonce(record.id), // issue #287 — unique per-tx marker echoed into the CCTP hookData
     )
   }
 
@@ -477,13 +489,10 @@ async function runWaitForDelivery(
   // bytes32(0) on outbound MessageSent; the destination contract emits an Iris-assigned
   // `eventNonce` which isn't derivable from the source side. So we drop the topic filter and
   // identify ours by looking inside the messageBody's hookData for a unique-per-tx marker.
-  // For unshield-xchain the hookData encodes only `recipient`; two parallel unshields to the
-  // same recipient would be indistinguishable by content. Combined with the burn-time
-  // `destFromBlock` cursor this is correct for in-series flows, and the rare parallel-same-
-  // recipient case is acceptable (either delivery satisfies one of the two records — both
-  // ultimately resolve as the second delivery lands).
-  const recipientBytes32 = pad(record.meta.recipient as `0x${string}`, { size: 32 })
-  const uniqueMarker = recipientBytes32.slice(2).toLowerCase()
+  // issue #287: the CCTP hookData now carries a per-transaction `uniqueNonce` (UnshieldData) derived
+  // from the record's ulid, so two parallel same-recipient unshields get distinct, unambiguous
+  // markers. We match the destination delivery on that nonce (recomputed here — no persisted state).
+  const uniqueMarker = deliveryNonce(record.id).slice(2).toLowerCase()
   // Build an ethers JsonRpcProvider for the destination chain. We deliberately bypass viem here
   // so the app-wide bisecting `eth_getLogs` patch (lib/rpc-bisecting.ts, installed in main.tsx)
   // applies — free-tier RPCs (Alchemy = 10-block cap) reject the configured 5_000-block window
@@ -546,7 +555,7 @@ async function runWaitForDelivery(
         getBlockNumber: async () => BigInt(await destProvider.getBlockNumber()),
         // Filter on the MessageReceived topic only — V2 puts an Iris-assigned `eventNonce` in
         // the indexed `nonce` topic that we can't predict source-side. The matchPredicate below
-        // narrows by hookData content (uniqueMarker = pad32(recipient)).
+        // narrows by hookData content (uniqueMarker = per-tx uniqueNonce, issue #287).
         getLogsForRange: (fromBlock, toBlock) => destProvider.getLogs({
           address: destMessageTransmitter,
           topics: [destMessageReceivedTopic],
@@ -561,7 +570,7 @@ async function runWaitForDelivery(
             })
             return matchesXchainDelivery(
               { messageBody: parsed?.args.messageBody, sourceDomain: parsed?.args.sourceDomain },
-              { recipientMarker: uniqueMarker, sourceDomain: hubDomain },
+              { marker: uniqueMarker, sourceDomain: hubDomain },
             )
           } catch {
             // Foreign log on the same address (different ABI / unindexed topic mismatch) — skip
@@ -657,6 +666,7 @@ function encodeAtomicCrossChainUnshield(
   destinationDomain: number,
   finalRecipient: `0x${string}`,
   maxFee: bigint,
+  uniqueNonce: `0x${string}`,
 ): `0x${string}` {
   return encodeFunctionData({
     abi: PRIVACY_POOL_XCHAIN_UNSHIELD_ABI,
@@ -669,6 +679,7 @@ function encodeAtomicCrossChainUnshield(
       destinationDomain,
       finalRecipient,
       maxFee,
+      uniqueNonce,
     ],
   })
 }

--- a/apps/armada-interface/src/features/unshield-xchain/scan.test.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/scan.test.ts
@@ -4,18 +4,18 @@ import { describe, it, expect, vi } from 'vitest'
 import { scanCctpDeliveryWindow, matchesXchainDelivery } from './scan'
 
 describe('matchesXchainDelivery (T-M7)', () => {
-  const marker = 'abc123' // pad32(recipient) tail, lowercase
-  const expected = { recipientMarker: marker, sourceDomain: 100 }
+  const marker = 'abc123' // per-tx uniqueNonce hex tail, lowercase (issue #287)
+  const expected = { marker, sourceDomain: 100 }
 
-  it('matches when the recipient marker is in the body AND the source domain is the hub', () => {
+  it('matches when the uniqueNonce marker is in the body AND the source domain is the hub', () => {
     expect(matchesXchainDelivery({ messageBody: `0xdeadABC123beef`, sourceDomain: 100 }, expected)).toBe(true)
   })
 
-  it('rejects a same-recipient transfer from a DIFFERENT source domain', () => {
+  it('rejects a transfer from a DIFFERENT source domain', () => {
     expect(matchesXchainDelivery({ messageBody: `0xdeadabc123beef`, sourceDomain: 6 }, expected)).toBe(false)
   })
 
-  it('rejects when the recipient marker is absent even if the source domain matches', () => {
+  it('rejects when the uniqueNonce marker is absent even if the source domain matches', () => {
     expect(matchesXchainDelivery({ messageBody: `0xdeadbeef`, sourceDomain: 100 }, expected)).toBe(false)
   })
 

--- a/apps/armada-interface/src/features/unshield-xchain/scan.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/scan.ts
@@ -80,20 +80,17 @@ export async function scanCctpDeliveryWindow<TLog extends ScanLog>(
 /**
  * Does a destination CCTP `MessageReceived` event match THIS unshield-xchain record's delivery? (T-M7)
  *
- * The V2 destination scan can't filter on the source nonce, so we identify our delivery by content.
- * Beyond the recipient marker in the hookData, we also require the event's CCTP `sourceDomain` to be
- * the hub's domain — so an unrelated CCTP transfer to the same recipient from a DIFFERENT source
- * chain can't false-complete the record with the wrong destTxHash.
- *
- * Burn-amount-within-maxFee matching (the other half of T-M7) is deferred to the full Iris-nonce
- * correlation: it needs byte-offset parsing of the CCTP BurnMessage, and a wrong offset would
- * silently break delivery detection (funds appear stuck) — too risky for this quick tightening.
+ * The V2 destination CCTP `nonce` is Iris-assigned and unpredictable source-side, so we identify our
+ * delivery by content: a per-transaction `uniqueNonce` marker in the hookData (issue #287) — distinct
+ * even between two same-recipient unshields. We also require the event's CCTP `sourceDomain` to be the
+ * hub's domain, so an unrelated CCTP transfer from a DIFFERENT source chain can't false-complete the
+ * record with the wrong destTxHash.
  */
 export function matchesXchainDelivery(
   args: { messageBody?: unknown; sourceDomain?: unknown },
-  expected: { recipientMarker: string; sourceDomain: number },
+  expected: { marker: string; sourceDomain: number },
 ): boolean {
   if (Number(args.sourceDomain) !== expected.sourceDomain) return false
   const body = args.messageBody
-  return typeof body === 'string' && body.toLowerCase().includes(expected.recipientMarker)
+  return typeof body === 'string' && body.toLowerCase().includes(expected.marker)
 }

--- a/contracts/privacy-pool/PrivacyPool.sol
+++ b/contracts/privacy-pool/PrivacyPool.sol
@@ -129,6 +129,8 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
      * @param destinationDomain Target client chain's CCTP domain
      * @param finalRecipient Address to receive USDC on client chain
      * @param maxFee Maximum CCTP relayer fee in USDC raw units (deducted from burn amount at protocol level, 0 = no fee)
+     * @param uniqueNonce Opaque per-tx marker echoed into the CCTP hookData for off-chain delivery
+     *        matching (issue #287). Not fund-relevant.
      * @return nonce CCTP message nonce
      * @dev The CCTP destinationCaller is pinned at the contract level to remoteHookRouters[destinationDomain]
      *      (see setRemoteHookRouter) — it is not caller-supplied, so a burn can only be delivered through
@@ -138,13 +140,14 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
         Transaction calldata _transaction,
         uint32 destinationDomain,
         address finalRecipient,
-        uint256 maxFee
+        uint256 maxFee,
+        bytes32 uniqueNonce
     ) external override returns (uint64) {
         bytes memory result = _delegatecall(
             transactModule,
             abi.encodeCall(
                 ITransactModule.atomicCrossChainUnshield,
-                (_transaction, destinationDomain, finalRecipient, maxFee)
+                (_transaction, destinationDomain, finalRecipient, maxFee, uniqueNonce)
             )
         );
         return abi.decode(result, (uint64));

--- a/contracts/privacy-pool/interfaces/IPrivacyPool.sol
+++ b/contracts/privacy-pool/interfaces/IPrivacyPool.sol
@@ -83,6 +83,7 @@ interface IPrivacyPool is IMessageHandlerV2 {
      * @param destinationDomain Target client chain's CCTP domain
      * @param finalRecipient Address to receive USDC on client chain
      * @param maxFee Maximum CCTP relayer fee in USDC raw units (deducted from burn amount at protocol level, 0 = no fee)
+     * @param uniqueNonce Opaque per-tx marker echoed into the CCTP hookData for off-chain delivery matching (issue #287)
      * @return nonce CCTP message nonce
      * @dev The CCTP destinationCaller is pinned to remoteHookRouters[destinationDomain] at the contract
      *      level (see setRemoteHookRouter) — it is not caller-supplied.
@@ -91,7 +92,8 @@ interface IPrivacyPool is IMessageHandlerV2 {
         Transaction calldata _transaction,
         uint32 destinationDomain,
         address finalRecipient,
-        uint256 maxFee
+        uint256 maxFee,
+        bytes32 uniqueNonce
     ) external returns (uint64 nonce);
 
     // ══════════════════════════════════════════════════════════════════════════

--- a/contracts/privacy-pool/interfaces/ITransactModule.sol
+++ b/contracts/privacy-pool/interfaces/ITransactModule.sol
@@ -72,6 +72,7 @@ interface ITransactModule {
      * @param destinationDomain Client chain's CCTP domain
      * @param finalRecipient Address to receive USDC on client chain
      * @param maxFee Maximum CCTP relayer fee in USDC raw units (deducted from burn amount at protocol level, 0 = no fee)
+     * @param uniqueNonce Opaque per-tx marker echoed into the CCTP hookData for off-chain delivery matching (issue #287)
      * @return nonce CCTP message nonce for tracking
      * @dev The CCTP destinationCaller is pinned to remoteHookRouters[destinationDomain] at the contract
      *      level — it is not caller-supplied.
@@ -80,6 +81,7 @@ interface ITransactModule {
         Transaction calldata _transaction,
         uint32 destinationDomain,
         address finalRecipient,
-        uint256 maxFee
+        uint256 maxFee,
+        bytes32 uniqueNonce
     ) external returns (uint64 nonce);
 }

--- a/contracts/privacy-pool/modules/TransactModule.sol
+++ b/contracts/privacy-pool/modules/TransactModule.sol
@@ -107,6 +107,8 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
      * @param _transaction Transaction with unshield proof
      * @param destinationDomain Client chain's CCTP domain
      * @param finalRecipient Address to receive USDC on client chain
+     * @param uniqueNonce Opaque per-tx marker echoed into the CCTP hookData so off-chain wallets can
+     *        match the destination delivery to this specific unshield (issue #287). Not fund-relevant.
      * @return nonce CCTP message nonce for tracking
      * @dev The CCTP destinationCaller is pinned to remoteHookRouters[destinationDomain] (not
      *      caller-supplied), so the burn can only be delivered through the destination chain's
@@ -116,7 +118,8 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
         Transaction calldata _transaction,
         uint32 destinationDomain,
         address finalRecipient,
-        uint256 maxFee
+        uint256 maxFee,
+        bytes32 uniqueNonce
     ) external override onlyDelegatecall returns (uint64 nonce) {
         // Post-wind-down SC emergency pause: block ALL operations including unshields.
         _requireNotEmergencyPaused();
@@ -128,7 +131,7 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
         _processAtomicUnshieldTransaction(_transaction);
 
         // Execute the CCTP burn and return nonce
-        nonce = _executeCCTPBurn(_transaction, destinationDomain, finalRecipient, maxFee);
+        nonce = _executeCCTPBurn(_transaction, destinationDomain, finalRecipient, maxFee, uniqueNonce);
     }
 
     /**
@@ -190,32 +193,27 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
         Transaction calldata _transaction,
         uint32 destinationDomain,
         address finalRecipient,
-        uint256 maxFee
+        uint256 maxFee,
+        bytes32 uniqueNonce
     ) internal returns (uint64 nonce) {
-        // Unshield is free per spec — the full preimage value is bridged.
-        // `fee` is retained at zero solely so the Unshield event below keeps its 4-field
-        // shape for downstream log parsers.
+        // Unshield is free per spec — the full preimage value is bridged. The Unshield event's fee
+        // field is emitted as 0 to keep its 4-field shape for downstream log parsers.
         uint120 base = _transaction.unshieldPreimage.value;
-        uint120 fee = 0;
 
         // Validate maxFee does not exceed the bridged amount
         require(maxFee <= base, "TransactModule: maxFee exceeds base");
 
         // Encode CCTP payload
         bytes memory hookData = CCTPPayloadLib.encodeUnshield(
-            UnshieldData({ recipient: finalRecipient })
+            UnshieldData({ recipient: finalRecipient, uniqueNonce: uniqueNonce })
         );
 
         // Burn via CCTP
         IERC20(usdc).safeApprove(tokenMessenger, base);
 
-        // Use configured finality threshold (STANDARD by default, FAST if enabled)
-        uint32 finality = defaultFinalityThreshold > 0
-            ? defaultFinalityThreshold
-            : CCTPFinality.STANDARD;
-
         // destinationCaller is pinned to the destination chain's hook router (validated non-zero in
         // _validateAtomicUnshieldInputs) so the message can only be delivered via its CCTPHookRouter.
+        // Finality: STANDARD by default, FAST if enabled (inlined to keep the stack shallow).
         ITokenMessengerV2(tokenMessenger).depositForBurnWithHook(
             base,
             destinationDomain,
@@ -223,14 +221,14 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
             usdc,
             remoteHookRouters[destinationDomain],
             maxFee,
-            finality,
+            defaultFinalityThreshold > 0 ? defaultFinalityThreshold : CCTPFinality.STANDARD,
             hookData
         );
         nonce = 0; // CCTP V2 depositForBurnWithHook does not return nonce
 
         // Emit events
         emit CrossChainUnshieldInitiated(destinationDomain, finalRecipient, base, nonce);
-        emit Unshield(finalRecipient, _transaction.unshieldPreimage.token, base, fee);
+        emit Unshield(finalRecipient, _transaction.unshieldPreimage.token, base, 0);
 
         // Update last event block
         lastEventBlock = block.number;

--- a/contracts/privacy-pool/types/CCTPTypes.sol
+++ b/contracts/privacy-pool/types/CCTPTypes.sol
@@ -53,9 +53,14 @@ struct ShieldData {
  *      Client just needs to know where to forward the USDC
  *
  * @param recipient Address to receive USDC on client chain
+ * @param uniqueNonce Opaque per-transaction marker (caller-supplied) so off-chain wallets can
+ *        match a destination CCTP delivery to the specific unshield that produced it. Two unshields
+ *        to the same recipient would otherwise produce bit-identical hookData and be indistinguishable
+ *        from chain state (issue #287). Not proof-bound and not fund-relevant — purely a matching aid.
  */
 struct UnshieldData {
     address recipient;
+    bytes32 uniqueNonce;
 }
 
 /**

--- a/relayer/lib/transact-shape.ts
+++ b/relayer/lib/transact-shape.ts
@@ -31,13 +31,14 @@ export const LEND_AND_SHIELD_SELECTOR = "0xf2987ad1";
 export const REDEEM_AND_SHIELD_SELECTOR = "0x0793b70e";
 
 /**
- * PrivacyPool.atomicCrossChainUnshield(Transaction, uint32, address, uint256) — A5 cross-chain
- * unshield. The Transaction struct burns shielded USDC into the pool's own EOA and the surrounding
- * wrapper args drive the CCTP burn-and-mint to a different chain. Same single-Transaction-in-arg-0
- * shape as the yield wrappers, so the synthetic-transact rewrite applies here too. The CCTP
- * destinationCaller is pinned on-chain (issue #64), so it is no longer a call argument.
+ * PrivacyPool.atomicCrossChainUnshield(Transaction, uint32, address, uint256, bytes32) — A5
+ * cross-chain unshield. The Transaction struct burns shielded USDC into the pool's own EOA and the
+ * surrounding wrapper args drive the CCTP burn-and-mint to a different chain. Same
+ * single-Transaction-in-arg-0 shape as the yield wrappers, so the synthetic-transact rewrite applies
+ * here too. The CCTP destinationCaller is pinned on-chain (issue #64); the trailing bytes32 is an
+ * opaque uniqueNonce for off-chain delivery matching (issue #287).
  */
-export const ATOMIC_CROSS_CHAIN_UNSHIELD_SELECTOR = "0xb8843aaa";
+export const ATOMIC_CROSS_CHAIN_UNSHIELD_SELECTOR = "0x2bcba06a";
 
 /** The wrappers that need synthetic-transact re-encoding before the SDK helper can decode. */
 export const WRAPPER_SELECTORS: ReadonlySet<string> = new Set([
@@ -102,5 +103,5 @@ export const TRANSACT_ABI: readonly string[] = [
 export const WRAPPER_ABIS: readonly string[] = [
   `function lendAndShield(${TRANSACTION_STRUCT} _transaction, bytes32 _npk, ${SHIELD_CIPHERTEXT_STRUCT} _shieldCiphertext)`,
   `function redeemAndShield(${TRANSACTION_STRUCT} _transaction, bytes32 _npk, ${SHIELD_CIPHERTEXT_STRUCT} _shieldCiphertext)`,
-  `function atomicCrossChainUnshield(${TRANSACTION_STRUCT} _transaction, uint32 destinationDomain, address finalRecipient, uint256 maxFee)`,
+  `function atomicCrossChainUnshield(${TRANSACTION_STRUCT} _transaction, uint32 destinationDomain, address finalRecipient, uint256 maxFee, bytes32 uniqueNonce)`,
 ];

--- a/relayer/modules/privacy-relay.ts
+++ b/relayer/modules/privacy-relay.ts
@@ -27,6 +27,12 @@ import {
   GASLESS_CROSS_CHAIN_SHIELD_SELECTOR,
   verifyGaslessFee,
 } from "./gasless-fee-verifier";
+import {
+  TRANSACT_SELECTOR,
+  LEND_AND_SHIELD_SELECTOR,
+  REDEEM_AND_SHIELD_SELECTOR,
+  ATOMIC_CROSS_CHAIN_UNSHIELD_SELECTOR,
+} from "../lib/transact-shape";
 import type { Counters } from "./counters";
 
 // ============ Constants ============
@@ -49,11 +55,15 @@ import type { Counters } from "./counters";
  *   - `gaslessCrossChainShield((permitInput),(dest))` — client `GaslessShieldWrapperClient`.
  *     Fee lives at `permitInput.fee`. Same atomic enforcement on the wrapper side.
  */
+// Selectors are sourced from the shared constants (lib/transact-shape + gasless-fee-verifier) rather
+// than hardcoded literals, so a wrapper-signature change updates the constant and this allowlist in
+// lockstep — no silent drift. (atomicCrossChainUnshield's selector changed with #64 and again with
+// #287; the literal here previously drifted.)
 const ALLOWED_SELECTORS: Record<string, string> = {
-  "0xd8ae136a": "transact",
-  "0xf2987ad1": "lendAndShield",
-  "0x0793b70e": "redeemAndShield",
-  "0xe484d408": "atomicCrossChainUnshield",
+  [TRANSACT_SELECTOR]: "transact",
+  [LEND_AND_SHIELD_SELECTOR]: "lendAndShield",
+  [REDEEM_AND_SHIELD_SELECTOR]: "redeemAndShield",
+  [ATOMIC_CROSS_CHAIN_UNSHIELD_SELECTOR]: "atomicCrossChainUnshield",
   [GASLESS_SHIELD_SELECTOR]: "gaslessShield",
   [GASLESS_CROSS_CHAIN_SHIELD_SELECTOR]: "gaslessCrossChainShield",
 };

--- a/relayer/test/modules/broadcaster-fee-verifier.test.ts
+++ b/relayer/test/modules/broadcaster-fee-verifier.test.ts
@@ -121,6 +121,7 @@ function encodeWrapperCalldata(
       0, // destinationDomain (uint32)
       ethers.ZeroAddress, // finalRecipient
       0n, // maxFee (uint256)
+      "0x" + "00".repeat(32), // uniqueNonce (bytes32)
     ]);
   }
   return iface.encodeFunctionData(fnName, [

--- a/test-foundry/OnlyDelegatecall.t.sol
+++ b/test-foundry/OnlyDelegatecall.t.sol
@@ -103,7 +103,7 @@ contract OnlyDelegatecallTest is Test {
         });
 
         vm.expectRevert(bytes(EXPECTED_REVERT));
-        transactModule.atomicCrossChainUnshield(txn, 1, address(1), 0);
+        transactModule.atomicCrossChainUnshield(txn, 1, address(1), 0, bytes32(0));
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/test-foundry/TransactModuleWindDown.t.sol
+++ b/test-foundry/TransactModuleWindDown.t.sol
@@ -209,7 +209,7 @@ contract TransactModuleWindDownTest is Test {
 
         Transaction memory tx0 = _buildMinimalTransaction(UnshieldType.NORMAL);
 
-        try pool.atomicCrossChainUnshield(tx0, 1, address(0xBEEF), 0) {
+        try pool.atomicCrossChainUnshield(tx0, 1, address(0xBEEF), 0, bytes32(0)) {
             // Success — guard didn't block
         } catch Error(string memory reason) {
             assertTrue(

--- a/test/privacy_pool_adversarial.ts
+++ b/test/privacy_pool_adversarial.ts
@@ -492,7 +492,7 @@ describe("Privacy Pool Adversarial", function () {
       });
 
       await privacyPool.atomicCrossChainUnshield(
-        tx, DOMAINS.client, bobAddress, 0
+        tx, DOMAINS.client, bobAddress, 0, ethers.ZeroHash
       );
 
       // Verify nullifier is spent
@@ -539,7 +539,7 @@ describe("Privacy Pool Adversarial", function () {
       await expect(
         privacyPool
           .connect(attacker)
-          .atomicCrossChainUnshield(buildTx(), DOMAINS.client, attackerAddress, 0)
+          .atomicCrossChainUnshield(buildTx(), DOMAINS.client, attackerAddress, 0, ethers.ZeroHash)
       )
         .to.emit(poolAsTransact, "CrossChainUnshieldInitiated")
         .withArgs(DOMAINS.client, attackerAddress, unshieldAmount, 0);
@@ -551,7 +551,7 @@ describe("Privacy Pool Adversarial", function () {
       await expect(
         privacyPool
           .connect(bob)
-          .atomicCrossChainUnshield(buildTx(), DOMAINS.client, bobAddress, 0)
+          .atomicCrossChainUnshield(buildTx(), DOMAINS.client, bobAddress, 0, ethers.ZeroHash)
       ).to.be.revertedWith("TransactModule: Note already spent");
     });
   });
@@ -706,7 +706,7 @@ describe("Privacy Pool Adversarial", function () {
       });
 
       await expect(
-        privacyPool.atomicCrossChainUnshield(tx, DOMAINS.hub, bobAddress, 0)
+        privacyPool.atomicCrossChainUnshield(tx, DOMAINS.hub, bobAddress, 0, ethers.ZeroHash)
       ).to.be.revertedWith("TransactModule: Use local unshield");
     });
 
@@ -730,7 +730,7 @@ describe("Privacy Pool Adversarial", function () {
       });
 
       await expect(
-        privacyPool.atomicCrossChainUnshield(tx, 999, bobAddress, 0)
+        privacyPool.atomicCrossChainUnshield(tx, 999, bobAddress, 0, ethers.ZeroHash)
       ).to.be.revertedWith("TransactModule: Unknown destination");
     });
 
@@ -754,7 +754,7 @@ describe("Privacy Pool Adversarial", function () {
       });
 
       await expect(
-        privacyPool.atomicCrossChainUnshield(tx, DOMAINS.client, ethers.ZeroAddress, 0)
+        privacyPool.atomicCrossChainUnshield(tx, DOMAINS.client, ethers.ZeroAddress, 0, ethers.ZeroHash)
       ).to.be.revertedWith("TransactModule: Invalid recipient");
     });
 
@@ -770,7 +770,7 @@ describe("Privacy Pool Adversarial", function () {
       });
 
       await expect(
-        privacyPool.atomicCrossChainUnshield(tx, DOMAINS.client, bobAddress, 0)
+        privacyPool.atomicCrossChainUnshield(tx, DOMAINS.client, bobAddress, 0, ethers.ZeroHash)
       ).to.be.revertedWith("TransactModule: Must include unshield");
     });
 
@@ -796,7 +796,7 @@ describe("Privacy Pool Adversarial", function () {
       // maxFee = 100 USDC >> base amount of ~10 USDC
       await expect(
         privacyPool.atomicCrossChainUnshield(
-          tx, DOMAINS.client, bobAddress, ethers.parseUnits("100", 6)
+          tx, DOMAINS.client, bobAddress, ethers.parseUnits("100", 6), ethers.ZeroHash
         )
       ).to.be.revertedWith("TransactModule: maxFee exceeds base");
     });

--- a/test/privacy_pool_gas.ts
+++ b/test/privacy_pool_gas.ts
@@ -435,7 +435,8 @@ describe("Privacy Pool Gas Profiling", function () {
         txData,
         DOMAINS.client,
         bobAddr,
-        0 // maxFee
+        0, // maxFee
+        ethers.ZeroHash
       );
       const receipt = await tx.wait();
       recordGas("atomicCrossChainUnshield", Number(receipt!.gasUsed));

--- a/test/privacy_pool_hardening.ts
+++ b/test/privacy_pool_hardening.ts
@@ -493,7 +493,7 @@ describe("Privacy Pool Integration Hardening", function () {
       });
 
       const unshieldTx = await privacyPool.atomicCrossChainUnshield(
-        unshieldTxData, DOMAINS.client, bobAddress, 0
+        unshieldTxData, DOMAINS.client, bobAddress, 0, ethers.ZeroHash
       );
       const unshieldReceipt = await unshieldTx.wait();
 

--- a/test/privacy_pool_integration.ts
+++ b/test/privacy_pool_integration.ts
@@ -608,6 +608,7 @@ describe("Privacy Pool Integration", function () {
         DOMAINS.client,
         bobAddress,         // finalRecipient on client chain
         MAX_FEE,
+        ethers.ZeroHash,
       );
       const receipt = await tx.wait();
 


### PR DESCRIPTION
Fixes #287. Option A from the issue.

## Problem
`UnshieldData` hookData carried only `recipient`, so two same-recipient cross-chain unshields produced **bit-identical** hookData. The frontend matches a destination CCTP delivery by content (the CCTP V2 destination `nonce` is Iris-assigned and unpredictable source-side, so it can't be used), so parallel same-recipient unshields could swap their displayed `destTxHash`. Not fund-safety — funds always arrive correctly — but confusing. Only affects the on-chain-scan fallback; the relayer `messageHash` path already disambiguates.

## Fix
Add an opaque `bytes32 uniqueNonce` to `UnshieldData`, threaded through `atomicCrossChainUnshield` → `_executeCCTPBurn` into the CCTP hookData. The frontend **derives it deterministically from the record's ulid** (`keccak256(toBytes(record.id))`) — so submit-time calldata and scan-time matching compute the identical marker with **no persisted or threaded state**, and it survives resume trivially. The scan predicate now matches on that nonce instead of the recipient. Not proof-bound / not fund-relevant — purely a matching aid.

`atomicCrossChainUnshield` gains a trailing `bytes32 uniqueNonce` param (new selector `0x2bcba06a`); to fit it I inlined two locals in `_executeCCTPBurn` (stack-too-deep).

## Also fixed — a latent #64 bug
The relayer's `/relay` selector allowlist (`privacy-relay.ts`) hardcoded the **original** `atomicCrossChainUnshield` selector `0xe484d408` as a literal. **#64 changed that selector to `0xb8843aaa` but missed this map** — so `main` currently rejects A5 unshield relays as an unknown selector. This PR sources all transact-family selectors from the shared `transact-shape` constants (computed keys), fixing the stale value and making the allowlist drift-proof going forward.

## Blast radius (all updated)
Contract (`CCTPTypes`, `TransactModule`, `PrivacyPool`, 2 interfaces) · relayer (`transact-shape` selector + ABI, `privacy-relay` allowlist, broadcaster-fee test) · frontend (unshield-xchain handler ABI + deterministic marker, `scan.ts` predicate `recipientMarker`→`marker`, scan test) · Foundry (2) + Hardhat (11 call sites).

## Tests — all green
**Foundry 759 · Hardhat 87** (integration, adversarial, hardening, gas) · **relayer 180** · **frontend 14 + typecheck**.

## Deploy note
`atomicCrossChainUnshield` ABI/selector changed again → relayer VPS pull+restart + frontend redeploy + `npm run setup` (contract redeploy). No new deploy wiring beyond #64's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)