### PR TITLE
feat(interface): Phase A read-path shadow differential

### DIFF
--- a/apps/armada-interface/src/App.tsx
+++ b/apps/armada-interface/src/App.tsx
@@ -18,6 +18,8 @@ import { useNowTicker } from '@/hooks/useNowTicker'
 import { useRailgunEngineSync } from '@/hooks/useRailgunEngineSync'
 import { useFees } from '@/hooks/useFees'
 import { useShieldedBalanceSync } from '@/hooks/useShieldedBalanceSync'
+import { useShadowDifferential } from '@/hooks/useShadowDifferential'
+import { useBalances } from '@/hooks/useBalances'
 import { useNullifierCrossCheck } from '@/hooks/useNullifierCrossCheck'
 import { useTabVisible } from '@/hooks/useTabVisible'
 import { useTxHistory } from '@/hooks/useTxHistory'
@@ -71,6 +73,9 @@ export function App() {
   // mirrors the active wallet's shielded USDC balance into shieldedUsdcAtom for BalanceHero
   // and the shield/unshield modals.
   useShieldedBalanceSync()
+  // Phase A read-path shadow: run @armada/sdk alongside the engine and telemetry-report parity
+  // (0zk address + shielded USDC + history). Dev-gated, observe-only — no behavior change.
+  useShadowDifferential(useBalances().shielded ?? undefined)
   // WI-5: after each shielded scan completes, cross-check the wallet's own unspent notes against
   // the hub PrivacyPool's on-chain nullifier set and block spending if the indexer omitted a spend.
   useNullifierCrossCheck()

--- a/apps/armada-interface/src/hooks/useShadowDifferential.ts
+++ b/apps/armada-interface/src/hooks/useShadowDifferential.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Phase A read-path shadow — runs the @armada/sdk read differential when the shielded USDC
+// ABOUTME: balance settles and reports parity (address + balance + history) via telemetry. Dev-gated; no behavior change.
+
+import { useEffect, useRef } from 'react'
+import { runShadowDifferential } from '../lib/railgun/shadow-sdk'
+import { isUnlocked } from '../lib/railgun/keyManager'
+import { track } from '../lib/telemetry'
+
+/** A validation probe, not a user feature — on in `dev` (not tests), or opt-in via VITE_SHADOW_SDK=1. */
+const SHADOW_ENABLED =
+  import.meta.env.MODE === 'development' || import.meta.env.VITE_SHADOW_SDK === '1'
+
+/**
+ * Observe read-path parity between @armada/sdk and the stock engine. Runs once per distinct settled
+ * engine USDC balance, compares 0zk address + balance + history, and emits a `railgun.shadow`
+ * telemetry line. Never changes app state; failures are reported, not thrown into render.
+ */
+export function useShadowDifferential(engineUsdcBalance: bigint | undefined): void {
+  const lastRun = useRef<bigint | null>(null)
+
+  useEffect(() => {
+    if (!SHADOW_ENABLED || engineUsdcBalance === undefined || !isUnlocked()) return
+    if (lastRun.current === engineUsdcBalance) return
+    lastRun.current = engineUsdcBalance
+
+    let cancelled = false
+    void (async () => {
+      try {
+        const cmp = await runShadowDifferential(engineUsdcBalance)
+        if (cancelled) return
+        track('railgun.shadow', {
+          addressMatch: cmp.addressMatch,
+          balanceMatch: cmp.balanceMatch,
+          sdkBalance: cmp.sdkUsdcBalance.toString(),
+          engineBalance: cmp.engineUsdcBalance.toString(),
+          historyCount: cmp.historyCount,
+          syncedThrough: cmp.syncedThrough,
+        })
+      } catch (err) {
+        if (cancelled) return
+        track('railgun.shadow', {
+          addressMatch: false,
+          balanceMatch: false,
+          sdkBalance: '0',
+          engineBalance: engineUsdcBalance.toString(),
+          historyCount: 0,
+          syncedThrough: 0,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [engineUsdcBalance])
+}

--- a/apps/armada-interface/src/lib/railgun/shadow-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/shadow-sdk.ts
@@ -1,0 +1,109 @@
+// ABOUTME: Read-path shadow differential — runs @armada/sdk alongside the stock Railgun engine for the
+// ABOUTME: unlocked wallet and compares 0zk address + USDC balance + history, WITHOUT changing app behavior.
+
+import {
+  createArmadaSdk,
+  MemoryStorageAdapter,
+  getTokenDataERC20,
+  getTokenDataHash,
+  type ArmadaSdk,
+  type ProverAdapter,
+  type ArtifactSource,
+} from '@armada/sdk'
+import { getCachedDeployments, getUsdcAddress } from '../../config/deployments'
+import { getNetworkConfig } from '../../config/network'
+import * as keyManager from './keyManager'
+
+// Read-only shadow: it only syncs + reads. Proving/artifacts are never exercised, so they throw if
+// something unexpectedly reaches the spend path — a loud signal rather than silent wrong behavior.
+const readOnlyProver: ProverAdapter = {
+  prove: async () => {
+    throw new Error('shadow-sdk: read-only shadow does not prove')
+  },
+  verify: async () => false,
+  close: async () => {},
+}
+const readOnlyArtifacts: ArtifactSource = {
+  resolve: async () => {
+    throw new Error('shadow-sdk: read-only shadow does not resolve artifacts')
+  },
+}
+
+export interface ShadowComparison {
+  /** The SDK-derived 0zk equals the engine's — the load-bearing identity-parity check. */
+  readonly addressMatch: boolean
+  /** The SDK-scanned USDC balance equals the engine's. */
+  readonly balanceMatch: boolean
+  readonly sdkAddress: string
+  readonly engineAddress: string
+  readonly sdkUsdcBalance: bigint
+  readonly engineUsdcBalance: bigint
+  readonly historyCount: number
+  readonly syncedThrough: number
+}
+
+/** Assemble the SDK config from the same deployment + network config the engine uses. */
+function shadowConfig(): {
+  pool: { chainId: number; poolAddress: `0x${string}`; deployBlock: number; usdcAddress: `0x${string}` }
+  rpc: { urls: string[] }
+} {
+  const deployments = getCachedDeployments()
+  if (deployments === null) throw new Error('shadow-sdk: deployments not loaded')
+  const hub = getNetworkConfig().hub
+  const poolAddress = deployments.hub.contracts.privacyPool as `0x${string}` | undefined
+  const usdcAddress = getUsdcAddress(deployments, hub) as `0x${string}` | undefined
+  if (!poolAddress || !usdcAddress) {
+    throw new Error('shadow-sdk: hub deployment missing privacyPool or usdc')
+  }
+  return {
+    pool: {
+      chainId: hub.chainId,
+      poolAddress,
+      deployBlock: deployments.hub.deployBlock ?? 0,
+      usdcAddress,
+    },
+    rpc: { urls: [...hub.rpcUrls] },
+  }
+}
+
+/**
+ * Build the SDK, sync the unlocked wallet from its rootSecret, and compare address + USDC balance to
+ * the engine's. In-memory storage (a fresh scan each run — this is a shadow, not the app's state). The
+ * SDK instance is always closed. Returns the comparison; the caller decides how to report it.
+ */
+export async function runShadowDifferential(engineUsdcBalance: bigint): Promise<ShadowComparison> {
+  const rootSecret = keyManager.getRootSecret()
+  const creationBlock = keyManager.getCreationBlock() ?? 0
+  const engineAddress = keyManager.getRailgunAddress()
+  const cfg = shadowConfig()
+
+  const sdk: ArmadaSdk = await createArmadaSdk({
+    ...cfg,
+    storage: new MemoryStorageAdapter(),
+    prover: readOnlyProver,
+    artifacts: readOnlyArtifacts,
+  })
+  try {
+    const wallet = await sdk.wallet.fromRootSecret(rootSecret, { creationBlock })
+    const { syncedThrough } = await wallet.sync()
+
+    const usdcHash = getTokenDataHash(getTokenDataERC20(cfg.pool.usdcAddress))
+    const balances = await wallet.balances()
+    const usdc = balances.find(b => b.tokenHash === usdcHash)
+    const sdkUsdcBalance = usdc ? usdc.spendable + usdc.pending : 0n
+    const history = await wallet.history()
+
+    return {
+      addressMatch: wallet.railgunAddress === engineAddress,
+      balanceMatch: sdkUsdcBalance === engineUsdcBalance,
+      sdkAddress: wallet.railgunAddress,
+      engineAddress,
+      sdkUsdcBalance,
+      engineUsdcBalance,
+      historyCount: history.length,
+      syncedThrough,
+    }
+  } finally {
+    await sdk.close()
+  }
+}

--- a/apps/armada-interface/src/lib/telemetry.ts
+++ b/apps/armada-interface/src/lib/telemetry.ts
@@ -43,6 +43,10 @@ export type EventRegistry = {
   //   'fell-back'  — attempted but failed → engine slow-scans (paired with a railgun.quickSync error)
   'railgun.quicksync':        { outcome: 'served' | 'no-indexer' | 'fell-back'; pages?: number; commitments?: number; unshields?: number; nullifiers?: number; throughBlock?: number; reason?: string }
 
+  // Read-path shadow differential — @armada/sdk scanned alongside the engine (Phase A). Booleans +
+  // balances only; no raw 0zk addresses (privacy). `addressMatch`/`balanceMatch` false = a parity gap.
+  'railgun.shadow':           { addressMatch: boolean; balanceMatch: boolean; sdkBalance: string; engineBalance: string; historyCount: number; syncedThrough: number; error?: string }
+
   'tx.submitted':             { id: string; kind: TxKind }
   'tx.transition':            { id: string; kind: TxKind; from: TxStage; to: TxStage; executionState: TxRecord['executionState'] }
   'tx.failed':                { id: string; kind: TxKind; errorCode?: string }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#71baf104e7f4b118974a39866becdece0f29bab0",
+        "@armada/sdk": "github:ship-armada/armada-sdk#0762c16792f341bfbd6f37d6ea4cf536069b99eb",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#71baf104e7f4b118974a39866becdece0f29bab0",
-      "integrity": "sha512-rS2fztqhrJpo++xjfPXJtPsvICIr59L96QWh//65m1Dqq1R+lEhbF/RUkyshqG39OplFY1iKJOGJ/N2NbHHCDQ==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#0762c16792f341bfbd6f37d6ea4cf536069b99eb",
+      "integrity": "sha512-9Yas/lp//B46WsFOPZWrKI+faxka/zhEMaN6xS13Mko7mzP0k7PWmfczy/V5jEfEfPFDfY+iUHUdctj9Fq1wXw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",
@@ -422,12 +422,26 @@
         "@railgun-community/curve25519-scalarmult-wasm": "0.1.5",
         "@railgun-community/poseidon-hash-wasm": "1.0.1",
         "@scure/base": "^1.1.1",
+        "assert": "^2.1.0",
         "buffer-xor": "^2.0.2",
         "ethereum-cryptography": "^2.0.0",
         "ethers": "^6.14.3",
         "fast-text-encoding": "^1.0.6",
         "msgpack-lite": "^0.1.26",
         "snarkjs": "^0.7.0"
+      }
+    },
+    "node_modules/@armada/sdk/node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
       }
     },
     "node_modules/@armada/ui": {
@@ -19278,6 +19292,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obliterator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#91b70362f8004813c29d8fee70f1b4f928a3a418",
+        "@armada/sdk": "github:ship-armada/armada-sdk#71baf104e7f4b118974a39866becdece0f29bab0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#91b70362f8004813c29d8fee70f1b4f928a3a418",
-      "integrity": "sha512-IQ+u5kywV2e1YUk1qAlTLedK67gd8U7BcaQ49m3OtLtlhHbvzdygJ7rdGIz7rwqgshBsQl34kr59Vdls6lTAwQ==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#71baf104e7f4b118974a39866becdece0f29bab0",
+      "integrity": "sha512-rS2fztqhrJpo++xjfPXJtPsvICIr59L96QWh//65m1Dqq1R+lEhbF/RUkyshqG39OplFY1iKJOGJ/N2NbHHCDQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#91b70362f8004813c29d8fee70f1b4f928a3a418",
+    "@armada/sdk": "github:ship-armada/armada-sdk#71baf104e7f4b118974a39866becdece0f29bab0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#71baf104e7f4b118974a39866becdece0f29bab0",
+    "@armada/sdk": "github:ship-armada/armada-sdk#0762c16792f341bfbd6f37d6ea4cf536069b99eb",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",


### PR DESCRIPTION
First interface-migration slice (Phase A). Runs `@armada/sdk` **alongside** the stock Railgun engine for the unlocked wallet and telemetry-reports read-path parity — **zero behavior change**, dev-gated.

## What
- **`lib/railgun/shadow-sdk.ts`** — `runShadowDifferential(engineUsdcBalance)`: assembles the SDK config from the same deployment/network config the engine uses, `createArmadaSdk` (in-memory storage, read-only prover/artifacts stubs), `fromRootSecret` (the unlocked wallet's rootSecret), syncs, and compares **0zk address + shielded USDC balance + history count** to the engine's.
- **`hooks/useShadowDifferential.ts`** — dev-gated (`MODE==='development'` or `VITE_SHADOW_SDK=1`), runs once per settled engine balance, emits a `railgun.shadow` telemetry line. Never throws into render; never touches app state.
- **`telemetry.ts`** — `railgun.shadow` event: `{ addressMatch, balanceMatch, sdkBalance, engineBalance, historyCount, syncedThrough }` (booleans + balances only; **no raw 0zk addresses** — privacy).
- **App.tsx** — mounted after `useShieldedBalanceSync`.
- **Root `@armada/sdk` re-pin** → latest main (quicksync EventSource #41 + native tx-history #42-44 + `toTransactionData` #45).

## Why
Validates the scariest migration risk — **identity + sync + history parity** between the SDK and the engine — against real wallets/deployments, at zero risk, before any cutover. Same de-risking approach as the relayer chain differentials.

## Acceptance (manual, against a chain)
Run local (`npm run chains` + `npm run setup` + `npm run armada:interface`) or Sepolia with a funded shielded wallet; grep the console for `railgun.shadow` and confirm `addressMatch: true` + `balanceMatch: true`. A false `addressMatch` surfaces a rootSecret→address derivation gap to reconcile before Phase A cutover.

## Notes
- Does **not** touch `relayer/` — no VPS restart. Dev-gated — no production behavior change.
- `MemoryStorageAdapter` for now (fresh scan each run); the IndexedDB `StorageAdapter` comes with the read-path cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)