### PR TITLE
feat(interface): off-main-thread Groth16 prover (Web Worker)

### DIFF
--- a/apps/armada-interface/src/lib/railgun/prover.worker.ts
+++ b/apps/armada-interface/src/lib/railgun/prover.worker.ts
@@ -1,0 +1,21 @@
+// ABOUTME: Web Worker entry for off-main-thread Groth16 proving — runs @armada/sdk's prover handler.
+// ABOUTME: snarkjs proves inside this worker; wasm/zkey arrive per prove request from the main thread.
+
+// Import from the LEAN `@armada/sdk/prover` subpath, NOT the root — the root is a 13MB wasm-inlined
+// bundle that would balloon the worker chunk and hang the build. This entry is prover + snarkjs only.
+import {
+  createProverWorkerHandler,
+  type ProverWorkerReply,
+  type ProverWorkerRequest,
+} from '@armada/sdk/prover'
+
+// Cast the worker global rather than pulling the `webworker` lib (it conflicts with the app's DOM lib).
+const ctx = self as unknown as {
+  postMessage: (reply: ProverWorkerReply) => void
+  onmessage: ((event: { data: ProverWorkerRequest }) => void) | null
+}
+
+const handle = createProverWorkerHandler((reply) => ctx.postMessage(reply))
+ctx.onmessage = (event) => {
+  void handle(event.data)
+}

--- a/apps/armada-interface/src/lib/railgun/sdk-prover.test.ts
+++ b/apps/armada-interface/src/lib/railgun/sdk-prover.test.ts
@@ -4,9 +4,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Artifact } from '@railgun-community/shared-models'
 
-// Stub the snarkjs prover so importing this module doesn't pull the proving stack into the test.
+// Stub the worker prover so importing this module doesn't pull the proving stack (or a Worker) into
+// the test. createInterfaceProver is lazy, so createWorkerProver isn't invoked until first prove().
 vi.mock('@armada/sdk', () => ({
-  createSnarkjsProver: () => ({ prove: async () => ({}), verify: async () => false, close: async () => {} }),
+  createWorkerProver: () => ({ prove: async () => ({}), verify: async () => false, close: async () => {} }),
 }))
 
 import { createInterfaceArtifactSource, createInterfaceProver } from './sdk-prover'

--- a/apps/armada-interface/src/lib/railgun/sdk-prover.ts
+++ b/apps/armada-interface/src/lib/railgun/sdk-prover.ts
@@ -2,21 +2,45 @@
 // ABOUTME: that resolves circuits from the interface's in-memory artifact registry (artifactGetter).
 
 import {
-  createSnarkjsProver,
+  createWorkerProver,
   type ArtifactSet,
   type ArtifactSource,
   type CircuitShape,
   type ProverAdapter,
+  type WorkerChannel,
 } from '@armada/sdk'
 import { armadaVariantKey, getArmadaArtifact } from './artifactGetter'
 
