### PR TITLE
feat(interface): default cross-chain unshield to @armada/sdk (opt out via VITE_SDK_XCHAIN_UNSHIELD=0)

### DIFF
--- a/apps/armada-interface/src/lib/railgun/unshield-xchain-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/unshield-xchain-sdk.ts
@@ -6,11 +6,12 @@ import { transactionToTuple, encodeCctpBinding } from '@armada/sdk'
 import { getSdkWallet } from './sdk-read'
 
 /**
- * Write-path cutover flag. When set, the cross-chain unshield handler builds + submits via
- * `@armada/sdk` (`buildXchainUnshieldSdk`) instead of the stock engine. Off by default; the engine drives.
+ * Write-path cutover flag. The cross-chain unshield handler builds + submits via `@armada/sdk`
+ * (`buildXchainUnshieldSdk`) by default; set `VITE_SDK_XCHAIN_UNSHIELD=0` to fall back to the stock
+ * engine (escape hatch, retained until the engine cross-chain unshield builder is deleted).
  */
 export function sdkXchainUnshieldEnabled(): boolean {
-  return import.meta.env.VITE_SDK_XCHAIN_UNSHIELD === '1'
+  return import.meta.env.VITE_SDK_XCHAIN_UNSHIELD !== '0'
 }
 
 /**


### PR DESCRIPTION
Phase B, xchain-unshield slice B — flips the default. Cross-chain unshield now builds + submits via `@armada/sdk` for everyone; `VITE_SDK_XCHAIN_UNSHIELD=0` is the escape hatch back to the stock engine (retained until the engine builder is deleted in slice C). Mirrors the unshield-local default-flip (#452).

One-line change: `sdkXchainUnshieldEnabled()` from `=== '1'` to `!== '0'`.

## Testing
- Interface typecheck clean; xchain tests unaffected (they mock the build path directly).
- **Runtime (Butters):** with no flag set, run a cross-chain withdraw and confirm it takes the SDK path (hub burn → CCTP delivery → terminal). Set `VITE_SDK_XCHAIN_UNSHIELD=0` and confirm engine fallback.

Next (slice C): delete the engine `buildXchainUnshieldTransaction` + `normalizeTransaction` + `BroadcasterFeeRecipient` (the whole `lib/railgun/unshield.ts`), the differential + flag, and the redundant local `cctpBinding.ts` — unshield becomes fully engine-free.