### PR TITLE
Centralize SNARK verify on router; zero-reset hub burn approve

### DIFF
--- a/contracts/privacy-pool/modules/TransactModule.sol
+++ b/contracts/privacy-pool/modules/TransactModule.sol
@@ -231,7 +231,10 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
             UnshieldData({ recipient: finalRecipient, uniqueNonce: uniqueNonce })
         );
 
-        // Burn via CCTP
+        // Burn via CCTP. Reset the allowance to zero before setting it — OZ 4.9 safeApprove reverts
+        // on a non-zero→non-zero change, so a residual TokenMessenger allowance would otherwise brick
+        // later burns. Matches the defensive pattern in PrivacyPoolClient and the gasless-shield wrappers.
+        IERC20(usdc).safeApprove(tokenMessenger, 0);
         IERC20(usdc).safeApprove(tokenMessenger, base);
 
         // destinationCaller is pinned to the destination chain's hook router (validated non-zero in
@@ -324,7 +327,9 @@ contract TransactModule is PrivacyPoolStorage, ITransactModule {
             }
         }
 
-        // Verify SNARK proof (via delegatecall to VerifierModule)
+        // Verify SNARK proof. During this module's delegatecall, address(this) is the PrivacyPool
+        // router, so this external staticcall dispatches to the router's own verify() — the
+        // authoritative implementation — not to the VerifierModule contract.
         if (!IVerifierModule(address(this)).verify(_transaction)) {
             return (false, "Invalid Proof");
         }

--- a/contracts/privacy-pool/modules/VerifierModule.sol
+++ b/contracts/privacy-pool/modules/VerifierModule.sol
@@ -3,16 +3,18 @@ pragma solidity ^0.8.17;
 
 import "../storage/PrivacyPoolStorage.sol";
 import "../interfaces/IVerifierModule.sol";
