### PR TITLE
fix(privacy-pool): restore token blocklist (governance) + reentrancy guard (#369)

### DIFF
--- a/contracts/privacy-pool/PrivacyPool.sol
+++ b/contracts/privacy-pool/PrivacyPool.sol
@@ -48,6 +48,19 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
         deployer = msg.sender;
     }
 
+    /// @notice Reentrancy guard for the router's state-changing entry points.
+    /// @dev Hardening (no known exploit today — nullifiers are marked before transfers, event indices
+    ///      computed after, and the shield balance check self-reverts on a nested same-token shield);
+    ///      guards against a malicious token's transfer hook re-entering a guarded entry, and future-
+    ///      proofs against ordering changes (#369). 0-based so a fresh slot needs no init. Module
+    ///      self-calls (e.g. IMerkleModule(address(this)).insertLeaves) are unguarded and don't trip it.
+    modifier nonReentrant() {
+        require(_reentrancyStatus == 0, "PrivacyPool: reentrant call");
+        _reentrancyStatus = 1;
+        _;
+        _reentrancyStatus = 0;
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // INITIALIZATION
     // ══════════════════════════════════════════════════════════════════════════
@@ -122,7 +135,7 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
      * @param _shieldRequests Array of shield requests
      * @param integrator Integrator address for fee split (address(0) for no integrator)
      */
-    function shield(ShieldRequest[] calldata _shieldRequests, address integrator) external override {
+    function shield(ShieldRequest[] calldata _shieldRequests, address integrator) external override nonReentrant {
         _delegatecall(shieldModule, abi.encodeCall(IShieldModule.shield, (_shieldRequests, integrator)));
     }
 
@@ -130,7 +143,7 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
      * @notice Execute private transactions (transfers and/or unshields)
      * @param _transactions Array of transactions to process
      */
-    function transact(Transaction[] calldata _transactions) external override {
+    function transact(Transaction[] calldata _transactions) external override nonReentrant {
         _delegatecall(transactModule, abi.encodeCall(ITransactModule.transact, (_transactions)));
     }
 
@@ -153,7 +166,7 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
         address finalRecipient,
         uint256 maxFee,
         bytes32 uniqueNonce
-    ) external override returns (uint64) {
+    ) external override nonReentrant returns (uint64) {
         bytes memory result = _delegatecall(
             transactModule,
             abi.encodeCall(
@@ -297,6 +310,39 @@ contract PrivacyPool is PrivacyPoolStorage, IPrivacyPool {
         require(msg.sender == owner, "PrivacyPool: Only owner");
         remoteHookRouters[domain] = routerAddress;
         emit RemoteHookRouterSet(domain, routerAddress);
+    }
+
+    /**
+     * @notice Add tokens to the shield blocklist (governance kill-switch for a compromised/incompatible token).
+     * @dev Faithful port of Railgun's TokenBlocklist: blocked tokens cannot be SHIELDED, but existing notes
+     *      remain transferable and UNSHIELDABLE so holders can always exit. Non-exhaustive by nature. Idempotent.
+     *      USDC (the pool's core asset) can never be blocked — doing so would make in-flight cross-chain shields
+     *      undeliverable (burned on the client, unmintable on the hub) and strand funds. (#369)
+     * @param _tokens Token addresses to block
+     */
+    function addToBlocklist(address[] calldata _tokens) external override {
+        require(msg.sender == owner, "PrivacyPool: Only owner");
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            require(_tokens[i] != usdc, "PrivacyPool: cannot block USDC");
+            if (!tokenBlocklist[_tokens[i]]) {
+                tokenBlocklist[_tokens[i]] = true;
+                emit AddToBlocklist(_tokens[i]);
+            }
+        }
+    }
+
+    /**
+     * @notice Remove tokens from the shield blocklist. Idempotent.
+     * @param _tokens Token addresses to unblock
+     */
+    function removeFromBlocklist(address[] calldata _tokens) external override {
+        require(msg.sender == owner, "PrivacyPool: Only owner");
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            if (tokenBlocklist[_tokens[i]]) {
+                delete tokenBlocklist[_tokens[i]];
+                emit RemoveFromBlocklist(_tokens[i]);
+            }
+        }
     }
 
     /**

--- a/contracts/privacy-pool/interfaces/IPrivacyPool.sol
+++ b/contracts/privacy-pool/interfaces/IPrivacyPool.sol
@@ -17,6 +17,8 @@ interface IPrivacyPool is IMessageHandlerV2 {
     /// @notice Emitted when a remote pool address is configured
     event RemotePoolSet(uint32 indexed domain, bytes32 poolAddress);
     event RemoteHookRouterSet(uint32 indexed domain, bytes32 routerAddress);
+    event AddToBlocklist(address indexed token);
+    event RemoveFromBlocklist(address indexed token);
 
     /// @notice Emitted when testing mode is changed
     event TestingModeSet(bool enabled);
@@ -114,6 +116,18 @@ interface IPrivacyPool is IMessageHandlerV2 {
      * @param routerAddress Address of the remote CCTPHookRouter (as bytes32)
      */
     function setRemoteHookRouter(uint32 domain, bytes32 routerAddress) external;
+
+    /**
+     * @notice Add tokens to the shield blocklist (governance kill-switch). Cannot block USDC.
+     * @param _tokens Token addresses to block
+     */
+    function addToBlocklist(address[] calldata _tokens) external;
+
+    /**
+     * @notice Remove tokens from the shield blocklist.
+     * @param _tokens Token addresses to unblock
+     */
+    function removeFromBlocklist(address[] calldata _tokens) external;
 
     /**
      * @notice Set a verification key for a circuit configuration

--- a/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
+++ b/contracts/privacy-pool/storage/PrivacyPoolStorage.sol
@@ -194,11 +194,17 @@ abstract contract PrivacyPoolStorage {
     ///      any third party call receiveMessage directly, skip the hook, and strand the funds.
     mapping(uint32 => bytes32) public remoteHookRouters;
 
+    /// @notice Reentrancy guard status for the router's state-changing entry points.
+    /// @dev 0 = NOT_ENTERED, 1 = ENTERED. 0-based so a fresh slot needs no constructor init and the
+    ///      value lives in shared pool storage (per the "all pool state in PrivacyPoolStorage" rule).
+    ///      Used by PrivacyPool's nonReentrant modifier on shield / transact / atomicCrossChainUnshield.
+    uint256 internal _reentrancyStatus;
+
     // ══════════════════════════════════════════════════════════════════════════
     // RESERVED FOR FUTURE USE
     // ══════════════════════════════════════════════════════════════════════════
 
     /// @dev Reserved storage slots for future upgrades
     ///      When adding new state variables above, decrement this gap
-    uint256[45] private __gap;
+    uint256[44] private __gap;
 }

--- a/contracts/test/MaliciousReentrantToken.sol
+++ b/contracts/test/MaliciousReentrantToken.sol
@@ -1,0 +1,56 @@
+// ABOUTME: Test-only ERC20 whose transfer/transferFrom re-enter the PrivacyPool, to exercise the
+// ABOUTME: nonReentrant guard on shield / transact / atomicCrossChainUnshield (#369).
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IPrivacyPool} from "../privacy-pool/interfaces/IPrivacyPool.sol";
+import {ShieldRequest, Transaction} from "../railgun/logic/Globals.sol";
+
+/**
+ * @title MaliciousReentrantToken
+ * @notice A "weird" ERC20 that attempts to re-enter the PrivacyPool from inside its transfer hooks —
+ *         the exact vector the #369 reentrancy guard defends against. `target` selects which guarded
+ *         entry to re-enter; the guard fires before any validation, so the re-entry args can be empty.
+ */
+contract MaliciousReentrantToken is ERC20 {
+    address public pool;
+    uint8 public target; // 0 = off, 1 = shield, 2 = transact, 3 = atomicCrossChainUnshield
+    bool private _attacking;
+
+    constructor() ERC20("Malicious", "EVIL") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function setAttack(address _pool, uint8 _target) external {
+        pool = _pool;
+        target = _target;
+    }
+
+    function _reenter() internal {
+        if (_attacking || target == 0 || pool == address(0)) return;
+        _attacking = true;
+        if (target == 1) {
+            IPrivacyPool(pool).shield(new ShieldRequest[](0), address(0));
+        } else if (target == 2) {
+            IPrivacyPool(pool).transact(new Transaction[](0));
+        } else if (target == 3) {
+            Transaction memory dummy;
+            IPrivacyPool(pool).atomicCrossChainUnshield(dummy, 1, address(1), 0, bytes32(0));
+        }
+        _attacking = false;
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        _reenter(); // fires during _transferTokenOut (unshield payout)
+        return super.transfer(to, amount);
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        _reenter(); // fires during _transferTokenIn (shield deposit)
+        return super.transferFrom(from, to, amount);
+    }
+}

--- a/test/privacy_pool_adversarial.ts
+++ b/test/privacy_pool_adversarial.ts
@@ -1226,4 +1226,126 @@ describe("Privacy Pool Adversarial", function () {
       ).to.be.revertedWith("PrivacyPoolClient: Finality below minimum");
     });
   });
