### PR TITLE
test(sdk): Phase 0 Spike 1 — seed→wallet keyset vectors + decision-6 resolution

### DIFF
--- a/scripts/capture/spike-seed-to-wallet.ts
+++ b/scripts/capture/spike-seed-to-wallet.ts
@@ -1,0 +1,199 @@
+// ABOUTME: Phase 0 Spike 1 — seed→wallet reproducibility. Derives a full Railgun keyset from a fixed
+// ABOUTME: rootSecret via the interface's Phase-1 mnemonic-shim path and proves it reproduces byte-for-byte.
+//
+// Throwaway spike code (armada-sdk Phase 0, ARMADA_SDK.md §10 / handoff Step 3). The PERMANENT
+// artifact is the emitted keyset-vectors.json; this script is not part of the standing test suite.
+//
+// What it pins (open decision 6): whether `rootSecret -> deriveInternalMnemonic -> createWalletFromMnemonic`
+// yields a stable canonical keyset (spending priv/pub, viewing priv/pub, nullifying key,
+// masterPublicKey, 0zk address). Runs OFFLINE — key derivation needs no chain/provider (lib/sdk/init.ts).
+//
+// Run:  npx ts-node scripts/capture/spike-seed-to-wallet.ts
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { entropyToMnemonic } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
+
+import {
+  RailgunEngine,
+  RailgunWallet,
+  POI,
+  POINodeInterface,
+} from '@railgun-community/engine';
+
+import { initializeEngine, shutdownEngine, clearDatabase, getEngine } from '../../lib/sdk/init';
+
+// ── POI stub ───────────────────────────────────────────────
+// The engine requires POI initialized even when unused (PPOI is stripped entirely in the SDK
+// fork — see ARMADA_SDK.md §3.5 — but the stock engine we capture against still expects it).
+class StubPOINodeInterface extends POINodeInterface {
+  isActive(): boolean { return false; }
+  async isRequired(): Promise<boolean> { return false; }
+  async getPOIsPerList(): Promise<Record<string, any>> { return {}; }
+  async getPOIMerkleProofs(): Promise<any[]> { return []; }
+  async validatePOIMerkleroots(): Promise<boolean> { return true; }
+  async submitPOI(): Promise<void> { /* no-op */ }
+  async submitLegacyTransactProofs(): Promise<void> { /* no-op */ }
+}
+POI.init([], new StubPOINodeInterface());
+
+// ── Provenance stamp ───────────────────────────────────────
+// Final: captured on main after #410/#417 merged (the pinned-base capture was byte-identical).
+const STAMP = {
+  engineVersion: '9.6.0',
+  capturedFromMainSha: 'b21d4d9b2fe0e06fa44589de164ba00c54bb2b43',
+  provisional: false,
+};
+
+const VECTORS_DIR = path.join(__dirname, 'vectors');
+const OUT_FILE = path.join(VECTORS_DIR, 'keyset-vectors.json');
+
+// The SDK encryption key only encrypts at-rest storage — it does NOT influence the derived
+// identity keyset or 0zk address. Fixed here so the spike is deterministic.
+const ENC_KEY = '0101010101010101010101010101010101010101010101010101010101010101';
+
+// ── Fixed rootSecret test seeds (known inputs → known keysets) ──
+const SEEDS: ReadonlyArray<{ name: string; hex: string }> = [
+  { name: 'all-ones', hex: '01'.repeat(32) },
+  { name: 'counting-1..32', hex: Array.from({ length: 32 }, (_, i) => (i + 1).toString(16).padStart(2, '0')).join('') },
+  { name: 'fixed-pseudorandom', hex: 'a3f291c8b7e0d4569a1f2e3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a6978' },
+];
+
+// ── Serialization helpers ──────────────────────────────────
+function bigintToHex(n: bigint): string {
+  return '0x' + n.toString(16).padStart(64, '0');
+}
+function bytesToHex(b: Uint8Array): string {
+  return '0x' + Buffer.from(b).toString('hex');
+}
+function hexToBytes(hex: string): Uint8Array {
+  return new Uint8Array(Buffer.from(hex, 'hex'));
+}
+
+interface Keyset {
+  masterPublicKey: string;
+  nullifyingKey: string;
+  spendingPublicKey: [string, string];
+  spendingPrivateKey: string;
+  viewingPublicKey: string;
+  viewingPrivateKey: string;
+  railgunAddress: string;
+  walletId: string;
+}
+
+// Mirrors apps/armada-interface/src/lib/crypto/kdf.ts::deriveInternalMnemonic — the Phase-1
+// mnemonic shim (24-word BIP-39 from the 32-byte rootSecret). Replicated (one deterministic
+// standard call) rather than cross-imported from the ESM interface workspace into this CJS script.
+function deriveInternalMnemonic(rootSecret: Uint8Array): string {
+  return entropyToMnemonic(rootSecret, wordlist);
+}
+
+async function deriveKeyset(rootSecretHex: string): Promise<{ keyset: Keyset; mnemonic: string }> {
+  const rootSecret = hexToBytes(rootSecretHex);
+  const mnemonic = deriveInternalMnemonic(rootSecret);
+
+  clearDatabase();
+  const engine = await initializeEngine('spike');
+  try {
+    const railgunWalletInfo = await engine.createWalletFromMnemonic(ENC_KEY, mnemonic, 0, undefined);
+    const wallet = engine.wallets[railgunWalletInfo.id] as RailgunWallet;
+
+    const spendingKeyPair = await wallet.getSpendingKeyPair(ENC_KEY);
+    const viewingKeyPair = wallet.getViewingKeyPair();
+
+    // Sanity: the encoded 0zk address must decode back to this wallet's public keys.
+    const decoded = RailgunEngine.decodeAddress(wallet.getAddress());
+    if (decoded.masterPublicKey !== wallet.masterPublicKey) {
+      throw new Error('0zk address masterPublicKey mismatch on decode round-trip');
+    }
+    if (bytesToHex(decoded.viewingPublicKey) !== bytesToHex(viewingKeyPair.pubkey)) {
+      throw new Error('0zk address viewingPublicKey mismatch on decode round-trip');
+    }
+
+    const keyset: Keyset = {
+      masterPublicKey: bigintToHex(wallet.masterPublicKey),
+      nullifyingKey: bigintToHex(wallet.nullifyingKey),
+      spendingPublicKey: [bigintToHex(spendingKeyPair.pubkey[0]), bigintToHex(spendingKeyPair.pubkey[1])],
+      spendingPrivateKey: bytesToHex(spendingKeyPair.privateKey),
+      viewingPublicKey: bytesToHex(viewingKeyPair.pubkey),
+      viewingPrivateKey: bytesToHex(viewingKeyPair.privateKey),
+      railgunAddress: wallet.getAddress(),
+      walletId: railgunWalletInfo.id,
+    };
+    return { keyset, mnemonic };
+  } finally {
+    await shutdownEngine();
+  }
+}
+
+function assertEqual(name: string, a: Keyset, b: Keyset): void {
+  const ja = JSON.stringify(a);
+  const jb = JSON.stringify(b);
+  if (ja !== jb) {
+    throw new Error(`REPRODUCIBILITY FAILURE for ${name}:\n  pass1=${ja}\n  pass2=${jb}`);
+  }
+}
+
+async function main() {
+  console.log('='.repeat(64));
+  console.log('  Phase 0 Spike 1 — seed → wallet reproducibility');
+  console.log(`  engine ${STAMP.engineVersion} · main ${STAMP.capturedFromMainSha.slice(0, 10)}`);
+  console.log('='.repeat(64));
+
+  const captured: any[] = [];
+
+  for (const seed of SEEDS) {
+    console.log(`\n── ${seed.name} ──`);
+    // Two fully independent passes (fresh engine + cleared DB each time) prove the keyset is a
+    // pure function of the seed, not cached state.
+    const pass1 = await deriveKeyset(seed.hex);
+    const pass2 = await deriveKeyset(seed.hex);
+    assertEqual(seed.name, pass1.keyset, pass2.keyset);
+    console.log(`  0zk address : ${pass1.keyset.railgunAddress}`);
+    console.log(`  masterPubKey: ${pass1.keyset.masterPublicKey}`);
+    console.log(`  reproducible: ✓ (2 independent passes byte-identical)`);
+
+    captured.push({
+      name: seed.name,
+      rootSecret: '0x' + seed.hex,
+      // Included because these are test vectors from KNOWN test seeds — not real user secrets.
+      internalMnemonic: pass1.mnemonic,
+      encryptionKey: '0x' + ENC_KEY,
+      keyset: pass1.keyset,
+      derivation: {
+        path: 'rootSecret -> deriveInternalMnemonic (BIP-39 entropyToMnemonic) -> createWalletFromMnemonic(index=0)',
+        note: 'Phase-1 mnemonic-shim path (apps/armada-interface/src/lib/crypto/kdf.ts). encryptionKey does NOT affect identity.',
+      },
+    });
+  }
+
+  fs.mkdirSync(VECTORS_DIR, { recursive: true });
+  const out = {
+    vectorType: 'keyset',
+    primitive: 'key-derivation (ARMADA_SDK.md §2)',
+    ...STAMP,
+    // Public evidence for open decision 6 (§9): a live testnet wallet's rootSecret reproduces its
+    // exact 0zk address via this same path (engine 9.6.0). Secret NOT stored — verified transiently
+    // via scripts/capture/verify-testnet-identity.ts (env-only input).
+    testnetCrosscheck: {
+      address: '0zk1qy4xqtzlh3qfhrg4d8xg0mr7qzna3kd6y6udwr4y4pjljaxlm5l43rv7j6fe3z53la5zz8nztyzg59wtgeswfy33gs8a5rl6vg5glsx7lyxr3tgkuld9cutqe08',
+      result: 'byte-identical',
+      note: 'reproduced from a live testnet wallet recovery secret; secret not stored',
+    },
+    vectors: captured,
+  };
+  fs.writeFileSync(OUT_FILE, JSON.stringify(out, null, 2) + '\n');
+
+  console.log(`\n${'='.repeat(64)}`);
+  console.log(`  ${captured.length} keyset vectors captured → ${path.relative(process.cwd(), OUT_FILE)}`);
+  console.log('  All seeds reproduced byte-for-byte across independent passes.');
+  console.log('='.repeat(64));
+}
+
+main().catch(async (err) => {
+  console.error('\nSpike failed:', err);
+  try { await shutdownEngine(); } catch { /* ignore */ }
+  process.exit(1);
+});

