### PR TITLE
feat(yield): withdraw broadcaster fee from proceeds, bound in adaptParams (#312)

### DIFF
--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -76,11 +76,12 @@ export function EarnModal() {
   // yield-withdraw is (still) forced to user-wallet submission. The original blocker — the SDK's
   // one-Transaction-per-token shape not fitting `redeemAndShield` — is RESOLVED by #312's
   // fee-from-proceeds design: redeem is now a single Transaction and the relayer fee is paid from the
-  // redeemed USDC (bound in adaptParams), so no separate broadcaster Transaction is generated. The
-  // remaining gate for gasless withdraw is relayer-side: fee-from-proceeds pays the relayer's EVM
-  // address on-chain, but /fees advertises only the relayer's shielded (0zk) address — so the relayer
-  // must expose an EVM fee-recipient and its verifier must check (feeRecipient, feeAmount) from the
-  // redeemAndShield calldata. Until that lands, withdraw stays wallet-submit. Tracked at #312.
+  // redeemed USDC by SHIELDING it to the relayer's 0zk address (bound in adaptParams), so no separate
+  // broadcaster Transaction is generated and the relayer is still paid to its shielded address. The
+  // only remaining gate for gasless withdraw is the relayer verifier: it must accept the new
+  // `redeemAndShield` selector and confirm the fee-shield output targets its 0zk address for >= the
+  // required amount. No /fees change is needed (the fee uses the relayer's existing 0zk address). Until
+  // the verifier lands, withdraw stays wallet-submit. Tracked at #312.
   const forceWalletForWithdraw = tab === 'withdraw'
   const effectiveUseWalletOverride = prefs.submitFromWallet || forceWalletForWithdraw
   // When the user-wallet path is in effect, no broadcaster fee is baked into the proof — the

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -73,13 +73,14 @@ export function EarnModal() {
   const syncGate = useSpendableSyncGate()
   // A4 — yield ops are relayer-mediated. Fee comes from the quote's crossContract tier.
   const yieldKind: 'yield-deposit' | 'yield-withdraw' = tab === 'add' ? 'yield-deposit' : 'yield-withdraw'
-  // TEMP — yield-withdraw is forced to user-wallet submission because the broadcaster-fee
-  // mechanism doesn't fit the current `ArmadaYieldAdapter.redeemAndShield` shape. The SDK
-  // generates one Transaction per token (shares unshield to adapter + USDC unshield to
-  // broadcaster), but the adapter only consumes a single Transaction whose unshieldPreimage
-  // MUST be shares. Tracked at ship-armada/armada-poc#312 (multi-Transaction adapter).
-  // yield-deposit is unaffected — input and broadcaster fee are both USDC, so the SDK fits
-  // them in a single Transaction.
+  // yield-withdraw is (still) forced to user-wallet submission. The original blocker — the SDK's
+  // one-Transaction-per-token shape not fitting `redeemAndShield` — is RESOLVED by #312's
+  // fee-from-proceeds design: redeem is now a single Transaction and the relayer fee is paid from the
+  // redeemed USDC (bound in adaptParams), so no separate broadcaster Transaction is generated. The
+  // remaining gate for gasless withdraw is relayer-side: fee-from-proceeds pays the relayer's EVM
+  // address on-chain, but /fees advertises only the relayer's shielded (0zk) address — so the relayer
+  // must expose an EVM fee-recipient and its verifier must check (feeRecipient, feeAmount) from the
+  // redeemAndShield calldata. Until that lands, withdraw stays wallet-submit. Tracked at #312.
   const forceWalletForWithdraw = tab === 'withdraw'
   const effectiveUseWalletOverride = prefs.submitFromWallet || forceWalletForWithdraw
   // When the user-wallet path is in effect, no broadcaster fee is baked into the proof — the

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -73,17 +73,14 @@ export function EarnModal() {
   const syncGate = useSpendableSyncGate()
   // A4 — yield ops are relayer-mediated. Fee comes from the quote's crossContract tier.
   const yieldKind: 'yield-deposit' | 'yield-withdraw' = tab === 'add' ? 'yield-deposit' : 'yield-withdraw'
-  // yield-withdraw is (still) forced to user-wallet submission. The original blocker — the SDK's
-  // one-Transaction-per-token shape not fitting `redeemAndShield` — is RESOLVED by #312's
-  // fee-from-proceeds design: redeem is now a single Transaction and the relayer fee is paid from the
-  // redeemed USDC by SHIELDING it to the relayer's 0zk address (bound in adaptParams), so no separate
-  // broadcaster Transaction is generated and the relayer is still paid to its shielded address. The
-  // only remaining gate for gasless withdraw is the relayer verifier: it must accept the new
-  // `redeemAndShield` selector and confirm the fee-shield output targets its 0zk address for >= the
-  // required amount. No /fees change is needed (the fee uses the relayer's existing 0zk address). Until
-  // the verifier lands, withdraw stays wallet-submit. Tracked at #312.
-  const forceWalletForWithdraw = tab === 'withdraw'
-  const effectiveUseWalletOverride = prefs.submitFromWallet || forceWalletForWithdraw
+  // yield-withdraw now uses the same submission model as every other kind: the user's `submitFromWallet`
+  // preference decides wallet vs. relayer. #312's fee-from-proceeds design removed the old blocker — the
+  // withdraw is a single Transaction and the relayer fee is shielded to the relayer's 0zk address (bound
+  // in adaptParams), so it fits the standard relayer/broadcaster path. NOTE: for the relayer (gasless)
+  // path to succeed end-to-end, the relayer's broadcaster-fee verifier must accept the new
+  // `redeemAndShield` selector and confirm the fee-shield output targets its 0zk address — tracked at
+  // #312 (relayer side). Users can fall back to wallet submission via the `submitFromWallet` preference.
+  const effectiveUseWalletOverride = prefs.submitFromWallet
   // When the user-wallet path is in effect, no broadcaster fee is baked into the proof — the
   // user pays gas in ETH instead.
   const fee: bigint = effectiveUseWalletOverride ? 0n : userFeeForKind(yieldKind, amount, quote)
@@ -296,10 +293,9 @@ export function EarnModal() {
             flowBreakdown={flowBreakdown}
             feeLoading={feeLoading}
             gasChainId={hubChainId}
-            // Add tab → relayer-mediated (gasless). Withdraw tab → force-routed through wallet
-            // because `redeemAndShield`'s multi-Transaction shape doesn't fit the broadcaster
-            // path today (tracked at ship-armada/armada-poc#312). `effectiveUseWalletOverride`
-            // already encodes this; the input step shows the gas notice when it's true.
+            // Both tabs are relayer-mediated (gasless) unless the user opts into wallet submission
+            // via `submitFromWallet`. `effectiveUseWalletOverride` encodes that; the input step shows
+            // the gas notice when it's true.
             gaslessMode={!effectiveUseWalletOverride}
             rate={yieldRate}
             continueBlockedReason={withdrawFeeBlockedReason}

--- a/apps/armada-interface/src/lib/railgun/yield.ts
+++ b/apps/armada-interface/src/lib/railgun/yield.ts
@@ -53,21 +53,24 @@ function encodeYieldAdaptParams(
 }
 
 /**
- * Withdraw (redeem) variant that also binds the broadcaster fee (recipient + amount) into adaptParams.
- * The adapter pays this fee from the redeemed USDC proceeds and shields the remainder — a single
- * Transaction, self-funding, and relayer-immutable (issue #312). Must match Solidity
- * YieldAdaptParams.encode(npk, bundle, shieldKey, feeRecipient, feeAmount).
+ * Withdraw (redeem) variant that also binds the broadcaster fee into adaptParams. The fee is paid as a
+ * SHIELD to the relayer's own 0zk destination (so the relayer is paid to its shielded address like every
+ * other tx type), from the redeemed USDC proceeds — a single Transaction, self-funding, relayer-immutable
+ * (issue #312). Must match Solidity
+ * YieldAdaptParams.encode(npk, bundle, shieldKey, feeNpk, feeBundle, feeShieldKey, feeAmount).
  */
 function encodeYieldAdaptParamsWithFee(
   npk: string,
   encryptedBundle: [string, string, string],
   shieldKey: string,
-  feeRecipient: string,
+  feeNpk: string,
+  feeEncryptedBundle: [string, string, string],
+  feeShieldKey: string,
   feeAmount: bigint,
 ): string {
   const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
-    ['bytes32', 'bytes32[3]', 'bytes32', 'address', 'uint256'],
-    [npk, encryptedBundle, shieldKey, feeRecipient, feeAmount],
+    ['bytes32', 'bytes32[3]', 'bytes32', 'bytes32', 'bytes32[3]', 'bytes32', 'uint256'],
+    [npk, encryptedBundle, shieldKey, feeNpk, feeEncryptedBundle, feeShieldKey, feeAmount],
   )
   return ethers.keccak256(encoded)
 }
@@ -168,7 +171,7 @@ function normalizeTransactionForAdapter(tx: unknown, hubChainId: number): unknow
  */
 const ADAPTER_ABI = [
   'function lendAndShield(tuple(tuple(tuple(uint256 x, uint256 y) a, tuple(uint256[2] x, uint256[2] y) b, tuple(uint256 x, uint256 y) c) proof, bytes32 merkleRoot, bytes32[] nullifiers, bytes32[] commitments, tuple(uint16 treeNumber, uint72 minGasPrice, uint8 unshield, uint64 chainID, address adaptContract, bytes32 adaptParams, tuple(bytes32[4] ciphertext, bytes32 blindedSenderViewingKey, bytes32 blindedReceiverViewingKey, bytes annotationData, bytes memo)[] commitmentCiphertext) boundParams, tuple(bytes32 npk, tuple(uint8 tokenType, address tokenAddress, uint256 tokenSubID) token, uint120 value) unshieldPreimage) _transaction, bytes32 _npk, tuple(bytes32[3] encryptedBundle, bytes32 shieldKey) _shieldCiphertext) returns (uint256)',
-  'function redeemAndShield(tuple(tuple(tuple(uint256 x, uint256 y) a, tuple(uint256[2] x, uint256[2] y) b, tuple(uint256 x, uint256 y) c) proof, bytes32 merkleRoot, bytes32[] nullifiers, bytes32[] commitments, tuple(uint16 treeNumber, uint72 minGasPrice, uint8 unshield, uint64 chainID, address adaptContract, bytes32 adaptParams, tuple(bytes32[4] ciphertext, bytes32 blindedSenderViewingKey, bytes32 blindedReceiverViewingKey, bytes annotationData, bytes memo)[] commitmentCiphertext) boundParams, tuple(bytes32 npk, tuple(uint8 tokenType, address tokenAddress, uint256 tokenSubID) token, uint120 value) unshieldPreimage) _transaction, bytes32 _npk, tuple(bytes32[3] encryptedBundle, bytes32 shieldKey) _shieldCiphertext, address _feeRecipient, uint256 _feeAmount) returns (uint256)',
+  'function redeemAndShield(tuple(tuple(tuple(uint256 x, uint256 y) a, tuple(uint256[2] x, uint256[2] y) b, tuple(uint256 x, uint256 y) c) proof, bytes32 merkleRoot, bytes32[] nullifiers, bytes32[] commitments, tuple(uint16 treeNumber, uint72 minGasPrice, uint8 unshield, uint64 chainID, address adaptContract, bytes32 adaptParams, tuple(bytes32[4] ciphertext, bytes32 blindedSenderViewingKey, bytes32 blindedReceiverViewingKey, bytes annotationData, bytes memo)[] commitmentCiphertext) boundParams, tuple(bytes32 npk, tuple(uint8 tokenType, address tokenAddress, uint256 tokenSubID) token, uint120 value) unshieldPreimage) _transaction, bytes32 _npk, tuple(bytes32[3] encryptedBundle, bytes32 shieldKey) _shieldCiphertext, bytes32 _feeNpk, tuple(bytes32[3] encryptedBundle, bytes32 shieldKey) _feeShieldCiphertext, uint256 _feeAmount) returns (uint256)',
 ]
 
 export interface YieldAdaptProofResult {
@@ -239,13 +242,43 @@ export async function buildYieldAdaptTransaction(opts: {
   // (input and fee are both USDC → a single Transaction already).
   const isRedeem = opts.mode === 'redeem'
   const feeAmount = isRedeem ? (opts.broadcasterFee?.amount ?? 0n) : 0n
-  const feeRecipient =
-    isRedeem && feeAmount > 0n
-      ? (opts.broadcasterFee?.recipientAddress ?? ethers.ZeroAddress)
-      : ethers.ZeroAddress
+
+  // For a fee-bearing withdraw, generate the relayer's OWN 0zk shield destination (from its 0zk address
+  // in the fee quote) and bind it into adaptParams. The adapter shields the fee to this destination, so
+  // the relayer is paid to its shielded address — consistent with every other tx type (#312).
+  let feeNpk = ethers.ZeroHash
+  let feeEncryptedBundle: [string, string, string] = [ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash]
+  let feeShieldKey = ethers.ZeroHash
+  if (isRedeem && feeAmount > 0n && opts.broadcasterFee) {
+    const feeShieldRandom = ByteUtils.randomHex(16)
+    const feeShieldReqs = await RelayAdaptHelper.generateRelayShieldRequests(
+      feeShieldRandom,
+      [{ tokenAddress: opts.shieldOutputToken, recipientAddress: opts.broadcasterFee.recipientAddress }],
+      [],
+    )
+    if (feeShieldReqs.length === 0) {
+      throw new Error('buildYieldAdaptTransaction: failed to generate relayer fee shield request')
+    }
+    const feeReq = feeShieldReqs[0]!
+    feeNpk = String(feeReq.preimage.npk)
+    feeEncryptedBundle = [
+      String(feeReq.ciphertext.encryptedBundle[0]),
+      String(feeReq.ciphertext.encryptedBundle[1]),
+      String(feeReq.ciphertext.encryptedBundle[2]),
+    ]
+    feeShieldKey = String(feeReq.ciphertext.shieldKey)
+  }
 
   const adaptParams = isRedeem
-    ? encodeYieldAdaptParamsWithFee(npk, encryptedBundle, shieldKey, feeRecipient, feeAmount)
+    ? encodeYieldAdaptParamsWithFee(
+        npk,
+        encryptedBundle,
+        shieldKey,
+        feeNpk,
+        feeEncryptedBundle,
+        feeShieldKey,
+        feeAmount,
+      )
     : encodeYieldAdaptParams(npk, encryptedBundle, shieldKey)
 
   // Generate the cross-contract-calls proof. The unshield recipient is the adapter address;
@@ -285,14 +318,16 @@ export async function buildYieldAdaptTransaction(opts: {
 
   const transaction = normalizeTransactionForAdapter(provedTransactions[0], opts.hubChainId)
   const iface = new ethers.Interface(ADAPTER_ABI)
-  // redeemAndShield additionally takes (feeRecipient, feeAmount), verified against adaptParams.
+  // redeemAndShield additionally takes the relayer fee-shield destination + amount, all verified
+  // against adaptParams.
   const data = (
     isRedeem
       ? iface.encodeFunctionData('redeemAndShield', [
           transaction,
           npk,
           { encryptedBundle, shieldKey },
-          feeRecipient,
+          feeNpk,
+          { encryptedBundle: feeEncryptedBundle, shieldKey: feeShieldKey },
           feeAmount,
         ])
       : iface.encodeFunctionData('lendAndShield', [transaction, npk, { encryptedBundle, shieldKey }])

--- a/apps/armada-interface/src/lib/railgun/yield.ts
+++ b/apps/armada-interface/src/lib/railgun/yield.ts
@@ -53,6 +53,26 @@ function encodeYieldAdaptParams(
 }
 
 /**
+ * Withdraw (redeem) variant that also binds the broadcaster fee (recipient + amount) into adaptParams.
+ * The adapter pays this fee from the redeemed USDC proceeds and shields the remainder — a single
+ * Transaction, self-funding, and relayer-immutable (issue #312). Must match Solidity
+ * YieldAdaptParams.encode(npk, bundle, shieldKey, feeRecipient, feeAmount).
+ */
+function encodeYieldAdaptParamsWithFee(
+  npk: string,
+  encryptedBundle: [string, string, string],
+  shieldKey: string,
+  feeRecipient: string,
+  feeAmount: bigint,
+): string {
+  const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
+    ['bytes32', 'bytes32[3]', 'bytes32', 'address', 'uint256'],
+    [npk, encryptedBundle, shieldKey, feeRecipient, feeAmount],
+  )
+  return ethers.keccak256(encoded)
+}
+
+/**
  * Normalize the SDK's proved Transaction tuple into the shape the adapter ABI expects. The
  * SDK returns ethers v6 Result proxies with maybe-numeric / maybe-string fields; the adapter
  * call needs strict bigint / hex types. Adapted from the legacy normalizeTransactionForAdapter.
@@ -148,7 +168,7 @@ function normalizeTransactionForAdapter(tx: unknown, hubChainId: number): unknow
  */
 const ADAPTER_ABI = [
   'function lendAndShield(tuple(tuple(tuple(uint256 x, uint256 y) a, tuple(uint256[2] x, uint256[2] y) b, tuple(uint256 x, uint256 y) c) proof, bytes32 merkleRoot, bytes32[] nullifiers, bytes32[] commitments, tuple(uint16 treeNumber, uint72 minGasPrice, uint8 unshield, uint64 chainID, address adaptContract, bytes32 adaptParams, tuple(bytes32[4] ciphertext, bytes32 blindedSenderViewingKey, bytes32 blindedReceiverViewingKey, bytes annotationData, bytes memo)[] commitmentCiphertext) boundParams, tuple(bytes32 npk, tuple(uint8 tokenType, address tokenAddress, uint256 tokenSubID) token, uint120 value) unshieldPreimage) _transaction, bytes32 _npk, tuple(bytes32[3] encryptedBundle, bytes32 shieldKey) _shieldCiphertext) returns (uint256)',
-  'function redeemAndShield(tuple(tuple(tuple(uint256 x, uint256 y) a, tuple(uint256[2] x, uint256[2] y) b, tuple(uint256 x, uint256 y) c) proof, bytes32 merkleRoot, bytes32[] nullifiers, bytes32[] commitments, tuple(uint16 treeNumber, uint72 minGasPrice, uint8 unshield, uint64 chainID, address adaptContract, bytes32 adaptParams, tuple(bytes32[4] ciphertext, bytes32 blindedSenderViewingKey, bytes32 blindedReceiverViewingKey, bytes annotationData, bytes memo)[] commitmentCiphertext) boundParams, tuple(bytes32 npk, tuple(uint8 tokenType, address tokenAddress, uint256 tokenSubID) token, uint120 value) unshieldPreimage) _transaction, bytes32 _npk, tuple(bytes32[3] encryptedBundle, bytes32 shieldKey) _shieldCiphertext) returns (uint256)',
+  'function redeemAndShield(tuple(tuple(tuple(uint256 x, uint256 y) a, tuple(uint256[2] x, uint256[2] y) b, tuple(uint256 x, uint256 y) c) proof, bytes32 merkleRoot, bytes32[] nullifiers, bytes32[] commitments, tuple(uint16 treeNumber, uint72 minGasPrice, uint8 unshield, uint64 chainID, address adaptContract, bytes32 adaptParams, tuple(bytes32[4] ciphertext, bytes32 blindedSenderViewingKey, bytes32 blindedReceiverViewingKey, bytes annotationData, bytes memo)[] commitmentCiphertext) boundParams, tuple(bytes32 npk, tuple(uint8 tokenType, address tokenAddress, uint256 tokenSubID) token, uint120 value) unshieldPreimage) _transaction, bytes32 _npk, tuple(bytes32[3] encryptedBundle, bytes32 shieldKey) _shieldCiphertext, address _feeRecipient, uint256 _feeAmount) returns (uint256)',
 ]
 
 export interface YieldAdaptProofResult {
@@ -213,11 +233,26 @@ export async function buildYieldAdaptTransaction(opts: {
   ] as [string, string, string]
   const shieldKey = String(shieldRequest.ciphertext.shieldKey)
 
-  const adaptParams = encodeYieldAdaptParams(npk, encryptedBundle, shieldKey)
+  // Redeem (withdraw) pays the broadcaster fee contract-side from the redeemed USDC proceeds, bound
+  // into adaptParams — NOT via the SDK broadcaster-fee leg, which would spend a second token (USDC)
+  // and produce a second Transaction the adapter can't consume (issue #312). Lend keeps the SDK leg
+  // (input and fee are both USDC → a single Transaction already).
+  const isRedeem = opts.mode === 'redeem'
+  const feeAmount = isRedeem ? (opts.broadcasterFee?.amount ?? 0n) : 0n
+  const feeRecipient =
+    isRedeem && feeAmount > 0n
+      ? (opts.broadcasterFee?.recipientAddress ?? ethers.ZeroAddress)
+      : ethers.ZeroAddress
+
+  const adaptParams = isRedeem
+    ? encodeYieldAdaptParamsWithFee(npk, encryptedBundle, shieldKey, feeRecipient, feeAmount)
+    : encodeYieldAdaptParams(npk, encryptedBundle, shieldKey)
 
   // Generate the cross-contract-calls proof. The unshield recipient is the adapter address;
-  // the proof binds via adaptContract + adaptParams so the adapter cannot redirect.
-  const sendWithPublicWallet = opts.broadcasterFee === null
+  // the proof binds via adaptContract + adaptParams so the adapter cannot redirect. Redeem never
+  // binds an SDK broadcaster into the proof (its fee is contract-side); lend may.
+  const sdkBroadcasterFee = isRedeem ? undefined : (opts.broadcasterFee ?? undefined)
+  const sendWithPublicWallet = isRedeem ? true : opts.broadcasterFee === null
   // Yield one frame so the caller's "Generating proof…" state paints before the WASM proof gen
   // blocks the main thread for 20-30s.
   await yieldToPaint()
@@ -237,7 +272,7 @@ export async function buildYieldAdaptTransaction(opts: {
       },
     ],
     [], // nftAmountRecipients
-    opts.broadcasterFee ?? undefined,
+    sdkBroadcasterFee,
     sendWithPublicWallet,
     { contract: opts.adapterAddress, parameters: adaptParams },
     false, // useDummyProof
@@ -249,13 +284,19 @@ export async function buildYieldAdaptTransaction(opts: {
   }
 
   const transaction = normalizeTransactionForAdapter(provedTransactions[0], opts.hubChainId)
-  const functionName = opts.mode === 'lend' ? 'lendAndShield' : 'redeemAndShield'
   const iface = new ethers.Interface(ADAPTER_ABI)
-  const data = iface.encodeFunctionData(functionName, [
-    transaction,
-    npk,
-    { encryptedBundle, shieldKey },
-  ]) as `0x${string}`
+  // redeemAndShield additionally takes (feeRecipient, feeAmount), verified against adaptParams.
+  const data = (
+    isRedeem
+      ? iface.encodeFunctionData('redeemAndShield', [
+          transaction,
+          npk,
+          { encryptedBundle, shieldKey },
+          feeRecipient,
+          feeAmount,
+        ])
+      : iface.encodeFunctionData('lendAndShield', [transaction, npk, { encryptedBundle, shieldKey }])
+  ) as `0x${string}`
 
   return {
     transaction: {

--- a/contracts/yield/ArmadaYieldAdapter.sol
+++ b/contracts/yield/ArmadaYieldAdapter.sol
@@ -260,7 +260,8 @@ contract ArmadaYieldAdapter is ReentrancyGuard {
         Transaction calldata _transaction,
         bytes32 _npk,
         ShieldCiphertext calldata _shieldCiphertext,
-        address _feeRecipient,
+        bytes32 _feeNpk,
+        ShieldCiphertext calldata _feeShieldCiphertext,
         uint256 _feeAmount
     ) external nonReentrant returns (uint256 assets) {
         _requireAuthorizedOrWithdrawOnly();
@@ -272,16 +273,18 @@ contract ArmadaYieldAdapter is ReentrancyGuard {
             "ArmadaYieldAdapter: invalid adaptContract"
         );
 
-        // 2. Verify adaptParams binds the npk, ciphertext, and broadcaster fee (recipient + amount).
-        //    Binding the fee into the proof makes it relayer-immutable: the submitter cannot redirect
-        //    the fee or inflate the amount beyond what the user committed to.
+        // 2. Verify adaptParams binds the user's shield destination, the relayer's fee-shield
+        //    destination, and the fee amount. Binding all three makes the fee relayer-immutable: the
+        //    submitter cannot redirect the fee to a different note or inflate the amount.
         require(
             YieldAdaptParams.verify(
                 _transaction.boundParams.adaptParams,
                 _npk,
                 _shieldCiphertext.encryptedBundle,
                 _shieldCiphertext.shieldKey,
-                _feeRecipient,
+                _feeNpk,
+                _feeShieldCiphertext.encryptedBundle,
+                _feeShieldCiphertext.shieldKey,
                 _feeAmount
             ),
             "ArmadaYieldAdapter: adaptParams mismatch"
@@ -306,36 +309,53 @@ contract ArmadaYieldAdapter is ReentrancyGuard {
         shareToken.approve(address(vault), shares);
         assets = vault.redeem(shares, address(this), address(this));
 
-        // 7. Pay the broadcaster (relayer) fee out of the redeemed proceeds. The fee is bound in
-        //    adaptParams (step 2), so it is the user's committed amount/recipient, not relayer-supplied.
-        //    Fee-from-proceeds keeps the whole withdraw a single Transaction and is self-funding — no
-        //    separately-shielded USDC is needed to pay the relayer (see issue #312).
+        // 7. Shield the redeemed proceeds: (assets - fee) to the user and, if fee > 0, the fee to the
+        //    relayer's own 0zk destination — both from proceeds, in a single privileged (fee-exempt)
+        //    shield. The fee is bound in adaptParams (step 2), so it is the user's committed
+        //    amount/recipient, not relayer-supplied. The relayer is paid to its shielded address, just
+        //    like every other tx type — self-funding, single Transaction (see issue #312).
         require(_feeAmount <= assets, "ArmadaYieldAdapter: fee exceeds proceeds");
-        uint256 shieldedAmount = assets - _feeAmount;
-        if (_feeAmount > 0) {
-            usdc.safeTransfer(_feeRecipient, _feeAmount);
-        }
+        usdc.approve(privacyPool, assets);
+        _shieldProceeds(_npk, _shieldCiphertext, _feeNpk, _feeShieldCiphertext, _feeAmount, assets);
 
-        // 8. Build shield request for the remaining USDC
-        ShieldRequest[] memory shieldRequests = new ShieldRequest[](1);
+        emit RedeemAndShield(_npk, shares, assets);
+    }
+
+    /**
+     * @notice Shield the redeemed proceeds — (assets - fee) to the user and, when fee > 0, the fee to
+     *         the relayer's 0zk destination — in one privileged (fee-exempt) shield call.
+     * @dev Extracted to keep redeemAndShield below the stack-depth limit. Values are set here (from the
+     *      redeemed proceeds); the shield destinations (npk + ciphertext) come from adaptParams-verified
+     *      inputs, so neither recipient can be altered by the submitter.
+     */
+    function _shieldProceeds(
+        bytes32 _npk,
+        ShieldCiphertext calldata _shieldCiphertext,
+        bytes32 _feeNpk,
+        ShieldCiphertext calldata _feeShieldCiphertext,
+        uint256 _feeAmount,
+        uint256 _assets
+    ) internal {
+        ShieldRequest[] memory shieldRequests = new ShieldRequest[](_feeAmount > 0 ? 2 : 1);
         shieldRequests[0] = ShieldRequest({
             preimage: CommitmentPreimage({
-                npk: _npk,  // User's npk from verified adaptParams
-                token: TokenData({
-                    tokenType: TokenType.ERC20,
-                    tokenAddress: address(usdc),
-                    tokenSubID: 0
-                }),
-                value: uint120(shieldedAmount)
+                npk: _npk, // User's npk from verified adaptParams
+                token: TokenData({ tokenType: TokenType.ERC20, tokenAddress: address(usdc), tokenSubID: 0 }),
+                value: uint120(_assets - _feeAmount)
             }),
             ciphertext: _shieldCiphertext
         });
-
-        // 9. Shield the remaining USDC to user's npk
-        usdc.approve(privacyPool, shieldedAmount);
+        if (_feeAmount > 0) {
+            shieldRequests[1] = ShieldRequest({
+                preimage: CommitmentPreimage({
+                    npk: _feeNpk, // Relayer's 0zk npk from verified adaptParams
+                    token: TokenData({ tokenType: TokenType.ERC20, tokenAddress: address(usdc), tokenSubID: 0 }),
+                    value: uint120(_feeAmount)
+                }),
+                ciphertext: _feeShieldCiphertext
+            });
+        }
         IPrivacyPool(privacyPool).shield(shieldRequests, address(0));
-
-        emit RedeemAndShield(_npk, shares, assets);
     }
 
     // ============ View Functions ============

--- a/contracts/yield/ArmadaYieldAdapter.sol
+++ b/contracts/yield/ArmadaYieldAdapter.sol
@@ -315,6 +315,10 @@ contract ArmadaYieldAdapter is ReentrancyGuard {
         //    amount/recipient, not relayer-supplied. The relayer is paid to its shielded address, just
         //    like every other tx type — self-funding, single Transaction (see issue #312).
         require(_feeAmount <= assets, "ArmadaYieldAdapter: fee exceeds proceeds");
+        // Defensive: a non-zero fee must have a real destination. adaptParams already pins feeNpk to
+        // the user's committed value, but a frontend bug committing feeNpk == 0 with feeAmount > 0 would
+        // shield the fee to an unspendable note (burning it). Refuse rather than silently burn funds.
+        require(_feeAmount == 0 || _feeNpk != bytes32(0), "ArmadaYieldAdapter: fee without destination");
         usdc.approve(privacyPool, assets);
         _shieldProceeds(_npk, _shieldCiphertext, _feeNpk, _feeShieldCiphertext, _feeAmount, assets);
 

--- a/contracts/yield/ArmadaYieldAdapter.sol
+++ b/contracts/yield/ArmadaYieldAdapter.sol
@@ -259,7 +259,9 @@ contract ArmadaYieldAdapter is ReentrancyGuard {
     function redeemAndShield(
         Transaction calldata _transaction,
         bytes32 _npk,
-        ShieldCiphertext calldata _shieldCiphertext
+        ShieldCiphertext calldata _shieldCiphertext,
+        address _feeRecipient,
+        uint256 _feeAmount
     ) external nonReentrant returns (uint256 assets) {
         _requireAuthorizedOrWithdrawOnly();
         require(privacyPool != address(0), "ArmadaYieldAdapter: no privacyPool");
@@ -270,13 +272,17 @@ contract ArmadaYieldAdapter is ReentrancyGuard {
             "ArmadaYieldAdapter: invalid adaptContract"
         );
 
-        // 2. Verify adaptParams binds the npk and ciphertext
+        // 2. Verify adaptParams binds the npk, ciphertext, and broadcaster fee (recipient + amount).
+        //    Binding the fee into the proof makes it relayer-immutable: the submitter cannot redirect
+        //    the fee or inflate the amount beyond what the user committed to.
         require(
             YieldAdaptParams.verify(
                 _transaction.boundParams.adaptParams,
                 _npk,
                 _shieldCiphertext.encryptedBundle,
-                _shieldCiphertext.shieldKey
+                _shieldCiphertext.shieldKey,
+                _feeRecipient,
+                _feeAmount
             ),
             "ArmadaYieldAdapter: adaptParams mismatch"
         );
@@ -300,7 +306,17 @@ contract ArmadaYieldAdapter is ReentrancyGuard {
         shareToken.approve(address(vault), shares);
         assets = vault.redeem(shares, address(this), address(this));
 
-        // 7. Build shield request for USDC
+        // 7. Pay the broadcaster (relayer) fee out of the redeemed proceeds. The fee is bound in
+        //    adaptParams (step 2), so it is the user's committed amount/recipient, not relayer-supplied.
+        //    Fee-from-proceeds keeps the whole withdraw a single Transaction and is self-funding — no
+        //    separately-shielded USDC is needed to pay the relayer (see issue #312).
+        require(_feeAmount <= assets, "ArmadaYieldAdapter: fee exceeds proceeds");
+        uint256 shieldedAmount = assets - _feeAmount;
+        if (_feeAmount > 0) {
+            usdc.safeTransfer(_feeRecipient, _feeAmount);
+        }
+
+        // 8. Build shield request for the remaining USDC
         ShieldRequest[] memory shieldRequests = new ShieldRequest[](1);
         shieldRequests[0] = ShieldRequest({
             preimage: CommitmentPreimage({
@@ -310,13 +326,13 @@ contract ArmadaYieldAdapter is ReentrancyGuard {
                     tokenAddress: address(usdc),
                     tokenSubID: 0
                 }),
-                value: uint120(assets)
+                value: uint120(shieldedAmount)
             }),
             ciphertext: _shieldCiphertext
         });
 
-        // 8. Shield USDC to user's npk
-        usdc.approve(privacyPool, assets);
+        // 9. Shield the remaining USDC to user's npk
+        usdc.approve(privacyPool, shieldedAmount);
         IPrivacyPool(privacyPool).shield(shieldRequests, address(0));
 
         emit RedeemAndShield(_npk, shares, assets);

--- a/contracts/yield/YieldAdaptParams.sol
+++ b/contracts/yield/YieldAdaptParams.sol
@@ -36,14 +36,18 @@ library YieldAdaptParams {
     }
 
     /**
-     * @notice Encode shield destination + broadcaster fee (redeem / withdraw path).
-     * @dev The fee is bound into adaptParams so a relayer cannot redirect it or inflate the amount.
-     *      Produces a DIFFERENT commitment than the 3-arg overload — the two paths are distinct.
+     * @notice Encode the user's shield destination + the broadcaster fee, where the fee is itself paid
+     *         as a SHIELD to the relayer's own 0zk destination (redeem / withdraw path).
+     * @dev Binding both shield destinations + the amount makes the fee relayer-immutable: the submitter
+     *      cannot redirect the fee to a different note or inflate its amount. Produces a DIFFERENT
+     *      commitment than the 3-arg overload — the two paths are distinct.
      *
-     * @param npk Note public key for re-shielding (user's receiving key)
-     * @param encryptedBundle Shield ciphertext bundle [3]
-     * @param shieldKey Public key used to generate shared encryption key
-     * @param feeRecipient Broadcaster (relayer) fee recipient, paid from proceeds (address(0) if no fee)
+     * @param npk Note public key for the user's re-shield (user's receiving key)
+     * @param encryptedBundle User's shield ciphertext bundle [3]
+     * @param shieldKey User's shield public key
+     * @param feeNpk Note public key for the relayer's fee shield (relayer's 0zk receiving key; 0 if no fee)
+     * @param feeEncryptedBundle Relayer's shield ciphertext bundle [3] (zeroed if no fee)
+     * @param feeShieldKey Relayer's shield public key (0 if no fee)
      * @param feeAmount Broadcaster fee amount in the proceeds token's raw units (0 if no fee)
      * @return adaptParams Keccak256 hash of all parameters
      */
@@ -51,10 +55,14 @@ library YieldAdaptParams {
         bytes32 npk,
         bytes32[3] memory encryptedBundle,
         bytes32 shieldKey,
-        address feeRecipient,
+        bytes32 feeNpk,
+        bytes32[3] memory feeEncryptedBundle,
+        bytes32 feeShieldKey,
         uint256 feeAmount
     ) internal pure returns (bytes32) {
-        return keccak256(abi.encode(npk, encryptedBundle, shieldKey, feeRecipient, feeAmount));
+        return keccak256(
+            abi.encode(npk, encryptedBundle, shieldKey, feeNpk, feeEncryptedBundle, feeShieldKey, feeAmount)
+        );
     }
 
     /**
@@ -76,15 +84,18 @@ library YieldAdaptParams {
     }
 
     /**
-     * @notice Verify a shield request + broadcaster fee match the bound adaptParams (redeem / withdraw path).
+     * @notice Verify the user's shield request + the relayer fee-shield destination match the bound
+     *         adaptParams (redeem / withdraw path).
      * @dev If this fails the adapter cannot proceed — ensuring trustless execution and a
-     *      relayer-immutable fee.
+     *      relayer-immutable fee paid to the relayer's own 0zk address.
      *
      * @param adaptParams The bound parameters from the user's transaction proof
-     * @param npk Note public key from shield request
-     * @param encryptedBundle Shield ciphertext from shield request
-     * @param shieldKey Shield public key from shield request
-     * @param feeRecipient Broadcaster fee recipient supplied to the adapter
+     * @param npk User's re-shield note public key
+     * @param encryptedBundle User's shield ciphertext
+     * @param shieldKey User's shield public key
+     * @param feeNpk Relayer's fee-shield note public key
+     * @param feeEncryptedBundle Relayer's fee-shield ciphertext
+     * @param feeShieldKey Relayer's fee-shield public key
      * @param feeAmount Broadcaster fee amount supplied to the adapter
      * @return True if parameters match the commitment
      */
@@ -93,9 +104,12 @@ library YieldAdaptParams {
         bytes32 npk,
         bytes32[3] memory encryptedBundle,
         bytes32 shieldKey,
-        address feeRecipient,
+        bytes32 feeNpk,
+        bytes32[3] memory feeEncryptedBundle,
+        bytes32 feeShieldKey,
         uint256 feeAmount
     ) internal pure returns (bool) {
-        return adaptParams == encode(npk, encryptedBundle, shieldKey, feeRecipient, feeAmount);
+        return adaptParams
+            == encode(npk, encryptedBundle, shieldKey, feeNpk, feeEncryptedBundle, feeShieldKey, feeAmount);
     }
 }

--- a/contracts/yield/YieldAdaptParams.sol
+++ b/contracts/yield/YieldAdaptParams.sol
@@ -11,16 +11,16 @@ import "../railgun/logic/Globals.sol";
  *      what the user committed to in their SNARK proof.
  *
  *      Trust Model:
- *      - User generates proof with adaptParams = hash(npk, encryptedBundle, shieldKey)
- *      - Adapter verifies the provided shield parameters match adaptParams
+ *      - User generates proof with adaptParams = hash(npk, encryptedBundle, shieldKey, feeRecipient, feeAmount)
+ *      - Adapter verifies the provided shield parameters AND broadcaster fee match adaptParams
  *      - If they don't match → revert
- *      - This makes the adapter trustless: it MUST use the user's committed parameters
+ *      - This makes the adapter trustless: it MUST use the user's committed parameters, and a
+ *        relayer cannot redirect the fee or inflate its amount beyond what the user committed to.
  */
 library YieldAdaptParams {
     /**
-     * @notice Encode yield operation parameters into adaptParams
-     * @dev Called by frontend when generating the unshield proof.
-     *      The resulting hash is set as boundParams.adaptParams in the transaction.
+     * @notice Encode shield-destination-only parameters (lend / deposit path — no adapter-side fee).
+     * @dev Called by frontend when generating the deposit unshield proof.
      *
      * @param npk Note public key for re-shielding (user's receiving key)
      * @param encryptedBundle Shield ciphertext bundle [3]
@@ -36,9 +36,29 @@ library YieldAdaptParams {
     }
 
     /**
-     * @notice Verify that shield request matches the bound adaptParams
-     * @dev Called by adapter before executing. If this fails, the adapter
-     *      cannot proceed - ensuring trustless execution.
+     * @notice Encode shield destination + broadcaster fee (redeem / withdraw path).
+     * @dev The fee is bound into adaptParams so a relayer cannot redirect it or inflate the amount.
+     *      Produces a DIFFERENT commitment than the 3-arg overload — the two paths are distinct.
+     *
+     * @param npk Note public key for re-shielding (user's receiving key)
+     * @param encryptedBundle Shield ciphertext bundle [3]
+     * @param shieldKey Public key used to generate shared encryption key
+     * @param feeRecipient Broadcaster (relayer) fee recipient, paid from proceeds (address(0) if no fee)
+     * @param feeAmount Broadcaster fee amount in the proceeds token's raw units (0 if no fee)
+     * @return adaptParams Keccak256 hash of all parameters
+     */
+    function encode(
+        bytes32 npk,
+        bytes32[3] memory encryptedBundle,
+        bytes32 shieldKey,
+        address feeRecipient,
+        uint256 feeAmount
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(npk, encryptedBundle, shieldKey, feeRecipient, feeAmount));
+    }
+
+    /**
+     * @notice Verify a shield request matches the bound adaptParams (lend / deposit path).
      *
      * @param adaptParams The bound parameters from the user's transaction proof
      * @param npk Note public key from shield request
@@ -53,5 +73,29 @@ library YieldAdaptParams {
         bytes32 shieldKey
     ) internal pure returns (bool) {
         return adaptParams == encode(npk, encryptedBundle, shieldKey);
+    }
+
+    /**
+     * @notice Verify a shield request + broadcaster fee match the bound adaptParams (redeem / withdraw path).
+     * @dev If this fails the adapter cannot proceed — ensuring trustless execution and a
+     *      relayer-immutable fee.
+     *
+     * @param adaptParams The bound parameters from the user's transaction proof
+     * @param npk Note public key from shield request
+     * @param encryptedBundle Shield ciphertext from shield request
+     * @param shieldKey Shield public key from shield request
+     * @param feeRecipient Broadcaster fee recipient supplied to the adapter
+     * @param feeAmount Broadcaster fee amount supplied to the adapter
+     * @return True if parameters match the commitment
+     */
+    function verify(
+        bytes32 adaptParams,
+        bytes32 npk,
+        bytes32[3] memory encryptedBundle,
+        bytes32 shieldKey,
+        address feeRecipient,
+        uint256 feeAmount
+    ) internal pure returns (bool) {
+        return adaptParams == encode(npk, encryptedBundle, shieldKey, feeRecipient, feeAmount);
     }
 }

--- a/test-foundry/AdapterRegistryEnforcement.t.sol
+++ b/test-foundry/AdapterRegistryEnforcement.t.sol
@@ -79,7 +79,7 @@ contract AdapterRegistryEnforcementTest is Test {
     function test_redeemAndShield_revertsWhenNotAuthorized() public {
         // Registry: adapter is NOT authorized and NOT withdraw-only
         vm.expectRevert("ArmadaYieldAdapter: not authorized or withdraw-only");
-        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext());
+        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), address(0), 0);
     }
 
     function test_redeemAndShield_passesAuthCheckWhenAuthorized() public {
@@ -88,7 +88,7 @@ contract AdapterRegistryEnforcementTest is Test {
 
         // Should pass auth check but revert later (no privacy pool)
         vm.expectRevert("ArmadaYieldAdapter: no privacyPool");
-        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext());
+        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), address(0), 0);
     }
 
     function test_redeemAndShield_passesAuthCheckWhenWithdrawOnly() public {
@@ -97,7 +97,7 @@ contract AdapterRegistryEnforcementTest is Test {
 
         // Should pass auth check but revert later (no privacy pool)
         vm.expectRevert("ArmadaYieldAdapter: no privacyPool");
-        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext());
+        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), address(0), 0);
     }
 
     // ======== Constructor validation ========
@@ -129,7 +129,7 @@ contract AdapterRegistryEnforcementTest is Test {
 
         // redeemAndShield still works (passes auth, reverts on privacyPool)
         vm.expectRevert("ArmadaYieldAdapter: no privacyPool");
-        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext());
+        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), address(0), 0);
     }
 
     function test_lifecycle_fullDeauthBlocksEverything() public {
@@ -138,6 +138,6 @@ contract AdapterRegistryEnforcementTest is Test {
         adapter.lendAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext());
 
         vm.expectRevert("ArmadaYieldAdapter: not authorized or withdraw-only");
-        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext());
+        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), address(0), 0);
     }
 }

--- a/test-foundry/AdapterRegistryEnforcement.t.sol
+++ b/test-foundry/AdapterRegistryEnforcement.t.sol
@@ -79,7 +79,7 @@ contract AdapterRegistryEnforcementTest is Test {
     function test_redeemAndShield_revertsWhenNotAuthorized() public {
         // Registry: adapter is NOT authorized and NOT withdraw-only
         vm.expectRevert("ArmadaYieldAdapter: not authorized or withdraw-only");
-        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), address(0), 0);
+        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), bytes32(0), _dummyCiphertext(), 0);
     }
 
     function test_redeemAndShield_passesAuthCheckWhenAuthorized() public {
@@ -88,7 +88,7 @@ contract AdapterRegistryEnforcementTest is Test {
 
         // Should pass auth check but revert later (no privacy pool)
         vm.expectRevert("ArmadaYieldAdapter: no privacyPool");
-        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), address(0), 0);
+        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), bytes32(0), _dummyCiphertext(), 0);
     }
 
     function test_redeemAndShield_passesAuthCheckWhenWithdrawOnly() public {
@@ -97,7 +97,7 @@ contract AdapterRegistryEnforcementTest is Test {
 
         // Should pass auth check but revert later (no privacy pool)
         vm.expectRevert("ArmadaYieldAdapter: no privacyPool");
-        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), address(0), 0);
+        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), bytes32(0), _dummyCiphertext(), 0);
     }
 
     // ======== Constructor validation ========
