### PR TITLE
feat(interface): railgun.sdkSync telemetry — observe resume vs rescan

### DIFF
--- a/apps/armada-interface/src/lib/CLAUDE.md
+++ b/apps/armada-interface/src/lib/CLAUDE.md
@@ -30,6 +30,7 @@ Pure logic — **no React imports allowed.** These modules are unit-testable wit
 - **No business logic in `components/**` — push it down here.** ESLint rule planned for the import check.
 - **Stubs throw on call.** Better to fail loudly during development than to return fake data and confuse downstream consumers. Hooks that call into stubs should be marked `// TODO: implement` until the corresponding lib function is real.
 - **Never log secrets.** No `console.log`/`console.debug` of mnemonics, viewing/spending keys, or anything derived from them. The eslint guard is configured to fail builds in `lib/railgun/`.
+- **Telemetry namespace.** New `track` events + `trackError` scopes are named for what they describe. `railgun.*` is reserved for **stock Railgun-engine** events (`@railgun-community/*`) — these get deleted with the engine in Phase B. **`@armada/sdk` concerns use `sdk.*`** (e.g. `sdk.sync`). Don't tag an SDK event `railgun.*` for grep-adjacency; the migration goal is to remove Railgun, and mislabeled namespaces outlive the code that justified them.
 
 ## Duplicated-from-shared note
 

--- a/apps/armada-interface/src/lib/railgun/sdk-read.test.ts
+++ b/apps/armada-interface/src/lib/railgun/sdk-read.test.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Unit test for sdk-read's syncTracked — asserts each wallet.sync() emits a railgun.sdkSync
+// ABOUTME: Unit test for sdk-read's syncTracked — asserts each wallet.sync() emits an sdk.sync
 // ABOUTME: telemetry line carrying the exact resume window, so resume-vs-rescan stays observable.
 
 import { describe, it, expect, vi } from 'vitest'
