### PR TITLE
feat(yield): relayer-mediated withdraw + redeem fee verification (#312)

### DIFF
--- a/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
@@ -74,16 +74,10 @@ export function EarnReviewStep({
         feeLabel="Relayer fee"
       />
       {tab === 'withdraw' ? (
-        <>
-          <div className={styles.slippageNotice}>
-            The vault rate moves with each new block. Your final USDC may differ slightly from
-            this quote.
-          </div>
-          <div className={styles.slippageNotice}>
-            Withdrawals require a wallet signature and a small amount of ETH for gas. Relayer-
-            mediated withdraw is tracked as a follow-up.
-          </div>
-        </>
+        <div className={styles.slippageNotice}>
+          The vault rate moves with each new block. Your final USDC may differ slightly from
+          this quote.
+        </div>
       ) : null}
       {submitBlockedReason ? (
         <div className={styles.syncNotice} role="status" aria-live="polite">

--- a/apps/armada-interface/src/features/unshield-xchain/handler.chainpin.test.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/handler.chainpin.test.ts
@@ -20,8 +20,7 @@ vi.mock('@/lib/tx/receipt', async (importActual) => {
 
 // Mock the Railgun SDK wrapper so importing the handler doesn't transitively load circomlibjs.
 vi.mock('@/lib/railgun/unshield', () => ({
-  buildXchainUnshieldTransactionStruct: vi.fn(),
-  generateXchainUnshieldProof: vi.fn(),
+  buildXchainUnshieldTransaction: vi.fn(),
 }))
 vi.mock('@/lib/railgun/sync', () => ({ refreshShieldedBalances: vi.fn(async () => {}) }))
 vi.mock('@/lib/railgun/keyManager', () => ({
@@ -75,7 +74,16 @@ function overrideRecordWithHash(): TxRecord<'unshield-xchain'> {
       broadcasterRailgunAddress: '0zk1relayer',
       useWalletOverride: true,
     },
-    artifacts: { sourceTxHash: '0xfeed' },
+    // A record at submit-relayer always carries the encoded calldata persisted at build-proof —
+    // required now that runSubmitAndBurn dispatches from artifacts rather than re-proving.
+    artifacts: {
+      sourceTxHash: '0xfeed',
+      unshieldTx: {
+        to: '0x5555555555555555555555555555555555555555',
+        data: '0xdeadbeef',
+        value: '0',
+      },
+    },
     walletContext: { evmAddress: '0xabc', railgunWalletId: 'rw-1', sourceChainId: 31337 },
   } as TxRecord<'unshield-xchain'>
 }

--- a/apps/armada-interface/src/features/unshield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/handler.ts
@@ -20,8 +20,7 @@ import {
 } from '@/lib/railgun/keyManager'
 import { refreshShieldedBalances } from '@/lib/railgun/sync'
 import {
-  buildXchainUnshieldTransactionStruct,
-  generateXchainUnshieldProof,
+  buildXchainUnshieldTransaction,
   type BroadcasterFeeRecipient,
 } from '@/lib/railgun/unshield'
 import {
@@ -206,23 +205,63 @@ async function runBuildProof(
   const deployments = await loadDeployments()
   const tokenAddress = deployments.hub.cctp.usdc
   const privacyPoolAddress = deployments.hub.contracts.privacyPool
+  const hubChainId = getNetworkConfig().hub.chainId
+
+  // Resolve the CCTP destination tuple. It is bound into the proof AND passed as the on-chain
+  // atomicCrossChainUnshield args below; both MUST match or the hub rejects with
+  // "destination not bound to proof" (#399).
+  const destChain = getNetworkConfig().clients.find(c => c.chainId === record.meta.toChainId)
+  if (!destChain) {
+    throw new Error(`Unknown destination chain ${record.meta.toChainId}`)
+  }
+  const destinationDomain = destChain.domain
+  const destClientDeployment = deployments.clients.find(c => c.chainId === record.meta.toChainId)
+  if (!destClientDeployment) {
+    throw new Error(`No deployment for destination chain ${record.meta.toChainId}`)
+  }
+  // maxFee = upper bound CCTP's MessageTransmitter accepts for `feeExecuted`. Iris sets the actual
+  // fee (1–1.3 bps depending on chain); we pass 2× the realistic estimate as headroom. Fee is
+  // deducted from the amount minted on the destination — recipient receives (amount − feeExecuted).
+  const maxFee = cctpMaxFeeForKind('unshield-xchain', record.meta.amount)
 
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   const progress = createProofProgressWriter(record, ctx.signal)
-  await generateXchainUnshieldProof({
+  const built = await buildXchainUnshieldTransaction({
     walletId,
     encryptionKey,
     tokenAddress,
     privacyPoolAddress,
     amount: record.meta.amount,
     broadcasterFee: broadcasterFeeFromRecord(record, tokenAddress),
+    finalRecipient: record.meta.recipient,
+    destinationDomain,
+    maxFee,
+    hubChainId,
     onProgress: progress.write,
   })
 
   if (ctx.signal.aborted) throw new Error('cancelled')
-  // Advance from the LIVE record (progress bumps incremented updatedSeq).
-  await ctx.upsert(advance(progress.latest(), 'submit-relayer'))
+
+  // The CCTP destinationCaller is pinned to remoteHookRouters[destinationDomain] by PrivacyPool
+  // (issue #64) — it is not passed here.
+  const calldata = encodeAtomicCrossChainUnshield(
+    built.transaction,
+    destinationDomain,
+    record.meta.recipient as `0x${string}`,
+    maxFee,
+    deliveryNonce(record.id), // issue #287 — unique per-tx marker echoed into the CCTP hookData
+  )
+
+  // Advance from the LIVE record (progress bumps incremented updatedSeq). Persist the encoded
+  // calldata so submit-relayer dispatches it without re-proving.
+  await ctx.upsert(advance(progress.latest(), 'submit-relayer', {
+    unshieldTx: {
+      to: privacyPoolAddress as `0x${string}`,
+      data: calldata,
+      value: '0',
+    },
+  }))
 }
 
 async function runSubmitAndBurn(
@@ -230,59 +269,15 @@ async function runSubmitAndBurn(
   ctx: Parameters<typeof unshieldXchainHandler.run>[1],
 ): Promise<void> {
   const deployments = await loadDeployments()
-  const privacyPoolAddress = deployments.hub.contracts.privacyPool
   const hubChainId = getNetworkConfig().hub.chainId
-  const existingHash = record.artifacts.sourceTxHash
-
-  // Build the hub-burn calldata only when we still need to broadcast. On re-entry (Retry /
-  // resume-on-reload) the hash is already persisted; rebuilding it would re-run the SDK proof
-  // (whose in-memory cache doesn't survive a reload) and serve no purpose. (P0-1)
-  let calldata: `0x${string}` | undefined
-  if (!existingHash) {
-    const walletId = kmGetWalletId()
-    const tokenAddress = deployments.hub.cctp.usdc
-
-    // Map destination chain id → CCTP domain. Both come from the network config.
-    const destChain = getNetworkConfig().clients.find(c => c.chainId === record.meta.toChainId)
-    if (!destChain) {
-      throw new Error(`Unknown destination chain ${record.meta.toChainId}`)
-    }
-    const destinationDomain = destChain.domain
-    const destClientDeployment = deployments.clients.find(c => c.chainId === record.meta.toChainId)
-    if (!destClientDeployment) {
-      throw new Error(`No deployment for destination chain ${record.meta.toChainId}`)
-    }
-
-    // Build the Transaction struct (decoded from the SDK's populated transact() calldata). The
-    // broadcaster fee must be passed here EXACTLY as it was passed to generateXchainUnshieldProof —
-    // the SDK's in-memory proof cache is keyed by it, and a mismatch throws "proof not found".
-    const txStruct = await buildXchainUnshieldTransactionStruct({
-      walletId,
-      tokenAddress,
-      privacyPoolAddress,
-      amount: record.meta.amount,
-      broadcasterFee: broadcasterFeeFromRecord(record, tokenAddress),
-    })
-    if (ctx.signal.aborted) throw new Error('cancelled')
-
-    // The CCTP destinationCaller is pinned to remoteHookRouters[destinationDomain] by PrivacyPool
-    // (issue #64) — it is not passed here.
-
-    // maxFee = upper bound CCTP's MessageTransmitter accepts for `feeExecuted`. Iris sets the
-    // actual fee (1–1.3 bps depending on chain); we pass 2× the realistic estimate as headroom.
-    // Fee is deducted from the amount minted on the destination — recipient receives
-    // (amount − feeExecuted). The modal's Review step shows the realistic fee (without the bound
-    // multiplier) so the user sees what they will actually pay, not the contract bound.
-    const maxFee = cctpMaxFeeForKind('unshield-xchain', record.meta.amount)
-
-    calldata = encodeAtomicCrossChainUnshield(
-      txStruct,
-      destinationDomain,
-      record.meta.recipient as `0x${string}`,
-      maxFee,
-      deliveryNonce(record.id), // issue #287 — unique per-tx marker echoed into the CCTP hookData
-    )
+  const unshieldTx = record.artifacts.unshieldTx
+  if (!unshieldTx) {
+    throw new Error('Cross-chain unshield tx missing — re-run build-proof stage.')
   }
+  // `unshieldTx` (the encoded atomicCrossChainUnshield calldata) is persisted at build-proof, so it
+  // survives a reload — no re-proving on resume. Only the broadcast itself is guarded against
+  // re-entry via the sourceTxHash idempotency check below. (P0-1)
+  const existingHash = record.artifacts.sourceTxHash
 
   // A6 wallet-override path — submit the wrapper calldata via the user's EVM wallet. The
   // CCTP-message extraction + destination polling are identical to the relayer path; the only
@@ -300,18 +295,18 @@ async function runSubmitAndBurn(
       const sender = record.walletContext.evmAddress
       if (sender) {
         await simulateOrThrow({
-          to: privacyPoolAddress as `0x${string}`,
-          data: calldata!,
-          value: 0n,
+          to: unshieldTx.to,
+          data: unshieldTx.data,
+          value: BigInt(unshieldTx.value),
           account: sender as `0x${string}`,
           chainId: hubChainId,
         })
         if (ctx.signal.aborted) throw new Error('cancelled')
       }
       userHash = await sendTransaction(wagmiConfig, {
-        to: privacyPoolAddress as `0x${string}`,
-        data: calldata!,
-        value: 0n,
+        to: unshieldTx.to,
+        data: unshieldTx.data,
+        value: BigInt(unshieldTx.value),
         chainId: hubChainId,
       })
       const broadcast = await recordBroadcastHash(record, userHash, ctx)
@@ -351,8 +346,8 @@ async function runSubmitAndBurn(
       submitResponse = await submitRelay(
         {
           chainId: hubChainId,
-          to: privacyPoolAddress,
-          data: calldata!,
+          to: unshieldTx.to,
+          data: unshieldTx.data,
           feesCacheId: record.meta.feeCacheId,
           idempotencyKey: record.id,
         },

--- a/apps/armada-interface/src/features/yield-withdraw/handler.ts
+++ b/apps/armada-interface/src/features/yield-withdraw/handler.ts
@@ -115,6 +115,9 @@ async function runBuildProof(
       data: built.transaction.data,
       value: built.transaction.value.toString(),
     },
+    // Persisted so submit-relayer can hand the relayer the fee note's random to verify the fee is
+    // shielded to it (#312). Undefined on the wallet-override / fee-less path.
+    feeShieldRandom: built.feeShieldRandom,
   }))
 }
 
@@ -186,6 +189,8 @@ async function runSubmitAndConfirm(
           data: yieldTx.data,
           feesCacheId: record.meta.feeCacheId,
           idempotencyKey: record.id,
+          // Redeem fee is contract-side (#312); the relayer needs this to verify the fee note is its own.
+          feeShieldRandom: record.artifacts.feeShieldRandom,
         },
         ctx.signal,
       )

--- a/apps/armada-interface/src/lib/railgun/init.ts
+++ b/apps/armada-interface/src/lib/railgun/init.ts
@@ -113,6 +113,16 @@ async function doInit(): Promise<void> {
   // routes to the sanctioned telemetry channel rather than console — keeping errors visible
   // without the verbose leak. Secret-handling rules still hold: secrets-bearing scopes
   // (wallet.ts, keyManager.ts) never log; the SDK's logs are about engine lifecycle, not keys.
+  // The engine subscribes to ALL events (`'*'`) on the PrivacyPool contract, then rejects any log
+  // that isn't one of its four 1-topic events (Nullified/Shield/Transact/Unshield). Armada's pool
+  // emits additional events — some with indexed params, so >1 topic — at that same address, so every
+  // successful pool tx trips one of these two guards. The engine catches + swallows them internally
+  // (they never affect tree sync), but they still reach this error logger. Demote them so they don't
+  // spam the console (DEV) or generate false-alarm Sentry events (prod). Genuine SDK errors still flow.
+  const isBenignEngineEventNoise = (err: Error): boolean =>
+    err.message === 'Requires one topic for railgun events' ||
+    err.message === 'Event topic not recognized'
+
   const debugLogging = import.meta.env.DEV
   setLoggers(
     debugLogging
@@ -123,10 +133,16 @@ async function doInit(): Promise<void> {
       : () => {},
     debugLogging
       ? (err: Error) => {
+          if (isBenignEngineEventNoise(err)) {
+            // eslint-disable-next-line no-console
+            console.debug('[railgun] (benign engine event noise)', err.message)
+            return
+          }
           // eslint-disable-next-line no-console
           console.error('[railgun]', err)
         }
       : (err: Error) => {
+          if (isBenignEngineEventNoise(err)) return
           trackError('railgun.sdk', err)
         },
   )

--- a/apps/armada-interface/src/lib/railgun/unshield.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield.ts
@@ -1,7 +1,9 @@
 // ABOUTME: SDK-side helpers for unshield — generateUnshieldProof + populateProvedUnshield with broadcaster-fee (relayer-mediated) support.
 // ABOUTME: Dynamic-imports the Railgun SDK + shared-models to dodge jsdom's circomlibjs crash; the populated calldata gets POSTed to /relay by features/unshield/handler.
 
+import { ethers } from 'ethers'
 import { loadHubNetwork } from './network'
+import { encodeCctpBinding } from './cctpBinding'
 import { yieldToPaint } from '@/lib/paint'
 
 type RailgunSdk = typeof import('@railgun-community/wallet')
@@ -164,144 +166,165 @@ export async function populateUnshieldTransaction(opts: {
 }
 
 /**
- * Cross-chain unshield: the proof is generated with the PrivacyPool itself as the unshield
- * recipient (the pool effectively burns the shielded UTXO and emits CCTP messages to deliver
- * USDC to the real recipient on a different chain). Same SDK fn, different recipient.
+ * Cross-chain unshield: generate the proof AND return the ready-to-encode Transaction struct in a
+ * single call. The proof is generated with the PrivacyPool itself as the unshield recipient (the
+ * pool burns the shielded UTXO and emits CCTP messages to deliver USDC to the real recipient on a
+ * different chain).
  *
- * `broadcasterFee`: A5 — when present, embeds a broadcaster-fee output to the relayer's 0zk
- * address so the relayer-mediated hub burn pays the relayer in the same atomic tx. When null,
- * falls back to a direct user-submitted hub burn (kept for the A6 wallet-override fallback).
+ * The CCTP destination (`finalRecipient`, `destinationDomain`, `maxFee`) is bound into the proof's
+ * `boundParams.adaptParams` via `encodeCctpBinding`. The hub `TransactModule` re-derives that hash
+ * from the submitted `atomicCrossChainUnshield` arguments and rejects any mismatch, so a relayer or
+ * front-runner cannot redirect the exit (#364/#378/#399). `adaptContract` is `ZeroAddress` — this is
+ * a plain unshield-to-pool, NOT a relay-adapt cross-contract call, and the contract requires
+ * `adaptContract == address(0)`.
+ *
+ * `broadcasterFee`: A5 — when present, embeds a broadcaster-fee output to the relayer's 0zk address
+ * so the relayer-mediated hub burn pays the relayer in the same atomic tx. When null, falls back to
+ * a direct user-submitted hub burn (kept for the A6 wallet-override fallback).
+ *
+ * Uses `generateProofTransactions` (not `generateUnshieldProof`) because only the lower-level API
+ * accepts a `relayAdaptID`, and it returns the proved Transaction struct directly — no populate +
+ * calldata-decode round-trip. Mirrors the yield.ts pattern.
  */
-export async function generateXchainUnshieldProof(opts: {
+export async function buildXchainUnshieldTransaction(opts: {
   walletId: string
   encryptionKey: string
   tokenAddress: string
   privacyPoolAddress: string
   amount: bigint
   broadcasterFee: BroadcasterFeeRecipient | null
+  finalRecipient: string
+  destinationDomain: number
+  maxFee: bigint
+  hubChainId: number
   onProgress?: (fraction: number) => void
-}): Promise<void> {
+}): Promise<{ transaction: unknown }> {
   await loadHubNetwork()
-  const [{ generateUnshieldProof }, { TXIDVersion, NetworkName }] = await Promise.all([
+  const [{ generateProofTransactions }, { TXIDVersion, ProofType, NetworkName }] = await Promise.all([
     railgunSdk(),
     sharedModels(),
   ])
+
+  const adaptParams = encodeCctpBinding(opts.finalRecipient, opts.destinationDomain, opts.maxFee)
+
   const sendWithPublicWallet = opts.broadcasterFee === null
   // Yield one frame so the caller's "Generating proof…" state paints before the WASM proof gen
   // blocks the main thread for 20-30s.
   await yieldToPaint()
-  await generateUnshieldProof(
-    TXIDVersion.V2_PoseidonMerkle,
+  const { provedTransactions } = await generateProofTransactions(
+    ProofType.Unshield,
     NetworkName.Hardhat,
     opts.walletId,
+    TXIDVersion.V2_PoseidonMerkle,
     opts.encryptionKey,
+    false, // showSenderAddressToRecipient
+    undefined, // memoText
     [
       {
         tokenAddress: opts.tokenAddress,
         amount: opts.amount,
         // The PrivacyPool itself receives the USDC — it then forwards via CCTP.
-        //
-        // TODO(#399): the hub now BINDS the destination (recipient, domain, maxFee) into the proof via
-        // boundParams.adaptParams (#364/#378, PR #398). This plain generateUnshieldProof sets
-        // adaptParams = 0, which the updated atomicCrossChainUnshield REJECTS. Switch this +
-        // buildXchainUnshieldTransactionStruct to generateProofTransactions(..., relayAdaptID = {
-        // contract: ZeroAddress, parameters: encodeCctpBinding(finalRecipient, destinationDomain,
-        // maxFee) }) — the yield.ts pattern. recipientAddress stays the pool (npk = pool; the cross-path
-        // replay is closed by a contract-side _transferTokenOut guard). Needs a real-proof e2e — see
-        // #399. Coupled: the pool must not be redeployed until this lands, or cross-chain unshields
-        // revert. `encodeCctpBinding` is ready in lib/railgun/cctpBinding.ts.
         recipientAddress: opts.privacyPoolAddress,
       },
     ],
     [], // nftAmountRecipients
     opts.broadcasterFee ?? undefined,
     sendWithPublicWallet,
+    { contract: ethers.ZeroAddress, parameters: adaptParams },
+    false, // useDummyProof
     undefined, // overallBatchMinGasPrice — A6/follow-up
     (progress) => opts.onProgress?.(progress / 100),
   )
+  if (!provedTransactions.length) {
+    throw new Error('buildXchainUnshieldTransaction: SDK returned no proved transactions')
+  }
+  return { transaction: normalizeTransaction(provedTransactions[0], opts.hubChainId) }
 }
 
 /**
- * Populate the proof + decode the engine's `transact([tx])` calldata to extract the single
- * inner `Transaction` struct. We need the struct (not the calldata) because the cross-chain
- * entry point is `atomicCrossChainUnshield(tx, ...)` — same struct, different surrounding args.
- *
- * Returns a deeply-cloned mutable object with bigints restored (ethers v6 returns frozen
- * Result proxies and large-magnitude integers are stringified during the JSON deep-clone).
+ * Coerce the SDK's proved Transaction struct into the exact tuple shape the on-chain
+ * `atomicCrossChainUnshield` ABI expects: strict bigint / hex types on every field. Adapted from
+ * the yield.ts adapter normalizer.
  */
-export async function buildXchainUnshieldTransactionStruct(opts: {
-  walletId: string
-  tokenAddress: string
-  privacyPoolAddress: string
-  amount: bigint
-  broadcasterFee: BroadcasterFeeRecipient | null
-}): Promise<unknown> {
-  const [{ populateProvedUnshield }, { TXIDVersion, NetworkName }] = await Promise.all([
-    railgunSdk(),
-    sharedModels(),
-  ])
-  const { ethers } = await import('ethers')
-
-  // A5: broadcaster mode flips sendWithPublicWallet to false → SDK selects Type1 (legacy) gas
-  // because the broadcaster flow needs `overallBatchMinGasPrice`, which only Type1 supports.
-  // Type2 here surfaces the SDK's "expected Type1, received Type2" runtime error. Direct submit
-  // (broadcasterFee=null) keeps Type2 to match what MetaMask sends.
-  const sendWithPublicWallet = opts.broadcasterFee === null
-  const gasDetails = await buildGasDetails(sendWithPublicWallet)
-  const result = await populateProvedUnshield(
-    TXIDVersion.V2_PoseidonMerkle,
-    NetworkName.Hardhat,
-    opts.walletId,
-    [
-      {
-        tokenAddress: opts.tokenAddress,
-        amount: opts.amount,
-        recipientAddress: opts.privacyPoolAddress,
-      },
-    ],
-    [], // nftAmountRecipients
-    opts.broadcasterFee ?? undefined,
-    sendWithPublicWallet,
-    undefined, // overallBatchMinGasPrice — A6/follow-up
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    gasDetails as any,
-  )
-  const calldata = result.transaction.data
-  if (!calldata) {
-    throw new Error('buildXchainUnshieldTransactionStruct: SDK returned no calldata')
+function normalizeTransaction(tx: unknown, hubChainId: number): unknown {
+  const toBigInt = (v: unknown): bigint => {
+    if (v == null) return 0n
+    if (typeof v === 'bigint') return v
+    if (typeof v === 'number' || typeof v === 'string') return BigInt(v)
+    return 0n
   }
-
-  // The SDK populates `transact([transaction])`; decode and pull the single inner struct.
-  const TRANSACT_ABI = [
-    'function transact((tuple(tuple(uint256 x, uint256 y) a, tuple(uint256[2] x, uint256[2] y) b, tuple(uint256 x, uint256 y) c) proof, bytes32 merkleRoot, bytes32[] nullifiers, bytes32[] commitments, tuple(uint16 treeNumber, uint72 minGasPrice, uint8 unshield, uint64 chainID, address adaptContract, bytes32 adaptParams, tuple(bytes32[4] ciphertext, bytes32 blindedSenderViewingKey, bytes32 blindedReceiverViewingKey, bytes annotationData, bytes memo)[] commitmentCiphertext) boundParams, tuple(bytes32 npk, tuple(uint8 tokenType, address tokenAddress, uint256 tokenSubID) token, uint120 value) unshieldPreimage)[] _transactions)',
+  const toHex = (v: unknown): string => {
+    if (v == null) return ethers.ZeroHash
+    if (typeof v === 'string' && v.startsWith('0x')) return v
+    try {
+      return ethers.hexlify(v as ethers.BytesLike)
+    } catch {
+      return ethers.ZeroHash
+    }
+  }
+  const t = tx as Record<string, unknown>
+  const bp = t.boundParams as Record<string, unknown> | undefined
+  const rawCiphertext = (bp?.commitmentCiphertext ?? []) as Array<Record<string, unknown> | null | undefined>
+  const defaultCiphertext: [string, string, string, string] = [
+    ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash,
   ]
-  const iface = new ethers.Interface(TRANSACT_ABI)
-  const decoded = iface.decodeFunctionData('transact', calldata)
-  const transactions = decoded[0]
-  if (!transactions || transactions.length === 0) {
-    throw new Error('buildXchainUnshieldTransactionStruct: no transactions in decoded calldata')
+  const commitmentCiphertext = rawCiphertext
+    .filter((c): c is Record<string, unknown> => c != null)
+    .map((c) => {
+      const ct = c.ciphertext as string[] | undefined
+      const arr = Array.isArray(ct) && ct.length >= 4
+        ? [ct[0], ct[1], ct[2], ct[3]] as [string, string, string, string]
+        : defaultCiphertext
+      return {
+        ciphertext: arr,
+        blindedSenderViewingKey: (c.blindedSenderViewingKey ?? ethers.ZeroHash) as string,
+        blindedReceiverViewingKey: (c.blindedReceiverViewingKey ?? ethers.ZeroHash) as string,
+        annotationData: (c.annotationData ?? '0x') as string,
+        memo: (c.memo ?? '0x') as string,
+      }
+    })
+
+  const up = t.unshieldPreimage as Record<string, unknown> | undefined
+  const token = (up?.token ?? {}) as Record<string, unknown>
+  const unshieldPreimage = {
+    npk: toHex(up?.npk) || ethers.ZeroHash,
+    token: {
+      tokenType: Number(token.tokenType ?? 0),
+      tokenAddress: (token.tokenAddress != null ? String(token.tokenAddress) : ethers.ZeroAddress) as string,
+      tokenSubID: toBigInt(token.tokenSubID),
+    },
+    value: toBigInt(up?.value),
   }
 
-  // ethers v6 returns frozen `Result` proxies. Deep-clone via JSON (with bigint stringification)
-  // and restore bigints where the contract expects them. Same trick the legacy app uses.
-  const raw = transactions[0]
-  const cloned = JSON.parse(
-    JSON.stringify(raw, (_, v) => (typeof v === 'bigint' ? v.toString() : v)),
-  )
-  function restoreBigints(value: unknown): unknown {
-    if (value === null || value === undefined) return value
-    if (typeof value === 'string' && /^\d+$/.test(value) && value.length > 15) {
-      return BigInt(value)
-    }
-    if (Array.isArray(value)) return value.map(restoreBigints)
-    if (typeof value === 'object') {
-      const out: Record<string, unknown> = {}
-      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-        out[k] = restoreBigints(v)
-      }
-      return out
-    }
-    return value
+  const proof = t.proof as Record<string, unknown> | undefined
+  const pa = (proof?.a ?? {}) as Record<string, unknown>
+  const pb = (proof?.b ?? {}) as Record<string, unknown>
+  const pc = (proof?.c ?? {}) as Record<string, unknown>
+  const pbx = pb.x as unknown[] | undefined
+  const pby = pb.y as unknown[] | undefined
+  const snarkProof = {
+    a: { x: toBigInt(pa.x), y: toBigInt(pa.y) },
+    b: {
+      x: [toBigInt(pbx?.[0]), toBigInt(pbx?.[1])] as [bigint, bigint],
+      y: [toBigInt(pby?.[0]), toBigInt(pby?.[1])] as [bigint, bigint],
+    },
+    c: { x: toBigInt(pc.x), y: toBigInt(pc.y) },
   }
-  return restoreBigints(cloned)
+
+  return {
+    proof: snarkProof,
+    merkleRoot: toHex(t.merkleRoot) || ethers.ZeroHash,
+    nullifiers: ((t.nullifiers ?? []) as unknown[]).map((n) => toHex(n) || ethers.ZeroHash) as string[],
+    commitments: ((t.commitments ?? []) as unknown[]).map((c) => toHex(c) || ethers.ZeroHash) as string[],
+    boundParams: {
+      treeNumber: Number(bp?.treeNumber ?? 0),
+      minGasPrice: toBigInt(bp?.minGasPrice),
+      unshield: Number(bp?.unshield ?? 1),
+      chainID: toBigInt(bp?.chainID) || BigInt(hubChainId),
+      adaptContract: (bp?.adaptContract != null ? String(bp.adaptContract) : ethers.ZeroAddress) as string,
+      adaptParams: toHex(bp?.adaptParams) || ethers.ZeroHash,
+      commitmentCiphertext,
+    },
+    unshieldPreimage,
+  }
 }

--- a/apps/armada-interface/src/lib/railgun/yield.ts
+++ b/apps/armada-interface/src/lib/railgun/yield.ts
@@ -177,6 +177,12 @@ const ADAPTER_ABI = [
 export interface YieldAdaptProofResult {
   /** Ready-to-send tx (to = adapterAddress, data = encoded calldata, value = 0). */
   transaction: { to: `0x${string}`; data: `0x${string}`; value: bigint }
+  /**
+   * Redeem-with-fee only: the 16-byte hex `random` of the fee note shielded to the relayer. The
+   * relayer-mediated submit passes this on the /relay request so the relayer can recompute the fee
+   * note's `npk` and confirm it's addressed to itself (#312). Undefined for lend / fee-less / direct.
+   */
+  feeShieldRandom?: string
 }
 
 /**
@@ -249,8 +255,11 @@ export async function buildYieldAdaptTransaction(opts: {
   let feeNpk = ethers.ZeroHash
   let feeEncryptedBundle: [string, string, string] = [ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash]
   let feeShieldKey = ethers.ZeroHash
+  // Surfaced in the result so the relayer-mediated submit can verify the fee note is addressed to it
+  // (the relayer recomputes npk = Poseidon(itsMPK, feeShieldRandom); see redeem-fee-verifier). #312
+  let feeShieldRandom: string | undefined
   if (isRedeem && feeAmount > 0n && opts.broadcasterFee) {
-    const feeShieldRandom = ByteUtils.randomHex(16)
+    feeShieldRandom = ByteUtils.randomHex(16)
     const feeShieldReqs = await RelayAdaptHelper.generateRelayShieldRequests(
       feeShieldRandom,
       [{ tokenAddress: opts.shieldOutputToken, recipientAddress: opts.broadcasterFee.recipientAddress }],
@@ -339,5 +348,6 @@ export async function buildYieldAdaptTransaction(opts: {
       data,
       value: 0n,
     },
+    feeShieldRandom,
   }
 }

--- a/apps/armada-interface/src/lib/relayer.ts
+++ b/apps/armada-interface/src/lib/relayer.ts
@@ -306,6 +306,12 @@ export interface RelayRequest {
    * `reports/relayer-idempotency-key-plan.md`.
    */
   idempotencyKey: string
+  /**
+   * Redeem (yield-withdraw) only (#312): the 16-byte hex `random` of the fee note shielded to the
+   * relayer. The relayer recomputes the fee note's `npk` from this + its own master key to confirm the
+   * fee is addressed to it before paying gas. Omitted for every other kind.
+   */
+  feeShieldRandom?: string
 }
 
 export interface RelayResponse {

--- a/apps/armada-interface/src/lib/tx/types.ts
+++ b/apps/armada-interface/src/lib/tx/types.ts
@@ -362,6 +362,17 @@ export interface ArtifactsCommon {
 }
 
 export interface ArtifactsXchain extends ArtifactsCommon {
+  /**
+   * Cross-chain unshield: the fully-encoded `atomicCrossChainUnshield` calldata built during
+   * build-proof, so submit-relayer can dispatch it without re-running the ~20-30s proof. The
+   * destination binding (recipient + domain + maxFee) is baked into the proof at build time, so
+   * these bytes are immutable once persisted. `value` stringified for IDB serializability.
+   */
+  unshieldTx?: {
+    to: `0x${string}`
+    data: `0x${string}`
+    value: string
+  }
   /** Iris message hash, used to poll attestations. */
   messageHash?: `0x${string}`
   /** Attestation bytes once Iris returns 'complete'. */

--- a/apps/armada-interface/src/lib/tx/types.ts
+++ b/apps/armada-interface/src/lib/tx/types.ts
@@ -437,6 +437,12 @@ export interface ArtifactsYield extends ArtifactsCommon {
     data: `0x${string}`
     value: string
   }
+  /**
+   * Withdraw-only (#312): the fee note's 16-byte hex `random`, captured at build-proof and sent on
+   * the /relay request so the relayer can verify the fee is shielded to itself. Absent on deposit /
+   * wallet-override / fee-less redeem.
+   */
+  feeShieldRandom?: string
 }
 
 /**

--- a/relayer/armada-relayer.ts
+++ b/relayer/armada-relayer.ts
@@ -302,14 +302,7 @@ async function main() {
     cctpRelayModule = irisRelay;
   } else {
     console.log("[armada] Initializing MOCK CCTP relay module...");
-    const cctpRelay = new CCTPRelayModule(nonceCoordinator, cctpDeliveryStore, async () => {
-      // CCTP mock relay reads from the hub schedule today — keeps existing behaviour.
-      const hubCalc = feeCalculators.get(hubChain.chainId)!;
-      const fees = await hubCalc.getCurrentFees();
-      const shieldFee = BigInt(fees.fees.crossChainShield);
-      const unshieldFee = BigInt(fees.fees.crossChainUnshield);
-      return shieldFee < unshieldFee ? shieldFee : unshieldFee;
-    });
+    const cctpRelay = new CCTPRelayModule(nonceCoordinator, cctpDeliveryStore);
     const initialized = await cctpRelay.initialize();
     if (!initialized) {
       console.warn("[armada] Some CCTP chains failed to initialize.");

--- a/relayer/lib/transact-shape.ts
+++ b/relayer/lib/transact-shape.ts
@@ -4,7 +4,9 @@
  * The relayer's verifier handles two flavours of calldata:
  *   1. Vanilla `transact(Transaction[])` — the SDK's calldata decoder accepts this directly.
  *   2. Wrapper functions that EMBED a single Transaction struct as their first argument
- *      (`lendAndShield`, `redeemAndShield`, and eventually `atomicCrossChainUnshield` in A5).
+ *      (`lendAndShield`, `atomicCrossChainUnshield`) whose broadcaster fee is an OUTPUT inside that
+ *      Transaction. (`redeemAndShield` also embeds a Transaction, but its fee is contract-side —
+ *      issue #312 — so it is verified separately by `redeem-fee-verifier.ts`, not this path.)
  *      The SDK's decoder is hard-coded to two function names and doesn't know our wrappers, so
  *      we decode them ourselves, lift the embedded Transaction, and re-encode it as a synthetic
  *      `transact([transaction])` call against the PrivacyPool address — same shape, same
@@ -27,8 +29,15 @@ export const TRANSACT_SELECTOR = "0xd8ae136a";
 /** ArmadaYieldAdapter.lendAndShield(Transaction, bytes32, ShieldCiphertext) — yield deposit. */
 export const LEND_AND_SHIELD_SELECTOR = "0xf2987ad1";
 
-/** ArmadaYieldAdapter.redeemAndShield(Transaction, bytes32, ShieldCiphertext) — yield withdraw. */
-export const REDEEM_AND_SHIELD_SELECTOR = "0x0793b70e";
+/**
+ * ArmadaYieldAdapter.redeemAndShield(Transaction, bytes32, ShieldCiphertext, bytes32, ShieldCiphertext,
+ * uint256) — yield withdraw. The fee is paid contract-side from the redeemed proceeds (issue #312),
+ * shielded to the relayer's own 0zk note via `_feeNpk`/`_feeShieldCiphertext`/`_feeAmount`. It is NOT a
+ * broadcaster output inside the embedded Transaction, so redeem is verified by `redeem-fee-verifier.ts`
+ * (npk + amount), NOT the broadcaster-output path — hence it is absent from WRAPPER_SELECTORS /
+ * WRAPPER_ABIS below and carries its own `REDEEM_AND_SHIELD_ABI`.
+ */
+export const REDEEM_AND_SHIELD_SELECTOR = "0x7e220759";
 
 /**
  * PrivacyPool.atomicCrossChainUnshield(Transaction, uint32, address, uint256, bytes32) — A5
@@ -40,10 +49,13 @@ export const REDEEM_AND_SHIELD_SELECTOR = "0x0793b70e";
  */
 export const ATOMIC_CROSS_CHAIN_UNSHIELD_SELECTOR = "0x2bcba06a";
 
-/** The wrappers that need synthetic-transact re-encoding before the SDK helper can decode. */
+/**
+ * The wrappers that carry a broadcaster-fee OUTPUT inside their embedded Transaction and so need
+ * synthetic-transact re-encoding before the SDK helper can decode. `redeemAndShield` is deliberately
+ * NOT here — its fee is contract-side (issue #312) and verified by `redeem-fee-verifier.ts`.
+ */
 export const WRAPPER_SELECTORS: ReadonlySet<string> = new Set([
   LEND_AND_SHIELD_SELECTOR,
-  REDEEM_AND_SHIELD_SELECTOR,
   ATOMIC_CROSS_CHAIN_UNSHIELD_SELECTOR,
 ]);
 
@@ -102,6 +114,14 @@ export const TRANSACT_ABI: readonly string[] = [
  *  fee-payment verification. */
 export const WRAPPER_ABIS: readonly string[] = [
   `function lendAndShield(${TRANSACTION_STRUCT} _transaction, bytes32 _npk, ${SHIELD_CIPHERTEXT_STRUCT} _shieldCiphertext)`,
-  `function redeemAndShield(${TRANSACTION_STRUCT} _transaction, bytes32 _npk, ${SHIELD_CIPHERTEXT_STRUCT} _shieldCiphertext)`,
   `function atomicCrossChainUnshield(${TRANSACTION_STRUCT} _transaction, uint32 destinationDomain, address finalRecipient, uint256 maxFee, bytes32 uniqueNonce)`,
+];
+
+/**
+ * Full redeemAndShield ABI (6-arg, fee-bearing — issue #312). Used by `redeem-fee-verifier.ts` to
+ * decode `_feeNpk` (arg 3) and `_feeAmount` (arg 5) — the fee destination + amount the relayer must
+ * verify pay it. The embedded struct fragments MUST stay in sync with the contract (see file header).
+ */
+export const REDEEM_AND_SHIELD_ABI: readonly string[] = [
+  `function redeemAndShield(${TRANSACTION_STRUCT} _transaction, bytes32 _npk, ${SHIELD_CIPHERTEXT_STRUCT} _shieldCiphertext, bytes32 _feeNpk, ${SHIELD_CIPHERTEXT_STRUCT} _feeShieldCiphertext, uint256 _feeAmount)`,
 ];

--- a/relayer/modules/broadcaster-fee-verifier.ts
+++ b/relayer/modules/broadcaster-fee-verifier.ts
@@ -22,9 +22,11 @@
  * Selector support (extended through Phase A4 + A5):
  *   - `transact(Transaction[])` — vanilla. SDK helper decodes directly.
  *   - `lendAndShield(Transaction, bytes32, ShieldCiphertext)` on ArmadaYieldAdapter — wrapper.
- *   - `redeemAndShield(Transaction, bytes32, ShieldCiphertext)` on ArmadaYieldAdapter — wrapper.
  *   - `atomicCrossChainUnshield(Transaction, uint32, address, bytes32, uint256)` on the
  *     PrivacyPool itself — A5 cross-chain unshield wrapper.
+ *
+ *   `redeemAndShield` is NOT here: its fee is paid contract-side from the redeemed proceeds (issue
+ *   #312), not as a broadcaster output inside the proof, so `redeem-fee-verifier.ts` handles it.
  *
  *   For all wrapper selectors the SDK's decoder doesn't know the function name (it expects
  *   `transact` or `relay`), so we decode the wrapper ourselves, lift the embedded Transaction

--- a/relayer/modules/cctp-relay.ts
+++ b/relayer/modules/cctp-relay.ts
@@ -293,7 +293,6 @@ export class CCTPRelayModule {
   private isRunning: boolean = false;
   private pollIntervalMs: number;
   private retryQueue: RetryEntry[] = [];
-  private getMinFee: (() => Promise<bigint>) | null;
   private cursorStore: CursorStore;
   /**
    * Durable backing for `retryQueue`. Without it, a restart while a failed message is queued for
@@ -317,18 +316,12 @@ export class CCTPRelayModule {
   /**
    * @param nonceCoordinator Shared per-chain nonce authority (see field doc).
    * @param deliveryStore Cross-chain delivery index written on relay success/failure.
-   * @param getMinFee Optional async function that returns the minimum acceptable
-   *   maxFee (in USDC raw units) for cross-chain shield relay. If provided,
-   *   messages with insufficient maxFee will be skipped. If null, all messages
-   *   are relayed (backward-compatible behavior).
    */
   constructor(
     nonceCoordinator: NonceCoordinator,
     deliveryStore: CctpDeliveryStore,
-    getMinFee?: () => Promise<bigint>,
   ) {
     this.pollIntervalMs = armadaRelayerSettings.cctpPollIntervalMs;
-    this.getMinFee = getMinFee || null;
     this.cursorStore = new CursorStore(RELAYER_STATE_DIR);
     this.nonceCoordinator = nonceCoordinator;
     this.deliveryStore = deliveryStore;
@@ -687,22 +680,9 @@ export class CCTPRelayModule {
     console.log(`  maxFee:              ${maxFeeDisplay}`);
     console.log(`  Source Tx:           ${event.txHash}`);
 
-    // Validate maxFee covers our minimum required fee
-    if (this.getMinFee && burnFee) {
-      const minFee = await this.getMinFee();
-      if (burnFee.maxFee < minFee) {
-        console.log(
-          `  [cctp-relay] SKIPPING: maxFee ${burnFee.maxFee} < minFee ${minFee} — insufficient fee`
-        );
-        // Dead-letter rather than silently marking processed: the burn is final, so a message we
-        // refuse to relay for fee reasons leaves the user's USDC stranded and needs visibility +
-        // a durable record for manual relay or a fee-policy change. deadLetter also marks it
-        // processed so the scanner won't re-attempt it.
-        await this.deadLetter(event, sourceState, "fee-too-low");
-        return false;
-      }
-      console.log(`  Fee check passed: maxFee ${burnFee.maxFee} >= minFee ${minFee}`);
-    }
+    // No relayer-side fee gate in mock mode: the real/Iris path delegates all fee decisions to
+    // Circle and has no such gate, so there is no production counterpart to mirror here. The mock
+    // relays every message regardless of the burn's maxFee.
 
     // /cctp-status delivery index is keyed by the SOURCE messageHash (keccak256 of the MessageSent
     // bytes) — the same value the frontend captures at burn time. Mark "in flight" before relaying.

--- a/relayer/modules/http-api.ts
+++ b/relayer/modules/http-api.ts
@@ -128,7 +128,7 @@ export class HttpApi {
     // POST /relay — Submit a shielded transaction
     this.app.post("/relay", this.rateLimitGuard(this.relayLimiter), async (req, res) => {
       try {
-        const { chainId, to, data, feesCacheId, idempotencyKey } = req.body as RelayRequest;
+        const { chainId, to, data, feesCacheId, idempotencyKey, feeShieldRandom } = req.body as RelayRequest;
 
         // Basic request validation
         if (!chainId || !to || !data || !feesCacheId) {
@@ -156,7 +156,7 @@ export class HttpApi {
         // key fall through to the legacy submit (calldata dedup in wallet-manager still applies).
         if (idempotencyKey) {
           const outcome = await this.idempotencyStore.submitOnce(idempotencyKey, async () => {
-            const r = await this.privacyRelay.handleRelayRequest({ chainId, to, data, feesCacheId });
+            const r = await this.privacyRelay.handleRelayRequest({ chainId, to, data, feesCacheId, feeShieldRandom });
             return { txHash: r.txHash, chainId };
           });
           if (outcome.replayed) {
@@ -172,6 +172,7 @@ export class HttpApi {
           to,
           data,
           feesCacheId,
+          feeShieldRandom,
         });
 
         res.json({ txHash: result.txHash, status: "pending" });

--- a/relayer/modules/privacy-relay.ts
+++ b/relayer/modules/privacy-relay.ts
@@ -59,7 +59,7 @@ import type { Counters } from "./counters";
 // than hardcoded literals, so a wrapper-signature change updates the constant and this allowlist in
 // lockstep — no silent drift. (atomicCrossChainUnshield's selector changed with #64 and again with
 // #287; the literal here previously drifted.)
-const ALLOWED_SELECTORS: Record<string, string> = {
+export const ALLOWED_SELECTORS: Record<string, string> = {
   [TRANSACT_SELECTOR]: "transact",
   [LEND_AND_SHIELD_SELECTOR]: "lendAndShield",
   [REDEEM_AND_SHIELD_SELECTOR]: "redeemAndShield",
@@ -87,7 +87,7 @@ const GASLESS_SELECTORS: ReadonlySet<string> = new Set([
  * Gasless wrapper selectors map to `shield` / `shieldXchain` — their gas profile is the wrapper
  * call + the underlying pool entry (`PrivacyPool.shield(...)` / `PrivacyPoolClient.crossChainShield(...)`).
  */
-function advertisedFeeForSelector(
+export function advertisedFeeForSelector(
   selector: string,
   fees: {
     transfer: string;
@@ -100,15 +100,15 @@ function advertisedFeeForSelector(
   },
 ): bigint {
   switch (selector) {
-    case "0xd8ae136a": {
+    case TRANSACT_SELECTOR: {
       const t = BigInt(fees.transfer);
       const u = BigInt(fees.unshield);
       return t < u ? t : u;
     }
-    case "0xf2987ad1":
-    case "0x0793b70e":
+    case LEND_AND_SHIELD_SELECTOR:
+    case REDEEM_AND_SHIELD_SELECTOR:
       return BigInt(fees.crossContract);
-    case "0xe484d408":
+    case ATOMIC_CROSS_CHAIN_UNSHIELD_SELECTOR:
       return BigInt(fees.crossChainUnshield);
     case GASLESS_SHIELD_SELECTOR:
       return BigInt(fees.shield);

--- a/relayer/modules/privacy-relay.ts
+++ b/relayer/modules/privacy-relay.ts
@@ -21,6 +21,7 @@ import { WalletLockedError } from "./wallet-manager";
 import type { FeeCalculator } from "./fee-calculator";
 import type { VerifierContext } from "./broadcaster-fee-verifier";
 import { verifyBroadcasterFee } from "./broadcaster-fee-verifier";
+import { verifyRedeemFee } from "./redeem-fee-verifier";
 import type { GaslessVerifierContext } from "./gasless-fee-verifier";
 import {
   GASLESS_SHIELD_SELECTOR,
@@ -176,7 +177,7 @@ export class PrivacyRelay {
   async handleRelayRequest(
     request: RelayRequest,
   ): Promise<{ txHash: string }> {
-    const { chainId, to, data, feesCacheId } = request;
+    const { chainId, to, data, feesCacheId, feeShieldRandom } = request;
 
     // 1. Validate chain ID — must be one of the configured chains
     const feeCalculator = this.feeCalculators.get(chainId);
@@ -239,6 +240,11 @@ export class PrivacyRelay {
           { chainId, to, data },
           advertisedFee,
         );
+      } else if (selector === REDEEM_AND_SHIELD_SELECTOR) {
+        // Redeem's fee is shielded to the relayer contract-side (issue #312), not embedded as a
+        // broadcaster output in the proof. Verify the fee note is ours via the frontend-supplied
+        // shield random. See redeem-fee-verifier.
+        verifyRedeemFee(this.verifierContext, { data }, advertisedFee, feeShieldRandom);
       } else {
         await verifyBroadcasterFee(this.verifierContext, { to, data }, advertisedFee);
       }

--- a/relayer/modules/redeem-fee-verifier.ts
+++ b/relayer/modules/redeem-fee-verifier.ts
@@ -1,0 +1,114 @@
+// ABOUTME: Server-side fee verifier for redeemAndShield (yield withdraw). Confirms the contract-side
+// ABOUTME: fee note is shielded to the relayer at the advertised amount before the relayer pays gas.
+
+/**
+ * Redeem Fee Verifier
+ *
+ * `redeemAndShield` (issue #312) does NOT pay the relayer via a broadcaster output inside the SNARK
+ * proof — that's `broadcaster-fee-verifier.ts`'s job for `lendAndShield` / `atomicCrossChainUnshield`.
+ * Instead the adapter shields `_feeAmount` USDC out of the redeemed proceeds to the relayer's own 0zk
+ * note (`_feeNpk` / `_feeShieldCiphertext`), with all three bound into the proof's `adaptParams`.
+ *
+ * The proof binding stops a *submitter* from altering the fee after proof-gen, but it does NOT prove
+ * the fee is directed at US: a malicious submitter can build a valid proof whose fee note is their
+ * OWN address, and the relayer would pay gas for a fee it never receives. So the relayer must
+ * independently confirm the fee note is addressed to itself.
+ *
+ * How:
+ *   A shield note's public key is a deterministic commitment `npk = Poseidon(masterPublicKey, random)`
+ *   (`ShieldNote.getNotePublicKey`). The masterPublicKey is public (it's in a 0zk address); the
+ *   per-note `random` is the secret blinding factor. The frontend generated this fee note to the
+ *   relayer's address and passes the `random` alongside the /relay request (the relayer is the note's
+ *   recipient — it would decrypt this same `random` during normal balance sync, so nothing new leaks).
+ *   We recompute `Poseidon(ourMasterPublicKey, random)` and require it to equal the on-chain `_feeNpk`.
+ *   Forging a `random` to hit a target npk under a *different* master key is preimage-hard, so a match
+ *   proves the fee note is ours. We also require `_feeAmount >= advertisedFee`.
+ *
+ *   Token is not checked here: the adapter shields the fee from the redeemed USDC proceeds, so the fee
+ *   note is always USDC by construction (the submitter cannot substitute a worthless token).
+ */
+
+import { ethers } from "ethers";
+import { RailgunWallet, ShieldNote } from "@railgun-community/engine";
+import { RelayError } from "../types";
+import { REDEEM_AND_SHIELD_ABI } from "../lib/transact-shape";
+
+/** Interface hoisted to module scope — built once instead of per /relay request. */
+const REDEEM_IFACE = new ethers.Interface(REDEEM_AND_SHIELD_ABI);
+
+export interface RedeemFeeVerifierContext {
+  /** The relayer's loaded Railgun wallet — supplies the master public key the fee note must match. */
+  wallet: RailgunWallet;
+}
+
+export interface RedeemFeeVerifyRequest {
+  /** ABI-encoded `redeemAndShield(...)` calldata as it would be sent on-chain. */
+  data: string;
+}
+
+/**
+ * Verify that a `redeemAndShield` request shields at least `advertisedFee` USDC to the relayer's own
+ * 0zk note. Returns the fee amount on success.
+ *
+ * @throws RelayError(INVALID_DATA)      calldata won't decode, or `feeShieldRandom` is missing
+ * @throws RelayError(FEE_INSUFFICIENT)  fee below advertised, or the fee note is not addressed to us
+ */
+export function verifyRedeemFee(
+  ctx: RedeemFeeVerifierContext,
+  request: RedeemFeeVerifyRequest,
+  advertisedFee: bigint,
+  feeShieldRandom: string | undefined,
+): bigint {
+  // The random is what lets us reconstruct (and thus verify) the fee note's npk. Without it we can't
+  // prove the fee is ours, so refuse rather than submit blind.
+  if (typeof feeShieldRandom !== "string" || feeShieldRandom.length === 0) {
+    throw new RelayError(
+      "INVALID_DATA",
+      "redeemAndShield relay requires feeShieldRandom to verify the fee destination.",
+    );
+  }
+
+  let decoded: ethers.Result;
+  try {
+    decoded = REDEEM_IFACE.decodeFunctionData("redeemAndShield", request.data);
+  } catch (e: any) {
+    throw new RelayError(
+      "INVALID_DATA",
+      `Failed to decode redeemAndShield calldata: ${e?.message ?? e}`,
+    );
+  }
+
+  // Args: [_transaction, _npk, _shieldCiphertext, _feeNpk, _feeShieldCiphertext, _feeAmount]
+  const feeNpk = BigInt(decoded[3]);
+  const feeAmount = BigInt(decoded[5]);
+
+  if (feeAmount < advertisedFee) {
+    throw new RelayError(
+      "FEE_INSUFFICIENT",
+      `Redeem fee too low: fee ${feeAmount} USDC raw, advertised ${advertisedFee} USDC raw. ` +
+        `Re-fetch the fee quote and re-build the proof with the matching fee.`,
+    );
+  }
+
+  // Recompute the note public key the fee note WOULD have if it were shielded to us with this random.
+  let expectedNpk: bigint;
+  try {
+    expectedNpk = ShieldNote.getNotePublicKey(ctx.wallet.masterPublicKey, feeShieldRandom);
+  } catch (e: any) {
+    throw new RelayError(
+      "INVALID_DATA",
+      `Could not derive expected fee-note key (bad feeShieldRandom?): ${e?.message ?? e}`,
+    );
+  }
+
+  if (feeNpk !== expectedNpk) {
+    // The bound fee note is addressed to someone else — submitting would pay gas for a fee we never
+    // receive. Reject.
+    throw new RelayError(
+      "FEE_INSUFFICIENT",
+      "Redeem fee note is not addressed to the relayer — refusing to relay.",
+    );
+  }
+
+  return feeAmount;
+}

--- a/relayer/test/modules/advertised-fee-selector.test.ts
+++ b/relayer/test/modules/advertised-fee-selector.test.ts
@@ -1,0 +1,43 @@
+// ABOUTME: Tests that every /relay-allowed selector has a matching advertised-fee mapping.
+// ABOUTME: WHY: the allowlist and the fee-map are two lists that must cover the same selector set.
+
+import { expect } from "chai";
+import {
+  ALLOWED_SELECTORS,
+  advertisedFeeForSelector,
+} from "../../modules/privacy-relay";
+
+// A fully-populated fee schedule; values are arbitrary non-empty numeric strings — the test only
+// checks that a fee is resolved without throwing, not the specific amount.
+const FEES = {
+  transfer: "1",
+  unshield: "2",
+  crossContract: "3",
+  crossChainShield: "4",
+  crossChainUnshield: "5",
+  shield: "6",
+  shieldXchain: "7",
+};
+
+describe("advertisedFeeForSelector — allowlist parity", function () {
+  // WHY: atomicCrossChainUnshield's selector changed with #64 and again with #287. The allowlist
+  // (constant-sourced) tracked the change but the fee-map (hardcoded literals) drifted, so a valid
+  // cross-chain unshield passed the allowlist then hit the "unreachable" default and was rejected
+  // INVALID_DATA. This pins the invariant that broke: every allowed selector must resolve to a fee.
+  it("resolves a fee for every selector in ALLOWED_SELECTORS", function () {
+    for (const selector of Object.keys(ALLOWED_SELECTORS)) {
+      expect(
+        () => advertisedFeeForSelector(selector, FEES),
+        `selector ${selector} (${ALLOWED_SELECTORS[selector]}) has no advertised-fee mapping`,
+      ).to.not.throw();
+    }
+  });
+
+  it("throws for a selector that is not allow-listed", function () {
+    // WHY: the default branch is the fail-closed guard for a genuinely unknown selector; it must
+    // still reject rather than silently returning a fee.
+    expect(() => advertisedFeeForSelector("0xdeadbeef", FEES)).to.throw(
+      "No advertised-fee mapping",
+    );
+  });
+});

--- a/relayer/test/modules/broadcaster-fee-verifier.test.ts
+++ b/relayer/test/modules/broadcaster-fee-verifier.test.ts
@@ -109,7 +109,7 @@ function emptyShieldCiphertext(): unknown {
 }
 
 function encodeWrapperCalldata(
-  fnName: "lendAndShield" | "redeemAndShield" | "atomicCrossChainUnshield",
+  fnName: "lendAndShield" | "atomicCrossChainUnshield",
 ): string {
   const iface = new ethers.Interface(WRAPPER_ABIS);
   if (fnName === "atomicCrossChainUnshield") {
@@ -283,22 +283,8 @@ describe("verifyBroadcasterFee", () => {
       expect(decoded[0].length).to.equal(1);
     });
 
-    it("decodes redeemAndShield the same way", async () => {
-      // WHY: same selector category, symmetric path. Asserting both wrappers traverse the
-      // normaliser independently — a copy-paste bug that hard-coded one selector in the route
-      // would silently break the other.
-      const rec = recordingStubWallet({ [USDC_ADDRESS.toLowerCase()]: ADVERTISED_FEE });
-      const wrapperCalldata = encodeWrapperCalldata("redeemAndShield");
-
-      const paid = await verifyBroadcasterFee(
-        ctxFor(rec.wallet),
-        { to: "0x4444444444444444444444444444444444444444", data: wrapperCalldata },
-        ADVERTISED_FEE,
-      );
-
-      expect(paid).to.equal(ADVERTISED_FEE);
-      expect(rec.lastRequest()?.data?.slice(0, 10)).to.equal("0xd8ae136a");
-    });
+    // NOTE: redeemAndShield is intentionally NOT verified here — its fee is contract-side (#312),
+    // covered by redeem-fee-verifier.test.ts. It was removed from WRAPPER_ABIS/WRAPPER_SELECTORS.
 
     it("rejects unknown selectors with INVALID_DATA (not FEE_INSUFFICIENT)", async () => {
       // WHY: keep the security framing honest. FEE_INSUFFICIENT means "we tried to verify and

--- a/relayer/test/modules/redeem-fee-verifier.test.ts
+++ b/relayer/test/modules/redeem-fee-verifier.test.ts
@@ -1,0 +1,138 @@
+// ABOUTME: Unit tests for verifyRedeemFee — the gate that confirms a redeemAndShield fee note is
+// ABOUTME: shielded to the relayer at the advertised amount before the relayer pays gas.
+
+import { expect } from "chai";
+import { ethers } from "ethers";
+import { RailgunWallet, ShieldNote } from "@railgun-community/engine";
+import { verifyRedeemFee, type RedeemFeeVerifierContext } from "../../modules/redeem-fee-verifier";
+import { REDEEM_AND_SHIELD_ABI } from "../../lib/transact-shape";
+import { RelayError } from "../../types";
+
+const REDEEM_IFACE = new ethers.Interface(REDEEM_AND_SHIELD_ABI);
+const ADVERTISED_FEE = 50_000n; // 0.05 USDC raw
+
+// A field-element master public key for the relayer's own wallet, and a distinct one for an attacker.
+const RELAYER_MPK = 1234567890123456789n;
+const ATTACKER_MPK = 9876543210987654321n;
+// 16-byte shield randoms (what generateRelayShieldRequests uses).
+const RANDOM_A = "0x" + "ab".repeat(16);
+const RANDOM_B = "0x" + "cd".repeat(16);
+
+/** Wallet stub — verifyRedeemFee only reads masterPublicKey. */
+function stubWallet(masterPublicKey: bigint): RailgunWallet {
+  return { masterPublicKey } as unknown as RailgunWallet;
+}
+function ctxFor(mpk: bigint): RedeemFeeVerifierContext {
+  return { wallet: stubWallet(mpk) };
+}
+
+const ZERO_CIPHERTEXT = {
+  encryptedBundle: [ethers.ZeroHash, ethers.ZeroHash, ethers.ZeroHash],
+  shieldKey: ethers.ZeroHash,
+};
+
+// Minimal zeroed Transaction struct — the verifier never inspects arg 0, only the fee fields.
+const DUMMY_TRANSACTION = {
+  proof: { a: { x: 0n, y: 0n }, b: { x: [0n, 0n], y: [0n, 0n] }, c: { x: 0n, y: 0n } },
+  merkleRoot: ethers.ZeroHash,
+  nullifiers: [],
+  commitments: [],
+  boundParams: {
+    treeNumber: 0,
+    minGasPrice: 0n,
+    unshield: 1,
+    chainID: 0n,
+    adaptContract: ethers.ZeroAddress,
+    adaptParams: ethers.ZeroHash,
+    commitmentCiphertext: [],
+  },
+  unshieldPreimage: {
+    npk: ethers.ZeroHash,
+    token: { tokenType: 0, tokenAddress: ethers.ZeroAddress, tokenSubID: 0n },
+    value: 0n,
+  },
+};
+
+/** Build redeemAndShield calldata with the given fee-note key + amount. */
+function encodeRedeemCalldata(feeNpk: bigint, feeAmount: bigint): string {
+  return REDEEM_IFACE.encodeFunctionData("redeemAndShield", [
+    DUMMY_TRANSACTION,
+    ethers.ZeroHash, // _npk (user's re-shield destination — not inspected)
+    ZERO_CIPHERTEXT, // _shieldCiphertext
+    ethers.toBeHex(feeNpk, 32), // _feeNpk
+    ZERO_CIPHERTEXT, // _feeShieldCiphertext
+    feeAmount, // _feeAmount
+  ]);
+}
+
+/** The npk a fee note shielded to `mpk` with `random` would carry — mirrors the frontend. */
+function noteKey(mpk: bigint, random: string): bigint {
+  return ShieldNote.getNotePublicKey(mpk, random);
+}
+
+describe("verifyRedeemFee", () => {
+  it("accepts a fee note shielded to the relayer at the advertised amount", () => {
+    // WHY: the happy path — frontend shields the fee to the relayer's own 0zk with RANDOM_A and
+    // passes RANDOM_A; the recomputed npk must match, proving the relayer is the payee.
+    const feeNpk = noteKey(RELAYER_MPK, RANDOM_A);
+    const data = encodeRedeemCalldata(feeNpk, ADVERTISED_FEE);
+    const paid = verifyRedeemFee(ctxFor(RELAYER_MPK), { data }, ADVERTISED_FEE, RANDOM_A);
+    expect(paid).to.equal(ADVERTISED_FEE);
+  });
+
+  it("accepts when the fee exceeds the advertised amount", () => {
+    // WHY: overpayment is fine — the relayer only requires AT LEAST the advertised fee.
+    const feeNpk = noteKey(RELAYER_MPK, RANDOM_A);
+    const data = encodeRedeemCalldata(feeNpk, ADVERTISED_FEE * 2n);
+    expect(verifyRedeemFee(ctxFor(RELAYER_MPK), { data }, ADVERTISED_FEE, RANDOM_A)).to.equal(
+      ADVERTISED_FEE * 2n,
+    );
+  });
+
+  it("rejects a fee note addressed to someone else (attacker steals the fee)", () => {
+    // WHY: the core security property. A submitter builds a valid proof whose fee note is the
+    // ATTACKER's address; the relayer would pay gas for a fee it never receives. Even though the
+    // attacker supplies a random, the npk recomputed under the RELAYER's key can't match a note
+    // committed to the attacker's key — so we reject.
+    const feeNpk = noteKey(ATTACKER_MPK, RANDOM_A); // shielded to attacker
+    const data = encodeRedeemCalldata(feeNpk, ADVERTISED_FEE);
+    expect(() => verifyRedeemFee(ctxFor(RELAYER_MPK), { data }, ADVERTISED_FEE, RANDOM_A))
+      .to.throw(RelayError)
+      .with.property("code", "FEE_INSUFFICIENT");
+  });
+
+  it("rejects when the supplied random doesn't match the on-chain fee note", () => {
+    // WHY: a mismatched random (even to our own key) means we can't prove this note is ours —
+    // fail closed rather than submit on an unverifiable claim.
+    const feeNpk = noteKey(RELAYER_MPK, RANDOM_A);
+    const data = encodeRedeemCalldata(feeNpk, ADVERTISED_FEE);
+    expect(() => verifyRedeemFee(ctxFor(RELAYER_MPK), { data }, ADVERTISED_FEE, RANDOM_B))
+      .to.throw(RelayError)
+      .with.property("code", "FEE_INSUFFICIENT");
+  });
+
+  it("rejects when the fee is below the advertised amount", () => {
+    // WHY: a correctly-addressed but underpaid fee still doesn't cover the relayer's gas.
+    const feeNpk = noteKey(RELAYER_MPK, RANDOM_A);
+    const data = encodeRedeemCalldata(feeNpk, ADVERTISED_FEE - 1n);
+    expect(() => verifyRedeemFee(ctxFor(RELAYER_MPK), { data }, ADVERTISED_FEE, RANDOM_A))
+      .to.throw(RelayError)
+      .with.property("code", "FEE_INSUFFICIENT");
+  });
+
+  it("rejects when feeShieldRandom is missing", () => {
+    // WHY: without the random we cannot verify the destination at all — refuse rather than relay blind.
+    const feeNpk = noteKey(RELAYER_MPK, RANDOM_A);
+    const data = encodeRedeemCalldata(feeNpk, ADVERTISED_FEE);
+    expect(() => verifyRedeemFee(ctxFor(RELAYER_MPK), { data }, ADVERTISED_FEE, undefined))
+      .to.throw(RelayError)
+      .with.property("code", "INVALID_DATA");
+  });
+
+  it("rejects calldata that isn't a redeemAndShield call", () => {
+    // WHY: defensive decode guard — a wrong/garbled selector must fail loudly, not silently pass.
+    expect(() => verifyRedeemFee(ctxFor(RELAYER_MPK), { data: "0xdeadbeef" }, ADVERTISED_FEE, RANDOM_A))
+      .to.throw(RelayError)
+      .with.property("code", "INVALID_DATA");
+  });
+});

--- a/relayer/types.ts
+++ b/relayer/types.ts
@@ -58,6 +58,12 @@ export interface RelayRequest {
    * it falls back to the in-memory calldata dedup in wallet-manager.
    */
   idempotencyKey?: string;
+  /**
+   * Redeem-only (issue #312): the 16-byte hex `random` of the fee note the yield-withdraw shields to
+   * the relayer. Lets the relayer recompute the fee note's `npk` and confirm it's addressed to itself
+   * before paying gas (see `redeem-fee-verifier.ts`). Ignored for every other selector.
+   */
+  feeShieldRandom?: string;
 }
 
 export interface RelayResponse {


### PR DESCRIPTION
## Summary

Completes relayer-mediated yield withdraw with server-side redeem-fee verification, plus supporting relayer/xchain fixes. Split out of the circuits-cutover PR (#404) where these commits had been bundled — they are independent of the circuit swap and belong on their own review track (continuation of ship-armada/armada-poc#312 / ship-armada/armada-interface#5).

## Commits (cherry-picked onto main, unchanged)

- `fix(relayer): remove mock-mode CCTP fee gate that dead-lettered valid shields`
- `fix(relayer): source advertised-fee selectors from constants so xchain unshield relays`
- `fix(interface): bind CCTP destination into cross-chain unshield proof (#399)`
- `fix(interface): silence benign railgun engine event-topic log noise`
- `feat(yield): complete relayer-mediated withdraw with redeem fee verification (#312)`

## Verification

- Interface `tsc -b --noEmit`: clean
- New/changed relayer unit tests pass locally: `redeem-fee-verifier` + `advertised-fee-selector` + `broadcaster-fee-verifier` (20 passing)
- These commits also passed as part of the combined ship-armada/armada-poc#404 branch (full `test:all` + live e2e for all tx types).

## Still needed before ready

- [ ] Full CI pass on this standalone branch (only ran targeted tests locally; the combined-branch run is the prior evidence)
- [ ] Independent e2e for yield-withdraw + cross-chain-unshield now that it's rebased off plain main
- [ ] Relayer runs on a VPS — merging this will require pulling + restarting the relayer

🤖 Generated with [Claude Code](https://claude.com/claude-code)