@@ -129,7 +129,7 @@ contract AdapterRegistryEnforcementTest is Test {
 
         // redeemAndShield still works (passes auth, reverts on privacyPool)
         vm.expectRevert("ArmadaYieldAdapter: no privacyPool");
-        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), address(0), 0);
+        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), bytes32(0), _dummyCiphertext(), 0);
     }
 
     function test_lifecycle_fullDeauthBlocksEverything() public {
@@ -138,6 +138,6 @@ contract AdapterRegistryEnforcementTest is Test {
         adapter.lendAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext());
 
         vm.expectRevert("ArmadaYieldAdapter: not authorized or withdraw-only");
-        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), address(0), 0);
+        adapter.redeemAndShield(_dummyTransaction(), bytes32(0), _dummyCiphertext(), bytes32(0), _dummyCiphertext(), 0);
     }
 }

--- a/test-foundry/YieldAdaptParamsFee.t.sol
+++ b/test-foundry/YieldAdaptParamsFee.t.sol
@@ -1,0 +1,62 @@
+// ABOUTME: Tests YieldAdaptParams fee binding — the withdraw broadcaster fee (recipient + amount) is
+// ABOUTME: committed into adaptParams so a relayer cannot redirect or inflate it (issue #312).
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/yield/YieldAdaptParams.sol";
+
+contract YieldAdaptParamsFeeTest is Test {
+    bytes32 constant NPK = bytes32(uint256(0x1234));
+    bytes32 constant SHIELD_KEY = bytes32(uint256(0x5678));
+
+    function _bundle() internal pure returns (bytes32[3] memory b) {
+        b[0] = bytes32(uint256(1));
+        b[1] = bytes32(uint256(2));
+        b[2] = bytes32(uint256(3));
+    }
+
+    /// @dev WHY: redeemAndShield verifies (feeRecipient, feeAmount) against adaptParams, so the exact
+    ///      committed values must pass verification for the happy path to work at all.
+    function test_verify_acceptsCommittedFee() public {
+        address feeRecipient = address(0xBEEF);
+        uint256 feeAmount = 1_000_000;
+        bytes32 ap = YieldAdaptParams.encode(NPK, _bundle(), SHIELD_KEY, feeRecipient, feeAmount);
+        assertTrue(YieldAdaptParams.verify(ap, NPK, _bundle(), SHIELD_KEY, feeRecipient, feeAmount));
+    }
+
+    /// @dev WHY: the core relayer-immutability property — a submitter that redirects the fee to a
+    ///      different recipient than the user committed to must fail verification (adapter reverts).
+    function test_verify_rejectsRedirectedFee() public {
+        bytes32 ap = YieldAdaptParams.encode(NPK, _bundle(), SHIELD_KEY, address(0xBEEF), 1_000_000);
+        assertFalse(YieldAdaptParams.verify(ap, NPK, _bundle(), SHIELD_KEY, address(0xBAD), 1_000_000));
+    }
+
+    /// @dev WHY: a submitter that inflates the fee amount beyond the user's commitment must fail.
+    function test_verify_rejectsInflatedFee() public {
+        bytes32 ap = YieldAdaptParams.encode(NPK, _bundle(), SHIELD_KEY, address(0xBEEF), 1_000_000);
+        assertFalse(YieldAdaptParams.verify(ap, NPK, _bundle(), SHIELD_KEY, address(0xBEEF), 2_000_000));
+    }
+
+    /// @dev WHY: fuzz the immutability — ANY deviation in recipient or amount from the commitment
+    ///      must fail verification.
+    function testFuzz_verify_rejectsAnyFeeDeviation(
+        address rightRecipient,
+        uint256 rightAmount,
+        address wrongRecipient,
+        uint256 wrongAmount
+    ) public {
+        vm.assume(rightRecipient != wrongRecipient || rightAmount != wrongAmount);
+        bytes32 ap = YieldAdaptParams.encode(NPK, _bundle(), SHIELD_KEY, rightRecipient, rightAmount);
+        assertFalse(YieldAdaptParams.verify(ap, NPK, _bundle(), SHIELD_KEY, wrongRecipient, wrongAmount));
+    }
+
+    /// @dev WHY: the deposit (3-arg, no fee) and withdraw (5-arg, fee-bound) schemes must produce
+    ///      DIFFERENT commitments, so a deposit proof cannot be replayed as a zero-fee withdraw.
+    function test_encode_depositAndWithdrawSchemesDiffer() public {
+        bytes32 deposit = YieldAdaptParams.encode(NPK, _bundle(), SHIELD_KEY);
+        bytes32 withdrawZeroFee = YieldAdaptParams.encode(NPK, _bundle(), SHIELD_KEY, address(0), 0);
+        assertTrue(deposit != withdrawZeroFee, "deposit and withdraw adaptParams schemes must differ");
+    }
+}