@@ -17,12 +17,12 @@ import { syncTracked } from './sdk-read'
 import { track } from '@/lib/telemetry'
 
 describe('syncTracked', () => {
-  it('emits railgun.sdkSync with the exact { fromBlock, syncedThrough, scanned } sync returned', async () => {
+  it('emits sdk.sync with the exact { fromBlock, syncedThrough, scanned } sync returned', async () => {
     // WHY: fromBlock and syncedThrough are both numbers, so a field swap wouldn't be caught by
     // types — but it would make the resume-vs-rescan signal lie. Pin the mapping.
     const wallet = { sync: vi.fn(async () => ({ fromBlock: 501, syncedThrough: 520, scanned: true })) }
     await syncTracked(wallet)
-    expect(track).toHaveBeenCalledWith('railgun.sdkSync', {
+    expect(track).toHaveBeenCalledWith('sdk.sync', {
       fromBlock: 501,
       syncedThrough: 520,
       scanned: true,
@@ -33,7 +33,7 @@ describe('syncTracked', () => {
     // WHY: the cheap-path signal — a warm reload with no new blocks. fromBlock stays checkpoint+1.
     const wallet = { sync: vi.fn(async () => ({ fromBlock: 521, syncedThrough: 520, scanned: false })) }
     await syncTracked(wallet)
-    expect(track).toHaveBeenCalledWith('railgun.sdkSync', {
+    expect(track).toHaveBeenCalledWith('sdk.sync', {
       fromBlock: 521,
       syncedThrough: 520,
       scanned: false,

--- a/apps/armada-interface/src/lib/railgun/sdk-read.test.ts
+++ b/apps/armada-interface/src/lib/railgun/sdk-read.test.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Unit test for sdk-read's syncTracked — asserts each wallet.sync() emits a railgun.sdkSync
+// ABOUTME: telemetry line carrying the exact resume window, so resume-vs-rescan stays observable.
+
+import { describe, it, expect, vi } from 'vitest'
+
+// Stub the heavy @armada/sdk value imports so importing sdk-read doesn't pull the SDK/wasm into the
+// test — syncTracked only needs the wallet's `sync()` return, not any real SDK runtime.
+vi.mock('@armada/sdk', () => ({
+  createArmadaSdk: vi.fn(),
+  IndexedDBStorageAdapter: class {},
+  getTokenDataERC20: vi.fn(),
+  getTokenDataHash: vi.fn(),
+}))
+vi.mock('@/lib/telemetry', () => ({ track: vi.fn() }))
+
+import { syncTracked } from './sdk-read'
+import { track } from '@/lib/telemetry'
+
+describe('syncTracked', () => {
+  it('emits railgun.sdkSync with the exact { fromBlock, syncedThrough, scanned } sync returned', async () => {
+    // WHY: fromBlock and syncedThrough are both numbers, so a field swap wouldn't be caught by
+    // types — but it would make the resume-vs-rescan signal lie. Pin the mapping.
+    const wallet = { sync: vi.fn(async () => ({ fromBlock: 501, syncedThrough: 520, scanned: true })) }
+    await syncTracked(wallet)
+    expect(track).toHaveBeenCalledWith('railgun.sdkSync', {
+      fromBlock: 501,
+      syncedThrough: 520,
+      scanned: true,
+    })
+  })
+
+  it('reports scanned:false for a no-op sync (head not advanced past the checkpoint)', async () => {
+    // WHY: the cheap-path signal — a warm reload with no new blocks. fromBlock stays checkpoint+1.
+    const wallet = { sync: vi.fn(async () => ({ fromBlock: 521, syncedThrough: 520, scanned: false })) }
+    await syncTracked(wallet)
+    expect(track).toHaveBeenCalledWith('railgun.sdkSync', {
+      fromBlock: 521,
+      syncedThrough: 520,
+      scanned: false,
+    })
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/sdk-read.ts
+++ b/apps/armada-interface/src/lib/railgun/sdk-read.ts
@@ -109,7 +109,7 @@ async function ensureInstance(): Promise<{ sdk: ArmadaSdk; wallet: ReadWallet; a
  */
 export async function syncTracked(wallet: Pick<ReadWallet, 'sync'>): Promise<void> {
   const { fromBlock, syncedThrough, scanned } = await wallet.sync()
-  track('railgun.sdkSync', { fromBlock, syncedThrough, scanned })
+  track('sdk.sync', { fromBlock, syncedThrough, scanned })
 }
 
 /** Sync the persistent SDK wallet and return its shielded USDC balance (spendable + pending). */

--- a/apps/armada-interface/src/lib/railgun/sdk-read.ts
+++ b/apps/armada-interface/src/lib/railgun/sdk-read.ts
@@ -14,6 +14,7 @@ import {
 import { getCachedDeployments, getUsdcAddress, loadYieldDeployment } from '../../config/deployments'
 import { getNetworkConfig } from '../../config/network'
 import * as keyManager from './keyManager'
+import { track } from '../telemetry'
 
 // Read-only: it only syncs + reads. Proving/artifacts are never exercised, so they throw if
 // something unexpectedly reaches the spend path — a loud signal rather than silent wrong behavior.
@@ -101,10 +102,20 @@ async function ensureInstance(): Promise<{ sdk: ArmadaSdk; wallet: ReadWallet; a
   return instance
 }
 
+/**
+ * Sync the wallet and emit a telemetry line so resume-vs-rescan is observable in the console. A low
+ * `fromBlock` (≈ deploy block) means a cold rescan; a high one means it resumed from the IndexedDB
+ * checkpoint. `scanned: false` = the head hadn't advanced, so no getLogs work was done.
+ */
+export async function syncTracked(wallet: Pick<ReadWallet, 'sync'>): Promise<void> {
+  const { fromBlock, syncedThrough, scanned } = await wallet.sync()
+  track('railgun.sdkSync', { fromBlock, syncedThrough, scanned })
+}
+
 /** Sync the persistent SDK wallet and return its shielded USDC balance (spendable + pending). */
 export async function syncSdkUsdcBalance(): Promise<bigint> {
   const { wallet } = await ensureInstance()
-  await wallet.sync()
+  await syncTracked(wallet)
   const cfg = await readPathConfig()
   const usdcHash = getTokenDataHash(getTokenDataERC20(cfg.pool.usdcAddress))
   const usdc = (await wallet.balances()).find(b => b.tokenHash === usdcHash)
@@ -116,7 +127,7 @@ export async function syncSdkYieldShares(): Promise<bigint> {
   const vault = await vaultTokenAddress()
   if (vault === undefined) return 0n
   const { wallet } = await ensureInstance()
-  await wallet.sync()
+  await syncTracked(wallet)
   const vaultHash = getTokenDataHash(getTokenDataERC20(vault))
   const shares = (await wallet.balances()).find(b => b.tokenHash === vaultHash)
   return shares ? shares.spendable + shares.pending : 0n
@@ -125,7 +136,7 @@ export async function syncSdkYieldShares(): Promise<bigint> {
 /** Sync + reconstruct the SDK wallet's tx history (optionally only entries at/after `sinceBlock`). */
 export async function syncSdkHistory(sinceBlock?: number): Promise<HistoryEntry[]> {
   const { wallet } = await ensureInstance()
-  await wallet.sync()
+  await syncTracked(wallet)
   return wallet.history(sinceBlock !== undefined ? { sinceBlock } : {})
 }
 

--- a/apps/armada-interface/src/lib/telemetry.ts
+++ b/apps/armada-interface/src/lib/telemetry.ts
@@ -44,10 +44,11 @@ export type EventRegistry = {
   'railgun.quicksync':        { outcome: 'served' | 'no-indexer' | 'fell-back'; pages?: number; commitments?: number; unshields?: number; nullifiers?: number; throughBlock?: number; reason?: string }
 
   // @armada/sdk read-instance sync outcome — one line per wallet.sync() so resume-vs-rescan is
-  // observable. Block numbers + a boolean only (no addresses/amounts). `fromBlock` = the resume
-  // point (checkpoint + 1): a low value ≈ deploy block means a cold rescan, a high value means it
-  // resumed from the IndexedDB checkpoint. `scanned` false = head hadn't advanced (no getLogs work).
-  'railgun.sdkSync':          { fromBlock: number; syncedThrough: number; scanned: boolean }
+  // observable. Named `sdk.*` (not `railgun.*`, which is reserved for stock-engine events) because
+  // this is the in-house SDK. Block numbers + a boolean only (no addresses/amounts). `fromBlock` =
+  // the resume point (checkpoint + 1): a low value ≈ deploy block means a cold rescan, a high value
+  // means it resumed from the IndexedDB checkpoint. `scanned` false = head hadn't advanced (no work).
+  'sdk.sync':                 { fromBlock: number; syncedThrough: number; scanned: boolean }
 
   'tx.submitted':             { id: string; kind: TxKind }
   'tx.transition':            { id: string; kind: TxKind; from: TxStage; to: TxStage; executionState: TxRecord['executionState'] }

--- a/apps/armada-interface/src/lib/telemetry.ts
+++ b/apps/armada-interface/src/lib/telemetry.ts
@@ -43,9 +43,11 @@ export type EventRegistry = {
   //   'fell-back'  — attempted but failed → engine slow-scans (paired with a railgun.quickSync error)
   'railgun.quicksync':        { outcome: 'served' | 'no-indexer' | 'fell-back'; pages?: number; commitments?: number; unshields?: number; nullifiers?: number; throughBlock?: number; reason?: string }
 
-  // Read-path shadow differential — @armada/sdk scanned alongside the engine (Phase A). Booleans +
-  // balances only; no raw 0zk addresses (privacy). `addressMatch`/`balanceMatch` false = a parity gap.
-  'railgun.shadow':           { addressMatch: boolean; balanceMatch: boolean; sdkBalance: string; engineBalance: string; historyCount: number; syncedThrough: number; error?: string }
+  // @armada/sdk read-instance sync outcome — one line per wallet.sync() so resume-vs-rescan is
+  // observable. Block numbers + a boolean only (no addresses/amounts). `fromBlock` = the resume
+  // point (checkpoint + 1): a low value ≈ deploy block means a cold rescan, a high value means it
+  // resumed from the IndexedDB checkpoint. `scanned` false = head hadn't advanced (no getLogs work).
+  'railgun.sdkSync':          { fromBlock: number; syncedThrough: number; scanned: boolean }
 
   'tx.submitted':             { id: string; kind: TxKind }
   'tx.transition':            { id: string; kind: TxKind; from: TxStage; to: TxStage; executionState: TxRecord['executionState'] }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#37c034da7bc8a2d7b2251733384b7f97190321f6",
+        "@armada/sdk": "github:ship-armada/armada-sdk#eb61f8313f1d92b60de90106593a6c380f9df3ba",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#37c034da7bc8a2d7b2251733384b7f97190321f6",
-      "integrity": "sha512-osrHVxNrF0F4c/EIwoYCK87fVvc9FFm5KLLMcnqgV96L0EOGTsGbD+bgl5QhwOT5iMbLNr3PqmEY9rrXVB4XAw==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#eb61f8313f1d92b60de90106593a6c380f9df3ba",
+      "integrity": "sha512-tssXLJ2SKhqxgzto5ND9he4SZPtXGGJ8UA6/quqbGAe4eMBjKlcCDEKo8zbNBb0H0iGc5dPdfmJWXxZC9rYa3g==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#37c034da7bc8a2d7b2251733384b7f97190321f6",
+    "@armada/sdk": "github:ship-armada/armada-sdk#eb61f8313f1d92b60de90106593a6c380f9df3ba",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",


### PR DESCRIPTION
Closes the observability gap raised while sanity-checking the SDK read path: there was no way to confirm from logs that a page reload *resumes* the shielded scan from the IndexedDB checkpoint rather than rescanning the pool from the deploy block.

## What
- Re-pin `@armada/sdk` → the merged sync-observability commit (armada-sdk#49), whose `wallet.sync()` now returns `{ fromBlock, syncedThrough, scanned }`.
- New typed telemetry event `sdk.sync { fromBlock, syncedThrough, scanned }` in `lib/telemetry.ts` (block numbers + a boolean only — no addresses/amounts). Namespaced `sdk.*`, not `railgun.*` — the `railgun.*` namespace is reserved for stock-engine events (`@railgun-community/*`); this is the in-house SDK.
- `sdk-read.ts`: a `syncTracked(wallet)` wrapper emits that line on every `wallet.sync()`; the three read entry points (`syncSdkUsdcBalance` / `syncSdkYieldShares` / `syncSdkHistory`) route through it.
- Removed the dead `railgun.shadow` registry entry (its only emitter, the shadow-differential hook, was deleted in the 5d cutover).

## What you'll see in the console
Per sync:
- **Cold** (first load / after a pool redeploy): `sdk.sync fromBlock=<deployBlock> syncedThrough=<head> scanned=true`
- **Warm reload** (resumed from IndexedDB): `sdk.sync fromBlock=<checkpoint+1> … scanned=true`, or `scanned=false` when the head hasn't advanced.

`fromBlock` is the tell: ≈ deploy block = cold rescan; a high value = it resumed. (DevTools → Network → the `eth_getLogs` `fromBlock` corroborates the same thing.)

Note: `railgun.quicksync` is a *separate*, correctly-named event — the stock Railgun engine's quick-sync. Seeing both means the engine and the SDK are each scanning right now (the engine remains the write path + balance-event bus); the engine + its event go away in Phase B.

## Tests
- `sdk-read.test.ts` pins the `sdk.sync` field mapping (a `fromBlock`/`syncedThrough` swap wouldn't be caught by types since both are numbers) for the scanned + no-op cases.
- Full interface suite green: 148 files / 1116 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)