### PR TITLE
feat(interface): persistent IndexedDB-backed shadow SDK instance

### DIFF
--- a/apps/armada-interface/src/hooks/useShadowDifferential.ts
+++ b/apps/armada-interface/src/hooks/useShadowDifferential.ts
@@ -2,7 +2,7 @@
 // ABOUTME: balance settles and reports parity (address + balance + history) via telemetry. Dev-gated; no behavior change.
 
 import { useEffect, useRef } from 'react'
-import { runShadowDifferential } from '../lib/railgun/shadow-sdk'
+import { runShadowDifferential, closeShadowSdk } from '../lib/railgun/shadow-sdk'
 import { isUnlocked } from '../lib/railgun/keyManager'
 import { track } from '../lib/telemetry'
 
@@ -19,7 +19,13 @@ export function useShadowDifferential(engineUsdcBalance: bigint | undefined): vo
   const lastRun = useRef<bigint | null>(null)
 
   useEffect(() => {
-    if (!SHADOW_ENABLED || engineUsdcBalance === undefined || !isUnlocked()) return
+    if (!SHADOW_ENABLED) return
+    if (engineUsdcBalance === undefined || !isUnlocked()) {
+      // Locked or not yet synced — tear down the persistent shadow instance (idempotent).
+      lastRun.current = null
+      void closeShadowSdk()
+      return
+    }
     if (lastRun.current === engineUsdcBalance) return
     lastRun.current = engineUsdcBalance
 

--- a/apps/armada-interface/src/lib/railgun/shadow-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/shadow-sdk.ts
@@ -3,7 +3,7 @@
 
 import {
   createArmadaSdk,
-  MemoryStorageAdapter,
+  IndexedDBStorageAdapter,
   getTokenDataERC20,
   getTokenDataHash,
   type ArmadaSdk,
@@ -66,44 +66,69 @@ function shadowConfig(): {
   }
 }
 
-/**
- * Build the SDK, sync the unlocked wallet from its rootSecret, and compare address + USDC balance to
- * the engine's. In-memory storage (a fresh scan each run — this is a shadow, not the app's state). The
- * SDK instance is always closed. Returns the comparison; the caller decides how to report it.
- */
-export async function runShadowDifferential(engineUsdcBalance: bigint): Promise<ShadowComparison> {
-  const rootSecret = keyManager.getRootSecret()
-  const creationBlock = keyManager.getCreationBlock() ?? 0
-  const engineAddress = keyManager.getRailgunAddress()
-  const cfg = shadowConfig()
+type ShadowWallet = Awaited<ReturnType<ArmadaSdk['wallet']['fromRootSecret']>>
 
-  const sdk: ArmadaSdk = await createArmadaSdk({
+// A PERSISTENT SDK instance for the session — IndexedDB-backed, so the scan state survives across
+// differential runs and page reloads (the first sync scans from deployBlock; later ones are
+// incremental). Recreated when the unlocked wallet changes; closed on lock via `closeShadowSdk`.
+let instance: { sdk: ArmadaSdk; wallet: ShadowWallet; address: string } | null = null
+
+/** Separate IDB database from the engine's (`armada-shielded`) so the shadow never touches app state. */
+const SHADOW_DB_NAME = 'armada-sdk-shadow'
+
+async function ensureInstance(): Promise<{ sdk: ArmadaSdk; wallet: ShadowWallet; address: string }> {
+  const engineAddress = keyManager.getRailgunAddress()
+  if (instance !== null && instance.address === engineAddress) return instance
+
+  if (instance !== null) await instance.sdk.close()
+
+  const cfg = shadowConfig()
+  const sdk = await createArmadaSdk({
     ...cfg,
-    storage: new MemoryStorageAdapter(),
+    storage: new IndexedDBStorageAdapter(SHADOW_DB_NAME),
     prover: readOnlyProver,
     artifacts: readOnlyArtifacts,
   })
-  try {
-    const wallet = await sdk.wallet.fromRootSecret(rootSecret, { creationBlock })
-    const { syncedThrough } = await wallet.sync()
+  const wallet = await sdk.wallet.fromRootSecret(keyManager.getRootSecret(), {
+    creationBlock: keyManager.getCreationBlock() ?? 0,
+  })
+  instance = { sdk, wallet, address: engineAddress }
+  return instance
+}
 
-    const usdcHash = getTokenDataHash(getTokenDataERC20(cfg.pool.usdcAddress))
-    const balances = await wallet.balances()
-    const usdc = balances.find(b => b.tokenHash === usdcHash)
-    const sdkUsdcBalance = usdc ? usdc.spendable + usdc.pending : 0n
-    const history = await wallet.history()
+/**
+ * Sync the persistent SDK wallet (incremental, from its IndexedDB-persisted checkpoint) and compare
+ * 0zk address + USDC balance + history count to the engine's. Reuses the instance across runs; the
+ * caller reports the comparison. Read-only — never mutates app state.
+ */
+export async function runShadowDifferential(engineUsdcBalance: bigint): Promise<ShadowComparison> {
+  const { wallet, address: engineAddress } = await ensureInstance()
+  const cfg = shadowConfig()
 
-    return {
-      addressMatch: wallet.railgunAddress === engineAddress,
-      balanceMatch: sdkUsdcBalance === engineUsdcBalance,
-      sdkAddress: wallet.railgunAddress,
-      engineAddress,
-      sdkUsdcBalance,
-      engineUsdcBalance,
-      historyCount: history.length,
-      syncedThrough,
-    }
-  } finally {
-    await sdk.close()
+  const { syncedThrough } = await wallet.sync()
+  const usdcHash = getTokenDataHash(getTokenDataERC20(cfg.pool.usdcAddress))
+  const balances = await wallet.balances()
+  const usdc = balances.find(b => b.tokenHash === usdcHash)
+  const sdkUsdcBalance = usdc ? usdc.spendable + usdc.pending : 0n
+  const history = await wallet.history()
+
+  return {
+    addressMatch: wallet.railgunAddress === engineAddress,
+    balanceMatch: sdkUsdcBalance === engineUsdcBalance,
+    sdkAddress: wallet.railgunAddress,
+    engineAddress,
+    sdkUsdcBalance,
+    engineUsdcBalance,
+    historyCount: history.length,
+    syncedThrough,
+  }
+}
+
+/** Close the persistent instance (call on wallet lock). Idempotent. */
+export async function closeShadowSdk(): Promise<void> {
+  if (instance !== null) {
+    const closing = instance.sdk
+    instance = null
+    await closing.close()
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#0762c16792f341bfbd6f37d6ea4cf536069b99eb",
+        "@armada/sdk": "github:ship-armada/armada-sdk#5c8a9b03ab6b15bb04152f22f124c85842eedbd1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#0762c16792f341bfbd6f37d6ea4cf536069b99eb",
-      "integrity": "sha512-9Yas/lp//B46WsFOPZWrKI+faxka/zhEMaN6xS13Mko7mzP0k7PWmfczy/V5jEfEfPFDfY+iUHUdctj9Fq1wXw==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#5c8a9b03ab6b15bb04152f22f124c85842eedbd1",
+      "integrity": "sha512-mf3vbYozx8MxOM2GpQQ0veO1dGIWy0XKnIvatisC5IUXfIuIgEGk1H33bwRU/75hv3qgGjLlVnHEfwBnf3ODaw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#0762c16792f341bfbd6f37d6ea4cf536069b99eb",
+    "@armada/sdk": "github:ship-armada/armada-sdk#5c8a9b03ab6b15bb04152f22f124c85842eedbd1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",


### PR DESCRIPTION
Read-path cutover, step 2. Swaps the shadow differential's **ephemeral** SDK instance (MemoryStorageAdapter, full rescan each run) for a **persistent** one backed by the SDK's new `IndexedDBStorageAdapter` (armada-sdk#47). Still dev-gated + observe-only.

## What
- `shadow-sdk.ts` — a module-scoped, session-persistent `createArmadaSdk` instance (IndexedDB `armada-sdk-shadow` DB, separate from the engine's `armada-shielded`). Created once per unlocked wallet, reused across differential runs; `sync()` is now **incremental** from the persisted checkpoint (first run scans from deployBlock, later ones just the delta — including across page reloads). Recreated on wallet change; `closeShadowSdk()` tears it down on lock.
- `useShadowDifferential.ts` — closes the persistent instance when the wallet locks.
- Re-pin `@armada/sdk` → armada-sdk#47 (IndexedDBStorageAdapter).

## Why
Validates the `IndexedDBStorageAdapter` in a real browser (persistence across runs + reloads) and establishes the persistent-instance pattern the cutover will build on — while staying observe-only, so parity keeps being reported without touching app state.

## Acceptance (in-browser, unlocked wallet)
`railgun.shadow` still shows `addressMatch: true` + `balanceMatch: true`; repeat runs are faster (incremental sync); reloading the page resumes from the IndexedDB checkpoint rather than rescanning from deployBlock.

## Next
Step 3 — surface the SDK instance's balances/history to the app behind a flag, with the shadow still comparing, then flip the read path from engine → SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)