-import "../../railgun/logic/Snark.sol";
 
 /**
  * @title VerifierModule
- * @notice Handles SNARK proof verification for the privacy pool
+ * @notice Manages SNARK verification-key storage and testing mode for the privacy pool.
  * @dev Called via delegatecall from PrivacyPool router.
  *      Based on Railgun's Verifier.sol implementation.
  *
  *      Verification keys are stored per circuit configuration (nullifiers x commitments).
  *      The POC includes a testing mode that bypasses verification for development.
+ *
+ *      Proof verification itself is performed by `PrivacyPool.verify` (the router copy),
+ *      not by this module — see the note on `verify` below.
  */
 contract VerifierModule is PrivacyPoolStorage, IVerifierModule {
     /// @notice Emitted when a verification key is set
@@ -54,60 +56,19 @@ contract VerifierModule is PrivacyPoolStorage, IVerifierModule {
     }
 
     /**
-     * @notice Verify a transaction's SNARK proof
-     * @dev Constructs public inputs from transaction data and verifies the proof.
-     *      In testing mode, always returns true.
-     *      Also returns true for gas estimation transactions (tx.origin == VERIFICATION_BYPASS).
-     *
-     * @param _transaction The transaction to verify
-     * @return True if proof is valid
+     * @notice Proof verification is not performed by this module — it lives on the PrivacyPool router.
+     * @dev The authoritative verifier is `PrivacyPool.verify`. During a module's own delegatecall,
+     *      `address(this)` is the router, so `IVerifierModule(address(this)).verify(...)` in
+     *      TransactModule dispatches to the router's copy — this module-level body is never reached
+     *      because the router deliberately does not delegatecall `verify` (a view/staticcall cannot
+     *      delegatecall the module and read its result, which is why the logic is inlined on the
+     *      router). Keeping a second copy of the public-input construction here would risk silent
+     *      drift from the authoritative implementation, so this stub reverts instead. Only
+     *      verification-key writes (`setVerificationKey`/`setTestingMode`) run in this module via
+     *      delegatecall; proof verification is centralized on the router.
      */
-    function verify(Transaction calldata _transaction) external view override onlyDelegatecall returns (bool) {
-        // POC: Bypass verification in testing mode
-        if (testingMode) {
-            return true;
-        }
-
-        uint256 nullifiersLength = _transaction.nullifiers.length;
-        uint256 commitmentsLength = _transaction.commitments.length;
-
-        // Retrieve verification key for this circuit configuration
-        VerifyingKey memory verifyingKey = verificationKeys[nullifiersLength][commitmentsLength];
-
-        // Check if verifying key is set (alpha1.x == 0 means not set)
-        require(verifyingKey.alpha1.x != 0, "VerifierModule: Key not set");
-
-        // Construct public inputs array
-        // Format: [merkleRoot, boundParamsHash, nullifiers..., commitments...]
-        uint256[] memory inputs = new uint256[](2 + nullifiersLength + commitmentsLength);
-
-        // Input 0: Merkle root
-        inputs[0] = uint256(_transaction.merkleRoot);
-
-        // Input 1: Hash of bound parameters
-        inputs[1] = hashBoundParams(_transaction.boundParams);
-
-        // Inputs 2 to 2+nullifiersLength-1: Nullifiers
-        for (uint256 i = 0; i < nullifiersLength; i++) {
-            inputs[2 + i] = uint256(_transaction.nullifiers[i]);
-        }
-
-        // Remaining inputs: Commitments
-        for (uint256 i = 0; i < commitmentsLength; i++) {
-            inputs[2 + nullifiersLength + i] = uint256(_transaction.commitments[i]);
-        }
-
-        // Verify the SNARK proof
-        bool validity = _verifyProof(verifyingKey, _transaction.proof, inputs);
-
-        // Always return true in gas estimation transactions
-        // This allows relayer fee calculation without computing a proof
-        // solhint-disable-next-line avoid-tx-origin
-        if (tx.origin == VERIFICATION_BYPASS) {
-            return true;
-        }
-
-        return validity;
+    function verify(Transaction calldata) external view override onlyDelegatecall returns (bool) {
+        revert("VerifierModule: verify handled by PrivacyPool router");
     }
 
     /**
@@ -130,20 +91,5 @@ contract VerifierModule is PrivacyPoolStorage, IVerifierModule {
         testingMode = _enabled;
 
         emit TestingModeSet(_enabled);
-    }
-
-    /**
-     * @notice Internal function to verify a SNARK proof
-     * @param _verifyingKey The verification key
-     * @param _proof The proof to verify
-     * @param _inputs The public inputs
-     * @return True if proof is valid
-     */
-    function _verifyProof(
-        VerifyingKey memory _verifyingKey,
-        SnarkProof calldata _proof,
-        uint256[] memory _inputs
-    ) internal view returns (bool) {
-        return Snark.verify(_verifyingKey, _proof, _inputs);
     }
 }


### PR DESCRIPTION
Addresses two code-quality findings from the privacy-pool review. Both are maintainability/consistency fixes — neither is a live exploit.

## CQ-1 — Deduplicate diverged SNARK verification
`TransactModule._validateTransaction` calls `IVerifierModule(address(this)).verify(...)`. During a module delegatecall `address(this)` is the router, so this dispatches to **`PrivacyPool.verify`** (the router copy), never to `VerifierModule.verify`. The module-level `verify` body was a full second copy of the public-input construction that had already drifted (different revert string; helper vs. inlined bound-params hash) and could silently diverge further.

- Collapsed the dead `VerifierModule.verify` body into a documented `revert` stub (interface still requires the function; the router remains the single authoritative implementation).
- Removed the now-orphaned `_verifyProof` helper and the unused `Snark.sol` import.
- Fixed the misleading `TransactModule` comment (it is an external staticcall to the router, not a delegatecall to `VerifierModule`).
- Kept `setVerificationKey` / `getVerificationKey` / `setTestingMode` / `hashBoundParams` and the `onlyDelegatecall` guard (preserves the module-guard invariant).

Router verification logic (`PrivacyPool.verify`) is unchanged.

## CQ-2 — Zero-reset the hub burn approve
`_executeCCTPBurn` did a single `safeApprove(tokenMessenger, base)`. OZ 4.9 `safeApprove` reverts on a non-zero→non-zero change, so any residual TokenMessenger allowance would brick later burns. Now does `safeApprove(0)` then `safeApprove(base)`, matching `PrivacyPoolClient` and both gasless-shield wrappers.

## Testing
- `npm run test:forge` — 771 passing (incl. `OnlyDelegatecall`, `TransactModuleWindDown`).
- `npm run test:all` — 861 passing / 1 pending. The end-to-end cross-chain unshield (real proofs) exercises both changed paths and confirms the module `verify` stub is never reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)