### PR TITLE
feat(interface): transfer write-path differential (Phase B, sub-step 2)

### DIFF
--- a/apps/armada-interface/src/features/transfer-shielded/handler.ts
+++ b/apps/armada-interface/src/features/transfer-shielded/handler.ts
@@ -19,6 +19,7 @@ import {
   populateTransferTransaction,
   type BroadcasterFeeRecipient,
 } from '@/lib/railgun/transfer'
+import { runTransferDifferential, transferDifferentialEnabled } from '@/lib/railgun/transfer-differential'
 import { submitRelay } from '@/lib/relayer'
 import { handleRelaySubmitError } from '@/lib/tx/relaySubmit'
 import { advance, markFailed } from '@/lib/tx/reducer'
@@ -103,6 +104,23 @@ async function runBuildProof(
     broadcasterFee: broadcasterFeeFromRecord(record, tokenAddress),
     onProgress: progress.write,
   })
+
+  // Phase B write-path differential (opt-in, observe-only): build this transfer with @armada/sdk and
+  // simulate it against the pool — telemetry-reports whether the SDK proof verifies on-chain. Fire-and-
+  // forget; never blocks or fails the transfer (the engine proof above is what actually submits).
+  const evmFrom = record.walletContext.evmAddress
+  const poolAddress = deployments.hub.contracts.privacyPool
+  if (transferDifferentialEnabled() && evmFrom && poolAddress) {
+    const bf = broadcasterFeeFromRecord(record, tokenAddress)
+    void runTransferDifferential({
+      recipient: record.meta.recipient,
+      amount: record.meta.amount,
+      broadcasterFee: bf ? { amount: bf.amount, recipientAddress: bf.recipientAddress } : null,
+      poolAddress: poolAddress as `0x${string}`,
+      from: evmFrom as `0x${string}`,
+      chainId: deployments.hub.chainId,
+    })
+  }
 
   if (ctx.signal.aborted) throw new Error('cancelled')
 

