### PR TITLE
feat(interface): SDK-sourced yield-vault shares (read-path cutover complete)

### DIFF
--- a/apps/armada-interface/src/hooks/useShieldedBalanceSync.ts
+++ b/apps/armada-interface/src/hooks/useShieldedBalanceSync.ts
@@ -16,7 +16,7 @@ import {
   refreshShieldedBalances,
   subscribeBalanceUpdates,
 } from '@/lib/railgun/sync'
-import { closeShadowSdk, sdkReadPathEnabled, syncSdkUsdcBalance } from '@/lib/railgun/shadow-sdk'
+import { closeShadowSdk, sdkReadPathEnabled, syncSdkUsdcBalance, syncSdkYieldShares } from '@/lib/railgun/shadow-sdk'
 import { trackError } from '@/lib/telemetry'
 
 /**
@@ -71,15 +71,19 @@ export function useShieldedBalanceSync(): void {
         const vaultAddress = yieldDeployment?.contracts.armadaYieldVault
 
         // Query USDC + (optional) yield-vault shares in parallel. Promise.allSettled so one
-        // chain hiccup doesn't blank the other atom. Under the read-path cutover flag, USDC comes
-        // from the @armada/sdk instance instead of the engine (yield shares stay engine-sourced).
+        // chain hiccup doesn't blank the other atom. Under the read-path cutover flag, BOTH come
+        // from the @armada/sdk instance instead of the engine.
         const [usdcResult, sharesResult] = await Promise.allSettled([
           sdkReadPathEnabled()
             ? syncSdkUsdcBalance()
             : usdcAddress
               ? getShieldedERC20Balance(walletId, usdcAddress)
               : Promise.resolve(0n),
-          vaultAddress ? getShieldedERC20Balance(walletId, vaultAddress) : Promise.resolve(0n),
+          sdkReadPathEnabled()
+            ? syncSdkYieldShares()
+            : vaultAddress
+              ? getShieldedERC20Balance(walletId, vaultAddress)
+              : Promise.resolve(0n),
         ])
 
         if (cancelled || latestWalletIdRef.current !== walletId) return

--- a/apps/armada-interface/src/lib/railgun/shadow-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/shadow-sdk.ts
@@ -11,7 +11,7 @@ import {
   type ArtifactSource,
   type HistoryEntry,
 } from '@armada/sdk'
-import { getCachedDeployments, getUsdcAddress } from '../../config/deployments'
+import { getCachedDeployments, getUsdcAddress, loadYieldDeployment } from '../../config/deployments'
 import { getNetworkConfig } from '../../config/network'
 import * as keyManager from './keyManager'
 
@@ -43,11 +43,23 @@ export interface ShadowComparison {
   readonly syncedThrough: number
 }
 
+/** The shielded yield-vault share token (ayUSDC), if a yield deployment exists. */
+async function vaultTokenAddress(): Promise<`0x${string}` | undefined> {
+  const yieldDeployment = await loadYieldDeployment()
+  return yieldDeployment?.contracts.armadaYieldVault as `0x${string}` | undefined
+}
+
 /** Assemble the SDK config from the same deployment + network config the engine uses. */
