### PR TITLE
feat(interface): cross-chain unshield submission cutover to @armada/sdk (VITE_SDK_XCHAIN_UNSHIELD)

### DIFF
--- a/apps/armada-interface/src/features/unshield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/unshield-xchain/handler.ts
@@ -24,6 +24,7 @@ import {
   type BroadcasterFeeRecipient,
 } from '@/lib/railgun/unshield'
 import { runXchainUnshieldDifferential, xchainUnshieldDifferentialEnabled } from '@/lib/railgun/unshield-xchain-differential'
+import { buildXchainUnshieldSdk, sdkXchainUnshieldEnabled } from '@/lib/railgun/unshield-xchain-sdk'
 import {
   extractCctpMessageFromReceipt,
   messageReceivedTopic,
@@ -228,6 +229,27 @@ async function runBuildProof(
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   const progress = createProofProgressWriter(record, ctx.signal)
+
+  if (sdkXchainUnshieldEnabled()) {
+    // @armada/sdk cutover: plan (unshield to pool + CCTP-binding adaptParams) → prove off-thread →
+    // encode atomicCrossChainUnshield, and stash the calldata so submit-relayer dispatches it without
+    // re-proving. Survives a reload (persisted in the record), unlike the engine's in-memory proof cache.
+    const bf = broadcasterFeeFromRecord(record, tokenAddress)
+    const { to, data } = await buildXchainUnshieldSdk({
+      amount: record.meta.amount,
+      broadcasterFee: bf ? { amount: bf.amount, recipientAddress: bf.recipientAddress } : null,
+      privacyPoolAddress: privacyPoolAddress as `0x${string}`,
+      finalRecipient: record.meta.recipient as `0x${string}`,
+      destinationDomain,
+      maxFee,
+      uniqueNonce: deliveryNonce(record.id), // issue #287 — unique per-tx marker echoed into the CCTP hookData
+      onProgress: progress.write,
+    })
+    if (ctx.signal.aborted) throw new Error('cancelled')
+    await ctx.upsert(advance(progress.latest(), 'submit-relayer', { unshieldTx: { to, data, value: '0' } }))
+    return
+  }
+
   const built = await buildXchainUnshieldTransaction({
     walletId,
     encryptionKey,

--- a/apps/armada-interface/src/lib/railgun/unshield-xchain-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield-xchain-sdk.ts
@@ -6,6 +6,14 @@ import { transactionToTuple, encodeCctpBinding } from '@armada/sdk'
 import { getSdkWallet } from './sdk-read'
 
 /**
+ * Write-path cutover flag. When set, the cross-chain unshield handler builds + submits via
+ * `@armada/sdk` (`buildXchainUnshieldSdk`) instead of the stock engine. Off by default; the engine drives.
+ */
+export function sdkXchainUnshieldEnabled(): boolean {
+  return import.meta.env.VITE_SDK_XCHAIN_UNSHIELD === '1'
+}
+
+/**
  * PrivacyPool.atomicCrossChainUnshield ABI — the proved Transaction struct wrapped with the CCTP
  * destination + recipient + maxFee + per-tx nonce. The Transaction tuple is passed POSITIONALLY
  * (via `transactionToTuple`, which applies the G2-coordinate swap), so viem encodes by order.


### PR DESCRIPTION
Phase B, xchain-unshield cutover (slice A). Behind `VITE_SDK_XCHAIN_UNSHIELD=1` the cross-chain unshield builds + submits via `@armada/sdk` instead of the stock engine; off by default. The differential (#454) validated `sdk.xchainUnshieldDiff { simulated: true }` on-chain. Mirrors the unshield-local cutover (#451).

## What
- **`unshield-xchain-sdk.ts`** — `sdkXchainUnshieldEnabled()` = `import.meta.env.VITE_SDK_XCHAIN_UNSHIELD === '1'`.
- **`features/unshield-xchain/handler.ts`** — `runBuildProof`: when the flag is on, `buildXchainUnshieldSdk` → stash the `atomicCrossChainUnshield` calldata in `artifacts.unshieldTx` → advance. Engine path unchanged when off (the differential stays wired there). The submit stage (`runSubmitAndBurn`) dispatches `artifacts.unshieldTx` verbatim — no change (calldata-agnostic, same as the other kinds).

## Testing
- Interface typecheck clean; xchain tests (16) green.
- **Runtime (Butters):** local stack, `VITE_SDK_XCHAIN_UNSHIELD=1`, do a cross-chain withdraw (destination ≠ hub) end-to-end (relayer + A6 wallet-override) — confirm the hub burn lands, CCTP delivers to the destination, and the record reaches terminal. With the flag unset it stays on the engine.

Next: default-flip (opt-out `VITE_SDK_XCHAIN_UNSHIELD=0`), then delete the engine `buildXchainUnshieldTransaction` + `normalizeTransaction` + the local `cctpBinding.ts` (superseded by the SDK's byte-identical `encodeCctpBinding`) — leaving unshield fully engine-free.