### PR TITLE
feat(interface): default unshield-local to @armada/sdk (opt out via VITE_SDK_UNSHIELD=0)

### DIFF
--- a/apps/armada-interface/src/lib/railgun/unshield-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield-sdk.ts
@@ -16,11 +16,12 @@ export interface SdkUnshieldInputs {
 }
 
 /**
- * Write-path cutover flag. When set, the unshield handler builds + submits the unshield via
- * `@armada/sdk` (`buildUnshieldSdk`) instead of the stock engine. Off by default; the engine drives.
+ * Write-path cutover flag. The unshield handler builds + submits via `@armada/sdk` (`buildUnshieldSdk`)
+ * by default; set `VITE_SDK_UNSHIELD=0` to fall back to the stock engine (escape hatch, retained until
+ * the engine unshield builder is deleted).
  */
 export function sdkUnshieldEnabled(): boolean {
-  return import.meta.env.VITE_SDK_UNSHIELD === '1'
+  return import.meta.env.VITE_SDK_UNSHIELD !== '0'
 }
 
 /**


### PR DESCRIPTION
Phase B, unshield-local slice B — flips the default. Same-chain unshield now builds + submits via `@armada/sdk` for everyone; `VITE_SDK_UNSHIELD=0` is the escape hatch back to the stock engine (retained until the engine unshield builder is deleted in slice C). Mirrors the transfer default-flip (#448).

One-line change: `sdkUnshieldEnabled()` from `=== '1'` to `!== '0'`.

## Testing
- Interface typecheck clean; unshield unit tests unaffected (they mock the build path directly).
- **Runtime (Butters):** with no flag set, run a same-chain unshield and confirm it takes the SDK path (`hub-confirmed`, USDC lands). Set `VITE_SDK_UNSHIELD=0` and confirm it falls back to the engine.

Next (slice C): delete the engine unshield builder (`generateUnshieldProofForRecipient` / `populateUnshieldTransaction`) + the differential + the flag, leaving unshield-local engine-free. Cross-chain unshield keeps `buildXchainUnshieldTransaction` until its own slice.