--- a/scripts/capture/vectors/keyset-vectors.json
+++ b/scripts/capture/vectors/keyset-vectors.json
@@ -1,0 +1,83 @@
+{
+  "vectorType": "keyset",
+  "primitive": "key-derivation (ARMADA_SDK.md §2)",
+  "engineVersion": "9.6.0",
+  "capturedFromMainSha": "b21d4d9b2fe0e06fa44589de164ba00c54bb2b43",
+  "provisional": false,
+  "testnetCrosscheck": {
+    "address": "0zk1qy4xqtzlh3qfhrg4d8xg0mr7qzna3kd6y6udwr4y4pjljaxlm5l43rv7j6fe3z53la5zz8nztyzg59wtgeswfy33gs8a5rl6vg5glsx7lyxr3tgkuld9cutqe08",
+    "result": "byte-identical",
+    "note": "reproduced from a live testnet wallet recovery secret; secret not stored"
+  },
+  "vectors": [
+    {
+      "name": "all-ones",
+      "rootSecret": "0x0101010101010101010101010101010101010101010101010101010101010101",
+      "internalMnemonic": "absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice comic",
+      "encryptionKey": "0x0101010101010101010101010101010101010101010101010101010101010101",
+      "keyset": {
+        "masterPublicKey": "0x247451823dfcc889991cde89847e14fc5a902ed5dc820e52537780177cd17269",
+        "nullifyingKey": "0x1fc97e2366f09719d870d2d056b606e4678d98e47018a1e13c151e7307b68a0c",
+        "spendingPublicKey": [
+          "0x1503e3c396df1e30bf3fc89d97a7bf2cd2b5e5b39e1a099a5c0862dbaa5988c2",
+          "0x0e83fbda9a2887993d4fd9368463eb8c3d9e01df47418a5214ebe57e0c9dc30d"
+        ],
+        "spendingPrivateKey": "0xa637ed80fec9ef2faa82aad19b04849c91e29d6084897059c219f6735fc53777",
+        "viewingPublicKey": "0x6c242244b7d1e35e201c8aa70747dd2a456ba96318c51c52ffb9fdb7b6bc2783",
+        "viewingPrivateKey": "0xe9c0b4b38415170876234dcfbf8451bbe97c88adfb5249a5f77ca4c9dd6730e5",
+        "railgunAddress": "0zk1qyj8g5vz8h7v3zvern0gnpr7zn794ypw6hwgyrjj2dmcq9mu69exnrv7j6fe3z53lakzggjyklg7xh3qrj92wp68m54y26afvvvv28zjl7ulmdakhsncxr5stlf",
+        "walletId": "00e781fb8fcb252a2113e4847c7ed911229100d9feb6ee126bc171f1eed506f1"
+      },
+      "derivation": {
+        "path": "rootSecret -> deriveInternalMnemonic (BIP-39 entropyToMnemonic) -> createWalletFromMnemonic(index=0)",
+        "note": "Phase-1 mnemonic-shim path (apps/armada-interface/src/lib/crypto/kdf.ts). encryptionKey does NOT affect identity."
+      }
+    },
+    {
+      "name": "counting-1..32",
+      "rootSecret": "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+      "internalMnemonic": "absurd avoid scissors anxiety gather lottery category door army half long cage bachelor another expect people blade school educate curtain scrub monitor lady beyond",
+      "encryptionKey": "0x0101010101010101010101010101010101010101010101010101010101010101",
+      "keyset": {
+        "masterPublicKey": "0x2e15539fe5ac8cd2a74fbcf01ce561109332e3c662ccbd492a5330a153ae07e1",
+        "nullifyingKey": "0x108a2a736cf86eab66b11baa3cd853b07dea8ce5c91fa6c0a2fc369f250c35d1",
+        "spendingPublicKey": [
+          "0x22824a635727eb1c6d24fb7dac9d008a8042a613301fde159673f20bdfa10074",
+          "0x1e56a6f6572fc84878dd7f0595b143b715215b911e5cf46dd3ee14663c7733b6"
+        ],
+        "spendingPrivateKey": "0x6555dcec7eae27f631d540f94a7ed2549ff45cee5d885a53eee01dc4e507d3a1",
+        "viewingPublicKey": "0x3e6fc88bb005f36b59d17a640e88955bf3dd454b9c465dd54af3ad85afc4a2ce",
+        "viewingPrivateKey": "0x61693d3cf5a1f0c0563b116b644402bf347460126b5689cc2043ca4752271b8b",
+        "railgunAddress": "0zk1qyhp25ulukkge548f770q889vygfxvhrce3ve02f9ffnpg2n4cr7rrv7j6fe3z53lulxljytkqzlx66e69axgr5gj4dl8h29fwwyvhw4fte6mpd0cj3vuwkxk3s",
+        "walletId": "748ef891de9ba8e55ab24b24ee1877c2f5f1ae46ad0f032cc0baf5c66b4d3ddb"
+      },
+      "derivation": {
+        "path": "rootSecret -> deriveInternalMnemonic (BIP-39 entropyToMnemonic) -> createWalletFromMnemonic(index=0)",
+        "note": "Phase-1 mnemonic-shim path (apps/armada-interface/src/lib/crypto/kdf.ts). encryptionKey does NOT affect identity."
+      }
+    },
+    {
+      "name": "fixed-pseudorandom",
+      "rootSecret": "0xa3f291c8b7e0d4569a1f2e3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a6978",
+      "internalMnemonic": "physical nest impulse hurt ask clip half total detail food olympic valve just fan spread kid tiger lesson shy foil seven pudding planet brass",
+      "encryptionKey": "0x0101010101010101010101010101010101010101010101010101010101010101",
+      "keyset": {
+        "masterPublicKey": "0x2f9418b3abead16f97087725c3a452c27cb90f5c35e50b9306802a18b1d2a706",
+        "nullifyingKey": "0x0bdf3faf3d5b4dcb151481513f5ff5958316ca6c0d95f6dfd5c8d0701301fda6",
+        "spendingPublicKey": [
+          "0x0bc089b8f899aa392dc62b0abc9a5340156c6c67e71c8dadfc44322f1ad13c84",
+          "0x0f15bc8718651654411ef26972bd6260433c219e0bc4e7213c455768e711ca73"
+        ],
+        "spendingPrivateKey": "0x2b2f0ca38e719ddc8ea7407e860fcfcfc9e30fd3159b5a32fcd59d082021d71c",
+        "viewingPublicKey": "0xd60131b7f0a731ea3bc087165760627ffb06fb30f279291b20f3c4a95ef1528b",
+        "viewingPrivateKey": "0x3fb11f8b41527f2b7976be457e848d13f4466482c046517bf080305ceada4f42",
+        "railgunAddress": "0zk1qyhegx9n404dzmuhppmjtsay2tp8ewg0ts672zunq6qz5x9362nsdrv7j6fe3z53lltqzvdh7znnr63mczr3v4mqvfllkphmxre8j2gmyreuf22779fgkwuhryy",
+        "walletId": "3957948dd7dd0c990e4cdb3b99b75e059ae0183753246ad8401aa13ca3eb2ae7"
+      },
+      "derivation": {
+        "path": "rootSecret -> deriveInternalMnemonic (BIP-39 entropyToMnemonic) -> createWalletFromMnemonic(index=0)",
+        "note": "Phase-1 mnemonic-shim path (apps/armada-interface/src/lib/crypto/kdf.ts). encryptionKey does NOT affect identity."
+      }
+    }
+  ]
+}

