### PR TITLE
fix(privacy-pool): gate initialize() to the deployer — front-run hijack (#368)

### DIFF
--- a/contracts/privacy-pool/PrivacyPool.sol
+++ b/contracts/privacy-pool/PrivacyPool.sol
@@ -38,6 +38,16 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
     /// @dev Bounds setShieldFee so a single mis-proposal cannot brick shields by consuming all deposited value.
     uint256 public constant MAX_SHIELD_FEE_BPS = 1000;
 
+    /// @notice The address that deployed this contract; the only address permitted to call initialize().
+    /// @dev initialize() runs in a separate tx after deployment and sets owner/treasury/modules. Gating it
+    ///      to the deployer prevents a front-runner from initializing the pool with malicious params on a
+    ///      public chain before the deployer's own init lands (issue #368).
+    address private immutable deployer;
+
+    constructor() {
+        deployer = msg.sender;
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // INITIALIZATION
     // ══════════════════════════════════════════════════════════════════════════
@@ -67,6 +77,7 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
         address _owner,
         address payable _treasury
     ) external override {
+        require(msg.sender == deployer, "PrivacyPool: Only deployer");
         require(!initialized, "PrivacyPool: Already initialized");
         require(_shieldModule != address(0), "PrivacyPool: zero shieldModule");
         require(_transactModule != address(0), "PrivacyPool: zero transactModule");

--- a/contracts/privacy-pool/PrivacyPoolClient.sol
+++ b/contracts/privacy-pool/PrivacyPoolClient.sol
@@ -26,6 +26,11 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
     // STATE VARIABLES
     // ══════════════════════════════════════════════════════════════════════════
 
+    /// @notice The address that deployed this contract; the only address permitted to call initialize().
+    /// @dev Gates the separate-tx initialize() to the deployer so a front-runner cannot initialize the
+    ///      client with malicious params on a public chain before the deployer's own init lands (#368).
+    address private immutable deployer;
+
     /// @notice Whether the contract has been initialized
     bool public initialized;
 
@@ -67,6 +72,10 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
     // INITIALIZATION
     // ══════════════════════════════════════════════════════════════════════════
 
+    constructor() {
+        deployer = msg.sender;
+    }
+
     /**
      * @notice Initialize the PrivacyPoolClient contract
      * @param _tokenMessenger CCTP TokenMessenger address
@@ -86,6 +95,7 @@ contract PrivacyPoolClient is IPrivacyPoolClient {
         bytes32 _hubPool,
         address _owner
     ) external override {
+        require(msg.sender == deployer, "PrivacyPoolClient: Only deployer");
         require(!initialized, "PrivacyPoolClient: Already initialized");
 
         tokenMessenger = _tokenMessenger;

--- a/test/privacy_pool_adversarial.ts
+++ b/test/privacy_pool_adversarial.ts
@@ -343,6 +343,43 @@ describe("Privacy Pool Adversarial", function () {
       ).to.be.revertedWith("PrivacyPoolClient: Already initialized");
     });
 
+    // WHY: #368 — initialize() runs in a separate tx after deploy and sets owner/treasury/modules. It
+    // must be callable ONLY by the deployer, or a front-runner could initialize a freshly-deployed pool
+    // with attacker-controlled owner + malicious module addresses before the deployer's own init lands.
+    it("initialize rejects a non-deployer (front-run) on PrivacyPool", async function () {
+      const freshPool = await (await ethers.getContractFactory("PrivacyPool")).deploy();
+      await expect(
+        freshPool.connect(attacker).initialize(
+          await shieldModule.getAddress(),
+          await transactModule.getAddress(),
+          await merkleModule.getAddress(),
+          await verifierModule.getAddress(),
+          await hubTokenMessenger.getAddress(),
+          await hubMessageTransmitter.getAddress(),
+          await hubUsdc.getAddress(),
+          DOMAINS.hub,
+          attackerAddress, // attacker tries to seize ownership
+          attackerAddress
+        )
+      ).to.be.revertedWith("PrivacyPool: Only deployer");
+    });
+
+    // WHY: #368 — same front-run protection for the client contract.
+    it("initialize rejects a non-deployer (front-run) on PrivacyPoolClient", async function () {
+      const freshClient = await (await ethers.getContractFactory("PrivacyPoolClient")).deploy();
+      await expect(
+        freshClient.connect(attacker).initialize(
+          await clientTokenMessenger.getAddress(),
+          await clientMessageTransmitter.getAddress(),
+          await clientUsdc.getAddress(),
+          DOMAINS.client,
+          DOMAINS.hub,
+          ethers.zeroPadValue(privacyPoolAddress, 32),
+          attackerAddress
+        )
+      ).to.be.revertedWith("PrivacyPoolClient: Only deployer");
+    });
+
     it("non-owner cannot call setPrivilegedShieldCaller", async function () {
       await expect(
         privacyPool.connect(attacker).setPrivilegedShieldCaller(attackerAddress, true)


### PR DESCRIPTION
Fixes #368.

## Problem
`PrivacyPool.initialize` / `PrivacyPoolClient.initialize` were guarded only by `require(!initialized)`. Both are called in a **separate tx** after deployment and set `owner`, `treasury`, and all module addresses. On a public chain an attacker could front-run that init with attacker-controlled `owner` + malicious module addresses and own the pool before it's ever used (High).

## Fix
Capture the deployer in a constructor and gate `initialize` on it:
```solidity
address private immutable deployer;
constructor() { deployer = msg.sender; }
// in initialize():
require(msg.sender == deployer, "PrivacyPool: Only deployer");
```
Only the deployer can ever call `initialize`, so a front-runner reverts — the window is closed with no factory/proxy needed. Both contracts are direct deployments, so `immutable` works cleanly.

## Scope
- Contracts only (`PrivacyPool.sol`, `PrivacyPoolClient.sol`) — constructor + one `require` each.
- **No deploy-script change** — the deployer signer already deploys *and* initializes, so `msg.sender == deployer` holds.
- **No interface / relayer / frontend impact** — `initialize`'s signature is unchanged; it's deploy-time only.

## Tests
`test/privacy_pool_adversarial.ts` — new front-run rejection tests: a non-deployer `initialize` on a freshly-deployed pool/client reverts `"Only deployer"`. Existing deploy-then-init flows unaffected (same signer).

Green: Foundry **771**, Hardhat adversarial **63** (+2), integration **11**.

## Note
Distinct from #349 — this closes the *deploy-time* unauthenticated takeover; #349 (permanent deployer-EOA ownership) is a separate concern and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)