### PR TITLE
feat(interface): transfer submission cutover to @armada/sdk (Phase B)

### DIFF
--- a/apps/armada-interface/src/features/transfer-shielded/handler.ts
+++ b/apps/armada-interface/src/features/transfer-shielded/handler.ts
@@ -20,6 +20,7 @@ import {
   type BroadcasterFeeRecipient,
 } from '@/lib/railgun/transfer'
 import { runTransferDifferential, transferDifferentialEnabled } from '@/lib/railgun/transfer-differential'
+import { buildTransferSdk, sdkTransferEnabled } from '@/lib/railgun/transfer-sdk'
 import { submitRelay } from '@/lib/relayer'
 import { handleRelaySubmitError } from '@/lib/tx/relaySubmit'
 import { advance, markFailed } from '@/lib/tx/reducer'
@@ -87,31 +88,50 @@ async function runBuildProof(
   if (!kmIsUnlocked()) {
     throw new Error('Private send requires an unlocked shielded wallet.')
   }
-  const walletId = kmGetWalletId()
-  const encryptionKey = kmGetSdkEncryptionKey()
   const deployments = await loadDeployments()
   const tokenAddress = deployments.hub.cctp.usdc
+  const bf = broadcasterFeeFromRecord(record, tokenAddress)
 
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   const progress = createProofProgressWriter(record, ctx.signal)
+
+  if (sdkTransferEnabled()) {
+    // @armada/sdk cutover: build (plan → prove off-thread → serialize) the transact calldata now and
+    // stash it, so submit-relayer dispatches it without re-proving — and, unlike the engine's in-memory
+    // proof cache, it survives a reload (persisted in the record).
+    const { to, data } = await buildTransferSdk({
+      recipient: record.meta.recipient,
+      amount: record.meta.amount,
+      broadcasterFee: bf ? { amount: bf.amount, recipientAddress: bf.recipientAddress } : null,
+      poolAddress: deployments.hub.contracts.privacyPool as `0x${string}`,
+      onProgress: progress.write,
+    })
+    if (ctx.signal.aborted) throw new Error('cancelled')
+    await ctx.upsert(advance(progress.latest(), 'submit-relayer', { transferTx: { to, data, value: '0' } }))
+    return
+  }
+
+  // Engine path (default).
+  const walletId = kmGetWalletId()
+  const encryptionKey = kmGetSdkEncryptionKey()
   await generateTransferProofForRecipient({
     walletId,
     encryptionKey,
     tokenAddress,
     recipient: record.meta.recipient,
     amount: record.meta.amount,
-    broadcasterFee: broadcasterFeeFromRecord(record, tokenAddress),
+    broadcasterFee: bf,
     onProgress: progress.write,
   })
 
-  // Phase B write-path differential (opt-in, observe-only): build this transfer with @armada/sdk and
-  // simulate it against the pool — telemetry-reports whether the SDK proof verifies on-chain. Fire-and-
-  // forget; never blocks or fails the transfer (the engine proof above is what actually submits).
+  // Pre-cutover differential (opt-in, observe-only): build this transfer with @armada/sdk and simulate
+  // it against the pool — telemetry-reports whether the SDK proof verifies on-chain. Fire-and-forget;
+  // never blocks or fails the transfer (the engine proof above is what submits). Moot once the SDK path
+  // is primary above.
   const evmFrom = record.walletContext.evmAddress
   const poolAddress = deployments.hub.contracts.privacyPool
   if (transferDifferentialEnabled() && evmFrom && poolAddress) {
-    const bf = broadcasterFeeFromRecord(record, tokenAddress)
     void runTransferDifferential({
       recipient: record.meta.recipient,
       amount: record.meta.amount,
@@ -143,17 +163,24 @@ async function runSubmitAndConfirm(
   // anyway — the SDK's in-memory proof cache doesn't survive a reload. (P0-1)
   let populated: Awaited<ReturnType<typeof populateTransferTransaction>> | undefined
   if (!existingHash) {
-    const walletId = kmGetWalletId()
-    const deployments = await loadDeployments()
-    const tokenAddress = deployments.hub.cctp.usdc
-    populated = await populateTransferTransaction({
-      walletId,
-      tokenAddress,
-      recipient: record.meta.recipient,
-      amount: record.meta.amount,
-      broadcasterFee: broadcasterFeeFromRecord(record, tokenAddress),
-    })
-    if (ctx.signal.aborted) throw new Error('cancelled')
+    const stashed = record.artifacts.transferTx
+    if (stashed) {
+      // SDK cutover: the transact calldata was built + persisted in build-proof, so it survives a
+      // reload (the engine's in-memory proof cache does not). Dispatch it directly.
+      populated = { to: stashed.to, data: stashed.data, value: BigInt(stashed.value) }
+    } else {
+      const walletId = kmGetWalletId()
+      const deployments = await loadDeployments()
+      const tokenAddress = deployments.hub.cctp.usdc
+      populated = await populateTransferTransaction({
+        walletId,
+        tokenAddress,
+        recipient: record.meta.recipient,
+        amount: record.meta.amount,
+        broadcasterFee: broadcasterFeeFromRecord(record, tokenAddress),
+      })
+      if (ctx.signal.aborted) throw new Error('cancelled')
+    }
   }
 
   // A6 wallet-override path — submit through the user's EVM wallet instead of the relayer.

--- a/apps/armada-interface/src/lib/railgun/transfer-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/transfer-sdk.ts
@@ -11,6 +11,16 @@ export interface SdkTransferInputs {
   /** Broadcaster (relayer) fee note, or null for direct user submission (no fee output). */
   readonly broadcasterFee: { readonly amount: bigint; readonly recipientAddress: string } | null
   readonly poolAddress: `0x${string}`
+  /** ZK-proof progress (0–1); the worker prover emits coarse start/end phases. */
+  readonly onProgress?: (fraction: number) => void
+}
+
+/**
+ * Write-path cutover flag. When set, the transfer handler builds + submits the transfer via
+ * `@armada/sdk` (`buildTransferSdk`) instead of the stock engine. Off by default; the engine drives.
+ */
+export function sdkTransferEnabled(): boolean {
+  return import.meta.env.VITE_SDK_TRANSFER === '1'
 }
 
 /**
@@ -40,7 +50,10 @@ export async function buildTransferSdk(
     outputs: [{ to0zk: inputs.recipient, amount: inputs.amount }],
     fee,
   })
-  const handle = await wallet.prove(plan)
+  const handle = await wallet.prove(
+    plan,
+    inputs.onProgress ? { onProgress: (p) => inputs.onProgress?.(p.fraction) } : undefined,
+  )
   const { to, data } = buildTransactCalldata([handle.toTransactionData()], inputs.poolAddress)
   return { to, data }
 }

--- a/apps/armada-interface/src/lib/tx/types.ts
+++ b/apps/armada-interface/src/lib/tx/types.ts
@@ -532,12 +532,27 @@ export interface ArtifactsShieldXchain extends ArtifactsXchain {
   approveSkipped?: boolean
 }
 
+export interface ArtifactsTransfer extends ArtifactsCommon {
+  /**
+   * The shielded-transfer `transact()` calldata built during build-proof (@armada/sdk plan → prove →
+   * serialize), so submit-relayer dispatches it without re-running the ~20-30s proof. Unlike the
+   * engine's in-memory proof cache (which a reload wipes), this survives a reload — it's persisted in
+   * the record. `value` is '0' (a shielded tx carries no native value); stringified for IDB.
+   */
+  transferTx?: {
+    to: `0x${string}`
+    data: `0x${string}`
+    value: string
+  }
+}
+
 export type ArtifactsFor<K extends TxKind> =
   K extends 'unshield-xchain' ? ArtifactsXchain
   : K extends 'shield' ? ArtifactsShield
   : K extends 'shield-xchain' ? ArtifactsShieldXchain
   : K extends 'yield-deposit' ? ArtifactsYield
   : K extends 'yield-withdraw' ? ArtifactsYield
+  : K extends 'transfer-shielded' ? ArtifactsTransfer
   : ArtifactsCommon
 
 /* Ownership / session context — captured at submit. Required for history


### PR DESCRIPTION
Cuts the shielded-transfer over to `@armada/sdk` behind `VITE_SDK_TRANSFER=1`, else the stock engine (default). Follows the validated transfer differential (`simulated:true`) + the off-thread worker prover.

## What
- **`build-proof`** — under the flag, `buildTransferSdk` (plan → prove off-thread → serialize) produces the `transact()` calldata and stashes it in `artifacts.transferTx`. Else the engine `generateTransferProof` + the observe-only differential (as before).
- **`submit-relayer`** — when `artifacts.transferTx` is present, it's dispatched directly (relayer or wallet-override path); else the engine's `populateProvedTransfer`.
- `ArtifactsTransfer.transferTx` added (mirrors `ArtifactsXchain.unshieldTx`).
- `sdkTransferEnabled()` flag + proof-progress threaded into `buildTransferSdk` (`wallet.prove(plan, { onProgress })`).

## Bonus: fixes a resume fragility
The engine path carries the proof in an **in-memory cache** that a reload wipes (the P0-1 note: re-populate on resume "would throw anyway"). The SDK path **persists the built calldata in the record**, so a resume after reload dispatches it correctly instead of failing.

## Default off — no behavior change
Flag unset → engine builds + submits, exactly as before. Suite green: 152 files / 1128 tests.

## Validate (`VITE_SDK_TRANSFER=1`, real local shielded send)
1. **Relayer path** — send lands, recipient balance updates, your balance decrements.
2. **Wallet-override path** — same via direct submit.
3. Proving runs **off-thread** (no UI freeze — the worker prover).
4. Bonus: mid-flight reload before submit → resume dispatches the stashed tx (doesn't fail INTERRUPTED).

## Next
Validate → flip `VITE_SDK_TRANSFER` default on → delete the engine transfer builder (`lib/railgun/transfer.ts`) + the differential — the first *proving* write-path Railgun reduction. Then unshield (re-verify `PlanTransferRequest.unshield`), xchain-unshield, yield.

🤖 Generated with [Claude Code](https://claude.com/claude-code)