--- a/scripts/capture/verify-testnet-identity.ts
+++ b/scripts/capture/verify-testnet-identity.ts
@@ -1,0 +1,68 @@
+// ABOUTME: Phase 0 Spike 1 cross-check — proves a live testnet wallet's rootSecret reproduces its
+// ABOUTME: 0zk address via the spike derivation path. Reads the secret from env; NEVER writes it anywhere.
+//
+// Throwaway. Secret comes from CROSSCHECK_ROOTSECRET (hex, no persistence); expected 0zk from
+// CROSSCHECK_EXPECTED_0ZK. Prints PASS/FAIL + the derived (public) 0zk only. No file output.
+//
+// Run: CROSSCHECK_ROOTSECRET=<hex> CROSSCHECK_EXPECTED_0ZK=<0zk...> npx ts-node scripts/capture/verify-testnet-identity.ts
+
+import { entropyToMnemonic } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
+import { RailgunWallet, POI, POINodeInterface } from '@railgun-community/engine';
+import { initializeEngine, shutdownEngine, clearDatabase } from '../../lib/sdk/init';
+
+class StubPOINodeInterface extends POINodeInterface {
+  isActive(): boolean { return false; }
+  async isRequired(): Promise<boolean> { return false; }
+  async getPOIsPerList(): Promise<Record<string, any>> { return {}; }
+  async getPOIMerkleProofs(): Promise<any[]> { return []; }
+  async validatePOIMerkleroots(): Promise<boolean> { return true; }
+  async submitPOI(): Promise<void> { /* no-op */ }
+  async submitLegacyTransactProofs(): Promise<void> { /* no-op */ }
+}
+POI.init([], new StubPOINodeInterface());
+
+const ENC_KEY = '0101010101010101010101010101010101010101010101010101010101010101';
+
+async function main() {
+  const rootSecretHex = (process.env.CROSSCHECK_ROOTSECRET ?? '').replace(/^0x/, '').trim();
+  const expected = (process.env.CROSSCHECK_EXPECTED_0ZK ?? '').trim();
+  if (rootSecretHex.length !== 64) {
+    throw new Error(`CROSSCHECK_ROOTSECRET must be 64 hex chars, got ${rootSecretHex.length}`);
+  }
+  if (!expected.startsWith('0zk')) {
+    throw new Error('CROSSCHECK_EXPECTED_0ZK must be a 0zk... address');
+  }
+
+  const rootSecret = new Uint8Array(Buffer.from(rootSecretHex, 'hex'));
+  // Same path as apps/armada-interface/src/lib/crypto/kdf.ts::deriveInternalMnemonic.
+  const mnemonic = entropyToMnemonic(rootSecret, wordlist);
+
+  clearDatabase();
+  const engine = await initializeEngine('xcheck');
+  let derived = '';
+  try {
+    const info = await engine.createWalletFromMnemonic(ENC_KEY, mnemonic, 0, undefined);
+    const wallet = engine.wallets[info.id] as RailgunWallet;
+    derived = wallet.getAddress();
+  } finally {
+    rootSecret.fill(0); // zeroize local secret copy
+    await shutdownEngine();
+  }
+
+  const match = derived === expected;
+  console.log('\n' + '='.repeat(64));
+  console.log('  Testnet identity cross-check (engine 9.6.0)');
+  console.log('='.repeat(64));
+  console.log('  derived 0zk :', derived);
+  console.log('  expected 0zk:', expected);
+  console.log('  result      :', match ? '✓ PASS — byte-identical' : '✗ FAIL — mismatch');
+  console.log('='.repeat(64));
+  if (!match) process.exit(2);
+}
+
+main().catch(async (err) => {
+  console.error('\nCross-check failed:', err);
+  try { await shutdownEngine(); } catch { /* ignore */ }
+  process.exit(1);
+});

