### PR TITLE
feat(relayer): broadcaster-fee verification via @armada/sdk decode API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#5dce34960d113f2a558d10bf3aad901c6a24a9f0",
+        "@armada/sdk": "github:ship-armada/armada-sdk#91b70362f8004813c29d8fee70f1b4f928a3a418",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#5dce34960d113f2a558d10bf3aad901c6a24a9f0",
-      "integrity": "sha512-YPP4Qrm30pctXuOAgwu6+/0QqM8NM7JfKdBfnp8Z672d1726TEeFWT/Jp3u71fodx2wbIOSkg2Imuwk2Nlsf0w==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#91b70362f8004813c29d8fee70f1b4f928a3a418",
+      "integrity": "sha512-IQ+u5kywV2e1YUk1qAlTLedK67gd8U7BcaQ49m3OtLtlhHbvzdygJ7rdGIz7rwqgshBsQl34kr59Vdls6lTAwQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#5dce34960d113f2a558d10bf3aad901c6a24a9f0",
+    "@armada/sdk": "github:ship-armada/armada-sdk#91b70362f8004813c29d8fee70f1b4f928a3a418",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",

--- a/relayer/armada-relayer.ts
+++ b/relayer/armada-relayer.ts
@@ -27,8 +27,10 @@ import { IdempotencyStore } from "./modules/idempotency-store";
 import { CctpDeliveryStore } from "./modules/cctp-delivery-store";
 import { CCTPRelayModule } from "./modules/cctp-relay";
 import { IrisRelayModule } from "./modules/iris-relay";
+import { deriveBroadcasterIdentity } from "./modules/broadcaster-fee-verifier";
 import type { PrivacyPoolDeployment, CCTPDeployment, RelayerHealth } from "./types";
 import { getNetworkConfig } from "../config/networks";
+import { selectedBackend } from "../lib/sdk/shielded-identity";
 import { installBisectingGetLogs } from "./lib/rpc-bisecting";
 import { NonceCoordinator } from "./lib/nonce-coordinator";
 
@@ -259,6 +261,22 @@ async function main() {
     }
   }
 
+  // Under SDK_BACKEND=armada, route broadcaster-fee verification through @armada/sdk's native
+  // decode API instead of the stock engine helper. Derive the broadcaster identity from the SAME
+  // mnemonic as the stock 0zk wallet so both backends verify against the same address. Presence of
+  // this field in the verifier context flips the path; stock remains the default when unset.
+  const armadaBroadcaster =
+    selectedBackend() === "armada"
+      ? await deriveBroadcasterIdentity(
+          armadaRelayerSettings.railgunWalletMnemonic.trim(),
+        )
+      : undefined;
+  if (armadaBroadcaster) {
+    console.log(
+      "[armada] SDK_BACKEND=armada — broadcaster-fee verification via @armada/sdk decode API",
+    );
+  }
+
   // Initialize privacy relay. Multi-chain — receives requests from any configured chain,
   // dispatches via the right provider, fee-verifies via the right path.
   console.log("[armada] Initializing privacy relay...");
@@ -271,6 +289,7 @@ async function main() {
       privacyPoolAddress: hubAddresses.privacyPool,
       hubChainId: netConfig.hub.chainId,
       usdcAddress: hubAddresses.usdc,
+      ...(armadaBroadcaster ? { armadaBroadcaster } : {}),
     },
     { wrappersByChain, wallet: railgunWallet.getWallet() },
     counters,

--- a/relayer/modules/broadcaster-fee-verifier.ts
+++ b/relayer/modules/broadcaster-fee-verifier.ts
@@ -50,6 +50,20 @@ import {
   TRANSACT_ABI,
   WRAPPER_ABIS,
 } from "../lib/transact-shape";
