### PR TITLE
feat(interface): cross-chain unshield write-path differential (@armada/sdk)

### DIFF
--- a/apps/armada-interface/src/features/unshield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/handler.ts
@@ -23,6 +23,7 @@ import {
   buildXchainUnshieldTransaction,
   type BroadcasterFeeRecipient,
 } from '@/lib/railgun/unshield'
+import { runXchainUnshieldDifferential, xchainUnshieldDifferentialEnabled } from '@/lib/railgun/unshield-xchain-differential'
 import {
   extractCctpMessageFromReceipt,
   messageReceivedTopic,
@@ -252,6 +253,25 @@ async function runBuildProof(
     maxFee,
     deliveryNonce(record.id), // issue #287 — unique per-tx marker echoed into the CCTP hookData
   )
+
+  // Pre-cutover differential (opt-in, observe-only): build this cross-chain unshield with @armada/sdk and
+  // simulate it against the pool — telemetry-reports whether the SDK proof + adaptParams binding verifies
+  // on-chain. Fire-and-forget; never blocks or fails the unshield (the engine build above is what submits).
+  const evmFrom = record.walletContext.evmAddress
+  if (xchainUnshieldDifferentialEnabled() && evmFrom) {
+    const bf = broadcasterFeeFromRecord(record, tokenAddress)
+    void runXchainUnshieldDifferential({
+      amount: record.meta.amount,
+      broadcasterFee: bf ? { amount: bf.amount, recipientAddress: bf.recipientAddress } : null,
+      privacyPoolAddress: privacyPoolAddress as `0x${string}`,
+      finalRecipient: record.meta.recipient as `0x${string}`,
+      destinationDomain,
+      maxFee,
+      uniqueNonce: deliveryNonce(record.id),
+      from: evmFrom as `0x${string}`,
+      chainId: hubChainId,
+    })
+  }
 
   // Advance from the LIVE record (progress bumps incremented updatedSeq). Persist the encoded
   // calldata so submit-relayer dispatches it without re-proving.

--- a/apps/armada-interface/src/lib/railgun/unshield-xchain-differential.test.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield-xchain-differential.test.ts
@@ -1,0 +1,56 @@
+// ABOUTME: Unit test for runXchainUnshieldDifferential — build the SDK xchain unshield, simulate it, and
+// ABOUTME: report sdk.xchainUnshieldDiff { simulated }; never throws into the caller (observe-only).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({ buildXchainUnshieldSdk: vi.fn(), simulateOrThrow: vi.fn() }))
+vi.mock('./unshield-xchain-sdk', () => ({ buildXchainUnshieldSdk: hoisted.buildXchainUnshieldSdk }))
+vi.mock('@/lib/tx/simulate', () => ({ simulateOrThrow: hoisted.simulateOrThrow }))
+vi.mock('@/lib/telemetry', () => ({ track: vi.fn(), trackError: vi.fn() }))
+
+import { runXchainUnshieldDifferential } from './unshield-xchain-differential'
+import { track, trackError } from '@/lib/telemetry'
+
+const inputs = {
+  amount: 5n,
+  broadcasterFee: { amount: 2n, recipientAddress: '0zk_relayer' },
+  privacyPoolAddress: '0xpool000000000000000000000000000000000000' as const,
+  finalRecipient: '0xbob0000000000000000000000000000000000000' as const,
+  destinationDomain: 6,
+  maxFee: 1_000n,
+  uniqueNonce: `0x${'11'.repeat(32)}` as const,
+  from: '0xuser000000000000000000000000000000000000' as const,
+  chainId: 31337,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hoisted.buildXchainUnshieldSdk.mockResolvedValue({ to: inputs.privacyPoolAddress, data: '0xdead' })
+})
+
+describe('runXchainUnshieldDifferential', () => {
+  it('reports simulated:true when the SDK calldata passes on-chain simulation', async () => {
+    hoisted.simulateOrThrow.mockResolvedValue(undefined)
+    await runXchainUnshieldDifferential(inputs)
+    expect(hoisted.simulateOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({ to: inputs.privacyPoolAddress, data: '0xdead', account: inputs.from, chainId: 31337 }),
+    )
+    expect(track).toHaveBeenCalledWith('sdk.xchainUnshieldDiff', { simulated: true })
+  })
+
+  it('reports simulated:false + trackError when the contract rejects the SDK tx', async () => {
+    // WHY: the on-chain verifier is the arbiter — a revert means the SDK xchain unshield (or its
+    // adaptParams↔args binding) is NOT valid, and must surface rather than silently pass.
+    hoisted.simulateOrThrow.mockRejectedValue(new Error('execution reverted'))
+    await runXchainUnshieldDifferential(inputs)
+    expect(track).toHaveBeenCalledWith('sdk.xchainUnshieldDiff', { simulated: false })
+    expect(trackError).toHaveBeenCalledWith('sdk.xchainUnshieldDiff.simulate', expect.any(Error), expect.any(Object))
+  })
+
+  it('never throws into the caller when the SDK build itself fails', async () => {
+    hoisted.buildXchainUnshieldSdk.mockRejectedValue(new Error('plan/prove/encode failed'))
+    await expect(runXchainUnshieldDifferential(inputs)).resolves.toBeUndefined()
+    expect(trackError).toHaveBeenCalledWith('sdk.xchainUnshieldDiff.build', expect.any(Error), expect.any(Object))
+    expect(track).not.toHaveBeenCalled()
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/unshield-xchain-differential.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield-xchain-differential.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Cross-chain unshield write-path differential — builds the atomicCrossChainUnshield calldata via
+// ABOUTME: @armada/sdk and validates it by SIMULATING against the pool (the on-chain verifier is the arbiter). Observe-only.
+
+import { simulateOrThrow } from '@/lib/tx/simulate'
+import { track, trackError } from '@/lib/telemetry'
+import { buildXchainUnshieldSdk, type SdkXchainUnshieldInputs } from './unshield-xchain-sdk'
+
+/**
+ * Opt-in gate (`VITE_SHADOW_SDK=1`) — NOT dev-default, because the differential runs a full Groth16
+ * proof on top of the engine's own. You turn it on to validate, not for every dev unshield. Retired
+ * once the cross-chain unshield cutover lands.
+ */
+export function xchainUnshieldDifferentialEnabled(): boolean {
+  return import.meta.env.VITE_SHADOW_SDK === '1'
+}
+
+/**
+ * Build the cross-chain unshield with `@armada/sdk` (plan with CCTP-binding adaptParams → prove →
+ * encode `atomicCrossChainUnshield`) and validate it by `eth_call`-simulating the calldata against the
+ * PrivacyPool on the hub. If the contract accepts it, the SDK produced a valid, submittable exit — the
+ * proof, nullifiers, merkleRoot, and the adaptParams↔args binding (#399) all verify on-chain. A
+ * proof-carrying tx can't be byte-compared to the engine's, so simulation is the correctness signal.
+ *
+ * Observe-only: never submits — the engine's build/submit runs unchanged alongside this. Never throws
+ * into the caller; emits one `sdk.xchainUnshieldDiff { simulated }` line per invocation.
+ */
+export async function runXchainUnshieldDifferential(
+  inputs: SdkXchainUnshieldInputs & { readonly from: `0x${string}`; readonly chainId: number },
+): Promise<void> {
+  try {
+    const { to, data } = await buildXchainUnshieldSdk(inputs)
+    try {
+      await simulateOrThrow({ to, data, value: 0n, account: inputs.from, chainId: inputs.chainId })
+      track('sdk.xchainUnshieldDiff', { simulated: true })
+    } catch (simErr) {
+      // The SDK built calldata but the contract rejected it — the load-bearing failure signal.
+      track('sdk.xchainUnshieldDiff', { simulated: false })
+      trackError('sdk.xchainUnshieldDiff.simulate', simErr, { scope: 'shielded.unshield', message: 'sdk xchain unshield failed on-chain simulation' })
+    }
+  } catch (err) {
+    // The SDK build itself failed (plan/prove/encode) — never surfaced to the unshield flow.
+    trackError('sdk.xchainUnshieldDiff.build', err, { scope: 'shielded.unshield', message: 'sdk xchain unshield build failed' })
+  }
+}

--- a/apps/armada-interface/src/lib/railgun/unshield-xchain-sdk.test.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield-xchain-sdk.test.ts
@@ -1,0 +1,87 @@
+// ABOUTME: Unit test for buildXchainUnshieldSdk — plans the unshield to the POOL with a CCTP-binding adaptParams,
+// ABOUTME: proves, and encodes atomicCrossChainUnshield from transactionToTuple + the CCTP args.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  planTransfer: vi.fn(),
+  prove: vi.fn(),
+  transactionToTuple: vi.fn(),
+  encodeCctpBinding: vi.fn(),
+  encodeFunctionData: vi.fn(),
+}))
+vi.mock('@armada/sdk', () => ({
+  transactionToTuple: hoisted.transactionToTuple,
+  encodeCctpBinding: hoisted.encodeCctpBinding,
+}))
+vi.mock('viem', async (importActual) => {
+  const actual = await importActual<typeof import('viem')>()
+  return { ...actual, encodeFunctionData: hoisted.encodeFunctionData }
+})
+vi.mock('./sdk-read', () => ({
+  getSdkWallet: async () => ({ planTransfer: hoisted.planTransfer, prove: hoisted.prove }),
+}))
+
+import { buildXchainUnshieldSdk } from './unshield-xchain-sdk'
+
+const POOL = '0xpool000000000000000000000000000000000000' as const
+const FINAL = '0xbob0000000000000000000000000000000000000' as const
+const NONCE = `0x${'11'.repeat(32)}` as const
+const BINDING = `0x${'cd'.repeat(32)}` as const
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hoisted.planTransfer.mockResolvedValue({ plan: true })
+  hoisted.prove.mockResolvedValue({ toTransactionData: () => ({ tx: 'data' }) })
+  hoisted.transactionToTuple.mockReturnValue(['TUPLE'])
+  hoisted.encodeCctpBinding.mockReturnValue(BINDING)
+  hoisted.encodeFunctionData.mockReturnValue('0xcalldata')
+})
+
+describe('buildXchainUnshieldSdk', () => {
+  it('plans the unshield to the POOL with the CCTP-binding adaptParams, then encodes the wrapper call', async () => {
+    const r = await buildXchainUnshieldSdk({
+      amount: 5_000_000n,
+      broadcasterFee: { amount: 20_000n, recipientAddress: '0zk_relayer' },
+      privacyPoolAddress: POOL,
+      finalRecipient: FINAL,
+      destinationDomain: 6,
+      maxFee: 1_000n,
+      uniqueNonce: NONCE,
+    })
+    // The binding covers the real destination (finalRecipient + domain + maxFee).
+    expect(hoisted.encodeCctpBinding).toHaveBeenCalledWith(FINAL, 6, 1_000n)
+    // The unshield note's recipient is the POOL (it forwards via CCTP); adaptParams carries the binding.
+    expect(hoisted.planTransfer).toHaveBeenCalledWith({
+      outputs: [],
+      unshield: { recipient: POOL, amount: 5_000_000n, adaptParams: BINDING },
+      fee: { schedule: { transfer: '20000' }, broadcasterRailgunAddress: '0zk_relayer', feesCacheId: '', expiresAt: 0 },
+    })
+    // The proved tx is embedded as a POSITIONAL tuple, then the CCTP args.
+    expect(hoisted.transactionToTuple).toHaveBeenCalledWith({ tx: 'data' })
+    expect(hoisted.encodeFunctionData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: 'atomicCrossChainUnshield',
+        args: [['TUPLE'], 6, FINAL, 1_000n, NONCE],
+      }),
+    )
+    expect(r).toEqual({ to: POOL, data: '0xcalldata' })
+  })
+
+  it('emits a zero fee (no broadcaster output) for direct submission', async () => {
+    await buildXchainUnshieldSdk({
+      amount: 1n,
+      broadcasterFee: null,
+      privacyPoolAddress: POOL,
+      finalRecipient: FINAL,
+      destinationDomain: 6,
+      maxFee: 0n,
+      uniqueNonce: NONCE,
+    })
+    expect(hoisted.planTransfer).toHaveBeenCalledWith({
+      outputs: [],
+      unshield: { recipient: POOL, amount: 1n, adaptParams: BINDING },
+      fee: { schedule: { transfer: '0' }, broadcasterRailgunAddress: '', feesCacheId: '', expiresAt: 0 },
+    })
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/unshield-xchain-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield-xchain-sdk.ts
@@ -1,0 +1,129 @@
+// ABOUTME: SDK-backed cross-chain unshield builder — planTransfer(unshield to pool + CCTP-binding adaptParams)
+// ABOUTME: → prove → toTransactionData → transactionToTuple → encode atomicCrossChainUnshield. @armada/sdk analogue of buildXchainUnshieldTransaction.
+
+import { encodeFunctionData } from 'viem'
+import { transactionToTuple, encodeCctpBinding } from '@armada/sdk'
+import { getSdkWallet } from './sdk-read'
+
+/**
+ * PrivacyPool.atomicCrossChainUnshield ABI — the proved Transaction struct wrapped with the CCTP
+ * destination + recipient + maxFee + per-tx nonce. The Transaction tuple is passed POSITIONALLY
+ * (via `transactionToTuple`, which applies the G2-coordinate swap), so viem encodes by order.
+ *
+ * NOTE: duplicated from features/unshield-xchain/handler.ts during the differential phase; at the
+ * cutover the handler drops its engine copy and imports this module's builder instead.
+ */
+const PRIVACY_POOL_XCHAIN_UNSHIELD_ABI = [
+  {
+    type: 'function',
+    name: 'atomicCrossChainUnshield',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: '_transaction', type: 'tuple', components: [
+        { name: 'proof', type: 'tuple', components: [
+          { name: 'a', type: 'tuple', components: [
+            { name: 'x', type: 'uint256' },
+            { name: 'y', type: 'uint256' },
+          ] },
+          { name: 'b', type: 'tuple', components: [
+            { name: 'x', type: 'uint256[2]' },
+            { name: 'y', type: 'uint256[2]' },
+          ] },
+          { name: 'c', type: 'tuple', components: [
+            { name: 'x', type: 'uint256' },
+            { name: 'y', type: 'uint256' },
+          ] },
+        ] },
+        { name: 'merkleRoot', type: 'bytes32' },
+        { name: 'nullifiers', type: 'bytes32[]' },
+        { name: 'commitments', type: 'bytes32[]' },
+        { name: 'boundParams', type: 'tuple', components: [
+          { name: 'treeNumber', type: 'uint16' },
+          { name: 'minGasPrice', type: 'uint72' },
+          { name: 'unshield', type: 'uint8' },
+          { name: 'chainID', type: 'uint64' },
+          { name: 'adaptContract', type: 'address' },
+          { name: 'adaptParams', type: 'bytes32' },
+          { name: 'commitmentCiphertext', type: 'tuple[]', components: [
+            { name: 'ciphertext', type: 'bytes32[4]' },
+            { name: 'blindedSenderViewingKey', type: 'bytes32' },
+            { name: 'blindedReceiverViewingKey', type: 'bytes32' },
+            { name: 'annotationData', type: 'bytes' },
+            { name: 'memo', type: 'bytes' },
+          ] },
+        ] },
+        { name: 'unshieldPreimage', type: 'tuple', components: [
+          { name: 'npk', type: 'bytes32' },
+          { name: 'token', type: 'tuple', components: [
+            { name: 'tokenType', type: 'uint8' },
+            { name: 'tokenAddress', type: 'address' },
+            { name: 'tokenSubID', type: 'uint256' },
+          ] },
+          { name: 'value', type: 'uint120' },
+        ] },
+      ] },
+      { name: 'destinationDomain', type: 'uint32' },
+      { name: 'finalRecipient', type: 'address' },
+      { name: 'maxFee', type: 'uint256' },
+      { name: 'uniqueNonce', type: 'bytes32' },
+    ],
+    outputs: [],
+  },
+] as const
+
+export interface SdkXchainUnshieldInputs {
+  readonly amount: bigint
+  /** Broadcaster (relayer) fee note, or null for direct user submission (no fee output). */
+  readonly broadcasterFee: { readonly amount: bigint; readonly recipientAddress: string } | null
+  /** PrivacyPool address — the unshield note's recipient (pool forwards via CCTP) AND the tx `to`. */
+  readonly privacyPoolAddress: `0x${string}`
+  /** Final USDC recipient on the destination chain — bound into adaptParams, NOT the unshield npk. */
+  readonly finalRecipient: `0x${string}`
+  readonly destinationDomain: number
+  readonly maxFee: bigint
+  /** Per-tx CCTP delivery marker (keccak256(recordId)) — echoed into hookData, not a proof input. */
+  readonly uniqueNonce: `0x${string}`
+  /** ZK-proof progress (0–1); the worker prover emits coarse start/end phases. */
+  readonly onProgress?: (fraction: number) => void
+}
+
+/**
+ * Build a cross-chain unshield transaction via `@armada/sdk`. The unshield note's recipient is the
+ * PrivacyPool itself (it burns the shielded UTXO and emits CCTP messages to deliver USDC to the real
+ * recipient on another chain); the real destination (`finalRecipient` + `destinationDomain` + `maxFee`)
+ * is bound into `boundParams.adaptParams` via `encodeCctpBinding`, so a relayer/front-runner cannot
+ * redirect the exit (#364/#378/#399). The proved struct is embedded into `atomicCrossChainUnshield`
+ * calldata via `transactionToTuple` (which applies the G2 swap). Returns `{ to, data }`.
+ */
+export async function buildXchainUnshieldSdk(
+  inputs: SdkXchainUnshieldInputs,
+): Promise<{ to: `0x${string}`; data: `0x${string}` }> {
+  const wallet = await getSdkWallet()
+  const fee = inputs.broadcasterFee
+    ? {
+        schedule: { transfer: inputs.broadcasterFee.amount.toString() },
+        broadcasterRailgunAddress: inputs.broadcasterFee.recipientAddress,
+        feesCacheId: '',
+        expiresAt: 0,
+      }
+    : { schedule: { transfer: '0' }, broadcasterRailgunAddress: '', feesCacheId: '', expiresAt: 0 }
+
+  const adaptParams = encodeCctpBinding(inputs.finalRecipient, inputs.destinationDomain, inputs.maxFee)
+  const plan = await wallet.planTransfer({
+    outputs: [],
+    unshield: { recipient: inputs.privacyPoolAddress, amount: inputs.amount, adaptParams },
+    fee,
+  })
+  const handle = await wallet.prove(
+    plan,
+    inputs.onProgress ? { onProgress: (p) => inputs.onProgress?.(p.fraction) } : undefined,
+  )
+  const data = encodeFunctionData({
+    abi: PRIVACY_POOL_XCHAIN_UNSHIELD_ABI,
+    functionName: 'atomicCrossChainUnshield',
+    // The proved Transaction as a positional tuple (G2-swapped by transactionToTuple), then the CCTP args.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    args: [transactionToTuple(handle.toTransactionData()) as any, inputs.destinationDomain, inputs.finalRecipient, inputs.maxFee, inputs.uniqueNonce],
+  })
+  return { to: inputs.privacyPoolAddress, data }
+}

