### PR TITLE
docs(fees): reconcile FEE_STRUCTURE spec with code (#169 mechanical subset)

### DIFF
--- a/contracts/fees/ArmadaFeeModule.sol
+++ b/contracts/fees/ArmadaFeeModule.sol
@@ -44,7 +44,9 @@ contract ArmadaFeeModule is Initializable, UUPSUpgradeable, OwnableUpgradeable, 
     /// @dev Governance-tunable via `setHarvestInterval`. Bounded by MIN/MAX_HARVEST_INTERVAL.
     uint256 public harvestInterval;
 
-    /// @notice Volume tiers (sorted descending by threshold). Max 10.
+    /// @notice Volume tiers. Order is not significant — `_getTieredTake` scans all tiers and picks
+    ///         the highest threshold that is <= the integrator's volume (order-independent best match),
+    ///         so `addTier`/`setTier` impose no ordering or duplicate constraint. Max MAX_TIERS.
     Tier[] internal _tiers;
 
     /// @notice Per-integrator registration and stats

--- a/specs/FEE_STRUCTURE.md
+++ b/specs/FEE_STRUCTURE.md
@@ -102,9 +102,11 @@ Governance can adjust:
 | Base Armada take | 50 bps | `setBaseArmadaTake(bps)` |
 | Volume threshold | $250k | `setTier(index, threshold, takeBps)` |
 | Armada take after threshold | 40 bps | `setTier(index, threshold, takeBps)` |
-| Yield fee | 15% | `setYieldFee(pct)` |
+| Yield fee | 15% (1500 bps) | `setYieldFee(bps)` |
 
-Governance can add additional tiers via `addTier(threshold, takeBps)`.
+`setYieldFee` takes **basis points**, not a percentage, bounded to `MIN_YIELD_FEE_BPS`–`MAX_YIELD_FEE_BPS` (see Safety Bounds). 15% is passed as `1500`.
+
+Governance can add tiers via `addTier(threshold, takeBps)` and remove one by index via `removeTier(index)` (swap-and-pop, so the last tier's index changes on removal).
 
 ### Custom Integrator Terms
 
@@ -124,21 +126,43 @@ Use cases:
 - Ecosystem grants (waived volume threshold)
 - Promotional periods
 
+### Safety Bounds
+
+The contract hard-caps every governance-tunable fee input. All setters revert outside these bounds:
+
+| Constant | Value | Applies to |
+|----------|-------|-----------|
+| `MAX_TIERS` | 10 | Max number of volume tiers (`addTier`) |
+| `MAX_BPS` | 1000 (10%) | Any single Armada-take component — base take, tier take, custom take |
+| `MIN_YIELD_FEE_BPS` | 100 (1%) | Lower bound on `setYieldFee` |
+| `MAX_YIELD_FEE_BPS` | 5000 (50%) | Upper bound on `setYieldFee` |
+| `MAX_INTEGRATOR_FEE_BPS` | 500 (5%) | Integrator base fee (`setIntegratorFee`) |
+
+Harvest cadence is separately bounded by `MIN_HARVEST_INTERVAL`/`MAX_HARVEST_INTERVAL` (`setHarvestInterval`).
+
 ---
 
 ## On-Chain Queries
 
 ```solidity
-// Integrator stats
-function getIntegratorVolume(address integrator) external view returns (uint256);
-function getIntegratorEarnings(address integrator) external view returns (uint256);
-function getIntegratorBaseFee(address integrator) external view returns (uint256);
+// Integrator stats & terms
+// IntegratorInfo bundles { baseFee, cumulativeVolume, cumulativeEarnings, registered };
+// CustomTerms bundles { customArmadaTakeBps, customVolumeThreshold, active }.
+function getIntegratorInfo(address integrator) external view returns (IntegratorInfo memory);
+function getIntegratorTerms(address integrator) external view returns (CustomTerms memory);
 function getIntegratorBonus(address integrator) external view returns (uint256);
-function getIntegratorTotalFee(address integrator) external view returns (uint256);
 
 // Fee calculation
+function calculateShieldFee(address integrator, uint256 amount)
+    external view returns (uint256 armadaTake, uint256 integratorFee, uint256 totalFee);
 function getArmadaTake(address integrator) external view returns (uint256);
 function getUserFee(address integrator) external view returns (uint256);
+
+// Tiers & yield config
+function getTiers() external view returns (Tier[] memory);
+function getTierCount() external view returns (uint256);
+function getYieldFeeBps() external view returns (uint256);
+function getHarvestInterval() external view returns (uint256);
 ```
 
 ---
@@ -146,6 +170,9 @@ function getUserFee(address integrator) external view returns (uint256);
 ## Events
 
 ```solidity
+// NOTE: the canonical home/name of the per-shield event is an OPEN design question (issue #167).
+// The fee module currently emits `ShieldFeeRecorded` (below) rather than this `Shield` shape; the
+// pool's ShieldModule separately emits its own `Shield` event. This block is not yet reconciled.
 event Shield(
     address indexed asset,
     uint256 amount,
@@ -155,15 +182,36 @@ event Shield(
     uint256 integratorFeeEarned
 );
 
-event IntegratorFeeUpdated(
+// As implemented on the fee module today:
+event ShieldFeeRecorded(
+    address indexed asset,
     address indexed integrator,
-    uint256 newFeeBps
+    uint256 amount,
+    uint256 armadaTakeBps,
+    uint256 armadaTakePaid,
+    uint256 integratorFeePaid,
+    uint256 integratorCumulativeVolume
+);
+
+event IntegratorRegistered(
+    address indexed integrator,
+    uint256 baseFee
+);
+
+event TierAdded(
+    uint256 index,
+    uint256 volumeThreshold,
+    uint256 armadaTakeBps
 );
 
 event TierUpdated(
-    uint256 indexed tierIndex,
+    uint256 index,
     uint256 volumeThreshold,
     uint256 armadaTakeBps
+);
+
+event TierRemoved(
+    uint256 index
 );
 ```
 


### PR DESCRIPTION
Partial progress on #169 — the **mechanical** spec/code reconciliation items. The two design questions (#167 event home, #168/#161 `customVolumeThreshold` semantics) are **deferred** and NOT touched here.

## Spec fixes (`specs/FEE_STRUCTURE.md`) — verified against current code
- **#159** — event `IntegratorFeeUpdated` → `IntegratorRegistered(address,uint256)` (matches `IArmadaFeeModule.sol:43`).
- **#160** — replaced 5 phantom getters (`getIntegratorVolume`/`Earnings`/`BaseFee`/`TotalFee`, …) with the real API: `getIntegratorInfo` (struct), `getIntegratorTerms`, `getIntegratorBonus`, `calculateShieldFee`, `getArmadaTake`, `getUserFee`, `getTiers`/`getTierCount`, `getYieldFeeBps`, `getHarvestInterval`.
- **#162** — `setYieldFee` documented as **bps** (bounded `MIN/MAX_YIELD_FEE_BPS`), not pct; 15% = `1500`.
- **#163** — documented `removeTier(index)` (swap-and-pop; last tier's index shifts on removal).
- **#164** — added `TierAdded` / `TierRemoved` to the events block.
- **#165** — new **Safety Bounds** table: `MAX_TIERS=10`, `MAX_BPS=1000`, `MIN/MAX_YIELD_FEE_BPS=100/5000`, `MAX_INTEGRATOR_FEE_BPS=500`, plus harvest-interval bounds.

## Contract comment (`ArmadaFeeModule.sol:47`)
- **#166** — the tier array comment claimed "sorted descending"; `_getTieredTake` is an order-independent best-match scan and `addTier`/`setTier` enforce no ordering. Comment corrected to match. **No behavioral change** (comment-only).

## Explicitly deferred (still open on #169)
- **#167** — canonical home/name of the per-shield event (spec `Shield` vs code `ShieldFeeRecorded`, plus the pool's own `Shield`). The spec's events block now carries an inline note flagging this as unreconciled rather than silently picking a winner.
- **#168 / #161** — `customVolumeThreshold` is stored but never read. Needs a decision: remove the field vs implement threshold-gating (the latter has a UUPS storage-layout consideration). Custom Integrator Terms spec block left untouched pending that call.

Also left out of scope (separate issues, per the #169 checklist): #51, #155, #230, armada-relayer#19.

## Tests
No behavioral change. Compiles clean; fee-module Foundry suite green (**101 passed**).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>