--- a/apps/armada-interface/src/lib/railgun/sdk-read.ts
+++ b/apps/armada-interface/src/lib/railgun/sdk-read.ts
@@ -92,6 +92,14 @@ async function ensureInstance(): Promise<{ sdk: ArmadaSdk; wallet: ReadWallet; a
 }
 
 /**
+ * The persistent, write-capable SDK wallet for the unlocked identity (ensures the instance). Used by
+ * the write-path builders (`planTransfer` / `prove`). Reads use the sync helpers below.
+ */
+export async function getSdkWallet(): Promise<ReadWallet> {
+  return (await ensureInstance()).wallet
+}
+
+/**
  * Sync the wallet and emit a telemetry line so resume-vs-rescan is observable in the console. A low
  * `fromBlock` (≈ deploy block) means a cold rescan; a high one means it resumed from the IndexedDB
  * checkpoint. `scanned: false` = the head hadn't advanced, so no getLogs work was done.

--- a/apps/armada-interface/src/lib/railgun/transfer-differential.test.ts
+++ b/apps/armada-interface/src/lib/railgun/transfer-differential.test.ts
@@ -1,0 +1,53 @@
+// ABOUTME: Unit test for runTransferDifferential — build the SDK transfer, simulate it, and report
+// ABOUTME: sdk.transferDiff { simulated }; never throws into the caller (observe-only).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({ buildTransferSdk: vi.fn(), simulateOrThrow: vi.fn() }))
+vi.mock('./transfer-sdk', () => ({ buildTransferSdk: hoisted.buildTransferSdk }))
+vi.mock('@/lib/tx/simulate', () => ({ simulateOrThrow: hoisted.simulateOrThrow }))
+vi.mock('@/lib/telemetry', () => ({ track: vi.fn(), trackError: vi.fn() }))
+
+import { runTransferDifferential } from './transfer-differential'
+import { track, trackError } from '@/lib/telemetry'
+
+const inputs = {
+  recipient: '0zk_bob',
+  amount: 5n,
+  broadcasterFee: { amount: 2n, recipientAddress: '0zk_relayer' },
+  poolAddress: '0xpool000000000000000000000000000000000000' as const,
+  from: '0xuser000000000000000000000000000000000000' as const,
+  chainId: 31337,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hoisted.buildTransferSdk.mockResolvedValue({ to: inputs.poolAddress, data: '0xdead' })
+})
+
+describe('runTransferDifferential', () => {
+  it('reports simulated:true when the SDK calldata passes on-chain simulation', async () => {
+    hoisted.simulateOrThrow.mockResolvedValue(undefined)
+    await runTransferDifferential(inputs)
+    expect(hoisted.simulateOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({ to: inputs.poolAddress, data: '0xdead', account: inputs.from, chainId: 31337 }),
+    )
+    expect(track).toHaveBeenCalledWith('sdk.transferDiff', { simulated: true })
+  })
+
+  it('reports simulated:false + trackError when the contract rejects the SDK tx', async () => {
+    // WHY: the on-chain verifier is the arbiter — a revert means the SDK transfer is NOT valid, and
+    // must surface as a failed differential rather than a silent pass.
+    hoisted.simulateOrThrow.mockRejectedValue(new Error('execution reverted'))
+    await runTransferDifferential(inputs)
+    expect(track).toHaveBeenCalledWith('sdk.transferDiff', { simulated: false })
+    expect(trackError).toHaveBeenCalledWith('sdk.transferDiff.simulate', expect.any(Error), expect.any(Object))
+  })
+
+  it('never throws into the caller when the SDK build itself fails', async () => {
+    hoisted.buildTransferSdk.mockRejectedValue(new Error('plan/prove failed'))
+    await expect(runTransferDifferential(inputs)).resolves.toBeUndefined()
+    expect(trackError).toHaveBeenCalledWith('sdk.transferDiff.build', expect.any(Error), expect.any(Object))
+    expect(track).not.toHaveBeenCalled()
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/transfer-differential.ts
+++ b/apps/armada-interface/src/lib/railgun/transfer-differential.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Transfer write-path differential — builds the transfer via @armada/sdk and validates it by
+// ABOUTME: SIMULATING the calldata against the pool (the on-chain verifier is the arbiter). Observe-only: never submits.
+
+import { simulateOrThrow } from '@/lib/tx/simulate'
+import { track, trackError } from '@/lib/telemetry'
+import { buildTransferSdk, type SdkTransferInputs } from './transfer-sdk'
+
+/**
+ * Opt-in gate (`VITE_SHADOW_SDK=1`) — NOT dev-default, because the differential runs a full Groth16
+ * proof (a 20-30s same-thread block on top of the engine's own). You turn it on to validate, not for
+ * every dev transfer. Retired once the transfer cutover lands (and made cheap by the worker prover).
+ */
+export function transferDifferentialEnabled(): boolean {
+  return import.meta.env.VITE_SHADOW_SDK === '1'
+}
+
+/**
+ * Build the transfer with `@armada/sdk` (plan → prove → calldata) and validate it by `eth_call`-simulating
+ * the calldata against the PrivacyPool — if the contract accepts it, the SDK produced a valid, submittable
+ * transfer (proof + nullifiers + merkleRoot + boundParams all verify on-chain). A proof-carrying tx can't
+ * be byte-compared to the engine (random salts + non-deterministic proof + independent note selection), so
+ * simulation is the correctness signal.
+ *
+ * Observe-only: never submits — the engine's build/submit runs unchanged alongside this. Never throws into
+ * the caller; emits one `sdk.transferDiff { simulated }` line per invocation.
+ */
+export async function runTransferDifferential(
+  inputs: SdkTransferInputs & { readonly from: `0x${string}`; readonly chainId: number },
+): Promise<void> {
+  try {
+    const { to, data } = await buildTransferSdk(inputs)
+    try {
+      await simulateOrThrow({ to, data, value: 0n, account: inputs.from, chainId: inputs.chainId })
+      track('sdk.transferDiff', { simulated: true })
+    } catch (simErr) {
+      // The SDK built calldata but the contract rejected it — the load-bearing failure signal.
+      track('sdk.transferDiff', { simulated: false })
+      trackError('sdk.transferDiff.simulate', simErr, { scope: 'shielded.transfer', message: 'sdk transfer failed on-chain simulation' })
+    }
+  } catch (err) {
+    // The SDK build itself failed (plan/prove/artifacts) — never surfaced to the transfer flow.
+    trackError('sdk.transferDiff.build', err, { scope: 'shielded.transfer', message: 'sdk transfer build failed' })
+  }
+}

