### PR TITLE
test(sdk): sync + tx chain differentials — armada verified on-chain

### DIFF
--- a/lib/sdk/armada-sync.ts
+++ b/lib/sdk/armada-sync.ts
@@ -1,0 +1,106 @@
+// ABOUTME: Live-provider glue for the @armada/sdk sync engine — wires an ethers provider's pool logs
+// ABOUTME: through the SDK decoder + scan orchestrator to produce shielded balances for one wallet.
+
+import { Interface, type Provider } from 'ethers';
+import {
+  fetchLogsRanged,
+  decodePoolEvents,
+  WalletScanState,
+  tryDecryptCommitment,
+  tryDecryptShield,
+  POOL_V2_EVENT_ABI,
+  type ParsedPoolLog,
+  type TokenBalance,
+} from '@armada/sdk';
+import {
+  getTokenDataERC20,
+  getTokenDataHash,
+  ChainType,
+  initPoseidonPromise,
+  type TokenData,
+} from '@armada/sdk/core';
+
+/** The wallet key material the armada scan needs (from `deriveKeyset`). */
+export interface ArmadaScanWallet {
+  readonly masterPublicKey: bigint;
+  readonly viewingPublicKey: Uint8Array;
+  readonly viewingPrivateKey: Uint8Array;
+  readonly nullifyingKey: bigint;
+}
+
+export interface ArmadaScanParams {
+  readonly provider: Provider;
+  readonly poolAddress: string;
+  readonly deployBlock: number;
+  readonly headBlock: number;
+  readonly chainId: number;
+  /** ERC20 token addresses in play — used to resolve tokenHash → tokenData during note decryption. */
+  readonly tokenAddresses: readonly string[];
+  readonly wallet: ArmadaScanWallet;
+  /** Per-provider getLogs range cap (bisected on over-range throws). */
+  readonly maxRange?: number;
+}
+
+/**
+ * Scan the pool's Shield/Transact/Nullified logs over `[deployBlock, headBlock]` with the SDK sync
+ * engine and return the wallet's per-token spendable/pending balances. Pure read path: builds an
+ * ephemeral in-memory tree/TXO set (no persistence) — the differential's armada side.
+ */
+export async function scanArmadaBalances(params: ArmadaScanParams): Promise<TokenBalance[]> {
+  await initPoseidonPromise;
+  const iface = new Interface(POOL_V2_EVENT_ABI as unknown as string[]);
+
+  // tokenHash → tokenData registry for the note tokenDataGetter (keyed by the canonical no-0x hash).
+  const tokenByHash = new Map<string, TokenData>();
+  for (const address of params.tokenAddresses) {
+    const tokenData = getTokenDataERC20(address);
+    tokenByHash.set(getTokenDataHash(tokenData), tokenData);
+  }
+  const tokenDataGetter = {
+    getTokenDataFromHash: async (_v: unknown, _c: unknown, tokenHash: string): Promise<TokenData> => {
+      const key = tokenHash.startsWith('0x') ? tokenHash.slice(2) : tokenHash;
+      const tokenData = tokenByHash.get(key);
+      if (tokenData === undefined) throw new Error(`armada-sync: unknown token hash ${tokenHash}`);
+      return tokenData;
+    },
+  };
+
+  // getLogs adapter: fetch the pool's logs for a window and parse them into ParsedPoolLog[].
+  const getLogs = async (fromBlock: number, toBlock: number): Promise<ParsedPoolLog[]> => {
+    const logs = await params.provider.getLogs({ address: params.poolAddress, fromBlock, toBlock });
+    const parsed: ParsedPoolLog[] = [];
+    for (const log of logs) {
+      const desc = iface.parseLog({ topics: [...log.topics], data: log.data });
+      if (desc === null) continue; // not one of our pool events
+      parsed.push({
+        name: desc.name,
+        args: desc.args as unknown as ParsedPoolLog['args'],
+        blockNumber: log.blockNumber,
+        txid: log.transactionHash,
+      });
+    }
+    return parsed;
+  };
+
+  const parsedLogs = await fetchLogsRanged(getLogs, {
+    fromBlock: params.deployBlock,
+    toBlock: params.headBlock,
+    ...(params.maxRange !== undefined ? { maxRange: params.maxRange } : {}),
+  });
+  const decoded = decodePoolEvents(parsedLogs);
+
+  const receiver = {
+    addressData: { masterPublicKey: params.wallet.masterPublicKey, viewingPublicKey: params.wallet.viewingPublicKey },
+    viewingPrivateKey: params.wallet.viewingPrivateKey,
+  };
+  const chain = { type: ChainType.EVM, id: params.chainId };
+
+  const state = new WalletScanState();
+  await state.apply(decoded, {
+    transact: (commitment) => tryDecryptCommitment(commitment.ciphertext, receiver, tokenDataGetter, chain),
+    shield: (commitment) => tryDecryptShield(commitment, receiver),
+  });
+
+  // finalityThreshold 0 — a local differential compares fully-confirmed balances at `headBlock`.
+  return state.balances(params.wallet.nullifyingKey, { currentBlock: params.headBlock, finalityThreshold: 0 });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#65bce0d372edf741dacd0eb432146412b4f3e28c",
+        "@armada/sdk": "github:ship-armada/armada-sdk#9854de76a0d6b1fada1f36c7fd3e0fc4443b206b",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#65bce0d372edf741dacd0eb432146412b4f3e28c",
-      "integrity": "sha512-UJhv61NaXg+bPEw2T40EK9BL8m1+3IUtcoNur35Fv8ykNxZutzY3ag5whccH8yA4OoljXySgqN3X167LnNAk+w==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#9854de76a0d6b1fada1f36c7fd3e0fc4443b206b",
+      "integrity": "sha512-kFK3LiM3v4qUDlsfCzSpC/LNWgXQySfT+bWeIgEEQtwZtBQxhM2WxPL3l/4spjXZq2MoG8goMQvvDNne477oFw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",
@@ -425,7 +425,8 @@
         "buffer-xor": "^2.0.2",
         "ethereum-cryptography": "^2.0.0",
         "ethers": "^6.14.3",
-        "fast-text-encoding": "^1.0.6"
+        "fast-text-encoding": "^1.0.6",
+        "snarkjs": "^0.7.0"
       }
     },
     "node_modules/@armada/ui": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#65bce0d372edf741dacd0eb432146412b4f3e28c",