--- a/apps/armada-interface/src/lib/telemetry.ts
+++ b/apps/armada-interface/src/lib/telemetry.ts
@@ -51,6 +51,12 @@ export type EventRegistry = {
   // means it resumed from the IndexedDB checkpoint. `scanned` false = head hadn't advanced (no work).
   'sdk.sync':                 { fromBlock: number; syncedThrough: number; scanned: boolean }
 
+  // @armada/sdk cross-chain-unshield write-path differential — one line per SDK build+simulate (opt-in
+  // VITE_SHADOW_SDK). `simulated` true = the pool's on-chain verifier accepted the SDK-built
+  // atomicCrossChainUnshield calldata (the arbiter — a proof-carrying tx can't be byte-compared, and it
+  // exercises the adaptParams↔CCTP-args binding #399). Observe-only; retired at the xchain unshield cutover.
+  'sdk.xchainUnshieldDiff':   { simulated: boolean }
+
   'tx.submitted':             { id: string; kind: TxKind }
   'tx.transition':            { id: string; kind: TxKind; from: TxStage; to: TxStage; executionState: TxRecord['executionState'] }
   'tx.failed':                { id: string; kind: TxKind; errorCode?: string }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#78c883c88f1cc1c824f18d2fe59e7360a1388348",
+        "@armada/sdk": "github:ship-armada/armada-sdk#0f1f3c2682fdf7788d0f155f0c28e12f0d78240a",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#78c883c88f1cc1c824f18d2fe59e7360a1388348",
-      "integrity": "sha512-KgHsPFN7aPLiA0cXa6zY35OUXv6SRxxTKmghI+UROjPHAppad6vq6pO/mr49PI2JRZ1fZtBoIgr1WvzLc24b/A==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#0f1f3c2682fdf7788d0f155f0c28e12f0d78240a",
+      "integrity": "sha512-V2ne4uRCC28wyPIXLNCXynEI9ZoJafYTk3f49uwbqaicpojBBYk1PxGd8dRuod8WvT3kaAyeKwU+FfHmxxD6Qg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#78c883c88f1cc1c824f18d2fe59e7360a1388348",
+    "@armada/sdk": "github:ship-armada/armada-sdk#0f1f3c2682fdf7788d0f155f0c28e12f0d78240a",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",


### PR DESCRIPTION
Phase B, xchain-unshield — the differential. Builds the cross-chain unshield (`atomicCrossChainUnshield`) via `@armada/sdk` and validates it by **on-chain simulation** against the hub PrivacyPool. Observe-only: the stock engine still builds + submits. Same playbook as transfer / unshield-local. Depends on armada-sdk#53 (adaptParams threading — re-pinned here).

## What
- **`lib/railgun/unshield-xchain-sdk.ts`** — `buildXchainUnshieldSdk`: `planTransfer({ outputs: [], unshield: { recipient: pool, amount, adaptParams: encodeCctpBinding(finalRecipient, destDomain, maxFee) }, fee })` → `prove` → `toTransactionData()` → **`transactionToTuple()`** (positional tuple, G2 swap applied by the SDK) → `encodeFunctionData(atomicCrossChainUnshield, [tuple, destDomain, finalRecipient, maxFee, uniqueNonce])`. The unshield note's recipient is the **pool** (it forwards via CCTP); the real destination is bound into `adaptParams` (#399).
- **`lib/railgun/unshield-xchain-differential.ts`** — build via SDK, `simulateOrThrow` against the pool on the hub. Never throws into the flow.
- **`features/unshield-xchain/handler.ts`** — fire-and-forget after the engine build, gated on `VITE_SHADOW_SDK=1`.
- **`lib/telemetry.ts`** — registers `sdk.xchainUnshieldDiff { simulated }`.
- Re-pins `@armada/sdk` to `0f1f3c2`.

## Notes for the cutover (next slice)
- The SDK's `encodeCctpBinding` is **byte-identical** to the interface's local `cctpBinding.ts` (verified: same domain tag `ArmadaCCTPUnshield.v1`, ABI types, order) — the local copy gets dropped at cutover.
- `transactionToTuple` replaces the engine's 80-line `normalizeTransaction`. Critical: it already applies the G2 swap, so there's no double-swap.

## Testing
- New unit tests (5): `unshield-xchain-sdk.test.ts` (plans to pool + binding adaptParams, encodes the wrapper with the positional tuple + CCTP args) + `unshield-xchain-differential.test.ts` (simulated true/false + never-throws). Interface typecheck clean; existing xchain tests (14) still green.
- **Runtime validation (Butters):** local stack, `VITE_SHADOW_SDK=1`, do a cross-chain withdraw (destination ≠ hub), grep the console for `sdk.xchainUnshieldDiff` — expect `{ simulated: true }`. A `false` (with a paired `.simulate` error) means the SDK proof or the adaptParams binding was rejected on-chain — do not cut over.