--- a/test-foundry/YieldAdaptParamsFee.t.sol
+++ b/test-foundry/YieldAdaptParamsFee.t.sol
@@ -1,5 +1,5 @@
-// ABOUTME: Tests YieldAdaptParams fee binding — the withdraw broadcaster fee (recipient + amount) is
-// ABOUTME: committed into adaptParams so a relayer cannot redirect or inflate it (issue #312).
+// ABOUTME: Tests YieldAdaptParams fee binding — the withdraw broadcaster fee (the relayer's 0zk shield
+// ABOUTME: destination + amount) is committed into adaptParams so a relayer cannot redirect or inflate it (#312).
 
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
@@ -10,53 +10,74 @@ import "../contracts/yield/YieldAdaptParams.sol";
 contract YieldAdaptParamsFeeTest is Test {
     bytes32 constant NPK = bytes32(uint256(0x1234));
     bytes32 constant SHIELD_KEY = bytes32(uint256(0x5678));
+    bytes32 constant FEE_NPK = bytes32(uint256(0xFEE1));
+    bytes32 constant FEE_SHIELD_KEY = bytes32(uint256(0xFEE2));
+    uint256 constant FEE_AMOUNT = 5_000_000;
 
-    function _bundle() internal pure returns (bytes32[3] memory b) {
-        b[0] = bytes32(uint256(1));
-        b[1] = bytes32(uint256(2));
-        b[2] = bytes32(uint256(3));
+    function _bundle(uint256 seed) internal pure returns (bytes32[3] memory b) {
+        b[0] = bytes32(seed + 1);
+        b[1] = bytes32(seed + 2);
+        b[2] = bytes32(seed + 3);
     }
 
-    /// @dev WHY: redeemAndShield verifies (feeRecipient, feeAmount) against adaptParams, so the exact
-    ///      committed values must pass verification for the happy path to work at all.
-    function test_verify_acceptsCommittedFee() public {
-        address feeRecipient = address(0xBEEF);
-        uint256 feeAmount = 1_000_000;
-        bytes32 ap = YieldAdaptParams.encode(NPK, _bundle(), SHIELD_KEY, feeRecipient, feeAmount);
-        assertTrue(YieldAdaptParams.verify(ap, NPK, _bundle(), SHIELD_KEY, feeRecipient, feeAmount));
+    /// @dev WHY: redeemAndShield verifies the relayer's fee-shield destination + amount against
+    ///      adaptParams, so the exact committed values must pass verification for the happy path.
+    function test_verify_acceptsCommittedFeeShield() public {
+        bytes32 ap =
+            YieldAdaptParams.encode(NPK, _bundle(0), SHIELD_KEY, FEE_NPK, _bundle(100), FEE_SHIELD_KEY, FEE_AMOUNT);
+        assertTrue(
+            YieldAdaptParams.verify(ap, NPK, _bundle(0), SHIELD_KEY, FEE_NPK, _bundle(100), FEE_SHIELD_KEY, FEE_AMOUNT)
+        );
     }
 
     /// @dev WHY: the core relayer-immutability property — a submitter that redirects the fee to a
-    ///      different recipient than the user committed to must fail verification (adapter reverts).
-    function test_verify_rejectsRedirectedFee() public {
-        bytes32 ap = YieldAdaptParams.encode(NPK, _bundle(), SHIELD_KEY, address(0xBEEF), 1_000_000);
-        assertFalse(YieldAdaptParams.verify(ap, NPK, _bundle(), SHIELD_KEY, address(0xBAD), 1_000_000));
+    ///      DIFFERENT 0zk destination (fee npk) than the user committed to must fail verification.
+    function test_verify_rejectsRedirectedFeeNpk() public {
+        bytes32 ap =
+            YieldAdaptParams.encode(NPK, _bundle(0), SHIELD_KEY, FEE_NPK, _bundle(100), FEE_SHIELD_KEY, FEE_AMOUNT);
+        bytes32 attackerNpk = bytes32(uint256(0xBAD));
+        assertFalse(
+            YieldAdaptParams.verify(
+                ap, NPK, _bundle(0), SHIELD_KEY, attackerNpk, _bundle(100), FEE_SHIELD_KEY, FEE_AMOUNT
+            )
+        );
     }
 
     /// @dev WHY: a submitter that inflates the fee amount beyond the user's commitment must fail.
     function test_verify_rejectsInflatedFee() public {
-        bytes32 ap = YieldAdaptParams.encode(NPK, _bundle(), SHIELD_KEY, address(0xBEEF), 1_000_000);
-        assertFalse(YieldAdaptParams.verify(ap, NPK, _bundle(), SHIELD_KEY, address(0xBEEF), 2_000_000));
+        bytes32 ap =
+            YieldAdaptParams.encode(NPK, _bundle(0), SHIELD_KEY, FEE_NPK, _bundle(100), FEE_SHIELD_KEY, FEE_AMOUNT);
+        assertFalse(
+            YieldAdaptParams.verify(
+                ap, NPK, _bundle(0), SHIELD_KEY, FEE_NPK, _bundle(100), FEE_SHIELD_KEY, FEE_AMOUNT * 2
+            )
+        );
     }
 
-    /// @dev WHY: fuzz the immutability — ANY deviation in recipient or amount from the commitment
+    /// @dev WHY: fuzz the immutability — ANY deviation in the fee npk or amount from the commitment
     ///      must fail verification.
     function testFuzz_verify_rejectsAnyFeeDeviation(
-        address rightRecipient,
+        bytes32 rightFeeNpk,
         uint256 rightAmount,
-        address wrongRecipient,
+        bytes32 wrongFeeNpk,
         uint256 wrongAmount
     ) public {
-        vm.assume(rightRecipient != wrongRecipient || rightAmount != wrongAmount);
-        bytes32 ap = YieldAdaptParams.encode(NPK, _bundle(), SHIELD_KEY, rightRecipient, rightAmount);
-        assertFalse(YieldAdaptParams.verify(ap, NPK, _bundle(), SHIELD_KEY, wrongRecipient, wrongAmount));
+        vm.assume(rightFeeNpk != wrongFeeNpk || rightAmount != wrongAmount);
+        bytes32 ap =
+            YieldAdaptParams.encode(NPK, _bundle(0), SHIELD_KEY, rightFeeNpk, _bundle(100), FEE_SHIELD_KEY, rightAmount);
+        assertFalse(
+            YieldAdaptParams.verify(
+                ap, NPK, _bundle(0), SHIELD_KEY, wrongFeeNpk, _bundle(100), FEE_SHIELD_KEY, wrongAmount
+            )
+        );
     }
 
-    /// @dev WHY: the deposit (3-arg, no fee) and withdraw (5-arg, fee-bound) schemes must produce
+    /// @dev WHY: the deposit (3-arg, no fee) and withdraw (7-arg, fee-bound) schemes must produce
     ///      DIFFERENT commitments, so a deposit proof cannot be replayed as a zero-fee withdraw.
     function test_encode_depositAndWithdrawSchemesDiffer() public {
-        bytes32 deposit = YieldAdaptParams.encode(NPK, _bundle(), SHIELD_KEY);
-        bytes32 withdrawZeroFee = YieldAdaptParams.encode(NPK, _bundle(), SHIELD_KEY, address(0), 0);
+        bytes32 deposit = YieldAdaptParams.encode(NPK, _bundle(0), SHIELD_KEY);
+        bytes32 withdrawZeroFee =
+            YieldAdaptParams.encode(NPK, _bundle(0), SHIELD_KEY, bytes32(0), _bundle(0), bytes32(0), 0);
         assertTrue(deposit != withdrawZeroFee, "deposit and withdraw adaptParams schemes must differ");
     }
 }

--- a/test/shielded_yield_integration.ts
+++ b/test/shielded_yield_integration.ts
@@ -737,6 +737,118 @@ describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
         )
       ).to.be.revertedWith("ArmadaYieldAdapter: adaptParams mismatch");
     });
