### PR TITLE
feat(interface): write-capable @armada/sdk instance (Phase B write-path, sub-step 1)

### DIFF
--- a/apps/armada-interface/src/lib/railgun/artifactGetter.ts
+++ b/apps/armada-interface/src/lib/railgun/artifactGetter.ts
@@ -23,6 +23,11 @@ export function hasArmadaArtifact(variant: string): boolean {
   return armadaArtifacts.has(variant)
 }
 
+/** Look up a registered circuit artifact by padded shape key. Used by the @armada/sdk ArtifactSource. */
+export function getArmadaArtifact(variant: string): Artifact | undefined {
+  return armadaArtifacts.get(variant)
+}
+
 /** Drop all registered artifacts. For hot-reload + test isolation. */
 export function clearArmadaArtifacts(): void {
   armadaArtifacts.clear()

--- a/apps/armada-interface/src/lib/railgun/sdk-prover.test.ts
+++ b/apps/armada-interface/src/lib/railgun/sdk-prover.test.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Unit test for the write-capable SDK wiring — the ArtifactSource resolves loaded circuits from
+// ABOUTME: the artifactGetter registry to the SDK's {wasm,zkey,vkey} shape, and fails loudly when unloaded.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Artifact } from '@railgun-community/shared-models'
+
+// Stub the snarkjs prover so importing this module doesn't pull the proving stack into the test.
+vi.mock('@armada/sdk', () => ({
+  createSnarkjsProver: () => ({ prove: async () => ({}), verify: async () => false, close: async () => {} }),
+}))
+
+import { createInterfaceArtifactSource, createInterfaceProver } from './sdk-prover'
+import { setArmadaArtifact, clearArmadaArtifacts } from './artifactGetter'
+
+const artifact = (wasm: Uint8Array | undefined): Artifact =>
+  ({ zkey: new Uint8Array([2]), wasm, vkey: { protocol: 'groth16' }, dat: undefined }) as Artifact
+
+describe('createInterfaceArtifactSource', () => {
+  beforeEach(() => {
+    clearArmadaArtifacts()
+  })
+
+  it('resolves a loaded circuit (by padded NNxMM shape) to { wasm, zkey, vkey }', async () => {
+    const wasm = new Uint8Array([1, 2, 3])
+    setArmadaArtifact('01x02', artifact(wasm))
+    const source = createInterfaceArtifactSource()
+    const set = await source.resolve({ nullifiers: 1, commitments: 2 })
+    expect(set.wasm).toBe(wasm)
+    expect(set.zkey).toEqual(new Uint8Array([2]))
+    expect(set.vkey).toEqual({ protocol: 'groth16' })
+  })
+
+  it('throws for a shape whose circuit has not been loaded', async () => {
+    // WHY: a missing circuit must fail loudly at resolve time, not hang the prover or prove garbage.
+    const source = createInterfaceArtifactSource()
+    await expect(source.resolve({ nullifiers: 2, commitments: 3 })).rejects.toThrow(/circuit 02x03 not loaded/)
+  })
+
+  it('throws when the registered artifact has no wasm (dat-only circuit)', async () => {
+    setArmadaArtifact('01x02', artifact(undefined))
+    const source = createInterfaceArtifactSource()
+    await expect(source.resolve({ nullifiers: 1, commitments: 2 })).rejects.toThrow(/not loaded/)
+  })
+})
+
+describe('createInterfaceProver', () => {
+  it('returns a ProverAdapter (snarkjs backend)', () => {
+    const prover = createInterfaceProver()
+    expect(typeof prover.prove).toBe('function')
+    expect(typeof prover.close).toBe('function')
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/sdk-prover.ts
+++ b/apps/armada-interface/src/lib/railgun/sdk-prover.ts
@@ -1,0 +1,43 @@
+// ABOUTME: Write-capable @armada/sdk wiring — a same-thread snarkjs ProverAdapter + an ArtifactSource
+// ABOUTME: that resolves circuits from the interface's in-memory artifact registry (artifactGetter).
+
+import {
+  createSnarkjsProver,
+  type ArtifactSet,
+  type ArtifactSource,
+  type CircuitShape,
+  type ProverAdapter,
+} from '@armada/sdk'
+import { armadaVariantKey, getArmadaArtifact } from './artifactGetter'
+
+/**
+ * Same-thread Groth16 prover (snarkjs). This is the correctness-first backend; the off-main-thread
+ * worker prover (`createWorkerProver`) is a follow-on swap that every proving flow inherits, since the
+ * prover is a single injected adapter on the SDK instance.
+ */
+export function createInterfaceProver(): ProverAdapter {
+  return createSnarkjsProver()
+}
+
+/**
+ * `ArtifactSource` bridging the SDK to the interface's in-memory circuit registry — the same
+ * `artifactGetter` registry the engine proves against, populated by the DEV circuit loader + the prod
+ * origin-preload (keyed by padded `NNxMM`). Resolves `(shape) → { wasm, zkey, vkey }`; throws if the
+ * shape's circuit hasn't been loaded, so a request for an unserved shape fails loudly rather than hanging.
+ */
+export function createInterfaceArtifactSource(): ArtifactSource {
+  return {
+    async resolve(shape: CircuitShape): Promise<ArtifactSet> {
+      const key = armadaVariantKey(shape.nullifiers, shape.commitments)
+      const artifact = getArmadaArtifact(key)
+      if (!artifact || artifact.wasm === undefined || artifact.zkey === undefined || artifact.vkey === undefined) {
+        throw new Error(`sdk-prover: circuit ${key} not loaded — ensure artifacts are preloaded before proving`)
+      }
+      return {
+        wasm: artifact.wasm as Uint8Array,
+        zkey: artifact.zkey as Uint8Array,
+        vkey: artifact.vkey as object,
+      }
+    },
+  }
+}

--- a/apps/armada-interface/src/lib/railgun/sdk-read.ts
+++ b/apps/armada-interface/src/lib/railgun/sdk-read.ts
@@ -1,5 +1,5 @@
-// ABOUTME: The @armada/sdk shielded read path — a persistent IndexedDB-backed SDK instance that syncs the
-// ABOUTME: unlocked wallet and reports its 0zk address, USDC balance, yield-vault shares, and tx history.
+// ABOUTME: The persistent @armada/sdk instance — IndexedDB-backed, syncs the unlocked wallet and reports
+// ABOUTME: its 0zk address / balances / history (reads), and is write-capable (real prover + artifacts) for proving.
 
 import {
   createArmadaSdk,
@@ -7,29 +7,13 @@ import {
   getTokenDataERC20,
   getTokenDataHash,
   type ArmadaSdk,
-  type ProverAdapter,
-  type ArtifactSource,
   type HistoryEntry,
 } from '@armada/sdk'
 import { getCachedDeployments, getUsdcAddress, loadYieldDeployment } from '../../config/deployments'
 import { getNetworkConfig } from '../../config/network'
 import * as keyManager from './keyManager'
+import { createInterfaceArtifactSource, createInterfaceProver } from './sdk-prover'
 import { track } from '../telemetry'
-
-// Read-only: it only syncs + reads. Proving/artifacts are never exercised, so they throw if
-// something unexpectedly reaches the spend path — a loud signal rather than silent wrong behavior.
-const readOnlyProver: ProverAdapter = {
-  prove: async () => {
-    throw new Error('sdk-read: read-only read path does not prove')
-  },
-  verify: async () => false,
-  close: async () => {},
-}
-const readOnlyArtifacts: ArtifactSource = {
-  resolve: async () => {
-    throw new Error('sdk-read: read-only read path does not resolve artifacts')
-  },
-}
 
 /** The shielded yield-vault share token (ayUSDC), if a yield deployment exists. */
 async function vaultTokenAddress(): Promise<`0x${string}` | undefined> {
@@ -92,8 +76,8 @@ async function ensureInstance(): Promise<{ sdk: ArmadaSdk; wallet: ReadWallet; a
   const sdk = await createArmadaSdk({
     ...cfg,
     storage: new IndexedDBStorageAdapter(READ_DB_NAME),
-    prover: readOnlyProver,
-    artifacts: readOnlyArtifacts,
+    prover: createInterfaceProver(),
+    artifacts: createInterfaceArtifactSource(),
   })
   const wallet = await sdk.wallet.fromRootSecret(keyManager.getRootSecret(), {
     creationBlock: keyManager.getCreationBlock() ?? 0,


### PR DESCRIPTION
Foundational step for migrating the **proving** write paths (transfer/unshield/yield) onto `@armada/sdk`. Upgrades the persistent SDK instance from a throwing read-only prover to a real one, so it can generate ZK proofs — the base the upcoming transfer differential + cutover build on.

## What
- `sdk-prover.ts` (new):
  - `createInterfaceProver()` — the SDK's same-thread `createSnarkjsProver()` (snarkjs is already a direct interface dep). Correctness-first backend; the off-main-thread worker prover is a follow-on swap every flow inherits (single injected adapter).
  - `createInterfaceArtifactSource()` — an `ArtifactSource` bridging the SDK to the interface's in-memory circuit registry (`artifactGetter`, populated by the DEV loader + prod origin-preload). Resolves `(shape) → {wasm,zkey,vkey}`; throws loudly for an unserved shape.
- `artifactGetter.ts` — exposes `getArmadaArtifact(variant)` for the source.
- `sdk-read.ts` — the persistent instance now takes the real prover + artifact source instead of the throwing read-only stubs.

## Safe for the read path
Prover + artifact source only fire on `prove()`; sync/balances/history never call them (snarkjs lazy-loads on first prove, so construction stays cheap). Read-path test set green.

## Tests
`sdk-prover.test.ts` — the ArtifactSource maps a loaded circuit to `{wasm,zkey,vkey}` and throws for unloaded / wasm-less shapes. Full suite green: 151 files / 1123 tests. Nothing proves yet — this only makes the instance *capable*; first prover exercise is the transfer differential (next).

## Plan note (surfaced during this work)
The plan lists "transfer / unshield-local" together, but the SDK reality differs: **`planTransfer` supports shielded→shielded transfer today, but hardcodes `unshield: 0`** and accepts only `toRailgunAddress` outputs. The lower layers (witness/serialize/boundParams/`PlanSummary.unshield`) already support unshield — so exposing it is an SDK addition to `planTransfer`, not new crypto. **Revised order: transfer first (SDK-ready) → worker prover → then add SDK unshield → unshield-local → xchain-unshield → yield.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)