### PR TITLE
feat(interface): flag-gated SDK read path for shielded USDC balance

### DIFF
--- a/apps/armada-interface/src/hooks/useShadowDifferential.ts
+++ b/apps/armada-interface/src/hooks/useShadowDifferential.ts
@@ -2,7 +2,7 @@
 // ABOUTME: balance settles and reports parity (address + balance + history) via telemetry. Dev-gated; no behavior change.
 
 import { useEffect, useRef } from 'react'
-import { runShadowDifferential, closeShadowSdk } from '../lib/railgun/shadow-sdk'
+import { runShadowDifferential, closeShadowSdk, sdkReadPathEnabled } from '../lib/railgun/shadow-sdk'
 import { isUnlocked } from '../lib/railgun/keyManager'
 import { track } from '../lib/telemetry'
 
@@ -19,7 +19,9 @@ export function useShadowDifferential(engineUsdcBalance: bigint | undefined): vo
   const lastRun = useRef<bigint | null>(null)
 
   useEffect(() => {
-    if (!SHADOW_ENABLED) return
+    // When the read-path cutover flag is on, useShieldedBalanceSync owns the SDK instance (it drives
+    // the balance); the shadow comparison is redundant and must not touch the instance.
+    if (!SHADOW_ENABLED || sdkReadPathEnabled()) return
     if (engineUsdcBalance === undefined || !isUnlocked()) {
       // Locked or not yet synced — tear down the persistent shadow instance (idempotent).
       lastRun.current = null

--- a/apps/armada-interface/src/hooks/useShieldedBalanceSync.ts
+++ b/apps/armada-interface/src/hooks/useShieldedBalanceSync.ts
@@ -16,6 +16,7 @@ import {
   refreshShieldedBalances,
   subscribeBalanceUpdates,
 } from '@/lib/railgun/sync'
+import { closeShadowSdk, sdkReadPathEnabled, syncSdkUsdcBalance } from '@/lib/railgun/shadow-sdk'
 import { trackError } from '@/lib/telemetry'
 
 /**
@@ -50,6 +51,8 @@ export function useShieldedBalanceSync(): void {
       setShieldedUsdc(null)
       setYieldShares(null)
       setSyncState({ status: 'idle', progress: 0 })
+      // Under the read-path flag, this hook owns the SDK instance — tear it down on lock.
+      if (sdkReadPathEnabled()) void closeShadowSdk()
       return
     }
 
@@ -68,9 +71,14 @@ export function useShieldedBalanceSync(): void {
         const vaultAddress = yieldDeployment?.contracts.armadaYieldVault
 
         // Query USDC + (optional) yield-vault shares in parallel. Promise.allSettled so one
-        // chain hiccup doesn't blank the other atom.
+        // chain hiccup doesn't blank the other atom. Under the read-path cutover flag, USDC comes
+        // from the @armada/sdk instance instead of the engine (yield shares stay engine-sourced).
         const [usdcResult, sharesResult] = await Promise.allSettled([
-          usdcAddress ? getShieldedERC20Balance(walletId, usdcAddress) : Promise.resolve(0n),
+          sdkReadPathEnabled()
+            ? syncSdkUsdcBalance()
+            : usdcAddress
+              ? getShieldedERC20Balance(walletId, usdcAddress)
+              : Promise.resolve(0n),
           vaultAddress ? getShieldedERC20Balance(walletId, vaultAddress) : Promise.resolve(0n),
         ])
 

--- a/apps/armada-interface/src/lib/railgun/shadow-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/shadow-sdk.ts
@@ -124,6 +124,25 @@ export async function runShadowDifferential(engineUsdcBalance: bigint): Promise<
   }
 }
 
+/**
+ * Read-path cutover flag. When set, the app sources its shielded **USDC** balance from the SDK
+ * (`syncSdkUsdcBalance`) instead of the stock engine — the engine still scans (fallback + yield
+ * shares), and the redundant shadow comparison is skipped. Off by default; the engine drives.
+ */
+export function sdkReadPathEnabled(): boolean {
+  return import.meta.env.VITE_SDK_READ_PATH === '1'
+}
+
+/** Sync the persistent SDK wallet and return its shielded USDC balance (spendable + pending). */
+export async function syncSdkUsdcBalance(): Promise<bigint> {
+  const { wallet } = await ensureInstance()
+  await wallet.sync()
+  const cfg = shadowConfig()
+  const usdcHash = getTokenDataHash(getTokenDataERC20(cfg.pool.usdcAddress))
+  const usdc = (await wallet.balances()).find(b => b.tokenHash === usdcHash)
+  return usdc ? usdc.spendable + usdc.pending : 0n
+}
+
 /** Close the persistent instance (call on wallet lock). Idempotent. */
 export async function closeShadowSdk(): Promise<void> {
   if (instance !== null) {


### PR DESCRIPTION
Read-path cutover, step 3 — the app can now source its shielded **USDC balance** from `@armada/sdk` instead of the stock engine, behind a flag. **Off by default; zero behavior change** until `VITE_SDK_READ_PATH=1`.

## What
- `shadow-sdk.ts` — `sdkReadPathEnabled()` (reads `VITE_SDK_READ_PATH`) + `syncSdkUsdcBalance()` (syncs the persistent SDK instance, returns shielded USDC).
- `useShieldedBalanceSync.ts` — under the flag, `refreshAll` writes `shieldedUsdcAtom` from the SDK instead of the engine. The engine still scans (fallback; yield-vault shares stay engine-sourced for now). On lock it closes the SDK instance (it owns the lifecycle under the flag).
- `useShadowDifferential.ts` — inert under the flag (the SDK is now authoritative; the comparison is redundant and must not touch the instance).

## Why / safety
This is the first step where the SDK *drives* app state rather than shadowing it. Flag-gating keeps `main` behavior identical (engine drives) while letting us exercise the SDK-driven balance in a real session, with instant rollback (unset the flag). Balance parity was already validated by the shadow (`balanceMatch: true` on real funds), so flipping the source is low-risk.

## Acceptance (in-browser)
Run with `VITE_SDK_READ_PATH=1`, unlock a funded wallet: the dashboard's shielded USDC balance is SDK-sourced and matches what the engine showed. Lock → instance torn down. Unset the flag → engine drives again, shadow resumes comparing.

## Scope
USDC balance only. Yield-vault shares + tx history remain engine-sourced — separate cutover steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)