+
+    // Build a redeem Transaction after lending `lendAmount`, with the given fee shield destination
+    // bound into adaptParams. Returns everything needed to call redeemAndShield.
+    async function lendThenRedeemInputs(seed: string, feeNpk: string, feeAmount: bigint) {
+      const lendAmount = ethers.parseUnits("1000", 6);
+      await shieldAndGetRoot(lendAmount);
+      const npk = validNpk();
+      const encryptedBundle: [string, string, string] = [
+        ethers.keccak256(ethers.toUtf8Bytes(`enc1-${seed}`)),
+        ethers.keccak256(ethers.toUtf8Bytes(`enc2-${seed}`)),
+        ethers.keccak256(ethers.toUtf8Bytes(`enc3-${seed}`)),
+      ];
+      const shieldKey = ethers.keccak256(ethers.toUtf8Bytes(`key-${seed}`));
+      const lendTx = await makeLendTransaction({
+        merkleRoot: await privacyPool.merkleRoot(),
+        nullifier: ethers.keccak256(ethers.toUtf8Bytes(`null-lend-${seed}`)),
+        unshieldPreimage: {
+          npk: ethers.zeroPadValue(adapterAddress, 32),
+          tokenAddress: usdcAddress,
+          value: lendAmount,
+        },
+        adaptContract: adapterAddress,
+        adaptParams: encodeYieldAdaptParams(npk, encryptedBundle, shieldKey),
+        npk,
+        encryptedBundle,
+        shieldKey,
+      });
+      await armadaYieldAdapter.lendAndShield(lendTx, npk, { encryptedBundle, shieldKey });
+      const shares = await armadaYieldVault.balanceOf(privacyPoolAddress);
+
+      const feeBundle: [string, string, string] = [
+        ethers.keccak256(ethers.toUtf8Bytes(`r1-${seed}`)),
+        ethers.keccak256(ethers.toUtf8Bytes(`r2-${seed}`)),
+        ethers.keccak256(ethers.toUtf8Bytes(`r3-${seed}`)),
+      ];
+      const feeShieldKey = ethers.keccak256(ethers.toUtf8Bytes(`rkey-${seed}`));
+      const redeemAdaptParams = encodeYieldAdaptParamsWithFee(
+        npk,
+        encryptedBundle,
+        shieldKey,
+        feeNpk,
+        feeBundle,
+        feeShieldKey,
+        feeAmount
+      );
+      const unshieldHash = computeCommitmentHash(
+        BigInt(ethers.zeroPadValue(adapterAddress, 32)),
+        BigInt(vaultAddress),
+        shares
+      );
+      const redeemTx = {
+        proof: { a: { x: 0, y: 0 }, b: { x: [0, 0], y: [0, 0] }, c: { x: 0, y: 0 } },
+        merkleRoot: await privacyPool.merkleRoot(),
+        nullifiers: [ethers.keccak256(ethers.toUtf8Bytes(`null-redeem-${seed}`))],
+        commitments: [unshieldHash],
+        boundParams: {
+          treeNumber: 0,
+          minGasPrice: 0,
+          unshield: 1,
+          chainID: (await ethers.provider.getNetwork()).chainId,
+          adaptContract: adapterAddress,
+          adaptParams: redeemAdaptParams,
+          commitmentCiphertext: [],
+        },
+        unshieldPreimage: {
+          npk: ethers.zeroPadValue(adapterAddress, 32),
+          token: { tokenType: 0, tokenAddress: vaultAddress, tokenSubID: 0 },
+          value: shares,
+        },
+      };
+      return { redeemTx, npk, encryptedBundle, shieldKey, feeBundle, feeShieldKey };
+    }
+
+    // WHY: the fee is paid from the redeemed proceeds, so a fee that exceeds the redeemed assets must
+    // revert (rather than underflow the user's shield or over-pay the relayer). Guards issue #312.
+    it("reverts when the fee amount exceeds the redeemed proceeds", async function () {
+      const feeNpk = ethers.zeroPadValue(
+        ethers.toBeHex(BigInt(ethers.keccak256(ethers.toUtf8Bytes("relayer-npk-fx"))) % SNARK_SCALAR_FIELD),
+        32
+      );
+      // Far larger than any assets the pool's cumulative shares can redeem to — guarantees the
+      // fee-exceeds-proceeds guard trips. The revert rolls back the redeem, so no state leaks.
+      const feeAmount = ethers.parseUnits("1000000000", 6);
+      const io = await lendThenRedeemInputs("fx", feeNpk, feeAmount);
+      await expect(
+        armadaYieldAdapter.redeemAndShield(
+          io.redeemTx,
+          io.npk,
+          { encryptedBundle: io.encryptedBundle, shieldKey: io.shieldKey },
+          feeNpk,
+          { encryptedBundle: io.feeBundle, shieldKey: io.feeShieldKey },
+          feeAmount
+        )
+      ).to.be.revertedWith("ArmadaYieldAdapter: fee exceeds proceeds");
+    });
+
+    // WHY: a fund-custody contract must not silently burn a fee to an unspendable note. A non-zero fee
+    // committed with a zero destination npk (e.g. a frontend bug) must revert, not shield to npk 0.
+    it("reverts when a non-zero fee has a zero destination npk", async function () {
+      const feeAmount = ethers.parseUnits("5", 6);
+      const io = await lendThenRedeemInputs("zn", ethers.ZeroHash, feeAmount);
+      await expect(
+        armadaYieldAdapter.redeemAndShield(
+          io.redeemTx,
+          io.npk,
+          { encryptedBundle: io.encryptedBundle, shieldKey: io.shieldKey },
+          ethers.ZeroHash,
+          { encryptedBundle: io.feeBundle, shieldKey: io.feeShieldKey },
+          feeAmount
+        )
+      ).to.be.revertedWith("ArmadaYieldAdapter: fee without destination");
+    });
   });
 
   describe("fee exemption", function () {

--- a/test/shielded_yield_integration.ts
+++ b/test/shielded_yield_integration.ts
@@ -45,6 +45,24 @@ function encodeYieldAdaptParams(
   return ethers.keccak256(encoded);
 }
 
+/**
+ * Encode the withdraw (redeem) YieldAdaptParams with the broadcaster fee bound in.
+ * Must match Solidity YieldAdaptParams.encode(npk, bundle, shieldKey, feeRecipient, feeAmount).
+ */
+function encodeYieldAdaptParamsWithFee(
+  npk: string,
+  encryptedBundle: [string, string, string],
+  shieldKey: string,
+  feeRecipient: string,
+  feeAmount: bigint
+): string {
+  const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
+    ["bytes32", "bytes32[3]", "bytes32", "address", "uint256"],
+    [npk, encryptedBundle, shieldKey, feeRecipient, feeAmount]
+  );
+  return ethers.keccak256(encoded);
+}
+
 describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
   let hubUsdc: Contract;
   let hubTokenMessenger: Contract;
@@ -417,7 +435,17 @@ describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
       const shares = await armadaYieldVault.balanceOf(privacyPoolAddress);
       expect(shares).to.be.gt(0n);
 
-      const redeemAdaptParams = encodeYieldAdaptParams(npk, encryptedBundle, shieldKey);
+      // No broadcaster fee for this base case: withdraw adaptParams still uses the 5-arg (fee-bound)
+      // scheme with (feeRecipient=0, feeAmount=0).
+      const feeRecipient = ethers.ZeroAddress;
+      const feeAmount = 0n;
+      const redeemAdaptParams = encodeYieldAdaptParamsWithFee(
+        npk,
+        encryptedBundle,
+        shieldKey,
+        feeRecipient,
+        feeAmount
+      );
       const unshieldHash = computeCommitmentHash(
         BigInt(ethers.zeroPadValue(adapterAddress, 32)),
         BigInt(vaultAddress),
@@ -455,12 +483,17 @@ describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
       const assets = await armadaYieldAdapter.redeemAndShield.staticCall(
         redeemTx,
         npk,
-        { encryptedBundle, shieldKey }
+        { encryptedBundle, shieldKey },
+        feeRecipient,
+        feeAmount
       );
-      await armadaYieldAdapter.redeemAndShield(redeemTx, npk, {
-        encryptedBundle,
-        shieldKey,
-      });
+      await armadaYieldAdapter.redeemAndShield(
+        redeemTx,
+        npk,
+        { encryptedBundle, shieldKey },
+        feeRecipient,
+        feeAmount
+      );
 
       const poolUsdcAfter = await hubUsdc.balanceOf(privacyPoolAddress);
       const poolAyAfter = await armadaYieldVault.balanceOf(privacyPoolAddress);
@@ -468,6 +501,185 @@ describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
       expect(assets).to.be.gt(0n);
       expect(poolAyAfter - poolAyBefore).to.equal(-shares);
       expect(poolUsdcAfter - poolUsdcBefore).to.be.closeTo(assets, 10n);
+    });
+
+    // WHY: issue #312 — the relayer fee is paid from the redeemed USDC proceeds (bound in adaptParams),
+    // not from a separate USDC unshield. Verifies the fee lands at the committed recipient and the
+    // remainder (assets - fee) is what gets shielded back, with value conserved.
+    it("pays the broadcaster fee from proceeds and shields the remainder", async function () {
+      const lendAmount = ethers.parseUnits("1000", 6);
+      await shieldAndGetRoot(lendAmount);
+
+      const npk = validNpk();
+      const encryptedBundle: [string, string, string] = [
+        ethers.keccak256(ethers.toUtf8Bytes("enc1-fee")),
+        ethers.keccak256(ethers.toUtf8Bytes("enc2-fee")),
+        ethers.keccak256(ethers.toUtf8Bytes("enc3-fee")),
+      ];
+      const shieldKey = ethers.keccak256(ethers.toUtf8Bytes("key-fee"));
+      const lendAdaptParams = encodeYieldAdaptParams(npk, encryptedBundle, shieldKey);
+
+      const lendTx = await makeLendTransaction({
+        merkleRoot: await privacyPool.merkleRoot(),
+        nullifier: ethers.keccak256(ethers.toUtf8Bytes("null-lend-redeem-fee")),
+        unshieldPreimage: {
+          npk: ethers.zeroPadValue(adapterAddress, 32),
+          tokenAddress: usdcAddress,
+          value: lendAmount,
+        },
+        adaptContract: adapterAddress,
+        adaptParams: lendAdaptParams,
+        npk,
+        encryptedBundle,
+        shieldKey,
+      });
+      await armadaYieldAdapter.lendAndShield(lendTx, npk, { encryptedBundle, shieldKey });
+
+      const shares = await armadaYieldVault.balanceOf(privacyPoolAddress);
+      expect(shares).to.be.gt(0n);
+
+      // The relayer that will be paid the broadcaster fee, and the fee amount — both bound in adaptParams.
+      const feeRecipient = await relayer.getAddress();
+      const feeAmount = ethers.parseUnits("5", 6);
+      const redeemAdaptParams = encodeYieldAdaptParamsWithFee(
+        npk,
+        encryptedBundle,
+        shieldKey,
+        feeRecipient,
+        feeAmount
+      );
+
+      const unshieldHash = computeCommitmentHash(
+        BigInt(ethers.zeroPadValue(adapterAddress, 32)),
+        BigInt(vaultAddress),
+        shares
+      );
+      const redeemTx = {
+        proof: { a: { x: 0, y: 0 }, b: { x: [0, 0], y: [0, 0] }, c: { x: 0, y: 0 } },
+        merkleRoot: await privacyPool.merkleRoot(),
+        nullifiers: [ethers.keccak256(ethers.toUtf8Bytes("null-redeem-fee-1"))],
+        commitments: [unshieldHash],
+        boundParams: {
+          treeNumber: 0,
+          minGasPrice: 0,
+          unshield: 1,
+          chainID: (await ethers.provider.getNetwork()).chainId,
+          adaptContract: adapterAddress,
+          adaptParams: redeemAdaptParams,
+          commitmentCiphertext: [],
+        },
+        unshieldPreimage: {
+          npk: ethers.zeroPadValue(adapterAddress, 32),
+          token: { tokenType: 0, tokenAddress: vaultAddress, tokenSubID: 0 },
+          value: shares,
+        },
+      };
+
+      const relayerUsdcBefore = await hubUsdc.balanceOf(feeRecipient);
+      const poolUsdcBefore = await hubUsdc.balanceOf(privacyPoolAddress);
+
+      const assets = await armadaYieldAdapter.redeemAndShield.staticCall(
+        redeemTx,
+        npk,
+        { encryptedBundle, shieldKey },
+        feeRecipient,
+        feeAmount
+      );
+      expect(assets).to.be.gt(feeAmount); // sanity: proceeds exceed the fee
+
+      await armadaYieldAdapter.redeemAndShield(
+        redeemTx,
+        npk,
+        { encryptedBundle, shieldKey },
+        feeRecipient,
+        feeAmount
+      );
+
+      const relayerUsdcAfter = await hubUsdc.balanceOf(feeRecipient);
+      const poolUsdcAfter = await hubUsdc.balanceOf(privacyPoolAddress);
+
+      // Fee lands at the committed recipient; the pool receives only (assets - fee); value conserved.
+      expect(relayerUsdcAfter - relayerUsdcBefore).to.equal(feeAmount);
+      expect(poolUsdcAfter - poolUsdcBefore).to.be.closeTo(assets - feeAmount, 10n);
+    });
+
+    // WHY: the fee is bound in adaptParams, so a submitter that inflates feeAmount (to skim more of
+    // the user's proceeds) must fail the adaptParams check — the core relayer-immutability property.
+    it("reverts when the submitted fee does not match the adaptParams commitment", async function () {
+      const lendAmount = ethers.parseUnits("1000", 6);
+      await shieldAndGetRoot(lendAmount);
+
+      const npk = validNpk();
+      const encryptedBundle: [string, string, string] = [
+        ethers.keccak256(ethers.toUtf8Bytes("enc1-mm")),
+        ethers.keccak256(ethers.toUtf8Bytes("enc2-mm")),
+        ethers.keccak256(ethers.toUtf8Bytes("enc3-mm")),
+      ];
+      const shieldKey = ethers.keccak256(ethers.toUtf8Bytes("key-mm"));
+      const lendAdaptParams = encodeYieldAdaptParams(npk, encryptedBundle, shieldKey);
+
+      const lendTx = await makeLendTransaction({
+        merkleRoot: await privacyPool.merkleRoot(),
+        nullifier: ethers.keccak256(ethers.toUtf8Bytes("null-lend-redeem-mm")),
+        unshieldPreimage: {
+          npk: ethers.zeroPadValue(adapterAddress, 32),
+          tokenAddress: usdcAddress,
+          value: lendAmount,
+        },
+        adaptContract: adapterAddress,
+        adaptParams: lendAdaptParams,
+        npk,
+        encryptedBundle,
+        shieldKey,
+      });
+      await armadaYieldAdapter.lendAndShield(lendTx, npk, { encryptedBundle, shieldKey });
+      const shares = await armadaYieldVault.balanceOf(privacyPoolAddress);
+
+      const feeRecipient = await relayer.getAddress();
+      const committedFee = ethers.parseUnits("5", 6);
+      const redeemAdaptParams = encodeYieldAdaptParamsWithFee(
+        npk,
+        encryptedBundle,
+        shieldKey,
+        feeRecipient,
+        committedFee
+      );
+      const unshieldHash = computeCommitmentHash(
+        BigInt(ethers.zeroPadValue(adapterAddress, 32)),
+        BigInt(vaultAddress),
+        shares
+      );
+      const redeemTx = {
+        proof: { a: { x: 0, y: 0 }, b: { x: [0, 0], y: [0, 0] }, c: { x: 0, y: 0 } },
+        merkleRoot: await privacyPool.merkleRoot(),
+        nullifiers: [ethers.keccak256(ethers.toUtf8Bytes("null-redeem-mm-1"))],
+        commitments: [unshieldHash],
+        boundParams: {
+          treeNumber: 0,
+          minGasPrice: 0,
+          unshield: 1,
+          chainID: (await ethers.provider.getNetwork()).chainId,
+          adaptContract: adapterAddress,
+          adaptParams: redeemAdaptParams,
+          commitmentCiphertext: [],
+        },
+        unshieldPreimage: {
+          npk: ethers.zeroPadValue(adapterAddress, 32),
+          token: { tokenType: 0, tokenAddress: vaultAddress, tokenSubID: 0 },
+          value: shares,
+        },
+      };
+
+      // Submitter tries to skim double the committed fee.
+      await expect(
+        armadaYieldAdapter.redeemAndShield(
+          redeemTx,
+          npk,
+          { encryptedBundle, shieldKey },
+          feeRecipient,
+          committedFee * 2n
+        )
+      ).to.be.revertedWith("ArmadaYieldAdapter: adaptParams mismatch");
     });
   });
 

