### PR TITLE
fix(scripts): verify GaslessShieldWrapper (hub + client) on Etherscan

### DIFF
--- a/scripts/verify_sepolia.ts
+++ b/scripts/verify_sepolia.ts
@@ -231,6 +231,15 @@ async function buildHubProtocolTasks(): Promise<VerifyTask[]> {
       // hookRouter constructor: (messageTransmitter)
       { name: "CCTPHookRouter (hub)", address: pc.hookRouter, constructorArguments: [pool.cctp.messageTransmitter] },
     );
+    // GaslessShieldWrapper constructor: (usdc, pool). Unlike the Poseidon-linked modules it has no
+    // library linking, so it verifies cleanly. Guarded because older manifests predate the wrapper.
+    if (pc.gaslessShieldWrapper) {
+      tasks.push({
+        name: "GaslessShieldWrapper",
+        address: pc.gaslessShieldWrapper,
+        constructorArguments: [pool.cctp.usdc, pc.privacyPool],
+      });
+    }
   }
 
   if (yieldD?.contracts && aave?.contracts && gov?.contracts && cctp?.contracts) {
@@ -299,11 +308,21 @@ async function buildClientChainTasks(role: "clientA" | "clientB"): Promise<Verif
     throw new Error(`PrivacyPoolClient manifest not found for role=${role}`);
   }
   const cc = client.contracts;
-  return [
+  const tasks: VerifyTask[] = [
     { name: "PrivacyPoolClient", address: cc.privacyPoolClient, constructorArguments: [] },
     // hookRouter constructor: (messageTransmitter)
     { name: "CCTPHookRouter (client)", address: cc.hookRouter, constructorArguments: [client.cctp.messageTransmitter] },
   ];
+  // GaslessShieldWrapperClient constructor: (usdc, pool) — mirrors the hub wrapper. Guarded because
+  // older client manifests predate the permit-gasless wrapper.
+  if (cc.gaslessShieldWrapperClient) {
+    tasks.push({
+      name: "GaslessShieldWrapperClient",
+      address: cc.gaslessShieldWrapperClient,
+      constructorArguments: [client.cctp.usdc, cc.privacyPoolClient],
+    });
+  }
+  return tasks;
 }
 
 async function main() {


### PR DESCRIPTION
`scripts/verify_sepolia.ts` verifies the privacy-pool router, modules, yield, aave, fee module, governance, and crowdfund — but never the **`GaslessShieldWrapper`** (hub) or **`GaslessShieldWrapperClient`** (clients), even though both are recorded in the same manifests it already reads. So those wrappers have stayed **unverified on Etherscan**.

That has a real user-facing consequence: the hub shield's gasless path asks the user to sign an **EIP-2612 USDC permit + EIP-712 `ShieldIntent`** whose spender / `verifyingContract` is the wrapper. Because the wrapper is unverified/unrecognized, MetaMask's Blockaid scanner flags the request as **"deceptive request … contains a malicious address."** Verifying the contract clears (or downgrades) that flag.

## Change
Adds two verification tasks, guarded so older manifests without the wrapper are skipped cleanly:
- **Hub** — `GaslessShieldWrapper`, constructor `(usdc, pool)` = `(pool.cctp.usdc, pc.privacyPool)`.
- **Client** — `GaslessShieldWrapperClient`, constructor `(usdc, pool)` = `(client.cctp.usdc, cc.privacyPoolClient)`.

Both constructors are `(usdc, pool)` with **no Poseidon library linking** (`deploy_gasless_wrapper.ts`), so unlike the Merkle/Shield/Transact modules they verify cleanly and don't belong in the skip list.

## Scope note
The hub wrapper + its deploy script have been on `main` since B2 (`e95e806a`) — so this is a **pre-existing `main` gap**, not introduced by the gasless PR (#410). Landing it standalone on `main` so it merges on its own timeline; #410 and the F5 branch inherit it on rebase.

## Interim unblock (no PR needed)
The live hub wrapper can be verified right now:
```bash
source config/sepolia.env && export ETHERSCAN_API_KEY=<key>
npx hardhat verify --network sepoliaHub \
  0xa669bA4E8127d8D6af06C98E1c124690843F652A \
  0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238 \
  0x3442e860d9Ec64c30e6beF2d3AFc21ef8605a1c3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)