### PR TITLE
feat(interface): unshield-local write-path differential (@armada/sdk)

### DIFF
--- a/apps/armada-interface/src/features/unshield/handler.ts
+++ b/apps/armada-interface/src/features/unshield/handler.ts
@@ -19,6 +19,7 @@ import {
   populateUnshieldTransaction,
   type BroadcasterFeeRecipient,
 } from '@/lib/railgun/unshield'
+import { runUnshieldDifferential, unshieldDifferentialEnabled } from '@/lib/railgun/unshield-differential'
 import { submitRelay } from '@/lib/relayer'
 import { handleRelaySubmitError } from '@/lib/tx/relaySubmit'
 import { advance, markFailed } from '@/lib/tx/reducer'
@@ -118,6 +119,23 @@ async function runBuildProof(
     broadcasterFee: broadcasterFeeFromRecord(record, tokenAddress),
     onProgress: progress.write,
   })
+
+  // Phase B write-path differential (opt-in, observe-only): build this unshield with @armada/sdk and
+  // simulate it against the pool — telemetry-reports whether the SDK proof verifies on-chain. Fire-and-
+  // forget; never blocks or fails the unshield (the engine proof above is what actually submits).
+  const evmFrom = record.walletContext.evmAddress
+  const poolAddress = deployments.hub.contracts.privacyPool
+  if (unshieldDifferentialEnabled() && evmFrom && poolAddress) {
+    const bf = broadcasterFeeFromRecord(record, tokenAddress)
+    void runUnshieldDifferential({
+      recipient: record.meta.recipient as `0x${string}`,
+      amount: record.meta.amount,
+      broadcasterFee: bf ? { amount: bf.amount, recipientAddress: bf.recipientAddress } : null,
+      poolAddress: poolAddress as `0x${string}`,
+      from: evmFrom as `0x${string}`,
+      chainId: deployments.hub.chainId,
+    })
+  }
 
   if (ctx.signal.aborted) throw new Error('cancelled')
 