--- a/test/shielded_yield_integration.ts
+++ b/test/shielded_yield_integration.ts
@@ -46,22 +46,28 @@ function encodeYieldAdaptParams(
 }
 
 /**
- * Encode the withdraw (redeem) YieldAdaptParams with the broadcaster fee bound in.
- * Must match Solidity YieldAdaptParams.encode(npk, bundle, shieldKey, feeRecipient, feeAmount).
+ * Encode the withdraw (redeem) YieldAdaptParams with the broadcaster fee bound in. The fee is paid as
+ * a SHIELD to the relayer's own 0zk destination, so both the user's and the relayer's shield
+ * destinations (npk + bundle + shieldKey) plus the amount are committed. Must match Solidity
+ * YieldAdaptParams.encode(npk, bundle, shieldKey, feeNpk, feeBundle, feeShieldKey, feeAmount).
  */
 function encodeYieldAdaptParamsWithFee(
   npk: string,
   encryptedBundle: [string, string, string],
   shieldKey: string,
-  feeRecipient: string,
+  feeNpk: string,
+  feeEncryptedBundle: [string, string, string],
+  feeShieldKey: string,
   feeAmount: bigint
 ): string {
   const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
-    ["bytes32", "bytes32[3]", "bytes32", "address", "uint256"],
-    [npk, encryptedBundle, shieldKey, feeRecipient, feeAmount]
+    ["bytes32", "bytes32[3]", "bytes32", "bytes32", "bytes32[3]", "bytes32", "uint256"],
+    [npk, encryptedBundle, shieldKey, feeNpk, feeEncryptedBundle, feeShieldKey, feeAmount]
   );
   return ethers.keccak256(encoded);
 }
