### PR TITLE
feat(interface): unshield-local submission cutover to @armada/sdk (VITE_SDK_UNSHIELD)

### DIFF
--- a/apps/armada-interface/src/features/unshield/handler.ts
+++ b/apps/armada-interface/src/features/unshield/handler.ts
@@ -20,6 +20,7 @@ import {
   type BroadcasterFeeRecipient,
 } from '@/lib/railgun/unshield'
 import { runUnshieldDifferential, unshieldDifferentialEnabled } from '@/lib/railgun/unshield-differential'
+import { buildUnshieldSdk, sdkUnshieldEnabled } from '@/lib/railgun/unshield-sdk'
 import { submitRelay } from '@/lib/relayer'
 import { handleRelaySubmitError } from '@/lib/tx/relaySubmit'
 import { advance, markFailed } from '@/lib/tx/reducer'
@@ -100,14 +101,33 @@ async function runBuildProof(
   if (!kmIsUnlocked()) {
     throw new Error('Unshield requires an unlocked shielded wallet.')
   }
-  const walletId = kmGetWalletId()
-  const encryptionKey = kmGetSdkEncryptionKey()
   const deployments = await loadDeployments()
   const tokenAddress = deployments.hub.cctp.usdc
+  const bf = broadcasterFeeFromRecord(record, tokenAddress)
 
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   const progress = createProofProgressWriter(record, ctx.signal)
+
+  if (sdkUnshieldEnabled()) {
+    // @armada/sdk cutover: build (plan → prove off-thread → serialize) the transact calldata now and
+    // stash it, so submit-relayer dispatches it without re-proving — and, unlike the engine's in-memory
+    // proof cache, it survives a reload (persisted in the record).
+    const { to, data } = await buildUnshieldSdk({
+      recipient: record.meta.recipient as `0x${string}`,
+      amount: record.meta.amount,
+      broadcasterFee: bf ? { amount: bf.amount, recipientAddress: bf.recipientAddress } : null,
+      poolAddress: deployments.hub.contracts.privacyPool as `0x${string}`,
+      onProgress: progress.write,
+    })
+    if (ctx.signal.aborted) throw new Error('cancelled')
+    await ctx.upsert(advance(progress.latest(), 'submit-relayer', { unshieldTx: { to, data, value: '0' } }))
+    return
+  }
+
+  // Engine path (default).
+  const walletId = kmGetWalletId()
+  const encryptionKey = kmGetSdkEncryptionKey()
   await generateUnshieldProofForRecipient({
     walletId,
     encryptionKey,
@@ -116,17 +136,17 @@ async function runBuildProof(
     amount: record.meta.amount,
     // A6: null when wallet-override is set → SDK builds a proof without a broadcaster output
     // (sendWithPublicWallet=true on the SDK side, no extra unshield commitment to the relayer).
-    broadcasterFee: broadcasterFeeFromRecord(record, tokenAddress),
+    broadcasterFee: bf,
     onProgress: progress.write,
   })
 
-  // Phase B write-path differential (opt-in, observe-only): build this unshield with @armada/sdk and
-  // simulate it against the pool — telemetry-reports whether the SDK proof verifies on-chain. Fire-and-
-  // forget; never blocks or fails the unshield (the engine proof above is what actually submits).
+  // Pre-cutover differential (opt-in, observe-only): build this unshield with @armada/sdk and simulate
+  // it against the pool — telemetry-reports whether the SDK proof verifies on-chain. Fire-and-forget;
+  // never blocks or fails the unshield (the engine proof above is what submits). Moot once the SDK path
+  // is primary above.
   const evmFrom = record.walletContext.evmAddress
   const poolAddress = deployments.hub.contracts.privacyPool
   if (unshieldDifferentialEnabled() && evmFrom && poolAddress) {
-    const bf = broadcasterFeeFromRecord(record, tokenAddress)
     void runUnshieldDifferential({
       recipient: record.meta.recipient as `0x${string}`,
       amount: record.meta.amount,
@@ -160,20 +180,27 @@ async function runSubmitAndConfirm(
   // and would throw anyway — the SDK's in-memory proof cache doesn't survive a reload. (P0-1)
   let populated: Awaited<ReturnType<typeof populateUnshieldTransaction>> | undefined
   if (!existingHash) {
-    const walletId = kmGetWalletId()
-    const deployments = await loadDeployments()
-    const tokenAddress = deployments.hub.cctp.usdc
-    // Re-populate must use the EXACT same args as the proof (the SDK's in-memory proof cache is
-    // keyed by them; mismatched broadcasterFee throws "proof not found"). Reading from meta keeps
-    // the values immutable across resumes-after-crash.
-    populated = await populateUnshieldTransaction({
-      walletId,
-      tokenAddress,
-      recipient: record.meta.recipient,
-      amount: record.meta.amount,
-      broadcasterFee: broadcasterFeeFromRecord(record, tokenAddress),
-    })
-    if (ctx.signal.aborted) throw new Error('cancelled')
+    const stashed = record.artifacts.unshieldTx
+    if (stashed) {
+      // SDK cutover: the transact calldata was built + persisted in build-proof, so it survives a
+      // reload (the engine's in-memory proof cache does not). Dispatch it directly.
+      populated = { to: stashed.to, data: stashed.data, value: BigInt(stashed.value) }
+    } else {
+      const walletId = kmGetWalletId()
+      const deployments = await loadDeployments()
+      const tokenAddress = deployments.hub.cctp.usdc
+      // Re-populate must use the EXACT same args as the proof (the SDK's in-memory proof cache is
+      // keyed by them; mismatched broadcasterFee throws "proof not found"). Reading from meta keeps
+      // the values immutable across resumes-after-crash.
+      populated = await populateUnshieldTransaction({
+        walletId,
+        tokenAddress,
+        recipient: record.meta.recipient,
+        amount: record.meta.amount,
+        broadcasterFee: broadcasterFeeFromRecord(record, tokenAddress),
+      })
+      if (ctx.signal.aborted) throw new Error('cancelled')
+    }
   }
 
   // A6 wallet-override path — bypass the relayer entirely and submit through the user's EVM

--- a/apps/armada-interface/src/lib/railgun/unshield-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield-sdk.ts
@@ -16,6 +16,14 @@ export interface SdkUnshieldInputs {
 }
 
 /**
+ * Write-path cutover flag. When set, the unshield handler builds + submits the unshield via
+ * `@armada/sdk` (`buildUnshieldSdk`) instead of the stock engine. Off by default; the engine drives.
+ */
+export function sdkUnshieldEnabled(): boolean {
+  return import.meta.env.VITE_SDK_UNSHIELD === '1'
+}
+
+/**
  * Build an unshield transaction via `@armada/sdk`: the wallet plans a transfer whose only public
  * output is the unshield (recipient EVM address, no shielded outputs), proves it (Groth16), and the
  * proved struct is serialized into `transact(...)` calldata. Returns `{ to, data }` (value is always

--- a/apps/armada-interface/src/lib/tx/types.ts
+++ b/apps/armada-interface/src/lib/tx/types.ts
@@ -546,8 +546,24 @@ export interface ArtifactsTransfer extends ArtifactsCommon {
   }
 }
 
+export interface ArtifactsUnshieldLocal extends ArtifactsCommon {
+  /**
+   * The same-chain unshield `transact()` calldata built during build-proof (@armada/sdk plan → prove →
+   * serialize), so submit-relayer dispatches it without re-running the ~20-30s proof. Unlike the
+   * engine's in-memory proof cache (which a reload wipes), this survives a reload — it's persisted in
+   * the record. `value` is '0' (a shielded tx carries no native value); stringified for IDB. Mirrors
+   * `ArtifactsTransfer.transferTx`; distinct from `ArtifactsXchain.unshieldTx` (cross-chain calldata).
+   */
+  unshieldTx?: {
+    to: `0x${string}`
+    data: `0x${string}`
+    value: string
+  }
+}
+
 export type ArtifactsFor<K extends TxKind> =
   K extends 'unshield-xchain' ? ArtifactsXchain
+  : K extends 'unshield-local' ? ArtifactsUnshieldLocal
   : K extends 'shield' ? ArtifactsShield
   : K extends 'shield-xchain' ? ArtifactsShieldXchain
   : K extends 'yield-deposit' ? ArtifactsYield


### PR DESCRIPTION
Phase B, unshield-local cutover — same structure as the transfer cutover (#447). Behind `VITE_SDK_UNSHIELD=1` the same-chain unshield builds + submits via `@armada/sdk` instead of the stock engine; off by default (engine drives). The differential (#450) validated `sdk.unshieldDiff { simulated: true }` on-chain, so this is the flag-gated switch.

## What
- **`unshield-sdk.ts`** — `sdkUnshieldEnabled()` = `import.meta.env.VITE_SDK_UNSHIELD === '1'`.
- **`features/unshield/handler.ts`**
  - `runBuildProof`: when the flag is on, `buildUnshieldSdk` (plan → prove off-thread → serialize) and stash the `transact()` calldata in `artifacts.unshieldTx`, then advance. Unlike the engine's in-memory proof cache, this survives a reload. Engine path unchanged when the flag is off (the pre-cutover differential stays wired there, moot once SDK is primary).
  - `runSubmitAndConfirm`: prefer the stashed calldata (dispatch directly, no re-populate); fall back to the engine `populateUnshieldTransaction` when absent. Both the relayer and A6 wallet-override submit paths are unchanged downstream.
- **`lib/tx/types.ts`** — `ArtifactsUnshieldLocal` with `unshieldTx?: { to, data, value }`, mapped for `unshield-local`. Distinct from `ArtifactsXchain.unshieldTx` (cross-chain calldata); mirrors `ArtifactsTransfer.transferTx`.

## Testing
- Interface typecheck clean; existing unshield unit tests (5) green.
- **Runtime validation (Butters):** local stack, set `VITE_SDK_UNSHIELD=1`, do a same-chain unshield end-to-end (relayer + A6 wallet-override), confirm the USDC lands and the record reaches `hub-confirmed`. With the flag unset it stays on the engine path.

Next: default-flip (opt-out via `VITE_SDK_UNSHIELD=0`), then delete the engine unshield builder + differential + flag. Cross-chain unshield stays on the engine until its own slice (it needs `adaptParams` + hand-encoded `atomicCrossChainUnshield`).