### PR TITLE
feat(interface): default transfer to @armada/sdk (Phase B)

### DIFF
--- a/apps/armada-interface/src/lib/railgun/transfer-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/transfer-sdk.ts
@@ -16,11 +16,12 @@ export interface SdkTransferInputs {
 }
 
 /**
- * Write-path cutover flag. When set, the transfer handler builds + submits the transfer via
- * `@armada/sdk` (`buildTransferSdk`) instead of the stock engine. Off by default; the engine drives.
+ * Write-path cutover flag. The transfer handler builds + submits via `@armada/sdk` (`buildTransferSdk`)
+ * by default; set `VITE_SDK_TRANSFER=0` to fall back to the stock engine (escape hatch, retained until
+ * the engine transfer builder is deleted).
  */
 export function sdkTransferEnabled(): boolean {
-  return import.meta.env.VITE_SDK_TRANSFER === '1'
+  return import.meta.env.VITE_SDK_TRANSFER !== '0'
 }
 
 /**


### PR DESCRIPTION
Flips `VITE_SDK_TRANSFER` from opt-in to opt-out: **shielded transfers now build + submit via `@armada/sdk` by default.** The stock engine remains reachable via `VITE_SDK_TRANSFER=0` (escape hatch, until the engine transfer builder is deleted next).

Validated in-browser under the explicit flag in #447 (relayer + wallet-override paths land, off-thread proving, resume). This makes that the default.

## Change
One line: `sdkTransferEnabled()` `=== '1'` → `!== '0'`.

## Tests unaffected
The transfer handler test (`handler.chainpin.test.ts`) starts at `submit-relayer` with no `transferTx` in artifacts, so it never reads the flag (build-proof) and falls through to the engine `populateProvedTransfer` path — unchanged. Suite green: 152 files / 1128 tests.

## Validate the default build, then deletion
Run with **no** `VITE_SDK_TRANSFER` set (default) and confirm a shielded send still lands + updates balance. Then the next PR deletes the engine transfer builder (`lib/railgun/transfer.ts`) + the differential + the flag — the first *proving* write-path Railgun reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)