+
+const ZERO_BUNDLE: [string, string, string] = [ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash];
 
 describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
   let hubUsdc: Contract;
@@ -435,15 +441,18 @@ describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
       const shares = await armadaYieldVault.balanceOf(privacyPoolAddress);
       expect(shares).to.be.gt(0n);
 
-      // No broadcaster fee for this base case: withdraw adaptParams still uses the 5-arg (fee-bound)
-      // scheme with (feeRecipient=0, feeAmount=0).
-      const feeRecipient = ethers.ZeroAddress;
+      // No broadcaster fee for this base case: withdraw adaptParams still uses the fee-bound scheme
+      // with a zeroed relayer destination and feeAmount 0.
+      const feeNpk = ethers.ZeroHash;
+      const feeShieldKey = ethers.ZeroHash;
       const feeAmount = 0n;
       const redeemAdaptParams = encodeYieldAdaptParamsWithFee(
         npk,
         encryptedBundle,
         shieldKey,
-        feeRecipient,
+        feeNpk,
+        ZERO_BUNDLE,
+        feeShieldKey,
         feeAmount
       );
       const unshieldHash = computeCommitmentHash(
@@ -484,14 +493,16 @@ describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
         redeemTx,
         npk,
         { encryptedBundle, shieldKey },
-        feeRecipient,
+        feeNpk,
+        { encryptedBundle: ZERO_BUNDLE, shieldKey: feeShieldKey },
         feeAmount
       );
       await armadaYieldAdapter.redeemAndShield(
         redeemTx,
         npk,
         { encryptedBundle, shieldKey },
-        feeRecipient,
+        feeNpk,
+        { encryptedBundle: ZERO_BUNDLE, shieldKey: feeShieldKey },
         feeAmount
       );
 
