### PR TITLE
feat(interface): default shield builder to @armada/sdk (Phase B slice 3a)

### DIFF
--- a/apps/armada-interface/src/lib/railgun/shield-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/shield-sdk.ts
@@ -5,12 +5,13 @@ import { buildShieldRequest, initPoseidonPromise } from '@armada/sdk'
 import type { ShieldRequestData } from './shield'
 
 /**
- * Write-path cutover flag. When set, the shield handler builds its `ShieldRequest` via `@armada/sdk`
- * (`createShieldRequestSdk`) instead of the stock engine. Off by default; the engine drives. Each
- * migrated write path checks this same flag — unmigrated ones ignore it and stay on the engine.
+ * Write-path cutover flag. Both shield handlers build their `ShieldRequest` via `@armada/sdk`
+ * (`createShieldRequestSdk`) by default; set `VITE_SDK_WRITE_PATH=0` to fall back to the stock engine
+ * (escape hatch, retained until the engine shield builder is deleted). Each migrated write path checks
+ * this same flag — unmigrated ones ignore it and stay on the engine regardless.
  */
 export function sdkShieldEnabled(): boolean {
-  return import.meta.env.VITE_SDK_WRITE_PATH === '1'
+  return import.meta.env.VITE_SDK_WRITE_PATH !== '0'
 }
 
 function hexToBytes(hex: string): Uint8Array {


### PR DESCRIPTION
Phase B slice 3a — flips `VITE_SDK_WRITE_PATH` from opt-in to opt-out: **both shield handlers (hub + cross-chain) now build their `ShieldRequest` with `@armada/sdk` by default.** The stock engine remains reachable via `VITE_SDK_WRITE_PATH=0` (escape hatch, retained until 3b deletes the engine builder).

Validated in-browser under the explicit flag in #440 (hub direct + gasless, cross-chain direct + gasless — all landed, balances updated). This makes that the default.

## Change
One line: `sdkShieldEnabled()` `=== '1'` → `!== '0'`.

## Tests unaffected
The shield handler tests all start records at `stage: 'submit-relayer'` with pre-built artifacts, so they never hit the build path where the flag is read. The builder unit test (`shield-sdk.test.ts`) mocks `buildShieldRequest` directly. Suite green: 150 files / 1122 tests.

## Validate the default build, then 3b
Run the app with **no** `VITE_SDK_WRITE_PATH` set (default) and confirm a hub + cross-chain shield still land + update balance — i.e. the SDK path works without the env var explicitly set. Then slice 3b: delete the engine `createShieldRequest` (`lib/railgun/shield.ts`) + the now-inert differential + the flag — the first write-path Railgun reduction (nothing else consumes the engine shield builder now that both handlers are migrated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)