### PR TITLE
feat(interface): shield write-path differential (Phase B slice 1)

### DIFF
--- a/apps/armada-interface/src/features/shield/handler.ts
+++ b/apps/armada-interface/src/features/shield/handler.ts
@@ -22,6 +22,7 @@ import {
   createShieldRequest,
   generateRandomShieldPrivateKey,
 } from '@/lib/railgun/shield'
+import { runShieldDifferential, shieldDifferentialEnabled } from '@/lib/railgun/shield-differential'
 import { signUsdcPermit } from '@/lib/wallet/permit'
 import { buildGaslessShieldCalldata } from '@/lib/wallet/gasless-shield'
 import {
@@ -186,6 +187,17 @@ async function runBuildProof(
     usdcAddress,
     shieldPrivateKey,
   )
+  // Phase B write-path differential (observe-only): rebuild this note with @armada/sdk from the
+  // same key + random and telemetry-report commitment parity. Fire-and-forget — never blocks or
+  // fails the shield; the engine-built request below is still what gets submitted.
+  if (shieldDifferentialEnabled()) {
+    void runShieldDifferential(request, {
+      railgunAddress,
+      amount: shieldValue,
+      tokenAddress: usdcAddress,
+      shieldPrivateKeyHex: shieldPrivateKey,
+    })
+  }
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   // Phase C — gasless path: build the relayer fee note (a second shield note to the relayer's 0zk),

--- a/apps/armada-interface/src/lib/railgun/shield-differential.test.ts
+++ b/apps/armada-interface/src/lib/railgun/shield-differential.test.ts
@@ -1,0 +1,93 @@
+// ABOUTME: Unit test for runShieldDifferential — feeds the SDK builder the engine's random and asserts
+// ABOUTME: the sdk.shieldDiff telemetry reflects commitment (npk/value/shieldKey) parity, match + mismatch.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Stub the SDK builder + poseidon init so the helper runs without wasm; stub telemetry to spy.
+const hoisted = vi.hoisted(() => ({ buildShieldRequest: vi.fn() }))
+vi.mock('@armada/sdk', () => ({
+  buildShieldRequest: hoisted.buildShieldRequest,
+  initPoseidonPromise: Promise.resolve(),
+}))
+vi.mock('@/lib/telemetry', () => ({ track: vi.fn(), trackError: vi.fn() }))
+
+import { runShieldDifferential } from './shield-differential'
+import { track, trackError } from '@/lib/telemetry'
+import type { ShieldRequestData } from './shield'
+
+const NPK = ('0x' + 'ab'.repeat(32)) as `0x${string}`
+const SHIELD_KEY = ('0x' + 'cd'.repeat(32)) as `0x${string}`
+const BUNDLE = ['0x' + '1'.repeat(64), '0x' + '2'.repeat(64), '0x' + '3'.repeat(64)] as unknown as readonly [
+  `0x${string}`, `0x${string}`, `0x${string}`,
+]
+
+const engineRequest: ShieldRequestData = {
+  npk: NPK,
+  value: 5_000_000n,
+  encryptedBundle: BUNDLE,
+  shieldKey: SHIELD_KEY,
+  random: 'ef'.repeat(16),
+}
+
+const inputs = {
+  railgunAddress: '0zk1qy' + 'a'.repeat(60),
+  amount: 5_000_000n,
+  tokenAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  shieldPrivateKeyHex: '11'.repeat(32),
+}
+
+// A matching SDK build (differs only in the non-reproducible bundle, which the diff ignores).
+const sdkResult = (over?: { npk?: string; value?: bigint; shieldKey?: string }) => ({
+  shieldRequest: {
+    preimage: {
+      npk: over?.npk ?? NPK,
+      token: { tokenType: 0, tokenAddress: inputs.tokenAddress, tokenSubID: 0n },
+      value: over?.value ?? 5_000_000n,
+    },
+    ciphertext: {
+      encryptedBundle: ['0x' + '9'.repeat(64), '0x' + '8'.repeat(64), '0x' + '7'.repeat(64)],
+      shieldKey: over?.shieldKey ?? SHIELD_KEY,
+    },
+  },
+  random: engineRequest.random,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('runShieldDifferential', () => {
+  it('feeds the SDK builder the engine random + key, and reports match when commitments agree', async () => {
+    // WHY: the differential rests on injecting the SAME random — otherwise the commitment can never
+    // match. Assert both the injection and the all-true telemetry.
+    hoisted.buildShieldRequest.mockResolvedValue(sdkResult())
+    await runShieldDifferential(engineRequest, inputs)
+
+    expect(hoisted.buildShieldRequest).toHaveBeenCalledWith(
+      { railgunAddress: inputs.railgunAddress, amount: inputs.amount, tokenAddress: inputs.tokenAddress },
+      expect.any(Uint8Array),
+      engineRequest.random,
+    )
+    expect(track).toHaveBeenCalledWith('sdk.shieldDiff', {
+      npkMatch: true, valueMatch: true, shieldKeyMatch: true, match: true,
+    })
+  })
+
+  it('reports match:false when the SDK npk diverges from the engine', async () => {
+    // WHY: npk IS the on-chain commitment leaf — a divergence there means a different note. It must
+    // surface as a failed differential, not pass silently.
+    hoisted.buildShieldRequest.mockResolvedValue(sdkResult({ npk: '0x' + '00'.repeat(32) }))
+    await runShieldDifferential(engineRequest, inputs)
+    expect(track).toHaveBeenCalledWith('sdk.shieldDiff', {
+      npkMatch: false, valueMatch: true, shieldKeyMatch: true, match: false,
+    })
+  })
+
+  it('never throws into the caller — a builder error is reported via telemetry', async () => {
+    // WHY: the differential is observe-only and must not fail the shield flow.
+    hoisted.buildShieldRequest.mockRejectedValue(new Error('poseidon boom'))
+    await expect(runShieldDifferential(engineRequest, inputs)).resolves.toBeUndefined()
+    expect(trackError).toHaveBeenCalledWith('sdk.shieldDiff', expect.any(Error), expect.any(Object))
+    expect(track).not.toHaveBeenCalled()
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/shield-differential.ts
+++ b/apps/armada-interface/src/lib/railgun/shield-differential.ts
@@ -1,0 +1,59 @@
+// ABOUTME: Shield write-path differential — rebuilds the ShieldRequest with @armada/sdk (same shieldPrivateKey + engine's random)
+// ABOUTME: and telemetry-reports commitment parity vs the engine. Read-only: the SDK note is compared then discarded, never submitted.
+
+import { buildShieldRequest, initPoseidonPromise } from '@armada/sdk'
+import { track, trackError } from '@/lib/telemetry'
+import type { ShieldRequestData } from './shield'
+
+/**
+ * Dev / opt-in gate. The differential is observe-only (builds a second request, compares, discards —
+ * never submits), so it's safe to run on every shield in dev; opt in elsewhere via VITE_SHADOW_SDK=1.
+ */
+export function shieldDifferentialEnabled(): boolean {
+  return import.meta.env.MODE === 'development' || import.meta.env.VITE_SHADOW_SDK === '1'
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const out = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+  }
+  return out
+}
+
+/**
+ * Rebuild the shield note with `@armada/sdk` from the SAME inputs the engine used — including the
+ * engine's `random` salt — and compare the deterministic **commitment** fields (`npk`, `value`,
+ * `shieldKey`). The `encryptedBundle` is deliberately excluded: it uses a fresh AES-GCM IV per call,
+ * so it is not byte-reproducible (its correctness property is decryptability, covered by the SDK's
+ * own tests — not byte-equality). A commitment match means the SDK builds the identical on-chain
+ * shield leaf as the engine.
+ *
+ * Read-only + never throws into the caller: a differential error is reported via telemetry, not
+ * surfaced to the shield flow. Emits one `sdk.shieldDiff` line per invocation.
+ */
+export async function runShieldDifferential(
+  engineRequest: ShieldRequestData,
+  inputs: { railgunAddress: string; amount: bigint; tokenAddress: string; shieldPrivateKeyHex: string },
+): Promise<void> {
+  try {
+    await initPoseidonPromise
+    const { shieldRequest } = await buildShieldRequest(
+      { railgunAddress: inputs.railgunAddress, amount: inputs.amount, tokenAddress: inputs.tokenAddress },
+      hexToBytes(inputs.shieldPrivateKeyHex),
+      engineRequest.random,
+    )
+    const npkMatch = shieldRequest.preimage.npk.toLowerCase() === engineRequest.npk.toLowerCase()
+    const valueMatch = shieldRequest.preimage.value === engineRequest.value
+    const shieldKeyMatch = shieldRequest.ciphertext.shieldKey.toLowerCase() === engineRequest.shieldKey.toLowerCase()
+    track('sdk.shieldDiff', {
+      npkMatch,
+      valueMatch,
+      shieldKeyMatch,
+      match: npkMatch && valueMatch && shieldKeyMatch,
+    })
+  } catch (err) {
+    trackError('sdk.shieldDiff', err, { scope: 'shielded.balance', message: 'shield differential failed' })
+  }
+}

--- a/apps/armada-interface/src/lib/telemetry.ts
+++ b/apps/armada-interface/src/lib/telemetry.ts
@@ -50,6 +50,13 @@ export type EventRegistry = {
   // means it resumed from the IndexedDB checkpoint. `scanned` false = head hadn't advanced (no work).
   'sdk.sync':                 { fromBlock: number; syncedThrough: number; scanned: boolean }
 
+  // Shield write-path differential (Phase B) — one line per shield build when the differential is
+  // enabled: @armada/sdk builds the same note (same shieldPrivateKey + engine's random) and we
+  // compare the deterministic COMMITMENT fields (npk/value/shieldKey) to the engine's. The
+  // encryptedBundle is excluded — fresh AES-GCM IV per call, so not byte-reproducible by design.
+  // `match` false = a shield-build parity gap; observe-only (the SDK note is never submitted).
+  'sdk.shieldDiff':           { npkMatch: boolean; valueMatch: boolean; shieldKeyMatch: boolean; match: boolean }
+
   'tx.submitted':             { id: string; kind: TxKind }
   'tx.transition':            { id: string; kind: TxKind; from: TxStage; to: TxStage; executionState: TxRecord['executionState'] }
   'tx.failed':                { id: string; kind: TxKind; errorCode?: string }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#eb61f8313f1d92b60de90106593a6c380f9df3ba",
+        "@armada/sdk": "github:ship-armada/armada-sdk#d09ef046c78bfed5dbe9d2e114969a3cf8b4bbf3",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#eb61f8313f1d92b60de90106593a6c380f9df3ba",
-      "integrity": "sha512-tssXLJ2SKhqxgzto5ND9he4SZPtXGGJ8UA6/quqbGAe4eMBjKlcCDEKo8zbNBb0H0iGc5dPdfmJWXxZC9rYa3g==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#d09ef046c78bfed5dbe9d2e114969a3cf8b4bbf3",
+      "integrity": "sha512-C5JmGH3P5UtWMAbb04EM4Kdc/kBS/fOjcjQwSD4yjF491Xr9BcFGGIIu7hvxDzROEZ+iYG1Trt7RCgLTcHAoCQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#eb61f8313f1d92b60de90106593a6c380f9df3ba",
+    "@armada/sdk": "github:ship-armada/armada-sdk#d09ef046c78bfed5dbe9d2e114969a3cf8b4bbf3",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",


### PR DESCRIPTION
Phase B (write path) begins — the read-path playbook applied to shield. Observe-only differential that proves `@armada/sdk` builds the **identical on-chain shield commitment** as the stock engine, before we cut submission over. **Zero behavior change** — the engine-built request is still what gets submitted.

## What
- Re-pin `@armada/sdk` → armada-sdk#50 (`buildShieldRequest` gained an optional `random`).
- `lib/railgun/shield-differential.ts` — `runShieldDifferential(engineRequest, inputs)` rebuilds the note with the SDK from the **same** `shieldPrivateKey` + the engine's **`random`**, and compares the deterministic commitment fields (`npk`, `value`, `shieldKey`). Emits `sdk.shieldDiff { npkMatch, valueMatch, shieldKeyMatch, match }`. Read-only, never throws into the shield flow.
- Shield handler calls it flag-gated + fire-and-forget after building the engine request.

## The determinism boundary (why only 3 fields)
The `encryptedBundle` uses a **fresh AES-GCM IV per call**, so it is *not* byte-reproducible — even the engine vs itself differs. Its correctness property is *decryptability* (covered by the SDK's own shield test), not byte-equality. So the differential compares exactly the deterministic commitment (`npk` = the on-chain leaf, `value`, `shieldKey`); a match means the SDK builds the identical shield.

## Gate
`shieldDifferentialEnabled()` — on in dev, opt-in elsewhere via `VITE_SHADOW_SDK=1`. Off in tests/prod-default, so existing shield behavior + tests are untouched.

## Tests
- `shield-differential.test.ts` — asserts the engine `random` + key are injected into the SDK builder, `match:true` on agreement, `match:false` on npk divergence, and that a builder error is swallowed to telemetry (never fails the shield).
- Full interface suite green: 149 files / 1119 tests.

## Next (this slice's follow-ons)
Once `sdk.shieldDiff match:true` reads clean in-browser on real deposits → cut shield submission over to the SDK-built request, then delete the engine shield builder (first write-path Railgun reduction). Then repeat for the gasless fee note + shield-xchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)