+    "@armada/sdk": "github:ship-armada/armada-sdk#9854de76a0d6b1fada1f36c7fd3e0fc4443b206b",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",

--- a/scripts/capture/e2e-sync-differential.ts
+++ b/scripts/capture/e2e-sync-differential.ts
@@ -1,0 +1,187 @@
+// ABOUTME: Sync differential — shields + privately transfers USDC via the stock Railgun SDK on local
+// ABOUTME: Anvil, then scans the same chain with @armada/sdk and asserts identical shielded balances.
+
+/**
+ * Sync Differential: stock SDK vs @armada/sdk
+ *
+ * Validates the armada sync engine (event-decoder + note/shield decrypt + merkletree + nullifiers +
+ * balances) against the reference implementation on a real chain:
+ *   1. SHIELD 10 USDC to Alice (direct contract call — no ZK proof).
+ *   2. TRANSFER 3 USDC Alice → Bob (real Groth16 proof via the stock SDK).
+ * After each step every wallet's stock balance is compared to an independent @armada/sdk scan.
+ *
+ * Prerequisites (local):
+ *   npm run chains                              # terminal 1
+ *   source config/local.env && npm run setup    # terminal 2
+ *   npx hardhat run scripts/capture/e2e-sync-differential.ts --network hub
+ */
+
+import { ethers } from 'hardhat';
+
+import { initializeEngine, shutdownEngine, clearDatabase, getEngine } from '../../lib/sdk/init';
+import { createWallet, DEFAULT_ENCRYPTION_KEY } from '../../lib/sdk/wallet';
+import { initializeProver } from '../../lib/sdk/prover';
+import { createShieldRequest, generateShieldPrivateKey } from '../../lib/sdk/shield';
+import { loadNetworkIntoEngine, scanWalletBalances, getWalletBalances } from '../../lib/sdk/network';
+import { createPrivateTransfer } from '../../lib/sdk/transfer';
+import { getChainById, getRpcUrl } from '../../lib/sdk/chain-config';
+import { loadDeployment } from '../deploy-utils';
+import { scanArmadaBalances } from '../../lib/sdk/armada-sync';
+
+import {
+  TXIDVersion, POI, POINodeInterface, RailgunWallet,
+  getTokenDataERC20 as engineTokenDataERC20, getTokenDataHash as engineTokenDataHash,
+} from '@railgun-community/engine';
+import { Chain } from '@railgun-community/shared-models';
+import { Mnemonic } from '@armada/sdk/core';
+import { deriveKeyset, type Keyset } from '@armada/sdk';
+import { getTokenDataERC20, getTokenDataHash } from '@armada/sdk/core';
+
+class StubPOINodeInterface extends POINodeInterface {
+  isActive(): boolean { return false; }
+  async isRequired(): Promise<boolean> { return false; }
+  async getPOIsPerList(): Promise<Record<string, any>> { return {}; }
+  async getPOIMerkleProofs(): Promise<any[]> { return []; }
+  async validatePOIMerkleroots(): Promise<boolean> { return true; }
+  async submitPOI(): Promise<void> { /* no-op */ }
+  async submitLegacyTransactProofs(): Promise<void> { /* no-op */ }
+}
+POI.init([], new StubPOINodeInterface());
+
+const bytesToHex = (b: Uint8Array): string => Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('');
+const seed = (fill: number): Uint8Array => new Uint8Array(32).fill(fill);
+
+interface DiffWallet {
+  label: string;
+  walletId: string;
+  railgunAddress: string;
+  wallet: RailgunWallet;
+  keyset: Keyset;
+}
+
+async function main() {
+  console.log('='.repeat(60));
+  console.log('  Sync Differential: stock SDK vs @armada/sdk');
+  console.log('='.repeat(60));
+
+  const deployments = loadDeployment('privacy-pool-hub.json');
+  if (!deployments) throw new Error('privacy-pool-hub.json not found — run `npm run setup` first');
+  const chainId: number = deployments.chainId;
+  const chain: Chain = getChainById(chainId)!;
+  console.log(`\nNetwork: local (chainId ${chainId}), deployBlock ${deployments.deployBlock}`);
+
+  const shieldAmount = ethers.parseUnits('10', 6);
+  const transferAmount = ethers.parseUnits('3', 6);
+
+  const signers = await ethers.getSigners();
+  const aliceSigner = signers[1];
+
+  const privacyPool = await ethers.getContractAt('PrivacyPool', deployments.contracts.privacyPool);
+  const usdc = await ethers.getContractAt('MockUSDCV2', deployments.cctp.usdc);
+  const usdcAddress = await usdc.getAddress();
+  const stockTokenHash = engineTokenDataHash(engineTokenDataERC20(usdcAddress));
+  const armadaTokenHash = getTokenDataHash(getTokenDataERC20(usdcAddress));
+
+  // ── Init stock engine + prover ──
+  console.log('\nInitializing stock engine + prover...');
+  clearDatabase();
+  await initializeEngine('diff');
+  await loadNetworkIntoEngine(chain, await privacyPool.getAddress(), ethers.ZeroAddress, getRpcUrl(chain), deployments.deployBlock ?? 0);
+  await initializeProver();
+
+  // ── Derive Alice + Bob on both backends from fixed rootSecrets ──
+  async function makeWallet(label: string, rootSecret: Uint8Array): Promise<DiffWallet> {
+    const keyset = await deriveKeyset(rootSecret);
+    const info = await createWallet(DEFAULT_ENCRYPTION_KEY, Mnemonic.fromEntropy(bytesToHex(rootSecret)), 0);
+    if (info.railgunAddress !== keyset.railgunAddress) {
+      throw new Error(`${label}: rootSecret derivation mismatch (stock ${info.railgunAddress} vs armada ${keyset.railgunAddress})`);
+    }
+    const wallet = getEngine().wallets[info.id] as unknown as RailgunWallet;
+    console.log(`  ${label}: ${info.railgunAddress}`);
+    return { label, walletId: info.id, railgunAddress: info.railgunAddress, wallet, keyset };
+  }
+  const alice = await makeWallet('Alice', seed(0x11));
+  const bob = await makeWallet('Bob', seed(0x22));
+
+  // ── Assert one wallet's stock balance == an independent armada scan ──
+  async function assertDifferential(w: DiffWallet, phase: string): Promise<bigint> {
+    await scanWalletBalances(w.walletId, chain);
+    const stock = (await getWalletBalances(w.walletId, chain, false))[stockTokenHash]?.balance ?? 0n;
+
+    const headBlock = await ethers.provider.getBlockNumber();
+    const armadaBalances = await scanArmadaBalances({
+      provider: ethers.provider,
+      poolAddress: await privacyPool.getAddress(),
+      deployBlock: deployments.deployBlock ?? 0,
+      headBlock,
+      chainId,
+      tokenAddresses: [usdcAddress],
+      wallet: {
+        masterPublicKey: w.keyset.masterPublicKey,
+        viewingPublicKey: w.keyset.viewingPublicKey,
+        viewingPrivateKey: w.keyset.viewingPrivateKey,
+        nullifyingKey: w.keyset.nullifyingKey,
+      },
+    });
+    const entry = armadaBalances.find((b) => b.tokenHash === armadaTokenHash);
+    const armada = entry ? entry.spendable + entry.pending : 0n;
+
+    const tag = `[${phase}] ${w.label}`;
+    console.log(`  ${tag}: stock=${ethers.formatUnits(stock, 6)}  armada=${ethers.formatUnits(armada, 6)} USDC`);
+    if (stock !== armada) throw new Error(`DIFFERENTIAL MISMATCH ${tag}: stock=${stock} armada=${armada}`);
+    return stock;
+  }
+
+  // ── STEP 1: SHIELD 10 USDC to Alice ──
+  console.log(`\nSHIELD ${ethers.formatUnits(shieldAmount, 6)} USDC → Alice`);
+  const shieldPrivateKey = generateShieldPrivateKey();
+  const { shieldRequest } = await createShieldRequest(
+    { railgunAddress: alice.railgunAddress, amount: shieldAmount, tokenAddress: usdcAddress },
+    shieldPrivateKey,
+  );
+  const aliceAddr = await aliceSigner.getAddress();
+  await (await usdc.mint(aliceAddr, shieldAmount)).wait();
+  await (await usdc.connect(aliceSigner).approve(await privacyPool.getAddress(), shieldAmount)).wait();
+  await (await privacyPool.connect(aliceSigner).shield([shieldRequest], ethers.ZeroAddress)).wait();
+
+  const aliceAfterShield = await assertDifferential(alice, 'post-shield');
+  if (aliceAfterShield === 0n) throw new Error('shield did not register — differential vacuous');
+
+  // ── STEP 2: PRIVATE TRANSFER 3 USDC Alice → Bob (real Groth16) ──
+  console.log(`\nTRANSFER ${ethers.formatUnits(transferAmount, 6)} USDC  Alice → Bob (proving`);
+  const transferResult = await createPrivateTransfer({
+    wallet: alice.wallet,
+    chain,
+    tokenAddress: usdcAddress,
+    recipientAddress: bob.railgunAddress,
+    amount: transferAmount,
+    encryptionKey: DEFAULT_ENCRYPTION_KEY,
+    progressCallback: () => process.stdout.write('.'),
+  });
+  process.stdout.write(')\n');
+  await (await aliceSigner.sendTransaction({
+    to: transferResult.contractTransaction.to,
+    data: transferResult.contractTransaction.data,
+  })).wait();
+  const proved = transferResult.transactions[0];
+  console.log(`✓ Transfer mined — circuit shape ${proved.nullifiers.length}x${proved.commitments.length}`);
+
+  // Alice: shield note nullified + change note; Bob: received note. Both backends must agree.
+  const aliceAfterTransfer = await assertDifferential(alice, 'post-transfer');
+  const bobAfterTransfer = await assertDifferential(bob, 'post-transfer');
+
+  console.log('\n' + '─'.repeat(50));
+  console.log('  ✓ DIFFERENTIAL PASS — armada sync reproduces stock balances');
+  console.log(`     Alice: ${ethers.formatUnits(aliceAfterShield, 6)} → ${ethers.formatUnits(aliceAfterTransfer, 6)} USDC (spent shield note + change)`);
+  console.log(`     Bob:   0.0 → ${ethers.formatUnits(bobAfterTransfer, 6)} USDC (received transfer)`);
+  console.log('─'.repeat(50));
+
+  await shutdownEngine();
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/capture/e2e-tx-differential.ts
+++ b/scripts/capture/e2e-tx-differential.ts
@@ -1,0 +1,243 @@
+// ABOUTME: tx chain differential — shields via the stock SDK, then builds+proves+submits a private
+// ABOUTME: transfer entirely with @armada/sdk (plan→witness→prove→calldata), verifying it on-chain.
+
+/**
+ * tx Chain Differential: @armada/sdk write path vs the deployed pool
+ *
+ * The load-bearing validation of the tx pipeline. Shields 10 USDC to Alice (stock SDK), then uses the
+ * armada write path ONLY — plan/witness/prove (real Groth16 over the deployed 1x2 circuit)/serialize —
+ * to transfer 3 USDC Alice → Bob, and submits it. On-chain success means the deployed Verifier accepted
+ * the proof: the witness format, boundParamsHash, G2 swap, and public-input ordering are all correct.
+ * Balances are then cross-checked against the stock SDK.
+ *
+ * Prerequisites (local):
+ *   npm run chains                              # terminal 1
+ *   source config/local.env && npm run setup    # terminal 2
+ *   npx hardhat run scripts/capture/e2e-tx-differential.ts --network hub
+ */
+
+import { ethers } from 'hardhat';
+import { Interface } from 'ethers';
+
+import { initializeEngine, shutdownEngine, clearDatabase, getEngine } from '../../lib/sdk/init';
+import { createWallet, DEFAULT_ENCRYPTION_KEY } from '../../lib/sdk/wallet';
+import { initializeProver } from '../../lib/sdk/prover';
+import { createShieldRequest, generateShieldPrivateKey } from '../../lib/sdk/shield';
+import { loadNetworkIntoEngine, scanWalletBalances, getWalletBalances } from '../../lib/sdk/network';
+import { getChainById, getRpcUrl } from '../../lib/sdk/chain-config';
+import { loadDeployment } from '../deploy-utils';
+import { getArtifact } from '../../lib/sdk/armada-artifacts';
+
+import {
+  TXIDVersion, POI, POINodeInterface, RailgunWallet,
+  getTokenDataERC20 as engineTokenDataERC20, getTokenDataHash as engineTokenDataHash,
+} from '@railgun-community/engine';
+import { Chain } from '@railgun-community/shared-models';
+
+import {
+  planTransfer, buildWitness, buildTransactCalldata,
+  createSnarkjsProver, UTXOMerkletree, decodePoolEvents, tryDecryptCommitment, tryDecryptShield,
+  fetchLogsRanged, LocalSigner, deriveKeyset, POOL_V2_EVENT_ABI,
+  type Keyset, type ParsedPoolLog, type TXO,
+} from '@armada/sdk';
+import { Mnemonic, getTokenDataERC20, getTokenDataHash, ChainType, TransactNote, initPoseidonPromise, type TokenData } from '@armada/sdk/core';
+
+class StubPOINodeInterface extends POINodeInterface {
+  isActive(): boolean { return false; }
+  async isRequired(): Promise<boolean> { return false; }
+  async getPOIsPerList(): Promise<Record<string, any>> { return {}; }
+  async getPOIMerkleProofs(): Promise<any[]> { return []; }
+  async validatePOIMerkleroots(): Promise<boolean> { return true; }
+  async submitPOI(): Promise<void> { /* no-op */ }
+  async submitLegacyTransactProofs(): Promise<void> { /* no-op */ }
+}
+POI.init([], new StubPOINodeInterface());
+
+const bytesToHex = (b: Uint8Array): string => Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('');
+const seed = (fill: number): Uint8Array => new Uint8Array(32).fill(fill);
+const toBig = (hexNo0x: string): bigint => BigInt(`0x${hexNo0x}`);
+
+interface OwnedTXO extends TXO {}
+
+async function main() {
+  console.log('='.repeat(60));
+  console.log('  tx Chain Differential: @armada/sdk write path');
+  console.log('='.repeat(60));
+  await initPoseidonPromise;
+
+  const deployments = loadDeployment('privacy-pool-hub.json');
+  if (!deployments) throw new Error('privacy-pool-hub.json not found — run `npm run setup` first');
+  const chainId: number = deployments.chainId;
+  const chain: Chain = getChainById(chainId)!;
+  console.log(`\nNetwork: local (chainId ${chainId}), deployBlock ${deployments.deployBlock}`);
+
+  const shieldAmount = ethers.parseUnits('10', 6);
+  const transferAmount = ethers.parseUnits('3', 6);
+  const aliceSigner = (await ethers.getSigners())[1];
+
+  const privacyPool = await ethers.getContractAt('PrivacyPool', deployments.contracts.privacyPool);
+  const poolAddress = (await privacyPool.getAddress()) as `0x${string}`;
+  const usdc = await ethers.getContractAt('MockUSDCV2', deployments.cctp.usdc);
+  const usdcAddress = (await usdc.getAddress()) as `0x${string}`;
+  const usdcTokenHash = getTokenDataHash(getTokenDataERC20(usdcAddress)); // armada hash (no-0x)
+  const tokenData: TokenData = getTokenDataERC20(usdcAddress);
+
+  const aliceRoot = seed(0x11);
+  const alice: Keyset = await deriveKeyset(aliceRoot);
+  const bob: Keyset = await deriveKeyset(seed(0x22));
+
+  // ── Stock engine: shield 10 USDC to Alice (so she has a spendable note) ──
+  console.log('\nInit stock engine + prover, shield 10 USDC → Alice...');
+  clearDatabase();
+  await initializeEngine('txdiff');
+  await loadNetworkIntoEngine(chain, poolAddress, ethers.ZeroAddress, getRpcUrl(chain), deployments.deployBlock ?? 0);
+  await initializeProver();
+  const aliceInfo = await createWallet(DEFAULT_ENCRYPTION_KEY, Mnemonic.fromEntropy(bytesToHex(aliceRoot)), 0);
+  if (aliceInfo.railgunAddress !== alice.railgunAddress) throw new Error('Alice derivation mismatch');
+
+  const shieldPrivateKey = generateShieldPrivateKey();
+  const { shieldRequest } = await createShieldRequest(
+    { railgunAddress: alice.railgunAddress, amount: shieldAmount, tokenAddress: usdcAddress }, shieldPrivateKey,
+  );
+  const aliceAddr = await aliceSigner.getAddress();
+  await (await usdc.mint(aliceAddr, shieldAmount)).wait();
+  await (await usdc.connect(aliceSigner).approve(poolAddress, shieldAmount)).wait();
+  await (await privacyPool.connect(aliceSigner).shield([shieldRequest], ethers.ZeroAddress)).wait();
+  console.log('✓ Shield mined');
+
+  // ── Armada scan: recover Alice's spendable TXO + build the merkletree for proofs ──
+  console.log('\nArmada scan (recover Alice TXO + merkle proof)...');
+  const headBlock = await ethers.provider.getBlockNumber();
+  const iface = new Interface(POOL_V2_EVENT_ABI as unknown as string[]);
+  const getLogs = async (from: number, to: number): Promise<ParsedPoolLog[]> => {
+    const logs = await ethers.provider.getLogs({ address: poolAddress, fromBlock: from, toBlock: to });
+    return logs.flatMap((log) => {
+      const d = iface.parseLog({ topics: [...log.topics], data: log.data });
+      return d ? [{ name: d.name, args: d.args as unknown as ParsedPoolLog['args'], blockNumber: log.blockNumber, txid: log.transactionHash }] : [];
+    });
+  };
+  const decoded = decodePoolEvents(await fetchLogsRanged(getLogs, { fromBlock: deployments.deployBlock ?? 0, toBlock: headBlock }));
+
+  const aliceReceiver = {
+    addressData: { masterPublicKey: alice.masterPublicKey, viewingPublicKey: alice.viewingPublicKey },
+    viewingPrivateKey: alice.viewingPrivateKey,
+  };
+  const tokenDataGetter = { getTokenDataFromHash: async () => tokenData };
+  const armadaChain = { type: ChainType.EVM, id: chainId };
+
+  // Single tree (tree 0) for this small scenario — insert all leaves in position order.
+  const tree = new UTXOMerkletree();
+  const owned: OwnedTXO[] = [];
+  const leaves = [
+    ...decoded.shields.map((c) => ({ kind: 'shield' as const, c })),
+    ...decoded.transacts.map((c) => ({ kind: 'transact' as const, c })),
+  ].sort((a, b) => a.c.tree - b.c.tree || a.c.position - b.c.position);
+  for (const leaf of leaves) {
+    tree.insert(leaf.c.hash);
+    if (leaf.kind === 'shield') {
+      const o = await tryDecryptShield(leaf.c, aliceReceiver);
+      if (o) owned.push({ tree: leaf.c.tree, position: leaf.c.position, tokenHash: o.tokenHash, value: o.value, blockNumber: leaf.c.blockNumber, random: o.random, notePublicKey: o.notePublicKey });
+    } else {
+      const n = await tryDecryptCommitment(leaf.c.ciphertext, aliceReceiver, tokenDataGetter, armadaChain);
+      if (n) owned.push({ tree: leaf.c.tree, position: leaf.c.position, tokenHash: n.tokenHash, value: n.value, blockNumber: leaf.c.blockNumber, random: n.random, notePublicKey: n.notePublicKey });
+    }
+  }
+  // Exclude notes already spent on-chain (so re-runs on an accumulated chain pick a fresh note).
+  const spent = new Set(decoded.nullifiers.map((n) => `${n.tree}:${n.nullifier}`));
+  const isSpent = (t: OwnedTXO): boolean => spent.has(`${t.tree}:${TransactNote.getNullifier(alice.nullifyingKey, t.position)}`);
+  const input = owned.filter((t) => !isSpent(t)).find((t) => t.value >= transferAmount);
+  if (!input) throw new Error('no spendable Alice note found by armada scan');
+  console.log(`✓ Alice note: value=${ethers.formatUnits(input.value, 6)} USDC at tree ${input.tree} pos ${input.position}`);
+
+  const merkleRoot = toBig(tree.root());
+  const proof = tree.merkleProof(input.position);
+  const merkleProofElements = proof.elements.map(toBig);
+
+  // ── Armada write path: plan → witness → prove → calldata ──
+  const changeValue = input.value - transferAmount; // no broadcaster fee in this scenario
+  const plan = planTransfer({
+    txos: [input], tokenAddress: usdcAddress,
+    outputs: [{ toRailgunAddress: bob.railgunAddress, value: transferAmount }],
+    roots: new Map([[input.tree, merkleRoot]]), chainID: BigInt(chainId),
+  });
+
+  console.log('\nBuilding witness + proving (real 1x2 Groth16)...');
+  const signer = await LocalSigner.fromRootSecret(aliceRoot);
+  const witness = await buildWitness({
+    inputs: [{ random: input.random, value: input.value, position: input.position, merkleProofElements }],
+    outputs: [
+      { receiverAddress: bob.railgunAddress, value: transferAmount },
+      { receiverAddress: alice.railgunAddress, value: changeValue }, // change back to Alice
+    ],
+    tokenAddress: usdcAddress,
+    sender: {
+      masterPublicKey: alice.masterPublicKey, viewingPublicKey: alice.viewingPublicKey,
+      viewingPrivateKey: alice.viewingPrivateKey, nullifyingKey: alice.nullifyingKey,
+      spendingPublicKey: alice.spendingPublicKey, senderAddress: alice.railgunAddress,
+    },
+    signer, summary: plan.summary, merkleRoot, treeNumber: input.tree,
+    chainType: ChainType.EVM, chainId,
+  });
+
+  const artifacts = getArtifact(witness.shape.nullifiers, witness.shape.commitments);
+  console.log(`  circuit shape ${witness.shape.nullifiers}x${witness.shape.commitments}`);
+  const prover = createSnarkjsProver();
+  try {
+    const groth16Proof = await prover.prove(witness.formattedInputs, { wasm: new Uint8Array(artifacts.wasm), zkey: new Uint8Array(artifacts.zkey), vkey: artifacts.vkey });
+
+    // Local verify BEFORE submitting — a wrong witness fails here.
+    const publicSignals = [witness.publicInputs.merkleRoot, witness.publicInputs.boundParamsHash, ...witness.publicInputs.nullifiers, ...witness.publicInputs.commitmentsOut];
+    const localOk = await prover.verify(groth16Proof, publicSignals, artifacts.vkey);
+    console.log(`  local verify: ${localOk}`);
+    if (!localOk) throw new Error('LOCAL VERIFY FAILED — witness does not satisfy the circuit');
+
+    const calldata = buildTransactCalldata([{
+      proof: groth16Proof, merkleRoot: witness.publicInputs.merkleRoot,
+      nullifiers: witness.publicInputs.nullifiers, commitments: witness.publicInputs.commitmentsOut,
+      boundParams: witness.boundParams,
+    }], poolAddress);
+
+    console.log(`  witness nullifier: ${witness.publicInputs.nullifiers[0]}`);
+
+    // ── Submit on-chain — success = the deployed Verifier accepted the armada-built proof ──
+    console.log('\nSubmitting transact() on-chain...');
+    const rcpt = await (await aliceSigner.sendTransaction({ to: calldata.to, data: calldata.data })).wait();
+    console.log(`✓ transact mined (block ${rcpt!.blockNumber}) — ON-CHAIN GROTH16 VERIFICATION PASSED`);
+    // Diagnose: parse the on-chain Nullified event and compare to the witness nullifier.
+    for (const log of rcpt!.logs) {
+      const d = iface.parseLog({ topics: [...log.topics], data: log.data });
+      if (d?.name === 'Nullified') console.log(`  on-chain Nullified: tree ${d.args.treeNumber} nullifier ${BigInt(d.args.nullifier[0])}`);
+    }
+  } finally {
+    await prover.close();
+  }
+
+  // ── Post-transfer balances: armada scan (nullifier-aware) is the primary differential ──
+  async function armadaBalance(ks: Keyset): Promise<bigint> {
+    const hb = await ethers.provider.getBlockNumber();
+    const dec = decodePoolEvents(await fetchLogsRanged(getLogs, { fromBlock: deployments.deployBlock ?? 0, toBlock: hb }));
+    const rcv = { addressData: { masterPublicKey: ks.masterPublicKey, viewingPublicKey: ks.viewingPublicKey }, viewingPrivateKey: ks.viewingPrivateKey };
+    const st = new (await import('@armada/sdk')).WalletScanState();
+    await st.apply(dec, {
+      transact: (c: any) => tryDecryptCommitment(c.ciphertext, rcv, tokenDataGetter, armadaChain),
+      shield: (c: any) => tryDecryptShield(c, rcv),
+    });
+    const e = st.balances(ks.nullifyingKey, { currentBlock: hb, finalityThreshold: 0 }).find((b: any) => b.tokenHash === usdcTokenHash);
+    return e ? e.spendable + e.pending : 0n;
+  }
+  const aliceArmada = await armadaBalance(alice);
+  const bobArmada = await armadaBalance(bob);
+
+  console.log('\n' + '─'.repeat(50));
+  console.log(`  ARMADA  Alice: ${ethers.formatUnits(aliceArmada, 6)}  Bob: ${ethers.formatUnits(bobArmada, 6)} USDC`);
+  console.log(`  EXPECT  Alice: ${ethers.formatUnits(changeValue, 6)}  Bob: ${ethers.formatUnits(transferAmount, 6)} USDC`);
+  if (aliceArmada !== changeValue || bobArmada !== transferAmount) {
+    throw new Error(`ARMADA BALANCE MISMATCH after armada-built transfer (Alice ${aliceArmada} Bob ${bobArmada})`);
+  }
+  console.log('  ✓ tx CHAIN DIFFERENTIAL PASS — armada-built transfer verified on-chain + balances correct');
+  console.log('─'.repeat(50));
+
+  await shutdownEngine();
+}
+
+main().then(() => process.exit(0)).catch((err) => { console.error(err); process.exit(1); });


### PR DESCRIPTION
> **Heads-up on the base:** the prior sync differential (#422) is **not on `main`** (its branch was never merged/pushed as a base), so this PR bundles it with the tx differential. It re-pins `@armada/sdk` `65bce0d` → `9854de76` (the tx-complete SDK + the WalletInfo dist fix). Depends on armada-sdk **#30**.

## Summary

Two chains-in-the-loop validations of the `@armada/sdk` read + write paths against the deployed pool.

### Sync differential (`e2e-sync-differential.ts` + `lib/sdk/armada-sync.ts`)
A fresh armada scan reproduces the stock SDK's shielded balances (shield + transfer) on local Anvil. Validates event-decoder, note/shield decryption, merkletree, nullifier exclusion, balances.

### tx differential (`e2e-tx-differential.ts`) — the load-bearing one
Shields via the stock SDK, then builds a private transfer **entirely with `@armada/sdk`** — `planTransfer` → `buildWitness` → `createSnarkjsProver` (real Groth16 over the **deployed 1x2 circuit**) → `buildTransactCalldata` — and submits it.

**Result:**
- **On-chain Groth16 verification PASSED** — the deployed Verifier accepted the armada-built proof (validates witness format, `boundParamsHash`, G2 swap, public-input ordering).
- On-chain `Nullified` nullifier == the witness nullifier exactly.
- Armada nullifier-aware scan post-transfer: **Alice 6.95, Bob 3.0** — exactly correct.

## Bug caught → armada-sdk #30

`core`'s `export { default as WalletInfo }` double-wraps in the built dist (class at `.default.default`), breaking `createTransferNote`. Only manifests through the bundler — vitest externalizes the vendored dist, so tests missed it. Fixed in #30; pinned to that fix SHA.

## SDK follow-ups surfaced (noted, not blocking)

1. `planTransfer` should return the selected TXOs (`buildWitness` needs them; harness handled single-input).
2. `WalletScanState` should expose `merkleProof`/spendable TXOs (harness rebuilt a `UTXOMerkletree`).

## Notes

Manual capture scripts (need `npm run chains` + `npm run setup`, real proving) — mirror `e2e-armada-circuits.ts`. Ran locally end-to-end; chains torn down after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)