+// Type-only imports from @armada/sdk's root entry (main/types are node10-resolvable). Erased at
+// compile time, so importing them costs the stock path nothing — the SDK's runtime values are loaded
+// lazily inside `extractFeeArmada`/`deriveBroadcasterIdentity` so the stock path never pulls in the
+// prover/poseidon deps. The SDK root re-exports the note-crypto/keyset/token helpers explicitly, so
+// node10 consumers like this one can import them (and their types) straight from the package root.
+import type { ReceiverNoteKeys, TokenDataGetter, Chain } from "@armada/sdk";
+
+/**
+ * The relayer's `0zk` identity in @armada/sdk form — the full identity (address data + viewing
+ * private key), which is what `extractFeeOutput` needs to *bind* a decrypted fee note to an on-chain
+ * commitment (it recomputes `npk = poseidon(masterPublicKey, random)`, not just trial-decrypts).
+ * Derived from the same mnemonic as the stock `wallet`, so both backends verify against the same 0zk.
+ */
+export type ArmadaBroadcasterIdentity = ReceiverNoteKeys;
 
 export interface VerifierContext {
   /** The relayer's loaded Railgun wallet — supplies the viewing key used for decryption. */
@@ -61,6 +75,13 @@ export interface VerifierContext {
   /** USDC token address on the hub chain. The verifier matches the broadcaster output's token
    *  against the Railgun-derived hash of this address; payments in any other token are ignored. */
   usdcAddress: string;
+  /**
+   * When present, fee extraction routes through @armada/sdk's native decode API (`decodeTransact` +
+   * `extractFeeOutput`) instead of the stock engine's `extractFirstNoteERC20AmountMap`. Set at boot
+   * only under `SDK_BACKEND=armada` (see `armada-relayer.ts`). The verifier switches on this field's
+   * PRESENCE, not the env flag directly, so tests can exercise either path without env juggling.
+   */
+  armadaBroadcaster?: ArmadaBroadcasterIdentity;
 }
 
 export interface BroadcasterFeeVerifyRequest {
@@ -123,6 +144,81 @@ function normaliseRequestToVanillaTransact(
   return { to: privacyPoolAddress, data: syntheticData };
 }
 
+/**
+ * Derive the relayer's @armada/sdk broadcaster identity from its BIP39 mnemonic — the same mnemonic
+ * `railgun-wallet.ts` derives the stock `0zk` wallet from, at the same default derivation index, so
+ * both backends resolve to the identical broadcaster address (keyset parity validated in Phase 0,
+ * seed-to-wallet vectors). Kept in this module (not in the wallet setup) so tests build the identity
+ * exactly the way the relayer does. The SDK is imported lazily to keep it off the stock boot path.
+ */
+export async function deriveBroadcasterIdentity(
+  mnemonic: string,
+): Promise<ArmadaBroadcasterIdentity> {
+  const { deriveKeysetFromMnemonic } = await import("@armada/sdk");
+  const ks = await deriveKeysetFromMnemonic(mnemonic);
+  return {
+    addressData: {
+      masterPublicKey: ks.masterPublicKey,
+      viewingPublicKey: ks.viewingPublicKey,
+    },
+    viewingPrivateKey: ks.viewingPrivateKey,
+  };
+}
+
+/**
+ * Armada-backend fee extraction — the SDK's native decode API, replacing the stock engine helper.
+ * `decodeTransact` ABI-decodes the (already wrapper-normalised) `transact(Transaction[])` calldata;
+ * for each bundled transaction `extractFeeOutput` trial-decrypts the commitment ciphertexts with the
+ * broadcaster's full identity and BINDS each decrypted note to an actual on-chain commitment before
+ * trusting its claimed value. Returns the stock helper's `{ tokenAddress -> amount }` shape so the
+ * caller's USDC lookup + threshold check stay backend-agnostic.
+ *
+ * Only USDC is resolvable (mirrors the stock wallet's DB-backed token getter): the getter throws for
+ * any other token hash, `tryDecryptCommitment` swallows that as "not ours", and a fee note in a
+ * non-USDC token simply never contributes to the map — the same outcome as the stock path ignoring
+ * non-USDC outputs.
+ */
+async function extractFeeArmada(
+  calldata: string,
+  broadcaster: ArmadaBroadcasterIdentity,
+  usdcAddress: string,
+  hubChainId: number,
+): Promise<Record<string, bigint>> {
+  const {
+    decodeTransact,
+    extractFeeOutput,
+    getTokenDataERC20,
+    getTokenDataHash,
+    initPoseidonPromise,
+    ChainType: SdkChainType,
+  } = await import("@armada/sdk");
+  // extractFeeOutput recomputes npk = poseidon(masterPublicKey, random) for its binding check.
+  await initPoseidonPromise;
+
+  const usdcTokenData = getTokenDataERC20(usdcAddress);
+  const usdcHash = getTokenDataHash(usdcTokenData);
+  const strip0x = (h: string): string => (h.startsWith("0x") ? h.slice(2) : h);
+  const tokenDataGetter: TokenDataGetter = {
+    getTokenDataFromHash: async (_txidVersion, _chain, tokenHash) => {
+      if (strip0x(tokenHash) === strip0x(usdcHash)) return usdcTokenData;
+      throw new Error(
+        `broadcaster-fee-verifier: unresolvable token hash ${tokenHash} (only USDC is resolvable)`,
+      );
+    },
+  };
+  const chain: Chain = { type: SdkChainType.EVM, id: hubChainId };
+
+  const amountMap: Record<string, bigint> = {};
+  for (const tx of decodeTransact(calldata as `0x${string}`)) {
+    const fee = await extractFeeOutput(tx, broadcaster, tokenDataGetter, chain);
+    if (fee) {
+      const key = fee.tokenAddress.toLowerCase();
+      amountMap[key] = (amountMap[key] ?? 0n) + fee.value;
+    }
+  }
+  return amountMap;
+}
+
 export async function verifyBroadcasterFee(
   ctx: VerifierContext,
   request: BroadcasterFeeVerifyRequest,
@@ -145,20 +241,31 @@ export async function verifyBroadcasterFee(
 
   let amountMap: Record<string, bigint>;
   try {
-    // V2 (Poseidon Merkle) — the only TXID version Armada's PrivacyPool supports. SDK helper
-    // returns a map of `tokenAddress -> amount` for every commitment in the proof that
-    // successfully decrypts under our viewing key. Outputs to other recipients (the user's
-    // change, the unshield-target, etc.) DON'T decrypt and don't appear.
-    //
-    // `useRelayAdapt: false` — vanilla `transact(...)`, decoded with the RailgunSmartWallet ABI.
-    // Wrapper functions need useRelayAdapt routing extensions; out of scope for A2 (see header).
-    amountMap = await ctx.wallet.extractFirstNoteERC20AmountMap(
-      TXIDVersion.V2_PoseidonMerkle,
-      chain,
-      transactionRequest,
-      false, // useRelayAdapt
-      ctx.privacyPoolAddress,
-    );
+    if (ctx.armadaBroadcaster) {
+      // Armada backend (SDK_BACKEND=armada) — decode + fee extraction via @armada/sdk's native
+      // decode API. Same `{ tokenAddress -> amount }` contract as the stock helper below.
+      amountMap = await extractFeeArmada(
+        normalised.data,
+        ctx.armadaBroadcaster,
+        ctx.usdcAddress,
+        ctx.hubChainId,
+      );
+    } else {
+      // V2 (Poseidon Merkle) — the only TXID version Armada's PrivacyPool supports. SDK helper
+      // returns a map of `tokenAddress -> amount` for every commitment in the proof that
+      // successfully decrypts under our viewing key. Outputs to other recipients (the user's
+      // change, the unshield-target, etc.) DON'T decrypt and don't appear.
+      //
+      // `useRelayAdapt: false` — vanilla `transact(...)`, decoded with the RailgunSmartWallet ABI.
+      // Wrapper functions need useRelayAdapt routing extensions; out of scope for A2 (see header).
+      amountMap = await ctx.wallet.extractFirstNoteERC20AmountMap(
+        TXIDVersion.V2_PoseidonMerkle,
+        chain,
+        transactionRequest,
+        false, // useRelayAdapt
+        ctx.privacyPoolAddress,
+      );
+    }
   } catch (e: any) {
     // SDK throws on:
     //   - `to` mismatch with contractAddress  (caller bug — privacy-relay should have rejected)

--- a/relayer/test/modules/broadcaster-fee-verifier.test.ts
+++ b/relayer/test/modules/broadcaster-fee-verifier.test.ts
@@ -6,10 +6,24 @@ import { ethers } from "ethers";
 import { RailgunWallet } from "@railgun-community/engine";
 import {
   verifyBroadcasterFee,
+  deriveBroadcasterIdentity,
   type VerifierContext,
+  type ArmadaBroadcasterIdentity,
 } from "../../modules/broadcaster-fee-verifier";
 import { TRANSACT_ABI, WRAPPER_ABIS } from "../../lib/transact-shape";
 import { RelayError } from "../../types";
+// All from @armada/sdk's root entry — the SDK explicitly re-exports the note-crypto/keyset/token
+// helpers so node10 (classic moduleResolution) consumers like this suite import them straight from the
+// package root, no subpath or facade needed.
+import {
+  buildTransactCalldata,
+  deriveKeyset,
+  createTransferNote,
+  encryptNoteToReceiver,
+  getTokenDataERC20,
+  initPoseidonPromise,
+} from "@armada/sdk";
+import type { Groth16Proof, TransactionData } from "@armada/sdk";
 
 // Fixed test addresses — no on-chain deployment, just shapes the verifier accepts.
 const USDC_ADDRESS = "0x1111111111111111111111111111111111111111";
@@ -394,3 +408,202 @@ async function expectRejectedAs(
   expect(err.code).to.equal(expectedCode);
   expect(err.message).to.match(messagePattern);
 }
+
+/**
+ * The armada backend routes fee extraction through @armada/sdk's native decode API (decodeTransact +
+ * extractFeeOutput) instead of the stock engine helper. Unlike the stubbed-wallet tests above, these
+ * build a REAL fee-bearing transact calldata with the SDK's own note-encryption + serializer, so the
+ * full path runs: ABI decode, ECIES trial-decrypt under the broadcaster viewing key, AND the
+ * commitment-binding check. Routing switches on `ctx.armadaBroadcaster` presence, so no SDK_BACKEND
+ * env juggling is needed. The stock wallet in these contexts THROWS if called — proving the armada
+ * path never silently falls back to the engine.
+ */
+describe("verifyBroadcasterFee — armada backend (SDK decode API)", () => {
+  // Anvil/Hardhat default BIP39 mnemonic — the relayer derives its 0zk from a mnemonic the same way.
+  const RELAYER_MNEMONIC =
+    "test test test test test test test test test test test junk";
+  // Plausible real ERC20 addresses (getTokenDataERC20 hashes the checksummed address).
+  const SDK_USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+  const SDK_OTHER_TOKEN = "0xdac17f958d2ee523a2206206994597c13d831ec7";
+  const SDK_POOL = "0x00000000000000000000000000000000000000dd";
+  const seed = (fill: number): Uint8Array => new Uint8Array(32).fill(fill);
+
+  // Decode-path fixture: the pool never verifies this proof (the decoder only ABI-decodes it), so a
+  // zero proof is enough to exercise fee extraction + binding.
+  const ZERO_PROOF: Groth16Proof = {
+    a: ["0", "0"],
+    b: [
+      ["0", "0"],
+      ["0", "0"],
+    ],
+    c: ["0", "0"],
+  };
+
+  let broadcaster: ArmadaBroadcasterIdentity;
+
+  before(async function () {
+    this.timeout(30_000);
+    await initPoseidonPromise; // note.hash + extractFeeOutput binding both need poseidon ready
+    broadcaster = await deriveBroadcasterIdentity(RELAYER_MNEMONIC);
+  });
+
+  // A wallet whose stock helper THROWS — asserts the armada path never falls through to the engine.
+  const stockMustNotRun = stubWalletThrowing(
+    new Error(
+      "stock extractFirstNoteERC20AmountMap must not run under the armada backend",
+    ),
+  );
+
+  function armadaCtx(): VerifierContext {
+    return {
+      wallet: stockMustNotRun,
+      privacyPoolAddress: SDK_POOL,
+      hubChainId: HUB_CHAIN_ID,
+      usdcAddress: SDK_USDC,
+      armadaBroadcaster: broadcaster,
+    };
+  }
+
+  /**
+   * Build a real `transact(Transaction[])` calldata carrying one fee note encrypted to `receiver`.
+   * `bindCommitment: false` omits the note hash from the transaction's `commitments[]`, simulating a
+   * sender who attaches a fee ciphertext with no matching on-chain commitment (the binding attack).
+   */
+  async function transactWithFeeNote(params: {
+    receiver: ArmadaBroadcasterIdentity;
+    feeAmount: bigint;
+    tokenAddress?: string;
+    bindCommitment?: boolean;
+  }): Promise<`0x${string}`> {
+    const sender = await deriveKeyset(seed(0x77));
+    const tokenData = getTokenDataERC20(params.tokenAddress ?? SDK_USDC);
+    const feeNote = createTransferNote({
+      receiverAddressData: params.receiver.addressData,
+      senderAddressData: {
+        masterPublicKey: sender.masterPublicKey,
+        viewingPublicKey: sender.viewingPublicKey,
+      },
+      value: params.feeAmount,
+      tokenData,
+    });
+    const feeCiphertext = await encryptNoteToReceiver(
+      feeNote,
+      {
+        masterPublicKey: sender.masterPublicKey,
+        viewingPublicKey: sender.viewingPublicKey,
+        viewingPrivateKey: sender.viewingPrivateKey,
+      },
+      params.receiver.addressData.viewingPublicKey,
+    );
+    const commitments = params.bindCommitment === false ? [] : [feeNote.hash];
+    const tx: TransactionData = {
+      proof: ZERO_PROOF,
+      merkleRoot: 1n,
+      nullifiers: [2n],
+      commitments,
+      boundParams: {
+        treeNumber: 0,
+        minGasPrice: 0n,
+        unshield: 0,
+        chainID: BigInt(HUB_CHAIN_ID),
+        adaptContract: ethers.ZeroAddress as `0x${string}`,
+        adaptParams: ("0x" + "00".repeat(32)) as `0x${string}`,
+        commitmentCiphertext: [feeCiphertext],
+      },
+    };
+    return buildTransactCalldata([tx], SDK_POOL).data;
+  }
+
+  it("accepts a transact whose fee note pays exactly the advertised USDC", async () => {
+    // WHY: the happy path — a real ECIES-encrypted fee note to the broadcaster, bound to an on-chain
+    // commitment, must decode + extract to its exact value. This is the whole point of the backend.
+    const data = await transactWithFeeNote({
+      receiver: broadcaster,
+      feeAmount: ADVERTISED_FEE,
+    });
+    const paid = await verifyBroadcasterFee(
+      armadaCtx(),
+      { to: SDK_POOL, data },
+      ADVERTISED_FEE,
+    );
+    expect(paid).to.equal(ADVERTISED_FEE);
+  });
+
+  it("accepts an overpaying fee note and reports the true amount", async () => {
+    // WHY: the verifier returns the actual paid amount (not the advertised floor); a regression that
+    // clamped to the floor would hide broadcaster over-collection.
+    const data = await transactWithFeeNote({
+      receiver: broadcaster,
+      feeAmount: ADVERTISED_FEE * 3n,
+    });
+    const paid = await verifyBroadcasterFee(
+      armadaCtx(),
+      { to: SDK_POOL, data },
+      ADVERTISED_FEE,
+    );
+    expect(paid).to.equal(ADVERTISED_FEE * 3n);
+  });
+
+  it("rejects when the fee note pays less than advertised", async () => {
+    // WHY: the fee floor must hold on the SDK path exactly as on the stock path.
+    const data = await transactWithFeeNote({
+      receiver: broadcaster,
+      feeAmount: ADVERTISED_FEE - 1n,
+    });
+    await expectRejectedAs(
+      verifyBroadcasterFee(armadaCtx(), { to: SDK_POOL, data }, ADVERTISED_FEE),
+      "FEE_INSUFFICIENT",
+      new RegExp(`paid ${ADVERTISED_FEE - 1n} USDC raw, advertised ${ADVERTISED_FEE}`),
+    );
+  });
+
+  it("rejects when the only fee note is addressed to a different 0zk", async () => {
+    // WHY: an output the broadcaster can't decrypt must not count. A note to a stranger's viewing key
+    // fails ECDH/AES-GCM, never enters the amount map → no USDC → FEE_INSUFFICIENT.
+    const stranger = await deriveBroadcasterIdentity(
+      "legal winner thank year wave sausage worth useful legal winner thank yellow",
+    );
+    const data = await transactWithFeeNote({
+      receiver: stranger,
+      feeAmount: ADVERTISED_FEE,
+    });
+    await expectRejectedAs(
+      verifyBroadcasterFee(armadaCtx(), { to: SDK_POOL, data }, ADVERTISED_FEE),
+      "FEE_INSUFFICIENT",
+      /Broadcaster fee too low: paid 0 USDC raw/,
+    );
+  });
+
+  it("rejects a fee ciphertext with no matching on-chain commitment (binding attack)", async () => {
+    // WHY: THE core security property of extractFeeOutput. A malicious sender attaches a ciphertext
+    // that decrypts to a large fee under our key, but the transaction's commitments[] contains no
+    // note with that hash — nothing was actually paid on-chain. The binding check (decrypted
+    // note.hash ∈ commitments) must reject it; without it the relayer would eat gas for free.
+    const data = await transactWithFeeNote({
+      receiver: broadcaster,
+      feeAmount: ADVERTISED_FEE * 10n,
+      bindCommitment: false,
+    });
+    await expectRejectedAs(
+      verifyBroadcasterFee(armadaCtx(), { to: SDK_POOL, data }, ADVERTISED_FEE),
+      "FEE_INSUFFICIENT",
+      /Broadcaster fee too low: paid 0 USDC raw/,
+    );
+  });
+
+  it("ignores a fee note paid in a non-USDC token (unresolvable → skipped)", async () => {
+    // WHY: single-token (USDC) policy must hold on the SDK path. A fee note in some other ERC20 fails
+    // token-hash resolution in the getter, is swallowed as not-ours, and contributes nothing — the
+    // same outcome as the stock path ignoring non-USDC outputs.
+    const data = await transactWithFeeNote({
+      receiver: broadcaster,
+      feeAmount: ADVERTISED_FEE * 5n,
+      tokenAddress: SDK_OTHER_TOKEN,
+    });
+    await expectRejectedAs(
+      verifyBroadcasterFee(armadaCtx(), { to: SDK_POOL, data }, ADVERTISED_FEE),
+      "FEE_INSUFFICIENT",
+      /Broadcaster fee too low: paid 0 USDC raw/,
+    );
+  });
+});


### PR DESCRIPTION
First integration slice wiring the relayer onto `@armada/sdk` (SPEC §10 Phase 2). Routes broadcaster-fee verification through the SDK's native decode API behind `SDK_BACKEND`, with the stock engine helper unchanged as the default.

## Changes

- **`broadcaster-fee-verifier.ts`** — new `extractFeeArmada()` routes fee extraction through `decodeTransact` + `extractFeeOutput` (replacing stock `wallet.extractFirstNoteERC20AmountMap`), returning the same `{ tokenAddress → amount }` shape so the USDC lookup + threshold stay backend-agnostic. `deriveBroadcasterIdentity(mnemonic)` builds the SDK identity from the same mnemonic as the stock `0zk` wallet. Routing switches on the **presence** of `ctx.armadaBroadcaster`, not the env flag directly.
- **`armada-relayer.ts`** — derives `armadaBroadcaster` at boot only when `SDK_BACKEND=armada`, injected via conditional spread (inert otherwise).
- **`broadcaster-fee-verifier.test.ts`** — 6 tests building *real* fee-bearing `transact` calldata with the SDK's note-encryption + serializer (no SDK stubbing), exercising ABI decode → ECIES trial-decrypt → **commitment-binding check**. Includes the security case: a fee ciphertext with no matching on-chain commitment is rejected.
- **`package.json`** — re-pin `@armada/sdk` to the root-export-widening merge (armada-sdk#40), letting the verifier + test import decode/token/keyset helpers straight from the package root (no facade).

## Deploy note

⚠️ Touches `relayer/` → **VPS pull + restart** candidate. Inert on the VPS while `SDK_BACKEND` stays `stock` (the default) — no behavior change until it's flipped.

## Tests

Full relayer suite green (199 passing, incl. 6 new armada + 11 existing stock fee-verifier); 0 type errors across the `armada-relayer` graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)