@@ -503,10 +514,11 @@ describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
       expect(poolUsdcAfter - poolUsdcBefore).to.be.closeTo(assets, 10n);
     });
 
-    // WHY: issue #312 — the relayer fee is paid from the redeemed USDC proceeds (bound in adaptParams),
-    // not from a separate USDC unshield. Verifies the fee lands at the committed recipient and the
-    // remainder (assets - fee) is what gets shielded back, with value conserved.
-    it("pays the broadcaster fee from proceeds and shields the remainder", async function () {
+    // WHY: issue #312 — the relayer fee is paid from the redeemed USDC proceeds by SHIELDING it to the
+    // relayer's own 0zk destination (bound in adaptParams), NOT by a public EVM transfer. Verifies both
+    // shields happen (user + relayer), ALL proceeds stay in the pool (nothing leaves to an EVM address),
+    // and value is conserved.
+    it("shields the broadcaster fee to the relayer's 0zk destination and the remainder to the user", async function () {
       const lendAmount = ethers.parseUnits("1000", 6);
       await shieldAndGetRoot(lendAmount);
 
@@ -538,14 +550,26 @@ describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
       const shares = await armadaYieldVault.balanceOf(privacyPoolAddress);
       expect(shares).to.be.gt(0n);
 
-      // The relayer that will be paid the broadcaster fee, and the fee amount — both bound in adaptParams.
-      const feeRecipient = await relayer.getAddress();
+      // The relayer's OWN 0zk shield destination (distinct from the user's) + the fee amount — all
+      // committed in adaptParams so the submitter can neither redirect nor inflate the fee.
+      const feeNpk = ethers.zeroPadValue(
+        ethers.toBeHex(BigInt(ethers.keccak256(ethers.toUtf8Bytes("relayer-npk"))) % SNARK_SCALAR_FIELD),
+        32
+      );
+      const feeBundle: [string, string, string] = [
+        ethers.keccak256(ethers.toUtf8Bytes("relayer-enc1")),
+        ethers.keccak256(ethers.toUtf8Bytes("relayer-enc2")),
+        ethers.keccak256(ethers.toUtf8Bytes("relayer-enc3")),
+      ];
+      const feeShieldKey = ethers.keccak256(ethers.toUtf8Bytes("relayer-key"));
       const feeAmount = ethers.parseUnits("5", 6);
       const redeemAdaptParams = encodeYieldAdaptParamsWithFee(
         npk,
         encryptedBundle,
         shieldKey,
-        feeRecipient,
+        feeNpk,
+        feeBundle,
+        feeShieldKey,
         feeAmount
       );
 
@@ -575,36 +599,56 @@ describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
         },
       };
 
-      const relayerUsdcBefore = await hubUsdc.balanceOf(feeRecipient);
+      const relayerEvmBefore = await hubUsdc.balanceOf(await relayer.getAddress());
       const poolUsdcBefore = await hubUsdc.balanceOf(privacyPoolAddress);
 
+      const feeCiphertext = { encryptedBundle: feeBundle, shieldKey: feeShieldKey };
       const assets = await armadaYieldAdapter.redeemAndShield.staticCall(
         redeemTx,
         npk,
         { encryptedBundle, shieldKey },
-        feeRecipient,
+        feeNpk,
+        feeCiphertext,
         feeAmount
       );
       expect(assets).to.be.gt(feeAmount); // sanity: proceeds exceed the fee
 
-      await armadaYieldAdapter.redeemAndShield(
+      const tx = await armadaYieldAdapter.redeemAndShield(
         redeemTx,
         npk,
         { encryptedBundle, shieldKey },
-        feeRecipient,
+        feeNpk,
+        feeCiphertext,
         feeAmount
       );
+      const receipt = await tx.wait();
 
-      const relayerUsdcAfter = await hubUsdc.balanceOf(feeRecipient);
       const poolUsdcAfter = await hubUsdc.balanceOf(privacyPoolAddress);
+      const relayerEvmAfter = await hubUsdc.balanceOf(await relayer.getAddress());
 
-      // Fee lands at the committed recipient; the pool receives only (assets - fee); value conserved.
-      expect(relayerUsdcAfter - relayerUsdcBefore).to.equal(feeAmount);
-      expect(poolUsdcAfter - poolUsdcBefore).to.be.closeTo(assets - feeAmount, 10n);
+      // The fee is SHIELDED, not transferred publicly: ALL proceeds stay in the pool and no EVM
+      // address (here the relayer's) is credited.
+      expect(poolUsdcAfter - poolUsdcBefore).to.be.closeTo(assets, 10n);
+      expect(relayerEvmAfter - relayerEvmBefore).to.equal(0n);
+
+      // Exactly two shield commitments were created: the user's (assets - fee) and the relayer's fee.
+      // The Shield event is emitted by ShieldModule (via delegatecall), so parse with its interface.
+      const shieldEvent = receipt!.logs
+        .map((log: any) => {
+          try {
+            return shieldModule.interface.parseLog(log);
+          } catch {
+            return null;
+          }
+        })
+        .find((p: any) => p?.name === "Shield");
+      expect(shieldEvent, "Shield event emitted").to.not.be.undefined;
+      expect(shieldEvent!.args.commitments.length).to.equal(2);
     });
 
-    // WHY: the fee is bound in adaptParams, so a submitter that inflates feeAmount (to skim more of
-    // the user's proceeds) must fail the adaptParams check — the core relayer-immutability property.
+    // WHY: the fee (relayer shield destination + amount) is bound in adaptParams, so a submitter that
+    // inflates feeAmount (to skim more of the user's proceeds) must fail the adaptParams check — the
+    // core relayer-immutability property.
     it("reverts when the submitted fee does not match the adaptParams commitment", async function () {
       const lendAmount = ethers.parseUnits("1000", 6);
       await shieldAndGetRoot(lendAmount);
@@ -635,13 +679,24 @@ describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
       await armadaYieldAdapter.lendAndShield(lendTx, npk, { encryptedBundle, shieldKey });
       const shares = await armadaYieldVault.balanceOf(privacyPoolAddress);
 
-      const feeRecipient = await relayer.getAddress();
+      const feeNpk = ethers.zeroPadValue(
+        ethers.toBeHex(BigInt(ethers.keccak256(ethers.toUtf8Bytes("relayer-npk-mm"))) % SNARK_SCALAR_FIELD),
+        32
+      );
+      const feeBundle: [string, string, string] = [
+        ethers.keccak256(ethers.toUtf8Bytes("relayer-enc1-mm")),
+        ethers.keccak256(ethers.toUtf8Bytes("relayer-enc2-mm")),
+        ethers.keccak256(ethers.toUtf8Bytes("relayer-enc3-mm")),
+      ];
+      const feeShieldKey = ethers.keccak256(ethers.toUtf8Bytes("relayer-key-mm"));
       const committedFee = ethers.parseUnits("5", 6);
       const redeemAdaptParams = encodeYieldAdaptParamsWithFee(
         npk,
         encryptedBundle,
         shieldKey,
-        feeRecipient,
+        feeNpk,
+        feeBundle,
+        feeShieldKey,
         committedFee
       );
       const unshieldHash = computeCommitmentHash(
@@ -676,7 +731,8 @@ describe("Shielded Yield (lendAndShield / redeemAndShield)", function () {
           redeemTx,
           npk,
           { encryptedBundle, shieldKey },
-          feeRecipient,
+          feeNpk,
+          { encryptedBundle: feeBundle, shieldKey: feeShieldKey },
           committedFee * 2n
         )
       ).to.be.revertedWith("ArmadaYieldAdapter: adaptParams mismatch");


### PR DESCRIPTION
Fixes #312.

Implements the fee-from-proceeds design for `#312` (see the [re-scoped plan](https://github.com/ship-armada/armada-poc/issues/312#issuecomment-4981175727)) — the yield-withdraw broadcaster fee is paid **from the redeemed USDC** and **shielded to the relayer's own 0zk address**, replacing the separate-USDC-unshield Transaction the adapter couldn't consume. Withdraw now routes through the standard relayer path like every other tx kind.

## Why this design
The "two Transactions" is a **circuit** constraint (one ZK proof balances one token), not an SDK artifact — so forking the SDK is the wrong lever. Since a withdraw already produces USDC, the relayer fee is paid from *that*, **shielded to the relayer's 0zk address** (so the relayer is paid privately, same as every other kind). Result: **single Transaction**, **self-funding**, **smaller security surface** (no arbitrary-`transact()` conduit), **no SDK fork**, **no `/fees` change**.

## Changes
**Contracts**
- `YieldAdaptParams` — 7-arg `encode`/`verify` overload binding the user's shield destination, the **relayer's fee-shield destination** (`feeNpk` + bundle + shieldKey), and `feeAmount`; deposit's 3-arg variant untouched.
- `ArmadaYieldAdapter.redeemAndShield` — gains `(bytes32 _feeNpk, ShieldCiphertext _feeShieldCiphertext, uint256 _feeAmount)`, verified against `adaptParams`; after redeem it shields `(assets - fee)` to the user and `fee` to the relayer's 0zk in one privileged (fee-exempt) `shield`. Selector `0x0793b70e` → **`0x7e220759`**.

**Frontend**
- `lib/railgun/yield.ts` — redeem generates the relayer's shield destination (from its `broadcasterRailgunAddress`), binds it + `feeAmount` in `adaptParams`, passes them to `redeemAndShield`; no SDK broadcaster leg → single-tx.
- `EarnModal.tsx` — **removed `forceWalletForWithdraw`**; withdraw now follows the `submitFromWallet` preference (relayer by default) like deposit.

**Tests**
- Foundry `YieldAdaptParamsFee.t.sol` — relayer-immutability (reject redirected fee-npk / inflated amount, incl. fuzz; scheme isolation).
- Hardhat `shielded_yield_integration.ts` — all proceeds stay in the pool (no EVM address credited), **two** shield commitments (user + relayer), value conserved; inflated fee reverts.

Green: Foundry **764**, Hardhat yield **7**, interface typecheck + vitest **36**.

## Cross-repo follow-up (not armada-poc)
The armada-poc side is complete. For the relayer (gasless) path to succeed end-to-end, the **v2 relayer (`ship-armada/armada-relayer`)** must accept the new `redeemAndShield` selector `0x7e220759` and verify the fee-shield output targets the relayer's 0zk address for ≥ the required amount. This is recorded in the v2-relayer handoff doc; no `/fees` change is needed. Until it lands, users can submit withdraw via the wallet path (`submitFromWallet`). Any compatibility issue will be resolved alongside that relayer work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)