### PR TITLE
feat(interface): shield submission cutover to @armada/sdk — hub + cross-chain (Phase B slice 2)

### DIFF
--- a/apps/armada-interface/src/features/shield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/shield-xchain/handler.ts
@@ -24,6 +24,8 @@ import {
   createShieldRequest,
   generateRandomShieldPrivateKey,
 } from '@/lib/railgun/shield'
+import { createShieldRequestSdk, sdkShieldEnabled } from '@/lib/railgun/shield-sdk'
+import { runShieldDifferential, shieldDifferentialEnabled } from '@/lib/railgun/shield-differential'
 import { extractCctpMessageFromReceipt, messageReceivedTopic } from '@/lib/cctp'
 import { cctpMaxFeeForKind, submitRelay, fetchCctpDeliveryStatus } from '@/lib/relayer'
 import { handleRelaySubmitError } from '@/lib/tx/relaySubmit'
@@ -194,12 +196,20 @@ async function runBuildProof(
     )
   }
   const shieldPrivateKey = generateRandomShieldPrivateKey()
-  const request = await createShieldRequest(
-    railgunAddress,
-    shieldValue,
-    hubUsdcAddress,
-    shieldPrivateKey,
-  )
+  // Phase B write-path cutover (same flag as hub shield). The cross-chain note-build is identical to
+  // the hub shield — only the CCTP wrapping below differs — so it shares slice 1's commitment-parity
+  // guarantee. Under VITE_SDK_WRITE_PATH the ShieldRequest is built by @armada/sdk; else the engine.
+  const request = sdkShieldEnabled()
+    ? await createShieldRequestSdk(railgunAddress, shieldValue, hubUsdcAddress, shieldPrivateKey)
+    : await createShieldRequest(railgunAddress, shieldValue, hubUsdcAddress, shieldPrivateKey)
+  if (!sdkShieldEnabled() && shieldDifferentialEnabled()) {
+    void runShieldDifferential(request, {
+      railgunAddress,
+      amount: shieldValue,
+      tokenAddress: hubUsdcAddress,
+      shieldPrivateKeyHex: shieldPrivateKey,
+    })
+  }
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   // Phase C — gasless path: build the relayer fee note (a second note carried across CCTP, minted
@@ -268,12 +278,9 @@ async function buildGaslessXchainArtifacts(
 
   // Fee note is HUB-usdc denominated — the commitment is minted on the hub after CCTP delivery.
   const feeShieldPrivateKey = generateRandomShieldPrivateKey()
-  const feeNote = await createShieldRequest(
-    record.meta.broadcasterRailgunAddress,
-    record.meta.feeAmount,
-    hubUsdcAddress,
-    feeShieldPrivateKey,
-  )
+  const feeNote = sdkShieldEnabled()
+    ? await createShieldRequestSdk(record.meta.broadcasterRailgunAddress, record.meta.feeAmount, hubUsdcAddress, feeShieldPrivateKey)
+    : await createShieldRequest(record.meta.broadcasterRailgunAddress, record.meta.feeAmount, hubUsdcAddress, feeShieldPrivateKey)
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   // Gasless cross-chain shields carry no integrator (address(0)).

--- a/apps/armada-interface/src/features/shield/handler.ts
+++ b/apps/armada-interface/src/features/shield/handler.ts
@@ -23,6 +23,7 @@ import {
   generateRandomShieldPrivateKey,
 } from '@/lib/railgun/shield'
 import { runShieldDifferential, shieldDifferentialEnabled } from '@/lib/railgun/shield-differential'
+import { createShieldRequestSdk, sdkShieldEnabled } from '@/lib/railgun/shield-sdk'
 import { signUsdcPermit } from '@/lib/wallet/permit'
 import { buildGaslessShieldCalldata } from '@/lib/wallet/gasless-shield'
 import {
@@ -181,16 +182,15 @@ async function runBuildProof(
     )
   }
   const shieldPrivateKey = generateRandomShieldPrivateKey()
-  const request = await createShieldRequest(
-    railgunAddress,
-    shieldValue,
-    usdcAddress,
-    shieldPrivateKey,
-  )
-  // Phase B write-path differential (observe-only): rebuild this note with @armada/sdk from the
-  // same key + random and telemetry-report commitment parity. Fire-and-forget — never blocks or
-  // fails the shield; the engine-built request below is still what gets submitted.
-  if (shieldDifferentialEnabled()) {
+  // Phase B write-path cutover: under VITE_SDK_WRITE_PATH the ShieldRequest is built by @armada/sdk;
+  // otherwise the stock engine (default). Both return the same ShieldRequestData shape.
+  const request = sdkShieldEnabled()
+    ? await createShieldRequestSdk(railgunAddress, shieldValue, usdcAddress, shieldPrivateKey)
+    : await createShieldRequest(railgunAddress, shieldValue, usdcAddress, shieldPrivateKey)
+  // Pre-cutover differential (observe-only): while the engine still builds the submitted request,
+  // rebuild it with @armada/sdk from the same key + random and telemetry-report commitment parity.
+  // Fire-and-forget — never blocks or fails the shield. Skipped once the SDK path is the primary.
+  if (!sdkShieldEnabled() && shieldDifferentialEnabled()) {
     void runShieldDifferential(request, {
       railgunAddress,
       amount: shieldValue,
@@ -264,12 +264,9 @@ async function buildGaslessArtifacts(
 
   // Build the relayer fee note to the relayer's published 0zk. value = the quoted fee.
   const feeShieldPrivateKey = generateRandomShieldPrivateKey()
-  const feeNote = await createShieldRequest(
-    record.meta.broadcasterRailgunAddress,
-    record.meta.feeAmount,
-    usdcAddress,
-    feeShieldPrivateKey,
-  )
+  const feeNote = sdkShieldEnabled()
+    ? await createShieldRequestSdk(record.meta.broadcasterRailgunAddress, record.meta.feeAmount, usdcAddress, feeShieldPrivateKey)
+    : await createShieldRequest(record.meta.broadcasterRailgunAddress, record.meta.feeAmount, usdcAddress, feeShieldPrivateKey)
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   // Bind the exact array the wrapper will shield: [userNote, feeNote].

--- a/apps/armada-interface/src/lib/railgun/shield-sdk.test.ts
+++ b/apps/armada-interface/src/lib/railgun/shield-sdk.test.ts
@@ -1,0 +1,60 @@
+// ABOUTME: Unit test for createShieldRequestSdk — maps the @armada/sdk ShieldRequest into the interface's
+// ABOUTME: ShieldRequestData shape (the drop-in for the engine builder) and validates its inputs.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({ buildShieldRequest: vi.fn() }))
+vi.mock('@armada/sdk', () => ({
+  buildShieldRequest: hoisted.buildShieldRequest,
+  initPoseidonPromise: Promise.resolve(),
+}))
+
+import { createShieldRequestSdk } from './shield-sdk'
+
+const NPK = '0x' + 'ab'.repeat(32)
+const SHIELD_KEY = '0x' + 'cd'.repeat(32)
+const BUNDLE = ['0x' + '1'.repeat(64), '0x' + '2'.repeat(64), '0x' + '3'.repeat(64)]
+const ZK = '0zk1q' + 'a'.repeat(60)
+const USDC = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+const KEY = '11'.repeat(32)
+
+describe('createShieldRequestSdk', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('maps the SDK ShieldRequest into ShieldRequestData and passes the key as bytes', async () => {
+    hoisted.buildShieldRequest.mockResolvedValue({
+      shieldRequest: {
+        preimage: { npk: NPK, token: { tokenType: 0, tokenAddress: USDC, tokenSubID: 0n }, value: 5_000_000n },
+        ciphertext: { encryptedBundle: BUNDLE, shieldKey: SHIELD_KEY },
+      },
+      random: 'ef'.repeat(16),
+    })
+
+    const r = await createShieldRequestSdk(ZK, 5_000_000n, USDC, KEY)
+
+    expect(r).toEqual({
+      npk: NPK,
+      value: 5_000_000n,
+      encryptedBundle: BUNDLE,
+      shieldKey: SHIELD_KEY,
+      random: 'ef'.repeat(16),
+    })
+    expect(hoisted.buildShieldRequest).toHaveBeenCalledWith(
+      { railgunAddress: ZK, amount: 5_000_000n, tokenAddress: USDC },
+      expect.any(Uint8Array),
+    )
+    // No random injected — the production path lets the SDK generate a fresh salt per deposit.
+    expect(hoisted.buildShieldRequest.mock.calls[0]!.length).toBe(2)
+  })
+
+  it('rejects a non-0zk recipient before building', async () => {
+    await expect(createShieldRequestSdk('0xnot-a-zk', 1n, USDC, KEY)).rejects.toThrow(/0zk address/)
+    expect(hoisted.buildShieldRequest).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-positive amount', async () => {
+    await expect(createShieldRequestSdk(ZK, 0n, USDC, KEY)).rejects.toThrow(/amount must be positive/)
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/shield-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/shield-sdk.ts
@@ -1,0 +1,63 @@
+// ABOUTME: SDK-backed shield-request builder (Phase B write-path cutover) — builds the ShieldRequest via
+// ABOUTME: @armada/sdk in the interface's ShieldRequestData shape, gated by VITE_SDK_WRITE_PATH.
+
+import { buildShieldRequest, initPoseidonPromise } from '@armada/sdk'
+import type { ShieldRequestData } from './shield'
+
+/**
+ * Write-path cutover flag. When set, the shield handler builds its `ShieldRequest` via `@armada/sdk`
+ * (`createShieldRequestSdk`) instead of the stock engine. Off by default; the engine drives. Each
+ * migrated write path checks this same flag — unmigrated ones ignore it and stay on the engine.
+ */
+export function sdkShieldEnabled(): boolean {
+  return import.meta.env.VITE_SDK_WRITE_PATH === '1'
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const out = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+  }
+  return out
+}
+
+function as0x(hex: string): `0x${string}` {
+  if (!hex.startsWith('0x')) throw new Error('createShieldRequestSdk: expected a 0x-prefixed hex value')
+  return hex as `0x${string}`
+}
+
+/**
+ * Build a single hub `ShieldRequest` via `@armada/sdk`, returned in the interface's `ShieldRequestData`
+ * shape so the handler's downstream tuple assembly is unchanged. Drop-in for the engine's
+ * `createShieldRequest` (verified byte-identical on the commitment fields by the shield differential).
+ */
+export async function createShieldRequestSdk(
+  railgunAddress: string,
+  amount: bigint,
+  tokenAddress: string,
+  shieldPrivateKeyHex: string,
+): Promise<ShieldRequestData> {
+  if (!railgunAddress.startsWith('0zk')) {
+    throw new Error('createShieldRequestSdk: recipient must be a 0zk address')
+  }
+  if (amount <= 0n) {
+    throw new Error('createShieldRequestSdk: amount must be positive')
+  }
+  await initPoseidonPromise
+  const { shieldRequest, random } = await buildShieldRequest(
+    { railgunAddress, amount, tokenAddress },
+    hexToBytes(shieldPrivateKeyHex),
+  )
+  return {
+    npk: as0x(shieldRequest.preimage.npk),
+    value: shieldRequest.preimage.value,
+    encryptedBundle: [
+      as0x(shieldRequest.ciphertext.encryptedBundle[0]),
+      as0x(shieldRequest.ciphertext.encryptedBundle[1]),
+      as0x(shieldRequest.ciphertext.encryptedBundle[2]),
+    ] as const,
+    shieldKey: as0x(shieldRequest.ciphertext.shieldKey),
+    random,
+  }
+}


### PR DESCRIPTION
Phase B slice 2 — **both** shield handlers (hub `shield` and cross-chain `shield-xchain`) build their `ShieldRequest` with `@armada/sdk` when `VITE_SDK_WRITE_PATH=1`, else the stock engine (default). Follows slice 1's `match:true` differential, which proved the SDK builds the byte-identical on-chain commitment.

## What
- `lib/railgun/shield-sdk.ts` — `createShieldRequestSdk(...)` wraps the SDK's `buildShieldRequest` and returns the interface's `ShieldRequestData` shape (npk/value/encryptedBundle/shieldKey/random). A drop-in for the engine's `createShieldRequest`; downstream tuple assembly + submit paths are unchanged. `sdkShieldEnabled()` reads the flag.
- **`shield` handler** — user note + gasless fee note pick the SDK builder under the flag.
- **`shield-xchain` handler** — same swap at both build sites. The cross-chain note-build is *identical* to the hub shield (only the CCTP `ShieldData` wrapping differs, which never touches the note crypto), so it shares slice 1's parity guarantee — no separate differential needed, though the observe-only differential now also runs on the xchain path when the flag is off.

## Default off — no behavior change
Flag unset → engine builds everything, exactly as before. Interface suite green: 150 files / 1122 tests.

## Why it's safe (both handlers, both paths)
- **Direct / on-chain commitment:** byte-identical to the engine (slice-1 differential), so the leaf + scan/balance are unchanged; only the `encryptedBundle` differs (fresh IV, still recipient-decryptable — covered by the SDK's own shield test).
- **Gasless:** the relayer's fee verifier recomputes the fee note's npk from `feeShieldRandom` — the SDK returns the same `random` and builds npk identically, so relayer verification passes; it never decrypts the bundle.

## Validate before flipping default (`VITE_SDK_WRITE_PATH=1`)
Real local shields:
1. **Hub direct** + **hub gasless** — shield lands, shielded USDC balance updates.
2. **Cross-chain** (client → CCTP → hub), direct + gasless — mint lands on hub, balance updates.

## Next
Once validated → flip `VITE_SDK_WRITE_PATH` default on, then slice 3: delete the engine `createShieldRequest` (`lib/railgun/shield.ts`) + the now-moot differential. With both shield handlers migrated, nothing else consumes it — the first write-path Railgun reduction. Then transfer/unshield/yield.

🤖 Generated with [Claude Code](https://claude.com/claude-code)