--- a/apps/armada-interface/src/lib/railgun/unshield-differential.test.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield-differential.test.ts
@@ -1,0 +1,53 @@
+// ABOUTME: Unit test for runUnshieldDifferential — build the SDK unshield, simulate it, and report
+// ABOUTME: sdk.unshieldDiff { simulated }; never throws into the caller (observe-only).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({ buildUnshieldSdk: vi.fn(), simulateOrThrow: vi.fn() }))
+vi.mock('./unshield-sdk', () => ({ buildUnshieldSdk: hoisted.buildUnshieldSdk }))
+vi.mock('@/lib/tx/simulate', () => ({ simulateOrThrow: hoisted.simulateOrThrow }))
+vi.mock('@/lib/telemetry', () => ({ track: vi.fn(), trackError: vi.fn() }))
+
+import { runUnshieldDifferential } from './unshield-differential'
+import { track, trackError } from '@/lib/telemetry'
+
+const inputs = {
+  recipient: '0xbob0000000000000000000000000000000000000' as const,
+  amount: 5n,
+  broadcasterFee: { amount: 2n, recipientAddress: '0zk_relayer' },
+  poolAddress: '0xpool000000000000000000000000000000000000' as const,
+  from: '0xuser000000000000000000000000000000000000' as const,
+  chainId: 31337,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hoisted.buildUnshieldSdk.mockResolvedValue({ to: inputs.poolAddress, data: '0xdead' })
+})
+
+describe('runUnshieldDifferential', () => {
+  it('reports simulated:true when the SDK calldata passes on-chain simulation', async () => {
+    hoisted.simulateOrThrow.mockResolvedValue(undefined)
+    await runUnshieldDifferential(inputs)
+    expect(hoisted.simulateOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({ to: inputs.poolAddress, data: '0xdead', account: inputs.from, chainId: 31337 }),
+    )
+    expect(track).toHaveBeenCalledWith('sdk.unshieldDiff', { simulated: true })
+  })
+
+  it('reports simulated:false + trackError when the contract rejects the SDK tx', async () => {
+    // WHY: the on-chain verifier is the arbiter — a revert means the SDK unshield is NOT valid, and
+    // must surface as a failed differential rather than a silent pass.
+    hoisted.simulateOrThrow.mockRejectedValue(new Error('execution reverted'))
+    await runUnshieldDifferential(inputs)
+    expect(track).toHaveBeenCalledWith('sdk.unshieldDiff', { simulated: false })
+    expect(trackError).toHaveBeenCalledWith('sdk.unshieldDiff.simulate', expect.any(Error), expect.any(Object))
+  })
+
+  it('never throws into the caller when the SDK build itself fails', async () => {
+    hoisted.buildUnshieldSdk.mockRejectedValue(new Error('plan/prove failed'))
+    await expect(runUnshieldDifferential(inputs)).resolves.toBeUndefined()
+    expect(trackError).toHaveBeenCalledWith('sdk.unshieldDiff.build', expect.any(Error), expect.any(Object))
+    expect(track).not.toHaveBeenCalled()
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/unshield-differential.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield-differential.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Unshield write-path differential — builds the unshield via @armada/sdk and validates it by
+// ABOUTME: SIMULATING the calldata against the pool (the on-chain verifier is the arbiter). Observe-only: never submits.
+
+import { simulateOrThrow } from '@/lib/tx/simulate'
+import { track, trackError } from '@/lib/telemetry'
+import { buildUnshieldSdk, type SdkUnshieldInputs } from './unshield-sdk'
+
+/**
+ * Opt-in gate (`VITE_SHADOW_SDK=1`) — NOT dev-default, because the differential runs a full Groth16
+ * proof on top of the engine's own. You turn it on to validate, not for every dev unshield. Retired
+ * once the unshield cutover lands.
+ */
+export function unshieldDifferentialEnabled(): boolean {
+  return import.meta.env.VITE_SHADOW_SDK === '1'
+}
+
+/**
+ * Build the unshield with `@armada/sdk` (plan → prove → calldata) and validate it by `eth_call`-simulating
+ * the calldata against the PrivacyPool — if the contract accepts it, the SDK produced a valid, submittable
+ * unshield (proof + nullifiers + merkleRoot + boundParams + unshield preimage all verify on-chain). A
+ * proof-carrying tx can't be byte-compared to the engine (random salts + non-deterministic proof +
+ * independent note selection), so simulation is the correctness signal.
+ *
+ * Observe-only: never submits — the engine's build/submit runs unchanged alongside this. Never throws into
+ * the caller; emits one `sdk.unshieldDiff { simulated }` line per invocation.
+ */
+export async function runUnshieldDifferential(
+  inputs: SdkUnshieldInputs & { readonly from: `0x${string}`; readonly chainId: number },
+): Promise<void> {
+  try {
+    const { to, data } = await buildUnshieldSdk(inputs)
+    try {
+      await simulateOrThrow({ to, data, value: 0n, account: inputs.from, chainId: inputs.chainId })
+      track('sdk.unshieldDiff', { simulated: true })
+    } catch (simErr) {
+      // The SDK built calldata but the contract rejected it — the load-bearing failure signal.
+      track('sdk.unshieldDiff', { simulated: false })
+      trackError('sdk.unshieldDiff.simulate', simErr, { scope: 'shielded.unshield', message: 'sdk unshield failed on-chain simulation' })
+    }
+  } catch (err) {
+    // The SDK build itself failed (plan/prove/artifacts) — never surfaced to the unshield flow.
+    trackError('sdk.unshieldDiff.build', err, { scope: 'shielded.unshield', message: 'sdk unshield build failed' })
+  }
+}

--- a/apps/armada-interface/src/lib/railgun/unshield-sdk.test.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield-sdk.test.ts
@@ -1,0 +1,53 @@
+// ABOUTME: Unit test for buildUnshieldSdk — maps inputs into a planTransfer request (unshield + fee, no
+// ABOUTME: shielded outputs) and threads plan → prove → toTransactionData → buildTransactCalldata into { to, data }.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  planTransfer: vi.fn(),
+  prove: vi.fn(),
+  buildTransactCalldata: vi.fn(),
+}))
+vi.mock('@armada/sdk', () => ({ buildTransactCalldata: hoisted.buildTransactCalldata }))
+vi.mock('./sdk-read', () => ({
+  getSdkWallet: async () => ({ planTransfer: hoisted.planTransfer, prove: hoisted.prove }),
+}))
+
+import { buildUnshieldSdk } from './unshield-sdk'
+
+const POOL = '0xpool000000000000000000000000000000000000' as const
+const RECIPIENT = '0xbob0000000000000000000000000000000000000' as const
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hoisted.planTransfer.mockResolvedValue({ plan: true })
+  hoisted.prove.mockResolvedValue({ toTransactionData: () => ({ tx: 'data' }) })
+  hoisted.buildTransactCalldata.mockReturnValue({ to: POOL, data: '0xdeadbeef', value: 0n })
+})
+
+describe('buildUnshieldSdk', () => {
+  it('plans the unshield (recipient EVM addr) + broadcaster fee, no shielded outputs, then serializes to { to, data }', async () => {
+    const r = await buildUnshieldSdk({
+      recipient: RECIPIENT,
+      amount: 5_000_000n,
+      broadcasterFee: { amount: 20_000n, recipientAddress: '0zk_relayer' },
+      poolAddress: POOL,
+    })
+    expect(hoisted.planTransfer).toHaveBeenCalledWith({
+      outputs: [],
+      unshield: { recipient: RECIPIENT, amount: 5_000_000n },
+      fee: { schedule: { transfer: '20000' }, broadcasterRailgunAddress: '0zk_relayer', feesCacheId: '', expiresAt: 0 },
+    })
+    expect(hoisted.buildTransactCalldata).toHaveBeenCalledWith([{ tx: 'data' }], POOL)
+    expect(r).toEqual({ to: POOL, data: '0xdeadbeef' })
+  })
+
+  it('emits a zero fee (no broadcaster output) for direct submission', async () => {
+    await buildUnshieldSdk({ recipient: RECIPIENT, amount: 1n, broadcasterFee: null, poolAddress: POOL })
+    expect(hoisted.planTransfer).toHaveBeenCalledWith({
+      outputs: [],
+      unshield: { recipient: RECIPIENT, amount: 1n },
+      fee: { schedule: { transfer: '0' }, broadcasterRailgunAddress: '', feesCacheId: '', expiresAt: 0 },
+    })
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/unshield-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield-sdk.ts
@@ -1,0 +1,55 @@
+// ABOUTME: SDK-backed unshield builder — planTransfer(unshield) → prove → toTransactionData → buildTransactCalldata,
+// ABOUTME: returning the raw { to, data } the handler submits. The @armada/sdk analogue of lib/railgun/unshield.ts.
+
+import { buildTransactCalldata } from '@armada/sdk'
+import { getSdkWallet } from './sdk-read'
+
+export interface SdkUnshieldInputs {
+  /** EVM recipient of the unshielded USDC — funds leave the pool to this address. */
+  readonly recipient: `0x${string}`
+  readonly amount: bigint
+  /** Broadcaster (relayer) fee note, or null for direct user submission (no fee output). */
+  readonly broadcasterFee: { readonly amount: bigint; readonly recipientAddress: string } | null
+  readonly poolAddress: `0x${string}`
+  /** ZK-proof progress (0–1); the worker prover emits coarse start/end phases. */
+  readonly onProgress?: (fraction: number) => void
+}
+
+/**
+ * Build an unshield transaction via `@armada/sdk`: the wallet plans a transfer whose only public
+ * output is the unshield (recipient EVM address, no shielded outputs), proves it (Groth16), and the
+ * proved struct is serialized into `transact(...)` calldata. Returns `{ to, data }` (value is always
+ * 0 — a shielded tx carries no native value; the USDC is paid out from the pool).
+ *
+ * The unshield is modelled inside `planTransfer` as `{ recipient, amount }` — the last output
+ * commitment (a public `UnshieldNoteERC20`, npk = recipient), which the contract pays out on. No
+ * shielded recipients, so `outputs` is empty; the broadcaster fee (when present) is the only shielded
+ * output. Proving runs on the instance's worker prover.
+ */
+export async function buildUnshieldSdk(
+  inputs: SdkUnshieldInputs,
+): Promise<{ to: `0x${string}`; data: `0x${string}` }> {
+  const wallet = await getSdkWallet()
+  // planTransfer reads only `schedule.transfer` + `broadcasterRailgunAddress`; `feesCacheId`/`expiresAt`
+  // are part of the FeeQuote contract but unused here (the quote's staleness is the relayer's concern).
+  const fee = inputs.broadcasterFee
+    ? {
+        schedule: { transfer: inputs.broadcasterFee.amount.toString() },
+        broadcasterRailgunAddress: inputs.broadcasterFee.recipientAddress,
+        feesCacheId: '',
+        expiresAt: 0,
+      }
+    : { schedule: { transfer: '0' }, broadcasterRailgunAddress: '', feesCacheId: '', expiresAt: 0 }
+
+  const plan = await wallet.planTransfer({
+    outputs: [],
+    unshield: { recipient: inputs.recipient, amount: inputs.amount },
+    fee,
+  })
+  const handle = await wallet.prove(
+    plan,
+    inputs.onProgress ? { onProgress: (p) => inputs.onProgress?.(p.fraction) } : undefined,
+  )
+  const { to, data } = buildTransactCalldata([handle.toTransactionData()], inputs.poolAddress)
+  return { to, data }
+}

--- a/apps/armada-interface/src/lib/telemetry.ts
+++ b/apps/armada-interface/src/lib/telemetry.ts
@@ -51,6 +51,12 @@ export type EventRegistry = {
   // means it resumed from the IndexedDB checkpoint. `scanned` false = head hadn't advanced (no work).
   'sdk.sync':                 { fromBlock: number; syncedThrough: number; scanned: boolean }
 
+  // @armada/sdk write-path differential — one line per SDK unshield build+simulate (opt-in
+  // VITE_SHADOW_SDK). `simulated` true = the pool's on-chain verifier accepted the SDK-built
+  // calldata (the arbiter, since a proof-carrying tx can't be byte-compared to the engine's).
+  // Observe-only: the engine still submits. Retired at the unshield cutover.
+  'sdk.unshieldDiff':         { simulated: boolean }
+
   'tx.submitted':             { id: string; kind: TxKind }
   'tx.transition':            { id: string; kind: TxKind; from: TxStage; to: TxStage; executionState: TxRecord['executionState'] }
   'tx.failed':                { id: string; kind: TxKind; errorCode?: string }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#c0bf5cf844b497ac69e282e2ea847ef25922076f",
+        "@armada/sdk": "github:ship-armada/armada-sdk#78c883c88f1cc1c824f18d2fe59e7360a1388348",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#c0bf5cf844b497ac69e282e2ea847ef25922076f",
-      "integrity": "sha512-P9LZ+bc1mYxGIeuWToajljzFILSlfAHFid8wbMSzWjGHjeJpYBcsJb4FZjuvki4vrIeN9y3mLx954P0Z++f5Ew==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#78c883c88f1cc1c824f18d2fe59e7360a1388348",
+      "integrity": "sha512-KgHsPFN7aPLiA0cXa6zY35OUXv6SRxxTKmghI+UROjPHAppad6vq6pO/mr49PI2JRZ1fZtBoIgr1WvzLc24b/A==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#c0bf5cf844b497ac69e282e2ea847ef25922076f",
+    "@armada/sdk": "github:ship-armada/armada-sdk#78c883c88f1cc1c824f18d2fe59e7360a1388348",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",


### PR DESCRIPTION
Phase B, unshield-local. Builds the same-chain unshield via `@armada/sdk` and validates it by **on-chain simulation** — the migration playbook proven for transfer (#449). Observe-only: the stock engine still builds + submits; this runs alongside and reports whether the SDK-built proof verifies on-chain.

## What
- **`lib/railgun/unshield-sdk.ts`** — `buildUnshieldSdk`: `getSdkWallet().planTransfer({ outputs: [], unshield: { recipient, amount }, fee })` → `prove` (worker prover) → `buildTransactCalldata([handle.toTransactionData()], pool)` → `{ to, data }`. The unshield is the last (public) output commitment; no shielded recipients, so `outputs` is empty and the broadcaster fee is the only shielded output.
- **`lib/railgun/unshield-differential.ts`** — `runUnshieldDifferential`: build via SDK, then `simulateOrThrow` the calldata against the PrivacyPool. A proof-carrying tx can't be byte-compared (random salts, non-deterministic proof, independent note selection), so the pool's verifier is the arbiter. Never throws into the caller.
- **`features/unshield/handler.ts`** — fire-and-forget after the engine proof, gated on `VITE_SHADOW_SDK=1`.
- **`lib/telemetry.ts`** — registers `sdk.unshieldDiff { simulated }`.
- Re-pins `@armada/sdk` to `78c883c` (armada-sdk#52 — unshield in `planTransfer`/`witness`/`prove`).

## Testing
- New unit tests (5): `unshield-sdk.test.ts` (planTransfer request mapping, zero-fee direct path) + `unshield-differential.test.ts` (simulated true/false + never-throws). Mirror the transfer differential's tests.
- Interface typecheck clean.
- **Runtime validation (Butters):** run the local stack, set `VITE_SHADOW_SDK=1`, do a same-chain unshield, and grep the console for `sdk.unshieldDiff` — expect `{ simulated: true }`. `{ simulated: false }` (paired with an `sdk.unshieldDiff.simulate` error) means the SDK proof was rejected on-chain and the cutover must not proceed.

Next slice (after this validates): submission cutover behind a flag → default-on → delete the engine unshield builder.