### PR TITLE
fix(sepolia): deploy gas headroom + RPC swap + verify-snark + etherscan aliases

### DIFF
--- a/config/sepolia.env
+++ b/config/sepolia.env
@@ -21,8 +21,11 @@ export DEPLOY_ENV=sepolia
 export CCTP_MODE=real
 
 # Hub chain: Ethereum Sepolia
-export HUB_RPC=https://sepolia.drpc.org
-# export HUB_RPC=https://ethereum-sepolia-rpc.publicnode.com
+# drpc.org's eth_estimateGas underestimates refund-heavy SSTOREs (clear-to-zero), causing
+# admin calls like governor.clearDeployer() to OOG at the EIP-2200 sentry. publicnode estimates
+# these correctly. Swap back to drpc/tenderly only if publicnode rate-limits.
+export HUB_RPC=https://ethereum-sepolia-rpc.publicnode.com
+# export HUB_RPC=https://sepolia.drpc.org
 # export HUB_RPC=https://sepolia.gateway.tenderly.co
 export HUB_CHAIN_ID=11155111
 export HUB_CCTP_DOMAIN=0

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -106,25 +106,29 @@ const config: HardhatUserConfig = {
     // ========== Sepolia Testnet Networks ==========
 
     // Hub: Ethereum Sepolia
+    // gasMultiplier 2.0 (not 1.2): public testnet RPCs underestimate eth_estimateGas for
+    // refund-heavy SSTOREs (clearing a slot to zero), leaving < 2300 gas at the EIP-2200
+    // sentry and OOG-reverting admin calls like governor.clearDeployer() / renounceRole().
+    // The extra headroom is unused on success (only actual gasUsed is charged), so it's safe.
     sepoliaHub: {
       url: process.env.HUB_RPC || "https://ethereum-sepolia-rpc.publicnode.com",
       chainId: 11155111,
       accounts: DEPLOYER_PRIVATE_KEY ? [DEPLOYER_PRIVATE_KEY] : [],
-      gasMultiplier: 1.2,
+      gasMultiplier: 2.0,
     },
     // Client A: Base Sepolia
     sepoliaClientA: {
       url: process.env.CLIENT_A_RPC || "https://sepolia.base.org",
       chainId: 84532,
       accounts: DEPLOYER_PRIVATE_KEY ? [DEPLOYER_PRIVATE_KEY] : [],
-      gasMultiplier: 1.2,
+      gasMultiplier: 2.0,
     },
     // Client B: Arbitrum Sepolia
     sepoliaClientB: {
       url: process.env.CLIENT_B_RPC || "https://sepolia-rollup.arbitrum.io/rpc",
       chainId: 421614,
       accounts: DEPLOYER_PRIVATE_KEY ? [DEPLOYER_PRIVATE_KEY] : [],
-      gasMultiplier: 1.2,
+      gasMultiplier: 2.0,
     },
 
     // ========== Mainnet Networks ==========

--- a/package.json
+++ b/package.json
@@ -107,7 +107,10 @@
     "check:sizes": "node scripts/check-contract-sizes.js",
     "slither": "slither . --config-file slither.config.json",
     "verify": "hardhat run scripts/verify_deployment.ts --network hub",
-    "verify:sepolia": "hardhat run scripts/verify_deployment.ts --network sepoliaHub"
+    "verify:sepolia": "hardhat run scripts/verify_deployment.ts --network sepoliaHub",
+    "verify:etherscan:sepolia": "hardhat run scripts/verify_sepolia.ts --network sepoliaHub",
+    "verify:etherscan:sepolia:clientA": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientA",
+    "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/scripts/deploy-utils.ts
+++ b/scripts/deploy-utils.ts
@@ -13,10 +13,14 @@
  */
 
 import { isLocal } from "../config/networks";
-import { ethers } from "hardhat";
 import * as fs from "fs";
 import * as path from "path";
 import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+// `ethers` is lazy-loaded from hardhat inside timelockCall (its only consumer) rather than
+// imported at module scope, so plain ts-node callers of this module — e.g.
+// scripts/test_sepolia.ts, which only use loadDeployment — don't fail at import time.
+// hardhat's `ethers` export only exists under a `hardhat run` runtime.
 
 // Well-known Anvil/Hardhat default accounts (#0-9), derived from the standard mnemonic:
 // "test test test test test test test test test test test junk"
@@ -168,6 +172,8 @@ export async function timelockCall(
   description: string,
   nm: NonceManager,
 ): Promise<boolean> {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { ethers } = require("hardhat");
   if (isLocal()) {
     const rpcUrl = process.env.HUB_RPC || "http://localhost:8545";
     const jsonRpc = async (method: string, params: any[] = []) => {

--- a/scripts/test_sepolia.ts
+++ b/scripts/test_sepolia.ts
@@ -48,7 +48,7 @@ const PRIVACY_POOL_ABI = [
   "function localDomain() view returns (uint32)",
   "function remotePools(uint32) view returns (bytes32)",
   "function getVerificationKey(uint256 nullifiers, uint256 commitments) view returns (tuple(string artifactsIPFSHash, tuple(uint256 x, uint256 y) alpha1, tuple(uint256[2] x, uint256[2] y) beta2, tuple(uint256[2] x, uint256[2] y) gamma2, tuple(uint256[2] x, uint256[2] y) delta2, tuple(uint256 x, uint256 y)[] ic))",
-  "function shield(tuple(tuple(bytes32 npk, tuple(uint8 tokenType, address tokenAddress, uint256 tokenSubID) token, uint120 value) preimage, tuple(bytes32[3] encryptedBundle, bytes32 shieldKey) ciphertext)[] _shieldRequests) external",
+  "function shield(tuple(tuple(bytes32 npk, tuple(uint8 tokenType, address tokenAddress, uint256 tokenSubID) token, uint120 value) preimage, tuple(bytes32[3] encryptedBundle, bytes32 shieldKey) ciphertext)[] _shieldRequests, address integrator) external",
 ];
 
 const PRIVACY_POOL_CLIENT_ABI = [
@@ -350,7 +350,8 @@ async function testHubShield(config: ReturnType<typeof getNetworkConfig>, amount
   };
 
   const fees2 = await getFeeOverrides(hubProvider, 2000000); // shield needs ~1.5M gas (Poseidon + Merkle tree)
-  const shieldTx = await privacyPool.shield([shieldRequest], fees2);
+  // integrator = address(0): no integrator-fee split (the smoke test isn't testing integrator fees)
+  const shieldTx = await privacyPool.shield([shieldRequest], ethers.ZeroAddress, fees2);
   info(`Tx: ${shieldTx.hash}`);
   const receipt = await waitForTx(shieldTx);
   passed(`Shield confirmed in block ${receipt.blockNumber}`);

--- a/scripts/verify_sepolia.ts
+++ b/scripts/verify_sepolia.ts
@@ -198,6 +198,7 @@ async function buildGovernanceCrowdfundTasks(): Promise<VerifyTask[]> {
         c.redemption,
         c.shieldPauseController,
         c.revenueCounter,
+        c.revenueLock,
         c.timelockController,
         revenueThreshold,    // read from on-chain
         windDownDeadline,    // read from on-chain

--- a/scripts/verify_snark_mode.ts
+++ b/scripts/verify_snark_mode.ts
@@ -11,16 +11,23 @@
 import { ethers } from "hardhat";
 import * as fs from "fs";
 import * as path from "path";
+import { getNetworkConfig } from "../config/networks";
+import { TESTING_ARTIFACT_CONFIGS } from "../lib/artifacts";
 
 async function main() {
   console.log("=== Verifying SNARK Verification Mode ===\n");
 
-  // Load deployment
+  // Load deployment. Manifests are namespaced by environment (e.g. -sepolia for testnet,
+  // empty for local), matching what deploy_privacy_pool.ts writes — so this must run against
+  // the manifest for the --network it was invoked with, not the local one.
+  const config = getNetworkConfig();
+  const suffix = config.env === "local" ? "" : `-${config.env}`;
+  const manifestName = `privacy-pool-hub${suffix}.json`;
   const deploymentsDir = path.join(__dirname, "..", "deployments");
-  const hubDeploymentPath = path.join(deploymentsDir, "privacy-pool-hub.json");
+  const hubDeploymentPath = path.join(deploymentsDir, manifestName);
 
   if (!fs.existsSync(hubDeploymentPath)) {
-    console.error("Error: privacy-pool-hub.json not found");
+    console.error(`Error: ${manifestName} not found`);
     console.error("Run deploy_privacy_pool.ts first");
     process.exit(1);
   }
@@ -53,22 +60,35 @@ async function main() {
   // Also check if verification keys are loaded
   console.log("\n--- Verification Keys Check ---");
 
-  const commonConfigs = [
-    [1, 1], // 1 nullifier, 1 commitment (lend/redeem)
-    [1, 2], // 1 nullifier, 2 commitments
-    [2, 2], // 2 nullifiers, 2 commitments
-    [1, 3], // 1 nullifier, 3 commitments
-    [2, 3], // 2 nullifiers, 3 commitments
-  ];
-
-  for (const [nullifiers, commitments] of commonConfigs) {
+  // Check every shape the deploy registers. TESTING_ARTIFACT_CONFIGS is the single source of
+  // truth that loadVerificationKeys iterates at deploy time, so this reports exactly which and
+  // how many vkeys are actually on-chain — not a hand-picked sample.
+  let loaded = 0;
+  const missing: string[] = [];
+  for (const { nullifiers, commitments } of TESTING_ARTIFACT_CONFIGS) {
+    const shape = `${nullifiers}x${commitments}`;
     try {
       const vk = await privacyPool.getVerificationKey(nullifiers, commitments);
-      const isSet = vk.alpha1.x !== 0n;
-      console.log(`  VK[${nullifiers}x${commitments}]: ${isSet ? "✓ Loaded" : "✗ Not set"}`);
+      if (vk.alpha1.x !== 0n) {
+        loaded++;
+        console.log(`  VK[${shape}]: ✓ Loaded`);
+      } else {
+        missing.push(shape);
+        console.log(`  VK[${shape}]: ✗ Not set`);
+      }
     } catch (e) {
-      console.log(`  VK[${nullifiers}x${commitments}]: ✗ Error reading`);
+      missing.push(shape);
+      console.log(`  VK[${shape}]: ✗ Error reading`);
     }
+  }
+
+  console.log(
+    `\n  ${loaded}/${TESTING_ARTIFACT_CONFIGS.length} verification keys registered on-chain`
+  );
+  if (missing.length > 0) {
+    console.log(`  ⚠️  Missing (${missing.length}): ${missing.join(", ")}`);
+  } else {
+    console.log("  ✓ All expected shapes registered");
   }
 
   console.log("\n=== Verification Complete ===");


### PR DESCRIPTION
## Summary

Small, independent fixes + tooling surfaced while doing a fresh Sepolia deploy of the Armada-circuits stack. No contract changes.

### 1. `hardhat.config.ts` — `gasMultiplier` 1.2 → 2.0 (sepolia networks only)
The crowdfund/governance deploy reverted at `governor.clearDeployer()` with `ReentrancySentryOOG` — an out-of-gas at the EIP-2200 sentry on a clear-to-zero SSTORE. Public testnet RPCs under-estimate `eth_estimateGas` for refund-heavy stores, and ×1.2 didn't cover the gap (est ~26.3k × 1.2 = 31,540, which OOG'd). ×2.0 gives ample headroom; it's unused on success (only actual `gasUsed` is charged). Also protects the tail-end `renounceRole` calls (same SSTORE shape). Mainnet left at 1.2 — a blunt 2× there is wasteful; mainnet should use a quality RPC instead.

### 2. `config/sepolia.env` — `HUB_RPC` → publicnode
`drpc.org`'s estimator is the root cause above; `ethereum-sepolia-rpc.publicnode.com` estimates these correctly. drpc/tenderly kept as commented fallbacks.

### 3. `scripts/verify_snark_mode.ts` — manifest namespacing + full-shape enumeration
- Was hardcoded to `privacy-pool-hub.json` (the local manifest), so `verify:snark:sepolia` read a stale local address and errored (`BAD_DATA`, `0x`). Now resolves `privacy-pool-hub${suffix}.json` from the network config, like every other script.
- Widened the vkey check from a 5-shape sample to the full `TESTING_ARTIFACT_CONFIGS` set, with an `N/19 registered` summary and an explicit `⚠️ Missing` line so a partial registration can't pass silently.

### 4. `package.json` — Etherscan verification aliases
Added `verify:etherscan:sepolia` (+ `:clientA` / `:clientB`) wrapping the existing `scripts/verify_sepolia.ts`, which had no npm alias. Requires `ETHERSCAN_API_KEY`; one V2 key covers all three explorers.

## Verification
Against the fresh Sepolia deploy: `verify:snark:sepolia` now reports `testingMode: false` (real Groth16) and `19/19 verification keys registered on-chain`.

## Deploy note
`config/sepolia.env` + `hardhat.config.ts` affect the relayer host — the VPS should pull before its next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)