-function shadowConfig(): {
-  pool: { chainId: number; poolAddress: `0x${string}`; deployBlock: number; usdcAddress: `0x${string}` }
+async function shadowConfig(): Promise<{
+  pool: {
+    chainId: number
+    poolAddress: `0x${string}`
+    deployBlock: number
+    usdcAddress: `0x${string}`
+    additionalTokens?: `0x${string}`[]
+  }
   rpc: { urls: string[] }
-} {
+}> {
   const deployments = getCachedDeployments()
   if (deployments === null) throw new Error('shadow-sdk: deployments not loaded')
   const hub = getNetworkConfig().hub
@@ -56,12 +68,15 @@ function shadowConfig(): {
   if (!poolAddress || !usdcAddress) {
     throw new Error('shadow-sdk: hub deployment missing privacyPool or usdc')
   }
+  // Scan the yield-vault share token too, so the SDK can report shielded ayUSDC shares.
+  const vault = await vaultTokenAddress()
   return {
     pool: {
       chainId: hub.chainId,
       poolAddress,
       deployBlock: deployments.hub.deployBlock ?? 0,
       usdcAddress,
+      ...(vault ? { additionalTokens: [vault] } : {}),
     },
     rpc: { urls: [...hub.rpcUrls] },
   }
@@ -83,7 +98,7 @@ async function ensureInstance(): Promise<{ sdk: ArmadaSdk; wallet: ShadowWallet;
 
   if (instance !== null) await instance.sdk.close()
 
-  const cfg = shadowConfig()
+  const cfg = await shadowConfig()
   const sdk = await createArmadaSdk({
     ...cfg,
     storage: new IndexedDBStorageAdapter(SHADOW_DB_NAME),
@@ -104,7 +119,7 @@ async function ensureInstance(): Promise<{ sdk: ArmadaSdk; wallet: ShadowWallet;
  */
 export async function runShadowDifferential(engineUsdcBalance: bigint): Promise<ShadowComparison> {
   const { wallet, address: engineAddress } = await ensureInstance()
-  const cfg = shadowConfig()
+  const cfg = await shadowConfig()
 
   const { syncedThrough } = await wallet.sync()
   const usdcHash = getTokenDataHash(getTokenDataERC20(cfg.pool.usdcAddress))
@@ -126,9 +141,9 @@ export async function runShadowDifferential(engineUsdcBalance: bigint): Promise<
 }
 
 /**
- * Read-path cutover flag. When set, the app sources its shielded **USDC** balance from the SDK
- * (`syncSdkUsdcBalance`) instead of the stock engine — the engine still scans (fallback + yield
- * shares), and the redundant shadow comparison is skipped. Off by default; the engine drives.
+ * Read-path cutover flag. When set, the app sources ALL shielded read state — USDC balance, yield
+ * shares, and tx history — from the SDK instead of the stock engine; the engine still scans as a
+ * fallback and the redundant shadow comparison is skipped. Off by default; the engine drives.
  */
 export function sdkReadPathEnabled(): boolean {
   return import.meta.env.VITE_SDK_READ_PATH === '1'
@@ -138,10 +153,21 @@ export function sdkReadPathEnabled(): boolean {
 export async function syncSdkUsdcBalance(): Promise<bigint> {
   const { wallet } = await ensureInstance()
   await wallet.sync()
-  const cfg = shadowConfig()
+  const cfg = await shadowConfig()
   const usdcHash = getTokenDataHash(getTokenDataERC20(cfg.pool.usdcAddress))
   const usdc = (await wallet.balances()).find(b => b.tokenHash === usdcHash)
   return usdc ? usdc.spendable + usdc.pending : 0n
+}
+
+/** Sync the persistent SDK wallet and return its shielded yield-vault shares (ayUSDC). 0 if no vault. */
+export async function syncSdkYieldShares(): Promise<bigint> {
+  const vault = await vaultTokenAddress()
+  if (vault === undefined) return 0n
+  const { wallet } = await ensureInstance()
+  await wallet.sync()
+  const vaultHash = getTokenDataHash(getTokenDataERC20(vault))
+  const shares = (await wallet.balances()).find(b => b.tokenHash === vaultHash)
+  return shares ? shares.spendable + shares.pending : 0n
 }
 
 /** Sync + reconstruct the SDK wallet's tx history (optionally only entries at/after `sinceBlock`). */

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#5c8a9b03ab6b15bb04152f22f124c85842eedbd1",
+        "@armada/sdk": "github:ship-armada/armada-sdk#37c034da7bc8a2d7b2251733384b7f97190321f6",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#5c8a9b03ab6b15bb04152f22f124c85842eedbd1",
-      "integrity": "sha512-mf3vbYozx8MxOM2GpQQ0veO1dGIWy0XKnIvatisC5IUXfIuIgEGk1H33bwRU/75hv3qgGjLlVnHEfwBnf3ODaw==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#37c034da7bc8a2d7b2251733384b7f97190321f6",
+      "integrity": "sha512-osrHVxNrF0F4c/EIwoYCK87fVvc9FFm5KLLMcnqgV96L0EOGTsGbD+bgl5QhwOT5iMbLNr3PqmEY9rrXVB4XAw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#5c8a9b03ab6b15bb04152f22f124c85842eedbd1",
+    "@armada/sdk": "github:ship-armada/armada-sdk#37c034da7bc8a2d7b2251733384b7f97190321f6",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",


### PR DESCRIPTION
Read-path cutover, step 5b — the last read surface. Shielded **yield-vault shares (ayUSDC)** now come from `@armada/sdk` behind `VITE_SDK_READ_PATH`. With this, **all three read surfaces (USDC balance, yield shares, tx history) run on the SDK under one flag.**

## What
- `shadow-sdk.ts` — the persistent SDK instance now scans the vault share token too (`PoolConfig.additionalTokens`, armada-sdk#48). `syncSdkYieldShares()` reads that token's balance from `wallet.balances()`. `shadowConfig` resolves the vault address from the yield deployment.
- `useShieldedBalanceSync.ts` — under the flag, yield shares come from `syncSdkYieldShares()` (was USDC-only last step).
- Re-pin `@armada/sdk` → armada-sdk#48.

## Off by default
Flag unset → engine drives all reads (unchanged). Interface typecheck clean; balance-sync test unchanged.

## Acceptance (`VITE_SDK_READ_PATH=1`, funded wallet with a yield position)
Shielded USDC, yield shares, and History all SDK-sourced and matching the engine.

## Cutover status
1 IndexedDB ✅ · 2 persistent instance ✅ · 3 SDK balance ✅ · 4 SDK history ✅ · **5b SDK yield shares ✅**
Remaining: **5c** flip the flag on by default (once all three validated in-browser), **5d** delete the engine read code — the first Railgun surface reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)