### PR TITLE
feat(interface): attach spend signer to the SDK instance (Phase B write-path, sub-step 1.5)

### DIFF
--- a/apps/armada-interface/src/lib/railgun/sdk-read.ts
+++ b/apps/armada-interface/src/lib/railgun/sdk-read.ts
@@ -4,6 +4,7 @@
 import {
   createArmadaSdk,
   IndexedDBStorageAdapter,
+  LocalSigner,
   getTokenDataERC20,
   getTokenDataHash,
   type ArmadaSdk,
@@ -79,8 +80,12 @@ async function ensureInstance(): Promise<{ sdk: ArmadaSdk; wallet: ReadWallet; a
     prover: createInterfaceProver(),
     artifacts: createInterfaceArtifactSource(),
   })
+  // Attach a spend signer so the instance is write-capable (planTransfer/prove) — not just view-only.
+  // Derived from the same in-memory rootSecret the viewing key comes from, so it adds no new secret
+  // exposure; it only signs during prove(). Reads never invoke it.
   const wallet = await sdk.wallet.fromRootSecret(keyManager.getRootSecret(), {
     creationBlock: keyManager.getCreationBlock() ?? 0,
+    signer: await LocalSigner.fromRootSecret(keyManager.getRootSecret()),
   })
   instance = { sdk, wallet, address: engineAddress }
   return instance


### PR DESCRIPTION
Completes the write-capable SDK instance from #443. That PR gave it a real prover + artifact source, but the wallet was still created **view-only** (`fromRootSecret` with no signer), so `wallet.planTransfer` / `wallet.prove` would throw `NoSpendCapabilityError`. This attaches a `LocalSigner`.

## What
- `sdk-read.ts` — the persistent wallet is created with `signer: await LocalSigner.fromRootSecret(rootSecret)`, so `canSpend` is true and the proving pipeline (`planTransfer → prove`) is reachable.

## Security
The signer is derived from the **same in-memory `rootSecret`** the viewing key already comes from — no new secret exposure. It only signs during `prove()`; reads never invoke it, and it's released on lock (instance close). Same spend-capability posture as the engine holds today.

## Tests
Read-path suite green (14 tests across sdk-read / sdk-prover / balance-sync / history-recovery). Nothing proves yet — this + #443 make the instance *capable*; the transfer builder + validation come next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)