--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -23,6 +23,7 @@ ALLOWED_FILES=(
   "config/secrets.env.template"  # Placeholder mnemonic ("word word word..."); real secret lives in gitignored secrets.env
   "relayer/test/modules/railgun-wallet.test.ts"  # Anvil's publicly-known test mnemonic — required to prove deterministic derivation
   "scripts/multicall3-bytecode.ts"  # Canonical Multicall3 public runtime bytecode (not a key) — etched onto local Anvil
+  "scripts/capture/vectors/keyset-vectors.json"  # Phase 0 keyset vectors derived from FIXED TEST SEEDS (not real secrets); the live-testnet crosscheck stores only the public 0zk address
 )
 
 # Patterns that indicate secrets. Each entry: "LABEL:::REGEX"

--- a/specs/ARMADA_SDK.md
+++ b/specs/ARMADA_SDK.md
@@ -318,6 +318,13 @@ Requirements:
   (§10.1). If byte-equality with the shim path is impossible without the mnemonic detour, the
   fallback is to keep the mnemonic construction *inside* `fromRootSecret` as an implementation
   detail — the API contract (raw bytes in, canonical keyset out, reproducible) is what matters.
+  Phase 0 Spike 1 (engine 9.6.0) — CONFIRMED: `fromRootSecret` retains the BIP-32 mnemonic
+  detour (`deriveInternalMnemonic` → `createWalletFromMnemonic`) internally. It reproduces the
+  full keyset byte-for-byte across independent engine instances
+  (`scripts/capture/vectors/keyset-vectors.json`) and resolves a live testnet wallet to its
+  exact on-chain 0zk address (`0zk1…cutqe08`). Direct HKDF would yield a different keyset (the
+  documented Phase-1/Phase-2 non-interop); the detour is retained to preserve testnet identity.
+  Load-bearing requirement satisfied.
 - Baby Jubjub validity checks on all derived/imported keys: subgroup membership, non-zero
   scalars, canonical encodings. Reject, never clamp silently.
 - Recovery-path parity per TX_SIGNING v2: re-sign (deterministic EOAs, double-sign verification
@@ -735,7 +742,7 @@ implement it against the same spec later.
 | 3 | Quick-sync indexer: build now vs later | 2 (defer ok) | Define interface now, implement later |
 | 4 | Claim-envelope AEAD: AES-256-GCM vs XChaCha20-Poly1305 | 3 | AES-256-GCM (WebCrypto-native, matches backup format) |
 | 5 | Recipient directory (ENS text records, integrator-held, none) | 3+ | Ship resolver orders (1)–(3) only; directory is product work |
-| 6 | `fromRootSecret` internal path if byte-equality demands the mnemonic detour | 0/2 | Accept internal detour; API contract unchanged (§4.2) |
+| 6 | `fromRootSecret` internal path — detour vs direct-HKDF | 0 ✓ RESOLVED | Retain BIP-32 mnemonic detour internally. Spike 1 (engine 9.6.0) verified byte-reproducibility + a live testnet wallet resolving to its exact 0zk. Direct-HKDF (fresh identity) rejected — breaks testnet continuity. API contract unchanged. |
 | 7 | Per-installation counter salt scheme for multi-device claim counters | 3 | Random per-installation component mixed into `info`; document |
 | 8 | `ExternalSigner` out-of-process transport (HTTP vs socket vs enclave RPC) | Integration project | Not an SDK decision — SDK freezes the in-process interface; transport defined per integration (`specs/PAROS_INTEGRATION.md`) |
 


### PR DESCRIPTION
Phase 0 Spike 1 of the `@armada/sdk` spin-off (`specs/ARMADA_SDK.md` §10). Throwaway spike code + **permanent keyset vectors**; no runtime/contract changes.

## What
- `scripts/capture/spike-seed-to-wallet.ts` — reproducibility spike: derives a full Railgun keyset from a fixed `rootSecret` via the Phase-1 mnemonic-shim path and proves it reproduces byte-for-byte across independent engine instances.
- `scripts/capture/vectors/keyset-vectors.json` — 3 keyset vectors (masterPublicKey, nullifyingKey, spending/viewing pairs, 0zk, walletId), stamped `engine 9.6.0 / main b21d4d9b`. Staged in the POC repo; copied into `armada-sdk/test/vectors/` at Step 4.
- `scripts/capture/verify-testnet-identity.ts` — env-driven cross-check (no secret in-file).
- `specs/ARMADA_SDK.md` — resolves open decision 6.

## Finding (resolves decision 6)
Confirmed on engine 9.6.0: `fromRootSecret` retains the BIP-32 mnemonic detour (`deriveInternalMnemonic → createWalletFromMnemonic`) internally. It (a) reproduces the keyset byte-for-byte across independent engine instances, and (b) resolves a **live testnet wallet** to its exact on-chain 0zk address. Direct-HKDF would yield a different keyset (the documented Phase-1/Phase-2 non-interop) → detour retained to preserve testnet identity.

## Secret hygiene
The testnet cross-check used a real recovery secret **transiently via env var** — never written to disk. Only the **public 0zk** is recorded in the fixture/spec. `keyset-vectors.json` (test-seed-derived keys) is allowlisted in `check-secrets.sh`, matching the existing test-vector allowlist convention.

## Notes
- Captured on `main` (post #410/#417 merge); the earlier pinned-base capture was byte-identical (promotion gate passed).
- Next: Chunk B (vector suite for the remaining §2 primitives — needs local chains) and Chunk C (claim-as-transfer).