--- a/apps/armada-interface/src/lib/railgun/transfer-sdk.test.ts
+++ b/apps/armada-interface/src/lib/railgun/transfer-sdk.test.ts
@@ -1,0 +1,50 @@
+// ABOUTME: Unit test for buildTransferSdk — maps inputs into a planTransfer request (outputs + fee) and
+// ABOUTME: threads plan → prove → toTransactionData → buildTransactCalldata into the { to, data } result.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  planTransfer: vi.fn(),
+  prove: vi.fn(),
+  buildTransactCalldata: vi.fn(),
+}))
+vi.mock('@armada/sdk', () => ({ buildTransactCalldata: hoisted.buildTransactCalldata }))
+vi.mock('./sdk-read', () => ({
+  getSdkWallet: async () => ({ planTransfer: hoisted.planTransfer, prove: hoisted.prove }),
+}))
+
+import { buildTransferSdk } from './transfer-sdk'
+
+const POOL = '0xpool000000000000000000000000000000000000' as const
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hoisted.planTransfer.mockResolvedValue({ plan: true })
+  hoisted.prove.mockResolvedValue({ toTransactionData: () => ({ tx: 'data' }) })
+  hoisted.buildTransactCalldata.mockReturnValue({ to: POOL, data: '0xdeadbeef', value: 0n })
+})
+
+describe('buildTransferSdk', () => {
+  it('plans with the recipient output + broadcaster fee, then serializes the proved tx to { to, data }', async () => {
+    const r = await buildTransferSdk({
+      recipient: '0zk_bob',
+      amount: 5_000_000n,
+      broadcasterFee: { amount: 20_000n, recipientAddress: '0zk_relayer' },
+      poolAddress: POOL,
+    })
+    expect(hoisted.planTransfer).toHaveBeenCalledWith({
+      outputs: [{ to0zk: '0zk_bob', amount: 5_000_000n }],
+      fee: { schedule: { transfer: '20000' }, broadcasterRailgunAddress: '0zk_relayer', feesCacheId: '', expiresAt: 0 },
+    })
+    expect(hoisted.buildTransactCalldata).toHaveBeenCalledWith([{ tx: 'data' }], POOL)
+    expect(r).toEqual({ to: POOL, data: '0xdeadbeef' })
+  })
+
+  it('emits a zero fee (no broadcaster output) for direct submission', async () => {
+    await buildTransferSdk({ recipient: '0zk_bob', amount: 1n, broadcasterFee: null, poolAddress: POOL })
+    expect(hoisted.planTransfer).toHaveBeenCalledWith({
+      outputs: [{ to0zk: '0zk_bob', amount: 1n }],
+      fee: { schedule: { transfer: '0' }, broadcasterRailgunAddress: '', feesCacheId: '', expiresAt: 0 },
+    })
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/transfer-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/transfer-sdk.ts
@@ -1,0 +1,46 @@
+// ABOUTME: SDK-backed shielded-transfer builder — planTransfer → prove → toTransactionData → buildTransactCalldata,
+// ABOUTME: returning the raw { to, data } the handler submits. The @armada/sdk analogue of lib/railgun/transfer.ts.
+
+import { buildTransactCalldata } from '@armada/sdk'
+import { getSdkWallet } from './sdk-read'
+
+export interface SdkTransferInputs {
+  /** 0zk recipient of the transfer. */
+  readonly recipient: string
+  readonly amount: bigint
+  /** Broadcaster (relayer) fee note, or null for direct user submission (no fee output). */
+  readonly broadcasterFee: { readonly amount: bigint; readonly recipientAddress: string } | null
+  readonly poolAddress: `0x${string}`
+}
+
+/**
+ * Build a shielded-transfer transaction via `@armada/sdk`: the wallet plans the transfer over its
+ * spendable notes, proves it (Groth16), and the proved struct is serialized into `transact(...)`
+ * calldata. Returns `{ to, data }` (value is always 0 — a shielded tx carries no native value).
+ *
+ * Proving runs on the instance's prover (same-thread today; worker follow-on). The caller decides
+ * whether to submit the result or (differential) only simulate it.
+ */
+export async function buildTransferSdk(
+  inputs: SdkTransferInputs,
+): Promise<{ to: `0x${string}`; data: `0x${string}` }> {
+  const wallet = await getSdkWallet()
+  // planTransfer reads only `schedule.transfer` + `broadcasterRailgunAddress`; `feesCacheId`/`expiresAt`
+  // are part of the FeeQuote contract but unused here (the quote's staleness is the relayer's concern).
+  const fee = inputs.broadcasterFee
+    ? {
+        schedule: { transfer: inputs.broadcasterFee.amount.toString() },
+        broadcasterRailgunAddress: inputs.broadcasterFee.recipientAddress,
+        feesCacheId: '',
+        expiresAt: 0,
+      }
+    : { schedule: { transfer: '0' }, broadcasterRailgunAddress: '', feesCacheId: '', expiresAt: 0 }
+
+  const plan = await wallet.planTransfer({
+    outputs: [{ to0zk: inputs.recipient, amount: inputs.amount }],
+    fee,
+  })
+  const handle = await wallet.prove(plan)
+  const { to, data } = buildTransactCalldata([handle.toTransactionData()], inputs.poolAddress)
+  return { to, data }
+}

--- a/apps/armada-interface/src/lib/telemetry.ts
+++ b/apps/armada-interface/src/lib/telemetry.ts
@@ -51,6 +51,12 @@ export type EventRegistry = {
   // means it resumed from the IndexedDB checkpoint. `scanned` false = head hadn't advanced (no work).
   'sdk.sync':                 { fromBlock: number; syncedThrough: number; scanned: boolean }
 
+  // Transfer write-path differential (Phase B, opt-in) — one line per transfer when enabled: @armada/sdk
+  // builds the transfer (plan→prove→calldata) and we SIMULATE it against the pool. `simulated:true` = the
+  // on-chain verifier accepted the SDK proof + nullifiers + root (a proof-carrying tx can't be byte-compared
+  // to the engine). Observe-only — the SDK tx is simulated, never submitted.
+  'sdk.transferDiff':         { simulated: boolean }
+
   'tx.submitted':             { id: string; kind: TxKind }
   'tx.transition':            { id: string; kind: TxKind; from: TxStage; to: TxStage; executionState: TxRecord['executionState'] }
   'tx.failed':                { id: string; kind: TxKind; errorCode?: string }


### PR DESCRIPTION
First exercise of the write-capable SDK instance (#443/#444). Builds a shielded transfer via `@armada/sdk` and validates it by **simulating the calldata against the pool** — the on-chain verifier is the arbiter. Observe-only, opt-in; the engine still does the real build + submit.

## Why simulate, not byte-compare
A proof-carrying tx can't be byte-diffed against the engine (random output salts, non-deterministic Groth16 proof, independent note selection). So instead: build the SDK transfer, `eth_call`-simulate it — if the contract accepts it, the SDK's **proof + nullifiers + merkleRoot + boundParams** all verify on-chain. Stronger than an engine comparison, and immune to the randomness/selection mismatches. (Confirmed approach.)

## What
- `transfer-sdk.ts` — `buildTransferSdk()`: `wallet.planTransfer → prove → toTransactionData → buildTransactCalldata` → `{ to, data }`. The `@armada/sdk` analogue of `lib/railgun/transfer.ts`.
- `transfer-differential.ts` — `runTransferDifferential()`: build via SDK, simulate against the pool, emit `sdk.transferDiff { simulated }`. Never throws into the transfer flow; on build/simulate failure it `trackError`s.
- `sdk-read.ts` — `getSdkWallet()` exposes the (now write-capable) persistent wallet.
- Transfer handler — fires the differential (fire-and-forget) after the engine proof in `build-proof`.

## Gate: opt-in, not dev-default
`transferDifferentialEnabled()` = `VITE_SHADOW_SDK=1`. Deliberately NOT dev-default: it runs a full Groth16 proof (~20-30s same-thread block on top of the engine's own), so you turn it on to validate, not for every dev transfer. This is also why the **worker prover is the very next step** (per plan) — it makes proving cheap for the cutover.

## Default off — no behavior change
Flag unset → the transfer handler is unchanged. Suite green: 152 files / 1128 tests.

## Validate (`VITE_SHADOW_SDK=1`, real local transfer)
Do a shielded send and watch the console:
```
sdk.transferDiff simulated=true
```
`simulated:true` on a real transfer = the SDK builds a fully valid, on-chain-verifiable transfer — the green light for the cutover. (Expect a long freeze while both engine + SDK prove same-thread; the worker prover fixes that next.)

## Next
`simulated:true` in-browser → **worker prover** (off-main-thread, one adapter swap all flows inherit) → transfer cutover → delete engine transfer → then unshield (re-verify whether `PlanTransferRequest.unshield` is already wired) → xchain-unshield → yield.

🤖 Generated with [Claude Code](https://claude.com/claude-code)