+
+  // ═══════════════════════════════════════════════════════════════════
+  // TOKEN BLOCKLIST (#369)
+  // ═══════════════════════════════════════════════════════════════════
+
+  describe("Token Blocklist (#369)", function () {
+    let tokenX: Contract;
+    let tokenXAddr: string;
+
+    beforeEach(async function () {
+      // A second, standard ERC-20 (not USDC). The pool is multi-asset, so this is normally shieldable.
+      tokenX = await (await ethers.getContractFactory("MockUSDCV2")).deploy("TokenX", "TKX");
+      tokenXAddr = await tokenX.getAddress();
+      await tokenX.mint(aliceAddress, ethers.parseUnits("100", 6));
+      await tokenX.connect(alice).approve(privacyPoolAddress, ethers.parseUnits("100", 6));
+    });
+
+    // WHY: #369 — restoring Railgun's blocklist gives governance a kill-switch for an incompatible/
+    // compromised token. Before the setter existed the mapping was a permanent no-op.
+    it("blocks shielding a blocklisted token", async function () {
+      await privacyPool.addToBlocklist([tokenXAddr]);
+      const req = makeShieldRequest(tokenXAddr, ethers.parseUnits("10", 6));
+      await expect(
+        privacyPool.connect(alice).shield([req], ethers.ZeroAddress)
+      ).to.be.revertedWith("ShieldModule: Token blocked");
+    });
+
+    // WHY: the block is reversible governance, not permanent — removeFromBlocklist re-enables shielding.
+    it("re-enables shielding after removeFromBlocklist", async function () {
+      await privacyPool.addToBlocklist([tokenXAddr]);
+      await privacyPool.removeFromBlocklist([tokenXAddr]);
+      const req = makeShieldRequest(tokenXAddr, ethers.parseUnits("10", 6));
+      await expect(privacyPool.connect(alice).shield([req], ethers.ZeroAddress)).to.not.be.reverted;
+    });
+
+    // WHY: Railgun semantics — a blocklisted token stays UNSHIELDABLE so holders can always exit; the
+    // check is shield-only. Shield first (allowed), then block, then confirm the unshield isn't gated.
+    it("still allows unshielding a token after it is blocklisted (exit path)", async function () {
+      const value = ethers.parseUnits("100", 6);
+      const npk = validNpk();
+      await privacyPool.connect(alice).shield([makeShieldRequest(tokenXAddr, value, npk)], ethers.ZeroAddress);
+      await privacyPool.addToBlocklist([tokenXAddr]);
+
+      const base = value - (value * 50n) / 10000n; // net of the 0.50% shield fee
+      const commitHash = computeCommitmentHash(BigInt(npk), BigInt(tokenXAddr), base);
+      const unshieldTx = makeTransaction({
+        merkleRoot: await privacyPool.merkleRoot(),
+        nullifiers: [ethers.keccak256(ethers.toUtf8Bytes("blocked-exit-null"))],
+        commitments: [commitHash],
+        unshield: 1,
+        unshieldPreimage: { npk, token: { tokenType: 0, tokenAddress: tokenXAddr, tokenSubID: 0 }, value: base },
+      });
+      await expect(privacyPool.transact([unshieldTx])).to.not.be.reverted;
+    });
+
+    // WHY: #369 core-asset guard — blocklisting USDC would make in-flight cross-chain shields
+    // undeliverable (burned on client, unmintable on hub → stranded). Must be impossible.
+    it("cannot blocklist USDC (protects the cross-chain shield path)", async function () {
+      await expect(
+        privacyPool.addToBlocklist([await hubUsdc.getAddress()])
+      ).to.be.revertedWith("PrivacyPool: cannot block USDC");
+    });
+
+    // WHY: the blocklist is a governance lever — only the owner may modify it.
+    it("only the owner can modify the blocklist", async function () {
+      await expect(
+        privacyPool.connect(attacker).addToBlocklist([tokenXAddr])
+      ).to.be.revertedWith("PrivacyPool: Only owner");
+      await expect(
+        privacyPool.connect(attacker).removeFromBlocklist([tokenXAddr])
+      ).to.be.revertedWith("PrivacyPool: Only owner");
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════
+  // REENTRANCY GUARD (#369)
+  // ═══════════════════════════════════════════════════════════════════
+
+  describe("Reentrancy Guard (#369)", function () {
+    let evil: Contract;
+    let evilAddr: string;
+
+    beforeEach(async function () {
+      evil = await (await ethers.getContractFactory("MaliciousReentrantToken")).deploy();
+      evilAddr = await evil.getAddress();
+      await evil.mint(aliceAddress, ethers.parseUnits("100", 6));
+      await evil.connect(alice).approve(privacyPoolAddress, ethers.parseUnits("100", 6));
+    });
+
+    // WHY: #369 hardening — a malicious token's transferFrom hook, fired during the shield deposit
+    // (_transferTokenIn), must not be able to re-enter ANY guarded entry. Covers all three targets.
+    for (const [target, name] of [[1, "shield"], [2, "transact"], [3, "atomicCrossChainUnshield"]] as const) {
+      it(`reverts when a shield deposit's transferFrom hook re-enters ${name}`, async function () {
+        await evil.setAttack(privacyPoolAddress, target);
+        const req = makeShieldRequest(evilAddr, ethers.parseUnits("10", 6));
+        await expect(
+          privacyPool.connect(alice).shield([req], ethers.ZeroAddress)
+        ).to.be.revertedWith("PrivacyPool: reentrant call");
+      });
+    }
+
+    // WHY: the OUT hook — an unshield payout's transfer hook (_transferTokenOut) re-entering a guarded
+    // entry must also revert. Shield with the attack off (creates a note), then unshield with it on.
+    it("reverts when an unshield payout's transfer hook re-enters transact", async function () {
+      await evil.setAttack(privacyPoolAddress, 0);
+      const value = ethers.parseUnits("100", 6);
+      const npk = validNpk();
+      await privacyPool.connect(alice).shield([makeShieldRequest(evilAddr, value, npk)], ethers.ZeroAddress);
+
+      await evil.setAttack(privacyPoolAddress, 2); // re-enter transact from the payout transfer hook
+      const base = value - (value * 50n) / 10000n;
+      const commitHash = computeCommitmentHash(BigInt(npk), BigInt(evilAddr), base);
+      const unshieldTx = makeTransaction({
+        merkleRoot: await privacyPool.merkleRoot(),
+        nullifiers: [ethers.keccak256(ethers.toUtf8Bytes("evil-out-null"))],
+        commitments: [commitHash],
+        unshield: 1,
+        unshieldPreimage: { npk, token: { tokenType: 0, tokenAddress: evilAddr, tokenSubID: 0 }, value: base },
+      });
+      await expect(privacyPool.transact([unshieldTx])).to.be.revertedWith("PrivacyPool: reentrant call");
+    });
+  });
 });


### PR DESCRIPTION
Closes #369.

## What
Two hardening changes to the PrivacyPool router:

1. **Token blocklist (restored).** `ShieldModule` already carried a dead `tokenBlocklist[token]` check with no way to populate the mapping. This ports Railgun's `addToBlocklist` / `removeFromBlocklist` (batch, owner-gated, `AddToBlocklist` / `RemoveFromBlocklist` events) onto the router so governance can actually block a token from the shield path. **Default-allow** — the pool stays intentionally multi-asset; this is a kill-switch, not an allowlist. USDC is **contract-enforced unblockable** (`require(_tokens[i] != usdc)`) so an operator can never strand the cross-chain shield path (which mints USDC and re-runs the blocklist check).

2. **Reentrancy guard (hardening — no known exploit).** Adds a 0-based manual `nonReentrant` guard (stored in `PrivacyPoolStorage`, not OZ, to honor the "all pool state in PrivacyPoolStorage" rule) on `shield`, `transact`, and `atomicCrossChainUnshield`. Defends against a weird/malicious ERC20 re-entering from a transfer hook. The yield adapter's sequential `transact`→`shield` is not nested, so it does not false-trip.

## Storage / deploy note
`PrivacyPoolStorage` gains `_reentrancyStatus` appended before `__gap` (`45→44`). **Layout-compatible append**, but the router + all four modules share this storage via delegatecall, so they **must be redeployed together**. `PrivacyPoolClient` is unchanged (USDC-hardcoded, no attacker-controllable external calls) — no client redeploy, no relayer ABI/selector change.

## Tests
- `test/privacy_pool_adversarial.ts` — 5 blocklist tests (blocks shield / re-enables after remove / blocked token still exits via unshield / USDC unblockable / owner-only) + 4 reentrancy tests (each guarded entry re-entered from a transfer hook, incl. the unshield OUT-path).
- New `contracts/test/MaliciousReentrantToken.sol` mock.
- Full suite green: Foundry **771**, adversarial **72**, yield + integration **20**.

## Ops
Never blocklist USDC (contract-enforced) or the yield share token (`ayUSDC`) — blocking the share token would break yield redemption's re-shield.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>