### PR TITLE
feat(interface): flag-gated SDK tx-history read path

### DIFF
--- a/apps/armada-interface/src/lib/railgun/history.test.ts
+++ b/apps/armada-interface/src/lib/railgun/history.test.ts
@@ -418,3 +418,47 @@ describe('walletContext on synthesized records', () => {
     expect(r!.walletContext.sourceChainId).toBe(HUB_CHAIN_ID)
   })
 })
+
+// ── @armada/sdk read-path mapper (historyEntryToTxRecord) ──────────────────
+import { historyEntryToTxRecord } from './history'
+import type { HistoryEntry } from '@armada/sdk'
+
+const SDK_CTX = { hubChainId: 31337 }
+const sdkEntry = (over: Partial<HistoryEntry>): HistoryEntry => ({
+  txid: '0xabc',
+  blockNumber: 100,
+  category: 'shield',
+  tokenAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  value: 1_000_000n,
+  ...over,
+})
+
+describe('historyEntryToTxRecord (@armada/sdk read path)', () => {
+  it('shield → shield, amount includes the shield fee', () => {
+    const r = historyEntryToTxRecord(sdkEntry({ category: 'shield', value: 995_000n, shieldFee: 5_000n }), 'w', SDK_CTX, 5000)
+    expect(r).toMatchObject({ kind: 'shield', id: 'synth:0xabc:shield', createdAt: 5000, meta: { amount: 1_000_000n } })
+  })
+
+  it('transfer-sent → transfer-shielded, recipient + broadcaster fee split from sentOutputs', () => {
+    const r = historyEntryToTxRecord(
+      sdkEntry({ category: 'transfer-sent', value: -500_000n, broadcasterFee: 20_000n, sentOutputs: [{ recipientRailgunAddress: '0zk_bob', value: 480_000n }] }),
+      'w', SDK_CTX, 5000,
+    )
+    expect(r).toMatchObject({ kind: 'transfer-shielded', meta: { amount: 480_000n, broadcasterFeeAmount: 20_000n, recipient: '0zk_bob' } })
+  })
+
+  it('transfer-received → received, memo passed through', () => {
+    const r = historyEntryToTxRecord(sdkEntry({ category: 'transfer-received', value: 250_000n, memo: 'hi' }), 'w', SDK_CTX, 5000)
+    expect(r).toMatchObject({ kind: 'transfer-shielded-received', meta: { amount: 250_000n, memoText: 'hi' } })
+  })
+
+  it('unshield → unshield-local, recipient + net amount (minus fees)', () => {
+    const r = historyEntryToTxRecord(sdkEntry({ category: 'unshield', value: -500_000n, broadcasterFee: 10_000n, unshieldFee: 2_500n, recipient: '0xrecipient' }), 'w', SDK_CTX, 5000)
+    expect(r).toMatchObject({ kind: 'unshield-local', meta: { amount: 487_500n, recipient: '0xrecipient', broadcasterFeeAmount: 10_000n } })
+  })
+
+  it('yield deposit + withdraw map natively (no adapter heuristic)', () => {
+    expect(historyEntryToTxRecord(sdkEntry({ category: 'yield-deposit', value: -900_000n }), 'w', SDK_CTX, 5000)).toMatchObject({ kind: 'yield-deposit', meta: { amount: 900_000n } })
+    expect(historyEntryToTxRecord(sdkEntry({ category: 'yield-withdraw', value: 950_000n }), 'w', SDK_CTX, 5000)).toMatchObject({ kind: 'yield-withdraw', meta: { amount: 950_000n } })
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/history.ts
+++ b/apps/armada-interface/src/lib/railgun/history.ts
@@ -12,6 +12,8 @@ import {
 import { lifecycleFor } from '@/lib/tx/lifecycles'
 import type { TxKind, TxRecord } from '@/lib/tx/types'
 import { getHubBlockTimestamps, getHubChainDescriptor } from './network'
+import { sdkReadPathEnabled, syncSdkHistory } from './shadow-sdk'
+import type { HistoryEntry } from '@armada/sdk'
 
 // Defer the SDK import to runtime — same jsdom-init-crash mitigation as wallet.ts / sync.ts.
 type RailgunSdk = typeof import('@railgun-community/wallet')
@@ -394,11 +396,118 @@ export interface HistoryScanResult {
  * pure-async (SDK + math, no side effects) lets tests stub `scanWalletHistory` with a fixture
  * and assert the mapping + checkpoint math without an IDB harness.
  */
+/* ───────────── @armada/sdk history mapper (read-path cutover) ───────────── */
+
+/**
+ * Map an @armada/sdk `HistoryEntry` → `TxRecord`. Simpler than the engine mapper: the SDK classifies
+ * yield deposit/withdraw natively (no adapter-address heuristic), and carries recipient + fee + memo
+ * inline. `value` is a signed wallet delta (negative = outflow); `timestampMs` is resolved by the
+ * caller from `blockNumber`. Returns null only if a future SDK category isn't handled here.
+ */
+export function historyEntryToTxRecord(
+  entry: HistoryEntry,
+  walletId: string,
+  ctx: HistoryMapContext,
+  timestampMs: number,
+): TxRecord | null {
+  const sourceTxHash = `0x${entry.txid.replace(/^0x/, '')}` as const
+  const walletContext = walletContextFor(walletId, ctx.hubChainId)
+  const abs = entry.value < 0n ? -entry.value : entry.value
+  const broadcasterFee = entry.broadcasterFee ?? 0n
+  const artifacts = { sourceTxHash }
+  const times = { updatedSeq: 0, createdAt: timestampMs, updatedAt: timestampMs } as const
+
+  switch (entry.category) {
+    case 'shield': {
+      const stages = terminalizeStages('shield')
+      return {
+        id: syntheticTxId(entry.txid, entry.category), kind: 'shield', executionState: 'completed',
+        stage: stages.stage, stagesCompleted: stages.stagesCompleted, ...times, artifacts, walletContext,
+        meta: { amount: entry.value + (entry.shieldFee ?? 0n), feeCacheId: '', fromChainId: ctx.hubChainId },
+      }
+    }
+    case 'transfer-received': {
+      const stages = terminalizeStages('transfer-shielded-received')
+      return {
+        id: syntheticTxId(entry.txid, entry.category), kind: 'transfer-shielded-received', executionState: 'completed',
+        stage: stages.stage, stagesCompleted: stages.stagesCompleted, ...times, artifacts, walletContext,
+        meta: { amount: entry.value, ...(entry.memo ? { memoText: entry.memo } : {}) },
+      }
+    }
+    case 'transfer-sent': {
+      const stages = terminalizeStages('transfer-shielded')
+      const recipientAmount = entry.sentOutputs?.reduce((a, o) => a + o.value, 0n) ?? abs - broadcasterFee
+      return {
+        id: syntheticTxId(entry.txid, entry.category), kind: 'transfer-shielded', executionState: 'completed',
+        stage: stages.stage, stagesCompleted: stages.stagesCompleted, ...times, artifacts, walletContext,
+        meta: {
+          amount: recipientAmount, feeCacheId: '',
+          recipient: entry.sentOutputs?.[0]?.recipientRailgunAddress ?? 'unknown',
+          broadcasterFeeAmount: broadcasterFee, broadcasterRailgunAddress: '',
+        },
+      }
+    }
+    case 'unshield': {
+      const stages = terminalizeStages('unshield-local')
+      return {
+        id: syntheticTxId(entry.txid, entry.category), kind: 'unshield-local', executionState: 'completed',
+        stage: stages.stage, stagesCompleted: stages.stagesCompleted, ...times, artifacts, walletContext,
+        meta: {
+          amount: abs - broadcasterFee - (entry.unshieldFee ?? 0n), feeCacheId: '',
+          recipient: entry.recipient ?? 'unknown',
+          broadcasterFeeAmount: broadcasterFee, broadcasterRailgunAddress: '',
+        },
+      }
+    }
+    case 'yield-deposit': {
+      const stages = terminalizeStages('yield-deposit')
+      return {
+        id: syntheticTxId(entry.txid, entry.category), kind: 'yield-deposit', executionState: 'completed',
+        stage: stages.stage, stagesCompleted: stages.stagesCompleted, ...times, artifacts, walletContext,
+        meta: { amount: abs, feeCacheId: '', broadcasterFeeAmount: broadcasterFee, broadcasterRailgunAddress: '' },
+      }
+    }
+    case 'yield-withdraw': {
+      const stages = terminalizeStages('yield-withdraw')
+      return {
+        id: syntheticTxId(entry.txid, entry.category), kind: 'yield-withdraw', executionState: 'completed',
+        stage: stages.stage, stagesCompleted: stages.stagesCompleted, ...times, artifacts, walletContext,
+        meta: { amount: entry.value, feeCacheId: '', shares: 0n, broadcasterFeeAmount: 0n, broadcasterRailgunAddress: '' },
+      }
+    }
+    default:
+      return null
+  }
+}
+
+/** SDK-sourced history scan (read-path cutover) — mirrors `runHistoryScan`'s contract. */
+async function runSdkHistoryScan(
+  walletId: string,
+  ctx: HistoryMapContext,
+  fromBlock: number | undefined,
+): Promise<HistoryScanResult> {
+  const entries = await syncSdkHistory(fromBlock)
+  const blocks = [...new Set(entries.map(e => e.blockNumber))]
+  const timestamps = blocks.length > 0 ? await getHubBlockTimestamps(blocks) : new Map<number, number>()
+
+  const records: TxRecord[] = []
+  let highest: number | null = null
+  for (const entry of entries) {
+    const seconds = timestamps.get(entry.blockNumber)
+    const record = historyEntryToTxRecord(entry, walletId, ctx, seconds !== undefined ? seconds * 1000 : 0)
+    if (record) records.push(record)
+    if (highest === null || entry.blockNumber > highest) highest = entry.blockNumber
+  }
+  records.sort((a, b) => b.updatedAt - a.updatedAt)
+  return { records, highestBlock: highest, itemCount: entries.length }
+}
+
 export async function runHistoryScan(
   walletId: string,
   ctx: HistoryMapContext,
   fromBlock: number | undefined,
 ): Promise<HistoryScanResult> {
+  if (sdkReadPathEnabled()) return runSdkHistoryScan(walletId, ctx, fromBlock)
   const items = await scanWalletHistory(walletId, fromBlock)
   // The SDK doesn't populate `item.timestamp` on every chain (observed on local Anvil and some
   // public RPC providers) — without backfill, downstream rows render the Unix epoch ("Dec 31,

--- a/apps/armada-interface/src/lib/railgun/shadow-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/shadow-sdk.ts
@@ -9,6 +9,7 @@ import {
   type ArmadaSdk,
   type ProverAdapter,
   type ArtifactSource,
+  type HistoryEntry,
 } from '@armada/sdk'
 import { getCachedDeployments, getUsdcAddress } from '../../config/deployments'
 import { getNetworkConfig } from '../../config/network'
@@ -141,6 +142,13 @@ export async function syncSdkUsdcBalance(): Promise<bigint> {
   const usdcHash = getTokenDataHash(getTokenDataERC20(cfg.pool.usdcAddress))
   const usdc = (await wallet.balances()).find(b => b.tokenHash === usdcHash)
   return usdc ? usdc.spendable + usdc.pending : 0n
+}
+
+/** Sync + reconstruct the SDK wallet's tx history (optionally only entries at/after `sinceBlock`). */
+export async function syncSdkHistory(sinceBlock?: number): Promise<HistoryEntry[]> {
+  const { wallet } = await ensureInstance()
+  await wallet.sync()
+  return wallet.history(sinceBlock !== undefined ? { sinceBlock } : {})
 }
 
 /** Close the persistent instance (call on wallet lock). Idempotent. */


### PR DESCRIPTION
Read-path cutover, step 4 — tx-history recovery from `@armada/sdk`'s `wallet.history()` instead of the engine's `getWalletTransactionHistory`, behind the same `VITE_SDK_READ_PATH` flag. **Off by default.**

## What
- `shadow-sdk.ts` — `syncSdkHistory(sinceBlock?)`: syncs the persistent SDK instance + returns `wallet.history()` entries.
- `history.ts` — `historyEntryToTxRecord()` maps an SDK `HistoryEntry` → `TxRecord` for all six categories; `runHistoryScan` branches to `runSdkHistoryScan` under the flag (block timestamps resolved via the existing `getHubBlockTimestamps` backfill).

## Cleaner than the engine mapper
The SDK **natively** classifies yield deposit/withdraw (H2) — no adapter-address heuristic — and carries recipient / broadcaster-fee / memo inline (H3). So the mapper is a direct category→kind switch. The rest of the recovery pipeline (dedup by `synth:` id, checkpoints, OCC persistence) is unchanged — only the source + mapper swap.

## Tests
5 mapper unit tests (shield fee-inclusive amount; transfer-sent recipient/fee split from `sentOutputs`; received memo; unshield net amount + recipient; native yield deposit/withdraw). Full history suite 23 passing; engine-path recovery tests unchanged (14 passing). Interface typecheck clean.

## Acceptance (in-browser, `VITE_SDK_READ_PATH=1`)
Unlock a funded wallet with prior activity → the History page's recovered rows come from the SDK and match the engine's (categories, amounts, fees). Off → engine drives.

## Cutover status
1 IndexedDB adapter ✅ · 2 persistent instance ✅ · 3 SDK balance ✅ · **4 SDK history ✅** · next: yield shares onto SDK, then flip the flag on by default + delete engine read code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)