### PR TITLE
feat(interface): default shielded read path to @armada/sdk

### DIFF
--- a/apps/armada-interface/src/lib/railgun/history.test.ts
+++ b/apps/armada-interface/src/lib/railgun/history.test.ts
@@ -307,9 +307,16 @@ describe('runHistoryScan — timestamp backfill', () => {
   }))
 
   beforeEach(() => {
+    // These cases exercise the ENGINE fallback path (getWalletTransactionHistory + timestamp
+    // backfill). The SDK read path is the default, so pin it off for this block.
+    vi.stubEnv('VITE_SDK_READ_PATH', '0')
     hoistedScan.getWalletTransactionHistory.mockReset()
     hoistedScan.getHubBlockTimestamps.mockReset()
     hoistedScan.getHubBlockTimestamps.mockResolvedValue(new Map())
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   function withoutTimestamp(txid: string, blockNumber: number, amount: bigint): TransactionHistoryItem {

--- a/apps/armada-interface/src/lib/railgun/shadow-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/shadow-sdk.ts
@@ -141,12 +141,13 @@ export async function runShadowDifferential(engineUsdcBalance: bigint): Promise<
 }
 
 /**
- * Read-path cutover flag. When set, the app sources ALL shielded read state — USDC balance, yield
- * shares, and tx history — from the SDK instead of the stock engine; the engine still scans as a
- * fallback and the redundant shadow comparison is skipped. Off by default; the engine drives.
+ * Read-path cutover flag. The SDK is the default source of ALL shielded read state — USDC balance,
+ * yield shares, and tx history; the redundant shadow comparison is skipped. Set
+ * `VITE_SDK_READ_PATH=0` to fall back to the stock engine (escape hatch retained until the engine
+ * read code is deleted). Any other value (or unset) → the SDK drives.
  */
 export function sdkReadPathEnabled(): boolean {
-  return import.meta.env.VITE_SDK_READ_PATH === '1'
+  return import.meta.env.VITE_SDK_READ_PATH !== '0'
 }
 
 /** Sync the persistent SDK wallet and return its shielded USDC balance (spendable + pending). */


### PR DESCRIPTION
Read-path cutover, step 5c — flip the default. `@armada/sdk` now drives **all three shielded read surfaces** (USDC balance, yield-vault shares, tx history) by default. The stock Railgun engine remains reachable as an escape hatch via `VITE_SDK_READ_PATH=0`, retained only until the engine read code is deleted (step 5d).

## What
- `shadow-sdk.ts::sdkReadPathEnabled()` — inverted from opt-in (`=== '1'`) to opt-out (`!== '0'`). SDK is the default; any value other than `'0'` (or unset) → SDK drives.
- As a consequence, `useShadowDifferential` is now inert by default — the read-path shadow comparison has served its purpose (validated address/balance/history parity in-browser against real funds) and is retired unless the engine path is explicitly re-selected.

## Tests
- `history.test.ts` — the `runHistoryScan — timestamp backfill` block exercises the **engine fallback** path (`getWalletTransactionHistory` + block-timestamp backfill), so it now pins `VITE_SDK_READ_PATH=0` in `beforeEach`. All other cases test the pure mappers directly.
- Full interface suite: 147 files / 1126 tests green.

## Cutover status
1 IDB ✅ · 2 instance ✅ · 3 balance ✅ · 4 history ✅ · 5b yield ✅ · **5c default-on ✅**
Remaining: **5d** — delete the engine read code (`getShieldedERC20Balance` engine path, engine `runHistoryScan` branch, the shadow-differential hook) and drop `VITE_SDK_READ_PATH`. First real Railgun surface reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)