### PR TITLE
fix(privacy-pool): bind cross-chain unshield destination into the proof (#364, #378)

### DIFF
--- a/apps/armada-interface/src/lib/railgun/cctpBinding.test.ts
+++ b/apps/armada-interface/src/lib/railgun/cctpBinding.test.ts
@@ -1,0 +1,43 @@
+// ABOUTME: Pins encodeCctpBinding to a fixed vector so it stays byte-identical to Solidity
+// ABOUTME: CCTPBindingLib (validated on the contract side by test-foundry/CCTPBindingLib.t.sol).
+
+import { describe, it, expect } from 'vitest'
+import { ethers } from 'ethers'
+import { encodeCctpBinding, CCTP_BINDING_DOMAIN_TAG } from './cctpBinding'
+
+describe('encodeCctpBinding', () => {
+  // WHY: the tag must equal keccak256("ArmadaCCTPUnshield.v1") — the exact Solidity DOMAIN_TAG.
+  it('uses the versioned domain tag matching Solidity', () => {
+    expect(CCTP_BINDING_DOMAIN_TAG).toBe(
+      '0x21356b6965af9c07c4d5fb7bc8b7ba6ca11fe531bc1418dd5534bd2269a03825',
+    )
+  })
+
+  // WHY: fixed vector — if the encoding drifts from Solidity CCTPBindingLib.encode, real cross-chain
+  // unshields would revert on the on-chain binding check. This freezes the format.
+  it('matches the fixed (recipient, domain, maxFee) vector', () => {
+    expect(encodeCctpBinding('0x0000000000000000000000000000000000000A11', 6, 5_000_000n)).toBe(
+      '0xc2a828ad2c65e1372bfddbc94a1d500429e6e19c55307305e02e5e766bc32940',
+    )
+  })
+
+  // WHY: any change to any field must change the commitment (the anti-redirect property).
+  it('changes with each field', () => {
+    const base = encodeCctpBinding('0x0000000000000000000000000000000000000A11', 6, 5_000_000n)
+    expect(encodeCctpBinding('0x000000000000000000000000000000000000bad0', 6, 5_000_000n)).not.toBe(base)
+    expect(encodeCctpBinding('0x0000000000000000000000000000000000000A11', 7, 5_000_000n)).not.toBe(base)
+    expect(encodeCctpBinding('0x0000000000000000000000000000000000000A11', 6, 5_000_001n)).not.toBe(base)
+  })
+
+  // WHY: the domain tag must make it distinct from a bare keccak(recipient, domain, fee) (#378).
+  it('is domain-separated from a bare hash', () => {
+    const tagged = encodeCctpBinding('0x0000000000000000000000000000000000000A11', 6, 5_000_000n)
+    const bare = ethers.keccak256(
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ['address', 'uint32', 'uint256'],
+        ['0x0000000000000000000000000000000000000A11', 6, 5_000_000n],
+      ),
+    )
+    expect(tagged).not.toBe(bare)
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/cctpBinding.ts
+++ b/apps/armada-interface/src/lib/railgun/cctpBinding.ts
@@ -1,0 +1,37 @@
+// ABOUTME: Computes the CCTP cross-chain-unshield destination binding that goes into a proof's
+// ABOUTME: boundParams.adaptParams, so a relayer/front-runner cannot redirect the exit (#364/#378).
+
+import { ethers } from 'ethers'
+
+/**
+ * Versioned domain tag — MUST match Solidity `CCTPBindingLib.DOMAIN_TAG`
+ * (`keccak256("ArmadaCCTPUnshield.v1")`). Namespaces the adaptParams format so a future layout
+ * cannot collide with v1 hashes.
+ */
+export const CCTP_BINDING_DOMAIN_TAG = ethers.keccak256(ethers.toUtf8Bytes('ArmadaCCTPUnshield.v1'))
+
+/**
+ * Encode the cross-chain unshield destination binding — the value the prover sets as
+ * `boundParams.adaptParams`. The hub `TransactModule` re-derives this from the submitted
+ * `atomicCrossChainUnshield` arguments and rejects any mismatch, so the destination cannot be
+ * altered after proof generation.
+ *
+ * MUST stay byte-identical to Solidity `CCTPBindingLib.encode`:
+ *   keccak256(abi.encode(DOMAIN_TAG, recipient, destinationDomain, maxFee))
+ *
+ * @param recipient Final USDC recipient on the destination chain (EVM address)
+ * @param destinationDomain CCTP domain of the destination chain
+ * @param maxFee Maximum CCTP fee, raw USDC units
+ */
+export function encodeCctpBinding(
+  recipient: string,
+  destinationDomain: number,
+  maxFee: bigint,
+): `0x${string}` {
+  return ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ['bytes32', 'address', 'uint32', 'uint256'],
+      [CCTP_BINDING_DOMAIN_TAG, recipient, destinationDomain, maxFee],
+    ),
+  ) as `0x${string}`
+}

--- a/apps/armada-interface/src/lib/railgun/unshield.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield.ts
@@ -199,8 +199,17 @@ export async function generateXchainUnshieldProof(opts: {
       {
         tokenAddress: opts.tokenAddress,
         amount: opts.amount,
-        // The PrivacyPool itself receives the USDC — it then forwards via CCTP. The actual user
-        // recipient is encoded in the atomicCrossChainUnshield args (not the proof).
+        // The PrivacyPool itself receives the USDC — it then forwards via CCTP.
+        //
+        // TODO(#399): the hub now BINDS the destination (recipient, domain, maxFee) into the proof via
+        // boundParams.adaptParams (#364/#378, PR #398). This plain generateUnshieldProof sets
+        // adaptParams = 0, which the updated atomicCrossChainUnshield REJECTS. Switch this +
+        // buildXchainUnshieldTransactionStruct to generateProofTransactions(..., relayAdaptID = {
+        // contract: ZeroAddress, parameters: encodeCctpBinding(finalRecipient, destinationDomain,
+        // maxFee) }) — the yield.ts pattern. recipientAddress stays the pool (npk = pool; the cross-path
+        // replay is closed by a contract-side _transferTokenOut guard). Needs a real-proof e2e — see
+        // #399. Coupled: the pool must not be redeployed until this lands, or cross-chain unshields
+        // revert. `encodeCctpBinding` is ready in lib/railgun/cctpBinding.ts.
         recipientAddress: opts.privacyPoolAddress,
       },
     ],

--- a/contracts/privacy-pool/CCTPBindingLib.sol
+++ b/contracts/privacy-pool/CCTPBindingLib.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+/**
+ * @title CCTPBindingLib
+ * @notice Binds the cross-chain-unshield CCTP destination tuple into a transaction's adaptParams.
+ * @dev In `atomicCrossChainUnshield` the destination `recipient`, `destinationDomain`, and `maxFee` are
+ *      plaintext arguments the SNARK proof does NOT otherwise cover. Without binding them, a relayer or
+ *      mempool front-runner can resubmit the victim's identical proof with `recipient = attacker` (or a
+ *      different domain / inflated fee) — the proof still verifies, the nullifier burns, and the funds
+ *      are stolen/redirected (issue #364, generalized in #378).
+ *
+ *      `boundParams.adaptParams` IS committed by the circuit (via hashBoundParams; it is a SNARK public
+ *      input), so committing a hash of these three fields into it makes them proof-bound with NO circuit
+ *      / trusted-setup change — the same mechanism `YieldAdaptParams` uses. The prover (frontend) sets
+ *      adaptParams = encode(recipient, destinationDomain, maxFee); the contract re-derives it from the
+ *      submitted arguments and rejects any mismatch.
+ *
+ *      `destinationCaller` is intentionally NOT bound here — it is pinned on-chain to
+ *      remoteHookRouters[destinationDomain] (issue #64), so it is not caller-supplied.
+ */
+library CCTPBindingLib {
+    /// @dev Versioned domain tag so a future adaptParams format cannot collide with v1 hashes (#378).
+    bytes32 private constant DOMAIN_TAG = keccak256("ArmadaCCTPUnshield.v1");
+
+    /**
+     * @notice Encode the cross-chain unshield destination binding.
+     * @param recipient Final USDC recipient on the destination chain
+     * @param destinationDomain CCTP domain of the destination chain
+     * @param maxFee Maximum CCTP fee (raw USDC units)
+     * @return The keccak256 commitment set as boundParams.adaptParams
+     */
+    function encode(
+        address recipient,
+        uint32 destinationDomain,
+        uint256 maxFee
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(DOMAIN_TAG, recipient, destinationDomain, maxFee));
+    }
+
+    /**
+     * @notice Verify submitted destination arguments match the proof-bound adaptParams.
+     * @param adaptParams The boundParams.adaptParams committed by the SNARK proof
+     * @param recipient Final USDC recipient argument
+     * @param destinationDomain CCTP destination domain argument
+     * @param maxFee maxFee argument
+     * @return True when the arguments hash to the committed adaptParams
+     */
+    function verify(
+        bytes32 adaptParams,
+        address recipient,
+        uint32 destinationDomain,
+        uint256 maxFee
+    ) internal pure returns (bool) {
+        return adaptParams == encode(recipient, destinationDomain, maxFee);
+    }
+}

--- a/contracts/privacy-pool/modules/TransactModule.sol
+++ b/contracts/privacy-pool/modules/TransactModule.sol
@@ -9,6 +9,7 @@ import "../interfaces/ITransactModule.sol";
 import "../interfaces/IMerkleModule.sol";
 import "../interfaces/IVerifierModule.sol";
 import "../types/CCTPTypes.sol";
+import "../CCTPBindingLib.sol";
 import "../../cctp/ICCTPV2.sol";
 import "../../railgun/logic/Poseidon.sol";
 import "../../governance/IShieldPauseController.sol";
@@ -125,7 +126,7 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
         _requireNotEmergencyPaused();
 
         // Validate inputs
-        _validateAtomicUnshieldInputs(_transaction, destinationDomain, finalRecipient);
+        _validateAtomicUnshieldInputs(_transaction, destinationDomain, finalRecipient, maxFee);
 
         // Validate and process the transaction (nullify, accumulate commitments)
         _processAtomicUnshieldTransaction(_transaction);
@@ -140,7 +141,8 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
     function _validateAtomicUnshieldInputs(
         Transaction calldata _transaction,
         uint32 destinationDomain,
-        address finalRecipient
+        address finalRecipient,
+        uint256 maxFee
     ) internal view {
         require(destinationDomain != localDomain, "TransactModule: Use local unshield");
         require(finalRecipient != address(0), "TransactModule: Invalid recipient");
@@ -152,6 +154,27 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
         require(
             remoteHookRouters[destinationDomain] != bytes32(0),
             "TransactModule: Hook router not configured"
+        );
+
+        // Bind the CCTP destination (recipient + domain + fee) to the proof. These are plaintext
+        // arguments the SNARK does not otherwise cover; without this a relayer/front-runner could
+        // resubmit the victim's identical proof with finalRecipient = attacker and steal every
+        // cross-chain exit (issue #364, generalized to the full tuple in #378). boundParams.adaptParams
+        // IS committed by the circuit, so the prover sets it to CCTPBindingLib.encode(...) and we reject
+        // any mismatch here. This also blocks hijacking a local unshield (adaptParams == 0) through this
+        // path. No circuit change; destinationCaller is already pinned on-chain per #64.
+        require(
+            _transaction.boundParams.adaptContract == address(0),
+            "TransactModule: unexpected adaptContract"
+        );
+        require(
+            CCTPBindingLib.verify(
+                _transaction.boundParams.adaptParams,
+                finalRecipient,
+                destinationDomain,
+                maxFee
+            ),
+            "TransactModule: destination not bound to proof"
         );
 
         // Validate the transaction proof
@@ -356,6 +379,13 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
 
         // Get recipient from npk (address encoded as bytes32)
         address recipient = address(uint160(uint256(_note.npk)));
+
+        // Never unshield to the pool itself. An xchain-unshield proof unshields to the pool (its USDC is
+        // burned via CCTP in atomicCrossChainUnshield, which does not call this function). Blocking
+        // recipient == pool here stops a griefing replay: submitting that same proof through the plain
+        // transact() path would otherwise send USDC pool->pool and destroy the note with funds stranded
+        // (issue #364 cross-path replay). No legitimate unshield targets the pool address.
+        require(recipient != address(this), "TransactModule: unshield to pool");
 
         // Unshield is free per spec — the full preimage value is paid out. The trailing
         // 0 in the Unshield event preserves the 4-field shape for downstream log parsers.

--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -19,6 +19,7 @@ ALLOWED_FILES=(
   "apps/armada-interface/vite.config.ts"  # Anvil deployer key for local dev /api/fund-gas endpoint
   "apps/armada-interface/src/lib/relayer.test.ts"  # Fake 0xdeadbeef-padded tx hash fixture for mocked /relay responses
   "apps/armada-interface/src/lib/tx/poller.test.ts"  # Fake 0xaaaa... tx hash fixture for mocked /status polling
+  "apps/armada-interface/src/lib/railgun/cctpBinding.test.ts"  # keccak256 binding-hash fixtures (publicly-derivable, not keys)
   "config/secrets.env.template"  # Placeholder mnemonic ("word word word..."); real secret lives in gitignored secrets.env
   "relayer/test/modules/railgun-wallet.test.ts"  # Anvil's publicly-known test mnemonic — required to prove deterministic derivation
   "scripts/multicall3-bytecode.ts"  # Canonical Multicall3 public runtime bytecode (not a key) — etched onto local Anvil

--- a/test-foundry/CCTPBindingLib.t.sol
+++ b/test-foundry/CCTPBindingLib.t.sol
@@ -1,0 +1,66 @@
+// ABOUTME: Tests CCTPBindingLib — the cross-chain unshield destination tuple (recipient, domain, maxFee)
+// ABOUTME: is committed into adaptParams so a relayer/front-runner cannot redirect the exit (#364/#378).
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../contracts/privacy-pool/CCTPBindingLib.sol";
+
+contract CCTPBindingLibTest is Test {
+    address constant RECIPIENT = address(0xA11CE);
+    uint32 constant DOMAIN = 6;
+    uint256 constant MAX_FEE = 5_000_000;
+
+    /// @dev WHY: the honest submission — exact committed args must verify.
+    function test_verify_acceptsCommittedTuple() public {
+        bytes32 ap = CCTPBindingLib.encode(RECIPIENT, DOMAIN, MAX_FEE);
+        assertTrue(CCTPBindingLib.verify(ap, RECIPIENT, DOMAIN, MAX_FEE));
+    }
+
+    /// @dev WHY: core anti-theft property — a redirected recipient must fail.
+    function test_verify_rejectsRedirectedRecipient() public {
+        bytes32 ap = CCTPBindingLib.encode(RECIPIENT, DOMAIN, MAX_FEE);
+        assertFalse(CCTPBindingLib.verify(ap, address(0xBAD), DOMAIN, MAX_FEE));
+    }
+
+    /// @dev WHY: a redirected destination domain (wrong-chain redirect) must fail.
+    function test_verify_rejectsChangedDomain() public {
+        bytes32 ap = CCTPBindingLib.encode(RECIPIENT, DOMAIN, MAX_FEE);
+        assertFalse(CCTPBindingLib.verify(ap, RECIPIENT, DOMAIN + 1, MAX_FEE));
+    }
+
+    /// @dev WHY: an inflated maxFee (starve the payout via the CCTP fee) must fail.
+    function test_verify_rejectsInflatedFee() public {
+        bytes32 ap = CCTPBindingLib.encode(RECIPIENT, DOMAIN, MAX_FEE);
+        assertFalse(CCTPBindingLib.verify(ap, RECIPIENT, DOMAIN, MAX_FEE * 2));
+    }
+
+    /// @dev WHY: a local unshield / plain transact carries adaptParams == 0, which must never satisfy
+    ///      the binding — this is what blocks hijacking a local proof through the cross-chain path (#364).
+    function test_verify_rejectsZeroAdaptParams() public {
+        assertFalse(CCTPBindingLib.verify(bytes32(0), RECIPIENT, DOMAIN, MAX_FEE));
+    }
+
+    /// @dev WHY: the versioned DOMAIN_TAG must make the commitment distinct from a bare
+    ///      keccak(recipient, domain, fee), so a future adaptParams format cannot collide with v1 (#378).
+    function test_encode_isDomainSeparated() public {
+        bytes32 tagged = CCTPBindingLib.encode(RECIPIENT, DOMAIN, MAX_FEE);
+        bytes32 bare = keccak256(abi.encode(RECIPIENT, DOMAIN, MAX_FEE));
+        assertTrue(tagged != bare, "encode must be domain-separated from a bare hash");
+    }
+
+    /// @dev WHY: fuzz the binding — ANY deviation in any field must fail verification.
+    function testFuzz_verify_rejectsAnyDeviation(
+        address recipient,
+        uint32 domain,
+        uint256 maxFee,
+        address wRecipient,
+        uint32 wDomain,
+        uint256 wMaxFee
+    ) public {
+        vm.assume(recipient != wRecipient || domain != wDomain || maxFee != wMaxFee);
+        bytes32 ap = CCTPBindingLib.encode(recipient, domain, maxFee);
+        assertFalse(CCTPBindingLib.verify(ap, wRecipient, wDomain, wMaxFee));
+    }
+}

--- a/test/privacy_pool_adversarial.ts
+++ b/test/privacy_pool_adversarial.ts
@@ -190,6 +190,18 @@ describe("Privacy Pool Adversarial", function () {
     };
   }
 
+  // Compute CCTPBindingLib.encode(recipient, domain, maxFee) — the adaptParams commitment that binds
+  // the cross-chain unshield destination into the proof (#364/#378). Must match the Solidity library.
+  const CCTP_BINDING_DOMAIN_TAG = ethers.keccak256(ethers.toUtf8Bytes("ArmadaCCTPUnshield.v1"));
+  function encodeCctpBinding(recipient: string, domain: number, maxFee: bigint): string {
+    return ethers.keccak256(
+      ethers.AbiCoder.defaultAbiCoder().encode(
+        ["bytes32", "address", "uint32", "uint256"],
+        [CCTP_BINDING_DOMAIN_TAG, recipient, domain, maxFee]
+      )
+    );
+  }
+
   function makeTransaction(opts: {
     merkleRoot: string;
     nullifiers: string[];
@@ -197,6 +209,7 @@ describe("Privacy Pool Adversarial", function () {
     unshield?: number;
     unshieldPreimage?: any;
     ciphertextCount?: number;
+    adaptParams?: string;
   }) {
     const unshieldType = opts.unshield ?? 0;
     const ciphertextCount = opts.ciphertextCount ??
@@ -221,7 +234,7 @@ describe("Privacy Pool Adversarial", function () {
         unshield: unshieldType,
         chainID: 31337,
         adaptContract: ethers.ZeroAddress,
-        adaptParams: ethers.ZeroHash,
+        adaptParams: opts.adaptParams ?? ethers.ZeroHash,
         commitmentCiphertext: ciphertext,
       },
       unshieldPreimage: opts.unshieldPreimage ?? {
@@ -484,6 +497,7 @@ describe("Privacy Pool Adversarial", function () {
         nullifiers: [nullifier],
         commitments: [commitHash],
         unshield: 1,
+        adaptParams: encodeCctpBinding(bobAddress, DOMAINS.client, 0n),
         unshieldPreimage: {
           npk: ethers.zeroPadValue(privacyPoolAddress, 32),
           token: { tokenType: 0, tokenAddress: await hubUsdc.getAddress(), tokenSubID: 0 },
@@ -500,59 +514,121 @@ describe("Privacy Pool Adversarial", function () {
       expect(isSpent).to.be.true;
     });
 
-    // WHY: PoC for #364. The cross-chain unshield destination (`finalRecipient`) is a plaintext
-    // argument that never enters proof validation and is not committed by `hashBoundParams`, unlike
-    // the local unshield path where the recipient is derived from the proof-bound note npk. This
-    // verifies that an attacker can front-run a victim's cross-chain unshield with the identical
-    // proof and redirect the funds — a direct theft of every cross-chain exit.
-    it("PoC #364: attacker front-runs a cross-chain unshield and redirects the funds", async function () {
+    // WHY: #364/#378 regression (this was the PoC that demonstrated the theft; it now asserts the fix).
+    // The cross-chain unshield destination (recipient + domain + maxFee) is bound into the proof via
+    // boundParams.adaptParams (CCTPBindingLib). An attacker resubmitting the victim's identical proof
+    // with a redirected finalRecipient no longer validates — the submitted args don't hash to the
+    // proof-committed adaptParams — so the theft reverts and the victim's note is untouched.
+    it("#364: attacker cannot redirect a cross-chain exit — destination is bound to the proof", async function () {
       const usdcAddr = await hubUsdc.getAddress();
       const root = await shieldAndGetRoot(ethers.parseUnits("200", 6));
       const unshieldAmount = ethers.parseUnits("50", 6);
-      const nullifier = ethers.keccak256(ethers.toUtf8Bytes("poc364-nullifier"));
+      const nullifier = ethers.keccak256(ethers.toUtf8Bytes("bind364-nullifier"));
 
-      // The unshield note is bound to a specific npk via the commitment hash (a SNARK public
-      // input). Here the npk encodes the VICTIM (bob) — the note cryptographically "belongs" to bob.
-      const victimNpk = ethers.zeroPadValue(bobAddress, 32);
-      const commitHash = computeCommitmentHash(BigInt(bobAddress), BigInt(usdcAddr), BigInt(unshieldAmount));
-
+      // The xchain unshield note unshields to the pool (its USDC is burned via CCTP); the destination
+      // recipient is bound separately via adaptParams — here to the VICTIM (bob).
+      const poolNpk = ethers.zeroPadValue(privacyPoolAddress, 32);
+      const commitHash = computeCommitmentHash(BigInt(privacyPoolAddress), BigInt(usdcAddr), BigInt(unshieldAmount));
+      const bindingToBob = encodeCctpBinding(bobAddress, DOMAINS.client, 0n);
       const buildTx = () =>
         makeTransaction({
           merkleRoot: root,
           nullifiers: [nullifier],
           commitments: [commitHash],
           unshield: 1,
+          adaptParams: bindingToBob,
           unshieldPreimage: {
-            npk: victimNpk,
+            npk: poolNpk,
             token: { tokenType: 0, tokenAddress: usdcAddr, tokenSubID: 0 },
             value: unshieldAmount,
           },
         });
 
-      // The CrossChainUnshieldInitiated event is emitted (via delegatecall) from the pool's
-      // address using TransactModule's ABI, so decode it through a TransactModule-at-pool handle.
-      const poolAsTransact = transactModule.attach(privacyPoolAddress);
-
-      // Bob would submit this with finalRecipient = bob. But `finalRecipient` never enters proof
-      // validation, so the attacker resubmits the IDENTICAL transaction (same proof, same note,
-      // same nullifier) with finalRecipient = attacker.
+      // Attacker resubmits bob's IDENTICAL transaction with finalRecipient = attacker → reverts; the
+      // nullifier is NOT consumed (the whole tx rolls back).
       await expect(
         privacyPool
           .connect(attacker)
           .atomicCrossChainUnshield(buildTx(), DOMAINS.client, attackerAddress, 0, ethers.ZeroHash)
-      )
-        .to.emit(poolAsTransact, "CrossChainUnshieldInitiated")
-        .withArgs(DOMAINS.client, attackerAddress, unshieldAmount, 0);
+      ).to.be.revertedWith("TransactModule: destination not bound to proof");
+      expect(await privacyPool.nullifiers(0, nullifier)).to.be.false;
 
-      // The note's npk encoded BOB, yet the CCTP burn was directed to the ATTACKER — the recipient
-      // is unbound. The nullifier is now spent, so bob's own (identical, correct) submission
-      // reverts: his funds are already gone to the attacker.
-      expect(await privacyPool.nullifiers(0, nullifier)).to.be.true;
+      // Bob's correct submission (finalRecipient matches the binding) succeeds.
+      const poolAsTransact = transactModule.attach(privacyPoolAddress);
       await expect(
         privacyPool
           .connect(bob)
           .atomicCrossChainUnshield(buildTx(), DOMAINS.client, bobAddress, 0, ethers.ZeroHash)
-      ).to.be.revertedWith("TransactModule: Note already spent");
+      )
+        .to.emit(poolAsTransact, "CrossChainUnshieldInitiated")
+        .withArgs(DOMAINS.client, bobAddress, unshieldAmount, 0);
+      expect(await privacyPool.nullifiers(0, nullifier)).to.be.true;
+    });
+
+    // WHY: #378 — the binding covers the whole tuple, so an inflated maxFee (which would let the CCTP
+    // fee starve the payout) must also fail, not just a redirected recipient. (Domain-redirect is
+    // covered by the CCTPBindingLib Foundry fuzz — an unconfigured domain reverts earlier here.)
+    it("#378: rejects an inflated maxFee not bound in the proof", async function () {
+      const usdcAddr = await hubUsdc.getAddress();
+      const root = await shieldAndGetRoot(ethers.parseUnits("200", 6));
+      const amount = ethers.parseUnits("40", 6);
+      const poolNpk = ethers.zeroPadValue(privacyPoolAddress, 32);
+      const commitHash = computeCommitmentHash(BigInt(privacyPoolAddress), BigInt(usdcAddr), BigInt(amount));
+      const binding = encodeCctpBinding(bobAddress, DOMAINS.client, 1n); // bound maxFee = 1
+      const tx = makeTransaction({
+        merkleRoot: root,
+        nullifiers: [ethers.keccak256(ethers.toUtf8Bytes("bind-fee-null"))],
+        commitments: [commitHash],
+        unshield: 1,
+        adaptParams: binding,
+        unshieldPreimage: { npk: poolNpk, token: { tokenType: 0, tokenAddress: usdcAddr, tokenSubID: 0 }, value: amount },
+      });
+      await expect(
+        privacyPool.connect(attacker).atomicCrossChainUnshield(tx, DOMAINS.client, bobAddress, 2, ethers.ZeroHash)
+      ).to.be.revertedWith("TransactModule: destination not bound to proof");
+    });
+
+    // WHY: #364 (bidirectional) — a valid LOCAL unshield proof carries adaptParams == 0, which can
+    // never satisfy the binding, so it cannot be hijacked into a cross-chain exit to an attacker.
+    it("#364: rejects a local unshield hijacked through atomicCrossChainUnshield", async function () {
+      const usdcAddr = await hubUsdc.getAddress();
+      const root = await shieldAndGetRoot(ethers.parseUnits("100", 6));
+      const amount = ethers.parseUnits("30", 6);
+      const commitHash = computeCommitmentHash(BigInt(bobAddress), BigInt(usdcAddr), BigInt(amount));
+      const localTx = makeTransaction({
+        merkleRoot: root,
+        nullifiers: [ethers.keccak256(ethers.toUtf8Bytes("hijack-null"))],
+        commitments: [commitHash],
+        unshield: 1, // adaptParams defaults to ZeroHash — a plain/local unshield
+        unshieldPreimage: { npk: ethers.zeroPadValue(bobAddress, 32), token: { tokenType: 0, tokenAddress: usdcAddr, tokenSubID: 0 }, value: amount },
+      });
+      await expect(
+        privacyPool.connect(attacker).atomicCrossChainUnshield(localTx, DOMAINS.client, attackerAddress, 0, ethers.ZeroHash)
+      ).to.be.revertedWith("TransactModule: destination not bound to proof");
+    });
+
+    // WHY: #364 cross-path replay — an xchain-unshield proof unshields to the pool (npk = pool).
+    // Replaying it through the plain transact() path would send USDC pool->pool and destroy the note
+    // with funds stranded; the _transferTokenOut guard reverts it, leaving the note intact.
+    it("#364: xchain-unshield proof replayed through transact() reverts (no pool->pool strand)", async function () {
+      const usdcAddr = await hubUsdc.getAddress();
+      const root = await shieldAndGetRoot(ethers.parseUnits("100", 6));
+      const amount = ethers.parseUnits("25", 6);
+      const poolNpk = ethers.zeroPadValue(privacyPoolAddress, 32);
+      const commitHash = computeCommitmentHash(BigInt(privacyPoolAddress), BigInt(usdcAddr), BigInt(amount));
+      const nullifier = ethers.keccak256(ethers.toUtf8Bytes("replay-null"));
+      const xchainTx = makeTransaction({
+        merkleRoot: root,
+        nullifiers: [nullifier],
+        commitments: [commitHash],
+        unshield: 1,
+        adaptParams: encodeCctpBinding(bobAddress, DOMAINS.client, 0n),
+        unshieldPreimage: { npk: poolNpk, token: { tokenType: 0, tokenAddress: usdcAddr, tokenSubID: 0 }, value: amount },
+      });
+      await expect(
+        privacyPool.connect(attacker).transact([xchainTx])
+      ).to.be.revertedWith("TransactModule: unshield to pool");
+      expect(await privacyPool.nullifiers(0, nullifier)).to.be.false;
     });
   });
 
@@ -786,6 +862,9 @@ describe("Privacy Pool Adversarial", function () {
         nullifiers: [nullifier],
         commitments: [commitHash],
         unshield: 1,
+        // Bind the (recipient, domain, maxFee) so the tx passes the adaptParams binding and reaches the
+        // maxFee-vs-base check inside _executeCCTPBurn (the case under test).
+        adaptParams: encodeCctpBinding(bobAddress, DOMAINS.client, ethers.parseUnits("100", 6)),
         unshieldPreimage: {
           npk: ethers.zeroPadValue(privacyPoolAddress, 32),
           token: { tokenType: 0, tokenAddress: await hubUsdc.getAddress(), tokenSubID: 0 },

--- a/test/privacy_pool_gas.ts
+++ b/test/privacy_pool_gas.ts
@@ -28,6 +28,17 @@ import {
 } from "../lib/artifacts";
 
 const DOMAINS = { hub: 100, client: 101 };
+
+const CCTP_BINDING_DOMAIN_TAG = ethers.keccak256(ethers.toUtf8Bytes("ArmadaCCTPUnshield.v1"));
+// CCTPBindingLib.encode(recipient, domain, maxFee) — adaptParams binding for xchain unshield (#364/#378).
+function encodeCctpBinding(recipient: string, domain: number, maxFee: bigint): string {
+  return ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["bytes32", "address", "uint32", "uint256"],
+      [CCTP_BINDING_DOMAIN_TAG, recipient, domain, maxFee]
+    )
+  );
+}
 const SNARK_SCALAR_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
 
 describe("Privacy Pool Gas Profiling", function () {
@@ -201,6 +212,7 @@ describe("Privacy Pool Gas Profiling", function () {
     unshield?: number;
     unshieldPreimage?: any;
     ciphertextCount?: number;
+    adaptParams?: string;
   }) {
     const unshieldType = opts.unshield ?? 0;
     const ciphertextCount = opts.ciphertextCount ??
@@ -225,7 +237,7 @@ describe("Privacy Pool Gas Profiling", function () {
         unshield: unshieldType,
         chainID: 31337,
         adaptContract: ethers.ZeroAddress,
-        adaptParams: ethers.ZeroHash,
+        adaptParams: opts.adaptParams ?? ethers.ZeroHash,
         commitmentCiphertext: ciphertext,
       },
       unshieldPreimage: opts.unshieldPreimage ?? {
@@ -420,6 +432,7 @@ describe("Privacy Pool Gas Profiling", function () {
         nullifiers: [ethers.keccak256(ethers.toUtf8Bytes("atomic-unshield-gas-null"))],
         commitments: [changeCommit, unshieldCommitHash],
         unshield: 1,
+        adaptParams: encodeCctpBinding(bobAddr, DOMAINS.client, 0n),
         unshieldPreimage: {
           npk: ethers.zeroPadValue(bobAddr, 32),
           token: { tokenType: 0, tokenAddress: usdcAddr, tokenSubID: 0 },

--- a/test/privacy_pool_hardening.ts
+++ b/test/privacy_pool_hardening.ts
@@ -28,6 +28,17 @@ import {
 } from "../lib/artifacts";
 
 const DOMAINS = { hub: 100, client: 101 };
+
+const CCTP_BINDING_DOMAIN_TAG = ethers.keccak256(ethers.toUtf8Bytes("ArmadaCCTPUnshield.v1"));
+// CCTPBindingLib.encode(recipient, domain, maxFee) — adaptParams binding for xchain unshield (#364/#378).
+function encodeCctpBinding(recipient: string, domain: number, maxFee: bigint): string {
+  return ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["bytes32", "address", "uint32", "uint256"],
+      [CCTP_BINDING_DOMAIN_TAG, recipient, domain, maxFee]
+    )
+  );
+}
 const SNARK_SCALAR_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
 
 describe("Privacy Pool Integration Hardening", function () {
@@ -214,6 +225,7 @@ describe("Privacy Pool Integration Hardening", function () {
     unshield?: number;
     unshieldPreimage?: any;
     ciphertextCount?: number;
+    adaptParams?: string;
   }) {
     const unshieldType = opts.unshield ?? 0;
     const ciphertextCount = opts.ciphertextCount ??
@@ -238,7 +250,7 @@ describe("Privacy Pool Integration Hardening", function () {
         unshield: unshieldType,
         chainID: 31337,
         adaptContract: ethers.ZeroAddress,
-        adaptParams: ethers.ZeroHash,
+        adaptParams: opts.adaptParams ?? ethers.ZeroHash,
         commitmentCiphertext: ciphertext,
       },
       unshieldPreimage: opts.unshieldPreimage ?? {
@@ -485,6 +497,7 @@ describe("Privacy Pool Integration Hardening", function () {
         nullifiers: [ethers.keccak256(ethers.toUtf8Bytes("roundtrip-null"))],
         commitments: [unshieldCommitHash],
         unshield: 1,
+        adaptParams: encodeCctpBinding(bobAddress, DOMAINS.client, 0n),
         unshieldPreimage: {
           npk: ethers.zeroPadValue(privacyPoolAddress, 32),
           token: { tokenType: 0, tokenAddress: usdcAddr, tokenSubID: 0 },

--- a/test/privacy_pool_integration.ts
+++ b/test/privacy_pool_integration.ts
@@ -32,6 +32,18 @@ import {
 } from "../lib/artifacts";
 
 // CCTP Domain IDs
+// Compute CCTPBindingLib.encode(recipient, domain, maxFee) — the adaptParams commitment that binds the
+// cross-chain unshield destination into the proof (#364/#378). Must match the Solidity library.
+const CCTP_BINDING_DOMAIN_TAG = ethers.keccak256(ethers.toUtf8Bytes("ArmadaCCTPUnshield.v1"));
+function encodeCctpBinding(recipient: string, domain: number, maxFee: bigint): string {
+  return ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["bytes32", "address", "uint32", "uint256"],
+      [CCTP_BINDING_DOMAIN_TAG, recipient, domain, maxFee]
+    )
+  );
+}
+
 const DOMAINS = {
   hub: 100,
   client: 101,
@@ -583,7 +595,8 @@ describe("Privacy Pool Integration", function () {
           unshield: 1, // UnshieldType.NORMAL
           chainID: 31337,
           adaptContract: ethers.ZeroAddress,
-          adaptParams: ethers.ZeroHash,
+          // Bind the CCTP destination (recipient + domain + fee) into the proof (#364/#378).
+          adaptParams: encodeCctpBinding(bobAddress, DOMAINS.client, MAX_FEE),
           commitmentCiphertext: [], // length = commitments.length - 1 = 0
         },
         unshieldPreimage: {


### PR DESCRIPTION
Fixes ship-armada/armada-poc#364. Closes ship-armada/armada-poc#378.

Implements the reviewed Option-B design ([spec on ship-armada/armada-poc#364](https://github.com/ship-armada/armada-poc/issues/364)) — binds the CCTP destination tuple into the cross-chain unshield proof so a relayer/front-runner can't redirect an exit.

## The vulnerability
`atomicCrossChainUnshield`'s `finalRecipient`/`destinationDomain`/`maxFee` were plaintext args the SNARK didn't cover, so a relayer could resubmit a victim's valid proof with `finalRecipient = attacker` and steal every cross-chain exit (Critical).

## Fix (contract) — this PR
- **`CCTPBindingLib`** — `encode/verify(recipient, domain, maxFee)` with a versioned `DOMAIN_TAG` (`ArmadaCCTPUnshield.v1`, ship-armada/armada-poc#378 format hygiene). Commits the tuple into `boundParams.adaptParams`, which the circuit already binds → **no circuit / trusted-setup change**.
- **`TransactModule._validateAtomicUnshieldInputs`** — `require(adaptParams == CCTPBindingLib.encode(...))` (+ `adaptContract == 0`, + it gains `maxFee`). A front-runner altering any of the three fails validation; the nullifier is untouched.
- **Finding-1 guard (`_transferTokenOut`)** — `require(recipient != address(this))`: an xchain-unshield proof (npk = pool) replayed through plain `transact()` would send USDC pool→pool and strand the note; this reverts it. Chosen over npk=recipient because the replay *reverts* (victim fully unaffected) rather than a benign-but-griefing local redirect.
- Fix is **bidirectional**: a local unshield (`adaptParams == 0`) can no longer be hijacked through the cross-chain path either.

## Tests — all green
- **Foundry (771):** new `CCTPBindingLib` unit + fuzz (any recipient/domain/fee/tag deviation, and `adaptParams == 0`, fail `verify`).
- **Hardhat adversarial (61):** the old "PoC ship-armada/armada-poc#364" (which *demonstrated* the theft) is flipped to assert the redirect **reverts** + the victim's correct call succeeds; plus inflated-maxFee reject, local-hijack reject, and the `transact()` replay guard. Existing unshield call sites updated to carry the binding.
- Integration / gas / hardening pass with the binding wired in.

## ⚠️ Coupled follow-up (NOT in this PR) — frontend proof-gen + e2e
The contract now **requires** the bound `adaptParams`; the current frontend builds a plain unshield proof (`adaptParams = 0`) via `generateUnshieldProof`, which this contract would reject. The frontend must switch `generateXchainUnshieldProof`/`buildXchainUnshieldTransactionStruct` to `generateProofTransactions(..., relayAdaptID = { contract: 0, parameters: CCTPBindingLib.encode(...) })` — the proven `yield.ts` pattern. This is a real proof-flow rewrite entangled with the handler's two-stage proof caching and **can only be validated by a real-proof e2e run** (headless typecheck is insufficient — per the spec's §8.1/§9). It was deliberately left out rather than shipped blind. **The pool must not be redeployed until the frontend change lands**, or real cross-chain unshields will revert on the binding check.

Relayer: **no ABI/selector change** (signature unchanged); recorded in the v2-relayer handoff doc, plus the pool-redeploy → VPS-manifest reminder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)