### PR TITLE
test(sdk): chain-based sync differential — armada scan reproduces stock balances

### DIFF
--- a/lib/sdk/armada-sync.ts
+++ b/lib/sdk/armada-sync.ts
@@ -1,0 +1,106 @@
+// ABOUTME: Live-provider glue for the @armada/sdk sync engine — wires an ethers provider's pool logs
+// ABOUTME: through the SDK decoder + scan orchestrator to produce shielded balances for one wallet.
+
+import { Interface, type Provider } from 'ethers';
+import {
+  fetchLogsRanged,
+  decodePoolEvents,
+  WalletScanState,
+  tryDecryptCommitment,
+  tryDecryptShield,
+  POOL_V2_EVENT_ABI,
+  type ParsedPoolLog,
+  type TokenBalance,
+} from '@armada/sdk';
+import {
+  getTokenDataERC20,
+  getTokenDataHash,
+  ChainType,
+  initPoseidonPromise,
+  type TokenData,
+} from '@armada/sdk/core';
+
+/** The wallet key material the armada scan needs (from `deriveKeyset`). */
+export interface ArmadaScanWallet {
+  readonly masterPublicKey: bigint;
+  readonly viewingPublicKey: Uint8Array;
+  readonly viewingPrivateKey: Uint8Array;
+  readonly nullifyingKey: bigint;
+}
+
+export interface ArmadaScanParams {
+  readonly provider: Provider;
+  readonly poolAddress: string;
+  readonly deployBlock: number;
+  readonly headBlock: number;
+  readonly chainId: number;
+  /** ERC20 token addresses in play — used to resolve tokenHash → tokenData during note decryption. */
+  readonly tokenAddresses: readonly string[];
+  readonly wallet: ArmadaScanWallet;
+  /** Per-provider getLogs range cap (bisected on over-range throws). */
+  readonly maxRange?: number;
+}
+
+/**
+ * Scan the pool's Shield/Transact/Nullified logs over `[deployBlock, headBlock]` with the SDK sync
+ * engine and return the wallet's per-token spendable/pending balances. Pure read path: builds an
+ * ephemeral in-memory tree/TXO set (no persistence) — the differential's armada side.
+ */
+export async function scanArmadaBalances(params: ArmadaScanParams): Promise<TokenBalance[]> {
+  await initPoseidonPromise;
+  const iface = new Interface(POOL_V2_EVENT_ABI as unknown as string[]);
+
+  // tokenHash → tokenData registry for the note tokenDataGetter (keyed by the canonical no-0x hash).
+  const tokenByHash = new Map<string, TokenData>();
+  for (const address of params.tokenAddresses) {
+    const tokenData = getTokenDataERC20(address);
+    tokenByHash.set(getTokenDataHash(tokenData), tokenData);
+  }
+  const tokenDataGetter = {
+    getTokenDataFromHash: async (_v: unknown, _c: unknown, tokenHash: string): Promise<TokenData> => {
+      const key = tokenHash.startsWith('0x') ? tokenHash.slice(2) : tokenHash;
+      const tokenData = tokenByHash.get(key);
+      if (tokenData === undefined) throw new Error(`armada-sync: unknown token hash ${tokenHash}`);
+      return tokenData;
+    },
+  };
+
+  // getLogs adapter: fetch the pool's logs for a window and parse them into ParsedPoolLog[].
+  const getLogs = async (fromBlock: number, toBlock: number): Promise<ParsedPoolLog[]> => {
+    const logs = await params.provider.getLogs({ address: params.poolAddress, fromBlock, toBlock });
+    const parsed: ParsedPoolLog[] = [];
+    for (const log of logs) {
+      const desc = iface.parseLog({ topics: [...log.topics], data: log.data });
+      if (desc === null) continue; // not one of our pool events
+      parsed.push({
+        name: desc.name,
+        args: desc.args as unknown as ParsedPoolLog['args'],
+        blockNumber: log.blockNumber,
+        txid: log.transactionHash,
+      });
+    }
+    return parsed;
+  };
+
+  const parsedLogs = await fetchLogsRanged(getLogs, {
+    fromBlock: params.deployBlock,
+    toBlock: params.headBlock,
+    ...(params.maxRange !== undefined ? { maxRange: params.maxRange } : {}),
+  });
+  const decoded = decodePoolEvents(parsedLogs);
+
+  const receiver = {
+    addressData: { masterPublicKey: params.wallet.masterPublicKey, viewingPublicKey: params.wallet.viewingPublicKey },
+    viewingPrivateKey: params.wallet.viewingPrivateKey,
+  };
+  const chain = { type: ChainType.EVM, id: params.chainId };
+
+  const state = new WalletScanState();
+  await state.apply(decoded, {
+    transact: (commitment) => tryDecryptCommitment(commitment.ciphertext, receiver, tokenDataGetter, chain),
+    shield: (commitment) => tryDecryptShield(commitment, receiver),
+  });
+
+  // finalityThreshold 0 — a local differential compares fully-confirmed balances at `headBlock`.
+  return state.balances(params.wallet.nullifyingKey, { currentBlock: params.headBlock, finalityThreshold: 0 });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#65bce0d372edf741dacd0eb432146412b4f3e28c",
+        "@armada/sdk": "github:ship-armada/armada-sdk#a95e16f3009099096ba8b03dfb4f18bc9b91471b",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#65bce0d372edf741dacd0eb432146412b4f3e28c",
-      "integrity": "sha512-UJhv61NaXg+bPEw2T40EK9BL8m1+3IUtcoNur35Fv8ykNxZutzY3ag5whccH8yA4OoljXySgqN3X167LnNAk+w==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#a95e16f3009099096ba8b03dfb4f18bc9b91471b",
+      "integrity": "sha512-y9N1RtR+OdNgLmEgX1uwtEo1EDYxnNhzjDEDHNQIPmI48i4PsEacziTFG+vjq0xL1rQTaRA5Jp3Jn0v4UlBcEg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#65bce0d372edf741dacd0eb432146412b4f3e28c",
+    "@armada/sdk": "github:ship-armada/armada-sdk#a95e16f3009099096ba8b03dfb4f18bc9b91471b",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",

--- a/scripts/capture/e2e-sync-differential.ts
+++ b/scripts/capture/e2e-sync-differential.ts
@@ -1,0 +1,187 @@
+// ABOUTME: Sync differential — shields + privately transfers USDC via the stock Railgun SDK on local
+// ABOUTME: Anvil, then scans the same chain with @armada/sdk and asserts identical shielded balances.
+
+/**
+ * Sync Differential: stock SDK vs @armada/sdk
+ *
+ * Validates the armada sync engine (event-decoder + note/shield decrypt + merkletree + nullifiers +
+ * balances) against the reference implementation on a real chain:
+ *   1. SHIELD 10 USDC to Alice (direct contract call — no ZK proof).
+ *   2. TRANSFER 3 USDC Alice → Bob (real Groth16 proof via the stock SDK).
+ * After each step every wallet's stock balance is compared to an independent @armada/sdk scan.
+ *
+ * Prerequisites (local):
+ *   npm run chains                              # terminal 1
+ *   source config/local.env && npm run setup    # terminal 2
+ *   npx hardhat run scripts/capture/e2e-sync-differential.ts --network hub
+ */
+
+import { ethers } from 'hardhat';
+
+import { initializeEngine, shutdownEngine, clearDatabase, getEngine } from '../../lib/sdk/init';
+import { createWallet, DEFAULT_ENCRYPTION_KEY } from '../../lib/sdk/wallet';
+import { initializeProver } from '../../lib/sdk/prover';
+import { createShieldRequest, generateShieldPrivateKey } from '../../lib/sdk/shield';
+import { loadNetworkIntoEngine, scanWalletBalances, getWalletBalances } from '../../lib/sdk/network';
+import { createPrivateTransfer } from '../../lib/sdk/transfer';
+import { getChainById, getRpcUrl } from '../../lib/sdk/chain-config';
+import { loadDeployment } from '../deploy-utils';
+import { scanArmadaBalances } from '../../lib/sdk/armada-sync';
+
+import {
+  TXIDVersion, POI, POINodeInterface, RailgunWallet,
+  getTokenDataERC20 as engineTokenDataERC20, getTokenDataHash as engineTokenDataHash,
+} from '@railgun-community/engine';
+import { Chain } from '@railgun-community/shared-models';
+import { Mnemonic } from '@armada/sdk/core';
+import { deriveKeyset, type Keyset } from '@armada/sdk';
+import { getTokenDataERC20, getTokenDataHash } from '@armada/sdk/core';
+
+class StubPOINodeInterface extends POINodeInterface {
+  isActive(): boolean { return false; }
+  async isRequired(): Promise<boolean> { return false; }
+  async getPOIsPerList(): Promise<Record<string, any>> { return {}; }
+  async getPOIMerkleProofs(): Promise<any[]> { return []; }
+  async validatePOIMerkleroots(): Promise<boolean> { return true; }
+  async submitPOI(): Promise<void> { /* no-op */ }
+  async submitLegacyTransactProofs(): Promise<void> { /* no-op */ }
+}
+POI.init([], new StubPOINodeInterface());
+
+const bytesToHex = (b: Uint8Array): string => Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('');
+const seed = (fill: number): Uint8Array => new Uint8Array(32).fill(fill);
+
+interface DiffWallet {
+  label: string;
+  walletId: string;
+  railgunAddress: string;
+  wallet: RailgunWallet;
+  keyset: Keyset;
+}
+
+async function main() {
+  console.log('='.repeat(60));
+  console.log('  Sync Differential: stock SDK vs @armada/sdk');
+  console.log('='.repeat(60));
+
+  const deployments = loadDeployment('privacy-pool-hub.json');
+  if (!deployments) throw new Error('privacy-pool-hub.json not found — run `npm run setup` first');
+  const chainId: number = deployments.chainId;
+  const chain: Chain = getChainById(chainId)!;
+  console.log(`\nNetwork: local (chainId ${chainId}), deployBlock ${deployments.deployBlock}`);
+
+  const shieldAmount = ethers.parseUnits('10', 6);
+  const transferAmount = ethers.parseUnits('3', 6);
+
+  const signers = await ethers.getSigners();
+  const aliceSigner = signers[1];
+
+  const privacyPool = await ethers.getContractAt('PrivacyPool', deployments.contracts.privacyPool);
+  const usdc = await ethers.getContractAt('MockUSDCV2', deployments.cctp.usdc);
+  const usdcAddress = await usdc.getAddress();
+  const stockTokenHash = engineTokenDataHash(engineTokenDataERC20(usdcAddress));
+  const armadaTokenHash = getTokenDataHash(getTokenDataERC20(usdcAddress));
+
+  // ── Init stock engine + prover ──
+  console.log('\nInitializing stock engine + prover...');
+  clearDatabase();
+  await initializeEngine('diff');
+  await loadNetworkIntoEngine(chain, await privacyPool.getAddress(), ethers.ZeroAddress, getRpcUrl(chain), deployments.deployBlock ?? 0);
+  await initializeProver();
+
+  // ── Derive Alice + Bob on both backends from fixed rootSecrets ──
+  async function makeWallet(label: string, rootSecret: Uint8Array): Promise<DiffWallet> {
+    const keyset = await deriveKeyset(rootSecret);
+    const info = await createWallet(DEFAULT_ENCRYPTION_KEY, Mnemonic.fromEntropy(bytesToHex(rootSecret)), 0);
+    if (info.railgunAddress !== keyset.railgunAddress) {
+      throw new Error(`${label}: rootSecret derivation mismatch (stock ${info.railgunAddress} vs armada ${keyset.railgunAddress})`);
+    }
+    const wallet = getEngine().wallets[info.id] as unknown as RailgunWallet;
+    console.log(`  ${label}: ${info.railgunAddress}`);
+    return { label, walletId: info.id, railgunAddress: info.railgunAddress, wallet, keyset };
+  }
+  const alice = await makeWallet('Alice', seed(0x11));
+  const bob = await makeWallet('Bob', seed(0x22));
+
+  // ── Assert one wallet's stock balance == an independent armada scan ──
+  async function assertDifferential(w: DiffWallet, phase: string): Promise<bigint> {
+    await scanWalletBalances(w.walletId, chain);
+    const stock = (await getWalletBalances(w.walletId, chain, false))[stockTokenHash]?.balance ?? 0n;
+
+    const headBlock = await ethers.provider.getBlockNumber();
+    const armadaBalances = await scanArmadaBalances({
+      provider: ethers.provider,
+      poolAddress: await privacyPool.getAddress(),
+      deployBlock: deployments.deployBlock ?? 0,
+      headBlock,
+      chainId,
+      tokenAddresses: [usdcAddress],
+      wallet: {
+        masterPublicKey: w.keyset.masterPublicKey,
+        viewingPublicKey: w.keyset.viewingPublicKey,
+        viewingPrivateKey: w.keyset.viewingPrivateKey,
+        nullifyingKey: w.keyset.nullifyingKey,
+      },
+    });
+    const entry = armadaBalances.find((b) => b.tokenHash === armadaTokenHash);
+    const armada = entry ? entry.spendable + entry.pending : 0n;
+
+    const tag = `[${phase}] ${w.label}`;
+    console.log(`  ${tag}: stock=${ethers.formatUnits(stock, 6)}  armada=${ethers.formatUnits(armada, 6)} USDC`);
+    if (stock !== armada) throw new Error(`DIFFERENTIAL MISMATCH ${tag}: stock=${stock} armada=${armada}`);
+    return stock;
+  }
+
+  // ── STEP 1: SHIELD 10 USDC to Alice ──
+  console.log(`\nSHIELD ${ethers.formatUnits(shieldAmount, 6)} USDC → Alice`);
+  const shieldPrivateKey = generateShieldPrivateKey();
+  const { shieldRequest } = await createShieldRequest(
+    { railgunAddress: alice.railgunAddress, amount: shieldAmount, tokenAddress: usdcAddress },
+    shieldPrivateKey,
+  );
+  const aliceAddr = await aliceSigner.getAddress();
+  await (await usdc.mint(aliceAddr, shieldAmount)).wait();
+  await (await usdc.connect(aliceSigner).approve(await privacyPool.getAddress(), shieldAmount)).wait();
+  await (await privacyPool.connect(aliceSigner).shield([shieldRequest], ethers.ZeroAddress)).wait();
+
+  const aliceAfterShield = await assertDifferential(alice, 'post-shield');
+  if (aliceAfterShield === 0n) throw new Error('shield did not register — differential vacuous');
+
+  // ── STEP 2: PRIVATE TRANSFER 3 USDC Alice → Bob (real Groth16) ──
+  console.log(`\nTRANSFER ${ethers.formatUnits(transferAmount, 6)} USDC  Alice → Bob (proving`);
+  const transferResult = await createPrivateTransfer({
+    wallet: alice.wallet,
+    chain,
+    tokenAddress: usdcAddress,
+    recipientAddress: bob.railgunAddress,
+    amount: transferAmount,
+    encryptionKey: DEFAULT_ENCRYPTION_KEY,
+    progressCallback: () => process.stdout.write('.'),
+  });
+  process.stdout.write(')\n');
+  await (await aliceSigner.sendTransaction({
+    to: transferResult.contractTransaction.to,
+    data: transferResult.contractTransaction.data,
+  })).wait();
+  const proved = transferResult.transactions[0];
+  console.log(`✓ Transfer mined — circuit shape ${proved.nullifiers.length}x${proved.commitments.length}`);
+
+  // Alice: shield note nullified + change note; Bob: received note. Both backends must agree.
+  const aliceAfterTransfer = await assertDifferential(alice, 'post-transfer');
+  const bobAfterTransfer = await assertDifferential(bob, 'post-transfer');
+
+  console.log('\n' + '─'.repeat(50));
+  console.log('  ✓ DIFFERENTIAL PASS — armada sync reproduces stock balances');
+  console.log(`     Alice: ${ethers.formatUnits(aliceAfterShield, 6)} → ${ethers.formatUnits(aliceAfterTransfer, 6)} USDC (spent shield note + change)`);
+  console.log(`     Bob:   0.0 → ${ethers.formatUnits(bobAfterTransfer, 6)} USDC (received transfer)`);
+  console.log('─'.repeat(50));
+
+  await shutdownEngine();
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
> Stacked on #421 (the `@armada/sdk` dependency lives on that branch; main doesn't have it yet). Merge after #421, or fold both into #421 as one "consume + validate SDK" unit.

## Summary

Validates the `@armada/sdk` sync engine end-to-end against the **stock Railgun SDK on a real chain** (local Anvil). This is Phase 2 step-2's acceptance gate — a fresh armada scan must reproduce the balances the stock SDK reports.

Also re-pins `@armada/sdk` `65bce0d` → `a95e16f` (the sync-complete build: event-decoder, note/shield decrypt, merkletree, balances, orchestrator).

## What's here

**`lib/sdk/armada-sync.ts`** — live-provider glue: `scanArmadaBalances(...)` builds an ethers `Interface` from the SDK's `POOL_V2_EVENT_ABI`, fetches the pool's logs through `fetchLogsRanged`, runs `decodePoolEvents` → `WalletScanState.apply({ transact: tryDecryptCommitment, shield: tryDecryptShield })`, and returns per-token balances. Provider-agnostic, no persistence.

**`scripts/capture/e2e-sync-differential.ts`** — the differential (run: `npm run chains` + `npm run setup`, then `npx hardhat run scripts/capture/e2e-sync-differential.ts --network hub`):
1. Derives Alice + Bob on **both** backends from fixed rootSecrets; asserts the 0zk addresses match (`deriveKeyset` parity gate).
2. **Shield** 10 USDC → Alice (direct call, no proof).
3. **Transfer** 3 USDC Alice → Bob (real Groth16 via the stock SDK).
4. After each step, compares every wallet's stock balance to an independent armada scan.

## Result (passing)

| Phase | Wallet | Stock | Armada |
|-------|--------|-------|--------|
| post-shield | Alice | 9.95 | 9.95 |
| post-transfer | Alice | 6.95 | 6.95 |
| post-transfer | Bob | 3.0 | 3.0 |

This exercises the **whole** sync engine against reality: event-decoder (Shield/Transact/Nullified), `tryDecryptShield` (Alice's shield note), `tryDecryptCommitment` (Alice's change note + Bob's received note), merkletree building, and **nullifier exclusion** (Alice's spent shield note: 9.95 → 6.95).

## Notes

- It's a manual capture script (needs live chains + real proving), not a CI test — mirrors `scripts/capture/e2e-armada-circuits.ts`.
- Ran locally; chains torn down after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)