+/** A `WorkerChannel` over a browser Web Worker running the @armada/sdk prover handler. */
+function createProverWorkerChannel(): WorkerChannel {
+  const worker = new Worker(new URL('./prover.worker.ts', import.meta.url), { type: 'module' })
+  return {
+    post: (message) => worker.postMessage(message),
+    onMessage: (handler) => {
+      worker.onmessage = (event: MessageEvent) => handler(event.data)
+    },
+    terminate: () => worker.terminate(),
+  }
+}
+
 /**
- * Same-thread Groth16 prover (snarkjs). This is the correctness-first backend; the off-main-thread
- * worker prover (`createWorkerProver`) is a follow-on swap that every proving flow inherits, since the
- * prover is a single injected adapter on the SDK instance.
+ * Off-main-thread Groth16 prover — snarkjs runs in a Web Worker so proving never blocks the UI
+ * (replaces the engine's `yieldToPaint` main-thread block). The worker is created LAZILY on first
+ * prove, so read-only sessions (which never prove) don't spawn one. `close()` terminates it.
  */
 export function createInterfaceProver(): ProverAdapter {
-  return createSnarkjsProver()
+  let inner: ProverAdapter | undefined
+  const ensure = (): ProverAdapter => {
+    if (inner === undefined) inner = createWorkerProver(createProverWorkerChannel())
+    return inner
+  }
+  return {
+    prove: (input, artifacts, options) => ensure().prove(input, artifacts, options),
+    verify: (proof, signals, vkey) => ensure().verify(proof, signals, vkey),
+    close: async () => {
+      if (inner !== undefined) await inner.close()
+    },
+  }
 }
 
 /**

--- a/apps/armada-interface/vite.config.ts
+++ b/apps/armada-interface/vite.config.ts
@@ -272,6 +272,20 @@ export default defineConfig({
       },
     }),
   ],
+  worker: {
+    // The Groth16 prover Web Worker (lib/railgun/prover.worker.ts) runs snarkjs off the main thread.
+    // snarkjs needs the same wasm + Node-polyfill treatment as the main bundle. `plugins` is a factory
+    // (Vite instantiates fresh plugin instances per worker build); `format: 'es'` matches the module worker.
+    format: 'es',
+    plugins: () => [
+      wasm(),
+      topLevelAwait(),
+      nodePolyfills({
+        include: ['buffer', 'process', 'util', 'stream', 'events', 'assert', 'crypto'],
+        globals: { Buffer: true, global: true, process: true },
+      }),
+    ],
+  },
   build: {
     // Bump the browser baseline above Vite's default 'modules' target
     // (chrome87 / edge88 / firefox78 / safari14 — early 2020). The default trips

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#d09ef046c78bfed5dbe9d2e114969a3cf8b4bbf3",
+        "@armada/sdk": "github:ship-armada/armada-sdk#c0bf5cf844b497ac69e282e2ea847ef25922076f",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#d09ef046c78bfed5dbe9d2e114969a3cf8b4bbf3",
-      "integrity": "sha512-C5JmGH3P5UtWMAbb04EM4Kdc/kBS/fOjcjQwSD4yjF491Xr9BcFGGIIu7hvxDzROEZ+iYG1Trt7RCgLTcHAoCQ==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#c0bf5cf844b497ac69e282e2ea847ef25922076f",
+      "integrity": "sha512-P9LZ+bc1mYxGIeuWToajljzFILSlfAHFid8wbMSzWjGHjeJpYBcsJb4FZjuvki4vrIeN9y3mLx954P0Z++f5Ew==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#d09ef046c78bfed5dbe9d2e114969a3cf8b4bbf3",
+    "@armada/sdk": "github:ship-armada/armada-sdk#c0bf5cf844b497ac69e282e2ea847ef25922076f",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",


### PR DESCRIPTION
Moves ZK proving off the main thread. The persistent SDK instance's prover is now a Web Worker running `@armada/sdk`'s `createProverWorkerHandler` (snarkjs proves in the worker), replacing the same-thread `createSnarkjsProver` (and the engine's `yieldToPaint` main-thread block). One injected adapter → every proving flow (transfer, and the coming unshield/yield) inherits it.

## What
- `prover.worker.ts` — the Web Worker entry. Imports from the **lean `@armada/sdk/prover` subpath** (armada-sdk#51), NOT the root: the root is a 13MB wasm-inlined bundle that balloons the worker chunk and hangs the build. This entry is prover + snarkjs only.
- `sdk-prover.ts` — `createInterfaceProver()` now returns a **lazy** `createWorkerProver` over a `WorkerChannel` wrapping the worker. Lazy so read-only sessions (the default read path) never spawn a worker; it's created on first `prove()`, terminated on lock.
- `vite.config.ts` — a `worker` config mirroring the main bundle's `wasm() + topLevelAwait() + nodePolyfills()` (snarkjs needs them in the worker context too).
- Re-pin `@armada/sdk` → #51 (the lean `./prover` entry).

## Build validated (this was the risk)
Full production `vite build` passes. The `prover.worker` chunk is **3.0 KB** — snarkjs stays a lazy dynamic-import chunk, not bundled into the worker. The lean-entry fix was essential: importing the SDK root instead made the build hang indefinitely (>15 min); with `/prover` it's a 3KB chunk.

## Pre-existing build caveats (NOT introduced here)
The prod build needs a heap bump (`NODE_OPTIONS=--max-old-space-size=8192`) and is slow (~17 min), both dominated by minifying the **14MB wasm-inlined `@armada/sdk` main chunk** — which `main` already bundles (the SDK's been a dep since the read-path migration) and which the transform-phase OOM is dominated by (it fails before the 3KB worker chunk exists). This is the tracked **SDK bundle-size trim (~13MB)** item, not this PR. Flagging so CI/deploy sets the heap flag.

## Tests
Full suite green: 152 files / 1128 tests.

## Validate in-browser (`VITE_SHADOW_SDK=1`, dev server, real local transfer)
Same `sdk.transferDiff simulated=true` as before — but now **the UI should NOT freeze during proving** (it runs in the worker). That's the acceptance signal: off-thread proof + `simulated=true`.

## Next
Worker prover in place → **transfer cutover** (submit the SDK-built transfer, delete engine transfer) → then unshield (re-verify `PlanTransferRequest.unshield`) → xchain-unshield → yield, all off-thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)