### PR TITLE
feat(sdk-backend): consume @armada/sdk via git-dep + 0zk parity seam

### DIFF
--- a/lib/sdk/shielded-identity.ts
+++ b/lib/sdk/shielded-identity.ts
@@ -1,0 +1,33 @@
+// ABOUTME: Backend-selectable shielded-identity derivation — routes 0zk address derivation to the
+// ABOUTME: stock Railgun engine or the new @armada/sdk, chosen by the SDK_BACKEND env flag (default stock).
+
+export type SdkBackend = 'stock' | 'armada';
+
+/** The active backend, from SDK_BACKEND (default 'stock' — nothing changes until we opt in). */
+export function selectedBackend(): SdkBackend {
+  return process.env.SDK_BACKEND === 'armada' ? 'armada' : 'stock';
+}
+
+/**
+ * Derive a wallet's 0zk shielded address from its 32-byte rootSecret.
+ *
+ * The armada backend uses `@armada/sdk`'s `deriveKeyset` (byte-identical to the stock engine per
+ * Phase 0 Spike 1 + the keyset differential vectors). The stock path is not wired here yet — the
+ * captured keyset vectors serve as the stock ground truth for the parity seam; the live stock-engine
+ * derivation stays in `lib/sdk/wallet.ts` until the full facade cutover.
+ */
+export async function deriveShieldedAddress(
+  rootSecret: Uint8Array,
+  backend: SdkBackend = selectedBackend(),
+): Promise<string> {
+  if (backend === 'armada') {
+    // Lazy import so the stock path never loads the SDK (or triggers its WASM init). deriveKeyset
+    // initialises poseidon internally (WASM, or a byte-identical JS fallback if not yet ready).
+    const { deriveKeyset } = await import('@armada/sdk');
+    return (await deriveKeyset(rootSecret)).railgunAddress;
+  }
+  // TODO(Phase 2 integration): wire the stock-engine 0zk derivation through this facade too, so both
+  // backends run side-by-side. For now the parity seam compares the armada backend to the
+  // stock-captured keyset vectors (scripts/capture/vectors/keyset-vectors.json).
+  throw new Error('deriveShieldedAddress: stock backend not wired here yet (Phase 2 integration TODO)');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#41899328d1b0f084e4e63e5efb454ed3ffcbb3a2",
+        "@armada/sdk": "github:ship-armada/armada-sdk#65bce0d372edf741dacd0eb432146412b4f3e28c",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#41899328d1b0f084e4e63e5efb454ed3ffcbb3a2",
-      "integrity": "sha512-JTjh44RuE5GRDjxzdc3ZbKiN2yQKuw/+ZiLwYEY8eAkFXNtYlW5nbXjrqfZ9SkmgFuwSFZivC/ISXymu4RumWA==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#65bce0d372edf741dacd0eb432146412b4f3e28c",
+      "integrity": "sha512-UJhv61NaXg+bPEw2T40EK9BL8m1+3IUtcoNur35Fv8ykNxZutzY3ag5whccH8yA4OoljXySgqN3X167LnNAk+w==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
+        "@armada/sdk": "github:ship-armada/armada-sdk#41899328d1b0f084e4e63e5efb454ed3ffcbb3a2",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -407,6 +408,25 @@
     "node_modules/@armada/interface": {
       "resolved": "apps/armada-interface",
       "link": true
+    },
+    "node_modules/@armada/sdk": {
+      "version": "0.0.0",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#41899328d1b0f084e4e63e5efb454ed3ffcbb3a2",
+      "integrity": "sha512-JTjh44RuE5GRDjxzdc3ZbKiN2yQKuw/+ZiLwYEY8eAkFXNtYlW5nbXjrqfZ9SkmgFuwSFZivC/ISXymu4RumWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^0.4.0",
+        "@noble/ed25519": "^1.7.1",
+        "@noble/hashes": "^1.3.2",
+        "@railgun-community/circomlibjs": "0.0.8",
+        "@railgun-community/curve25519-scalarmult-wasm": "0.1.5",
+        "@railgun-community/poseidon-hash-wasm": "1.0.1",
+        "@scure/base": "^1.1.1",
+        "buffer-xor": "^2.0.2",
+        "ethereum-cryptography": "^2.0.0",
+        "ethers": "^6.14.3",
+        "fast-text-encoding": "^1.0.6"
+      }
     },
     "node_modules/@armada/ui": {
       "resolved": "packages/ui",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:mcp:e2e": "npx mocha --require ts-node/register mcp-server/test/e2e.test.ts",
     "test:mcp:all": "npx mocha --require ts-node/register 'mcp-server/test/**/*.test.ts'",
     "test:relayer": "npx mocha --require ts-node/register 'relayer/test/**/*.test.ts'",
+    "test:sdk-backend": "TS_NODE_TRANSPILE_ONLY=1 npx mocha --require ts-node/register 'test/sdk-backend/**/*.test.ts'",
     "test:forge": "forge test --offline",
     "halmos": "halmos",
     "halmos:allocation": "halmos --contract HalmosAllocationTest --match-test '^(check_allocPlusRefundEqualsCommitted|check_allocNeverExceedsCommitted|check_underSubscribedFullAllocation|check_zeroCommittedReturnsZero)'",
@@ -113,6 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
+    "@armada/sdk": "github:ship-armada/armada-sdk#41899328d1b0f084e4e63e5efb454ed3ffcbb3a2",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -157,8 +159,8 @@
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.57.1",
-    "lightningcss-linux-x64-gnu": "1.30.2",
-    "@tailwindcss/oxide-linux-x64-gnu": "4.1.18"
+    "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
+    "lightningcss-linux-x64-gnu": "1.30.2"
   },
   "overrides": {
     "ethers": "$ethers"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test:mcp:e2e": "npx mocha --require ts-node/register mcp-server/test/e2e.test.ts",
     "test:mcp:all": "npx mocha --require ts-node/register 'mcp-server/test/**/*.test.ts'",
     "test:relayer": "npx mocha --require ts-node/register 'relayer/test/**/*.test.ts'",
-    "test:sdk-backend": "TS_NODE_TRANSPILE_ONLY=1 npx mocha --require ts-node/register 'test/sdk-backend/**/*.test.ts'",
+    "test:sdk-backend": "npx mocha --require ts-node/register 'test/sdk-backend/**/*.test.ts'",
     "test:forge": "forge test --offline",
     "halmos": "halmos",
     "halmos:allocation": "halmos --contract HalmosAllocationTest --match-test '^(check_allocPlusRefundEqualsCommitted|check_allocNeverExceedsCommitted|check_underSubscribedFullAllocation|check_zeroCommittedReturnsZero)'",
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#41899328d1b0f084e4e63e5efb454ed3ffcbb3a2",
+    "@armada/sdk": "github:ship-armada/armada-sdk#65bce0d372edf741dacd0eb432146412b4f3e28c",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",

--- a/test/sdk-backend/key-derivation.test.ts
+++ b/test/sdk-backend/key-derivation.test.ts
@@ -1,0 +1,38 @@
+// ABOUTME: Integration seam test — the POC consumes @armada/sdk (git dependency) and its 0zk
+// ABOUTME: derivation reproduces the stock-captured keyset vectors (armada-vs-stock differential).
+
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { deriveShieldedAddress } from '../../lib/sdk/shielded-identity';
+
+const vectors = JSON.parse(
+  readFileSync(join(__dirname, '../../scripts/capture/vectors/keyset-vectors.json'), 'utf8'),
+).vectors as Array<{ name: string; rootSecret: string; keyset: { railgunAddress: string } }>;
+
+function hexToBytes(hex: string): Uint8Array {
+  const s = hex.replace(/^0x/, '');
+  const out = new Uint8Array(s.length / 2);
+  for (let i = 0; i < out.length; i += 1) out[i] = parseInt(s.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+describe('@armada/sdk backend — 0zk derivation parity (git-dep integration seam)', () => {
+  for (const v of vectors) {
+    it(`${v.name}: armada backend reproduces the stock-captured 0zk address`, async () => {
+      const address = await deriveShieldedAddress(hexToBytes(v.rootSecret), 'armada');
+      expect(address).to.equal(v.keyset.railgunAddress);
+    });
+  }
+
+  it('SDK_BACKEND selects the backend; stock path is not wired here yet', async () => {
+    let threw = false;
+    try {
+      await deriveShieldedAddress(new Uint8Array(32).fill(1), 'stock');
+    } catch (e) {
+      threw = true;
+      expect((e as Error).message).to.match(/stock backend not wired/);
+    }
+    expect(threw).to.equal(true);
+  });
+});


### PR DESCRIPTION
Phase 2 integration — first POC→SDK seam (Steps 3–4). Proves the POC repo can consume the published `@armada/sdk` and that its derivation matches the stock engine.

## What
- **Depend on `@armada/sdk`** via git-SHA (`github:ship-armada/armada-sdk#4189932`), built on install via the SDK's `prepare` script.
- **`lib/sdk/shielded-identity.ts`** — a backend selector: `SDK_BACKEND=stock|armada` (default `stock`, so nothing changes until we opt in). The armada path derives the 0zk via `@armada/sdk`'s `deriveKeyset`.
- **`test/sdk-backend/key-derivation.test.ts`** — the armada backend reproduces the **stock-captured keyset vectors' 0zk addresses byte-for-byte** (the vectors are stock ground truth, so this is the stock-vs-armada differential). `npm run test:sdk-backend` — 4 passing.

## Notes
- The seam test runs `TS_NODE_TRANSPILE_ONLY=1` — the POC's `moduleResolution: Node` (classic) doesn't read the SDK's `exports`/`types` map, but runtime resolution (node honors `exports`) is correct. **Follow-ups:** add a top-level `types` field to the SDK for classic-resolution consumers, and/or modernize the POC's `moduleResolution` — then full typechecking works without transpile-only.
- No `relayer/` or `config/*.env` changes → no VPS action.

Next: wire more paths behind the flag (sync/tx) against local chains, closing the note-ciphertext deferral.