### PR TITLE
test(sdk): shield chain differential — SDK-built shield validated on-chain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#de4ca57f18ba816739539fe947ea8a7fd88051e9",
+        "@armada/sdk": "github:ship-armada/armada-sdk#5dce34960d113f2a558d10bf3aad901c6a24a9f0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#de4ca57f18ba816739539fe947ea8a7fd88051e9",
-      "integrity": "sha512-QudPjWDVKmL6BXlcd6Glt/OcKHvuRzD+azhuOjEJ628sTgK/MI3OiAB1BDfFDn94Zxlt4cTJR/NdothKxQu+6Q==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#5dce34960d113f2a558d10bf3aad901c6a24a9f0",
+      "integrity": "sha512-YPP4Qrm30pctXuOAgwu6+/0QqM8NM7JfKdBfnp8Z672d1726TEeFWT/Jp3u71fodx2wbIOSkg2Imuwk2Nlsf0w==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#de4ca57f18ba816739539fe947ea8a7fd88051e9",
+    "@armada/sdk": "github:ship-armada/armada-sdk#5dce34960d113f2a558d10bf3aad901c6a24a9f0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",

--- a/scripts/capture/e2e-shield-differential.ts
+++ b/scripts/capture/e2e-shield-differential.ts
@@ -1,0 +1,133 @@
+// ABOUTME: Shield chain differential — the @armada/sdk builds the shield request natively
+// ABOUTME: (buildShieldRequest), submits it, and both the armada scan AND the stock SDK recover it.
+
+/**
+ * Shield Chain Differential: @armada/sdk buildShieldRequest vs the deployed pool
+ *
+ * The last write-path validation: a shield request built ENTIRELY by @armada/sdk
+ * (`buildShieldRequest`) is accepted on-chain and decrypts to the recipient. Both the armada scan
+ * (instance API) and the stock Railgun SDK independently recover the shielded balance.
+ *
+ * Prerequisites (local):
+ *   npm run chains                              # terminal 1
+ *   source config/local.env && npm run setup    # terminal 2
+ *   npx hardhat run scripts/capture/e2e-shield-differential.ts --network hub
+ */
+
+import { ethers } from 'hardhat';
+
+import { initializeEngine, clearDatabase } from '../../lib/sdk/init';
+import { createWallet, DEFAULT_ENCRYPTION_KEY } from '../../lib/sdk/wallet';
+import { loadNetworkIntoEngine, scanWalletBalances, getWalletBalances } from '../../lib/sdk/network';
+import { getChainById, getRpcUrl } from '../../lib/sdk/chain-config';
+import { loadDeployment } from '../deploy-utils';
+import { getArtifact } from '../../lib/sdk/armada-artifacts';
+
+import {
+  POI, POINodeInterface,
+  getTokenDataERC20 as engineTokenDataERC20, getTokenDataHash as engineTokenDataHash,
+} from '@railgun-community/engine';
+import { Chain } from '@railgun-community/shared-models';
+
+import { createArmadaSdk, createSnarkjsProver, MemoryStorageAdapter, deriveKeyset, buildShieldRequest, generateShieldPrivateKey } from '@armada/sdk';
+import type { ArtifactSource, CircuitShape } from '@armada/sdk';
+import { Mnemonic, getTokenDataERC20, getTokenDataHash, initPoseidonPromise } from '@armada/sdk/core';
+
+class StubPOINodeInterface extends POINodeInterface {
+  isActive(): boolean { return false; }
+  async isRequired(): Promise<boolean> { return false; }
+  async getPOIsPerList(): Promise<Record<string, any>> { return {}; }
+  async getPOIMerkleProofs(): Promise<any[]> { return []; }
+  async validatePOIMerkleroots(): Promise<boolean> { return true; }
+  async submitPOI(): Promise<void> { /* no-op */ }
+  async submitLegacyTransactProofs(): Promise<void> { /* no-op */ }
+}
+POI.init([], new StubPOINodeInterface());
+
+const bytesToHex = (b: Uint8Array): string => Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('');
+const seed = (fill: number): Uint8Array => new Uint8Array(32).fill(fill);
+const fmt = (v: bigint): string => ethers.formatUnits(v, 6);
+
+async function main() {
+  console.log('='.repeat(60));
+  console.log('  Shield Chain Differential: @armada/sdk buildShieldRequest');
+  console.log('='.repeat(60));
+  await initPoseidonPromise;
+
+  const deployments = loadDeployment('privacy-pool-hub.json');
+  if (!deployments) throw new Error('privacy-pool-hub.json not found — run `npm run setup` first');
+  const chainId: number = deployments.chainId;
+  const chain: Chain = getChainById(chainId)!;
+  const deployBlock: number = deployments.deployBlock ?? 0;
+  console.log(`\nNetwork: local (chainId ${chainId}), deployBlock ${deployBlock}`);
+
+  const shieldAmount = ethers.parseUnits('10', 6);
+  const expected = ethers.parseUnits('9.95', 6); // 10 − 50bps shield fee
+  const aliceSigner = (await ethers.getSigners())[1];
+
+  const privacyPool = await ethers.getContractAt('PrivacyPool', deployments.contracts.privacyPool);
+  const poolAddress = (await privacyPool.getAddress()) as `0x${string}`;
+  const usdc = await ethers.getContractAt('MockUSDCV2', deployments.cctp.usdc);
+  const usdcAddress = (await usdc.getAddress()) as `0x${string}`;
+
+  const aliceRoot = seed(0x11);
+  const alice = await deriveKeyset(aliceRoot);
+
+  // ── SDK builds the shield request natively, then we submit it on-chain ──
+  console.log('\n@armada/sdk: buildShieldRequest(10 USDC → Alice)...');
+  const { shieldRequest } = await buildShieldRequest(
+    { railgunAddress: alice.railgunAddress, amount: shieldAmount, tokenAddress: usdcAddress },
+    generateShieldPrivateKey(),
+  );
+  const aliceAddr = await aliceSigner.getAddress();
+  await (await usdc.mint(aliceAddr, shieldAmount)).wait();
+  await (await usdc.connect(aliceSigner).approve(poolAddress, shieldAmount)).wait();
+  const rcpt = await (await privacyPool.connect(aliceSigner).shield([shieldRequest], ethers.ZeroAddress)).wait();
+  console.log(`✓ Shield mined (block ${rcpt!.blockNumber}) — pool accepted the SDK-built request`);
+
+  // ── Armada scan (instance API) recovers the balance ──
+  const artifacts: ArtifactSource = {
+    resolve: async (shape: CircuitShape) => {
+      const a = getArtifact(shape.nullifiers, shape.commitments);
+      return { wasm: new Uint8Array(a.wasm), zkey: new Uint8Array(a.zkey), vkey: a.vkey };
+    },
+  };
+  const sdk = await createArmadaSdk({
+    pool: { chainId, poolAddress, deployBlock, usdcAddress },
+    rpc: { urls: ['http://localhost:8545'] },
+    storage: new MemoryStorageAdapter(),
+    prover: createSnarkjsProver(),
+    artifacts,
+  });
+  const aliceWallet = await sdk.wallet.fromRootSecret(aliceRoot, { creationBlock: deployBlock });
+  await aliceWallet.sync();
+  const armadaHash = getTokenDataHash(getTokenDataERC20(usdcAddress));
+  const armadaEntry = (await aliceWallet.balances()).find((b) => b.tokenHash === armadaHash);
+  const armadaBalance = armadaEntry ? armadaEntry.spendable + armadaEntry.pending : 0n;
+
+  // ── Stock SDK independently recovers the same balance ──
+  clearDatabase();
+  await initializeEngine('shielddiff');
+  await loadNetworkIntoEngine(chain, poolAddress, ethers.ZeroAddress, getRpcUrl(chain), deployBlock);
+  const stockInfo = await createWallet(DEFAULT_ENCRYPTION_KEY, Mnemonic.fromEntropy(bytesToHex(aliceRoot)), 0);
+  await scanWalletBalances(stockInfo.id, chain);
+  const stockHash = engineTokenDataHash(engineTokenDataERC20(usdcAddress));
+  const stockBalance = (await getWalletBalances(stockInfo.id, chain, false))[stockHash]?.balance ?? 0n;
+
+  console.log('\n' + '─'.repeat(50));
+  console.log(`  ARMADA ${fmt(armadaBalance)}  STOCK ${fmt(stockBalance)}  EXPECT ${fmt(expected)} USDC`);
+  if (armadaBalance !== expected || stockBalance !== expected) {
+    throw new Error(`SHIELD MISMATCH — armada ${armadaBalance} stock ${stockBalance} expected ${expected}`);
+  }
+  console.log('  ✓ SHIELD DIFFERENTIAL PASS — SDK-built shield accepted on-chain + recovered by both backends');
+  console.log('─'.repeat(50));
+
+  await sdk.close();
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

Closes the last write-path validation gap (#37). A shield request built **entirely by `@armada/sdk`** (`buildShieldRequest`) is accepted on-chain by the pool and independently recovered by **both** the armada scan (instance API) and the stock Railgun SDK.

Flow: `buildShieldRequest(10 USDC → Alice)` → submit `privacyPool.shield([...])` → armada `createArmadaSdk` instance syncs → 9.95, and the stock SDK scans → 9.95. Re-pins `@armada/sdk` → `5dce349`.

## Result (passing, first run)

`ARMADA 9.95  STOCK 9.95  EXPECT 9.95 USDC` — the pool accepted the SDK-built request, and both backends decrypt it to the same shielded balance.

Combined with the tx + facade differentials, **every SDK write path (shield + transfer) is now chain-validated**, at the component and assembled-instance levels.

## Trust-merge checklist
- ✅ passes on-chain end-to-end (SDK-built shield accepted by the deployed pool)
- ✅ cross-validated: armada scan AND stock SDK both recover 9.95
- ✅ ran locally; chains torn down after
- ✅ secret scan clean
- ℹ️ manual capture script (needs `npm run chains` + `npm run setup`) — mirrors the other differentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)