### PR TITLE
feat(interface): yield SDK migration — differential + flag-gated cutover (VITE_SDK_YIELD)

### DIFF
--- a/apps/armada-interface/src/features/yield-deposit/handler.ts
+++ b/apps/armada-interface/src/features/yield-deposit/handler.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/railgun/keyManager'
 import { refreshShieldedBalances } from '@/lib/railgun/sync'
 import { buildYieldAdaptTransaction, type BroadcasterFeeRecipient } from '@/lib/railgun/yield'
+import { runYieldDifferential, yieldDifferentialEnabled } from '@/lib/railgun/yield-differential'
 import { submitRelay } from '@/lib/relayer'
 import { handleRelaySubmitError } from '@/lib/tx/relaySubmit'
 import { advance, markFailed } from '@/lib/tx/reducer'
@@ -113,6 +114,26 @@ async function runBuildProof(
   })
 
   if (ctx.signal.aborted) throw new Error('cancelled')
+
+  // Pre-cutover differential (opt-in, observe-only): build this deposit with @armada/sdk and simulate
+  // it against the adapter — telemetry-reports whether the SDK proof + re-shield binding verifies
+  // on-chain. Fire-and-forget; never blocks or fails the deposit (the engine build above is what submits).
+  const evmFrom = record.walletContext.evmAddress
+  if (yieldDifferentialEnabled() && evmFrom) {
+    const bf = broadcasterFeeFromRecord(record, usdcAddress)
+    void runYieldDifferential({
+      mode: 'lend',
+      amount: record.meta.amount,
+      unshieldToken: usdcAddress as `0x${string}`,
+      shieldOutputToken: vaultAddress as `0x${string}`,
+      adapterAddress: adapterAddress as `0x${string}`,
+      railgunAddress,
+      broadcasterFee: bf ? { amount: bf.amount, recipientAddress: bf.recipientAddress } : null,
+      from: evmFrom as `0x${string}`,
+      chainId: getNetworkConfig().hub.chainId,
+    })
+  }
+
   // Stash the populated calldata so submit-relayer skips re-proving. The SDK's
   // generateProofTransactions is stateless — without this, a resume after a transient relayer
   // error would pay the ~20-30s proving cost again.

--- a/apps/armada-interface/src/features/yield-deposit/handler.ts
+++ b/apps/armada-interface/src/features/yield-deposit/handler.ts
@@ -17,6 +17,7 @@ import {
 import { refreshShieldedBalances } from '@/lib/railgun/sync'
 import { buildYieldAdaptTransaction, type BroadcasterFeeRecipient } from '@/lib/railgun/yield'
 import { runYieldDifferential, yieldDifferentialEnabled } from '@/lib/railgun/yield-differential'
+import { buildYieldAdaptSdk, sdkYieldEnabled } from '@/lib/railgun/yield-sdk'
 import { submitRelay } from '@/lib/relayer'
 import { handleRelaySubmitError } from '@/lib/tx/relaySubmit'
 import { advance, markFailed } from '@/lib/tx/reducer'
@@ -99,6 +100,27 @@ async function runBuildProof(
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   const progress = createProofProgressWriter(record, ctx.signal)
+
+  if (sdkYieldEnabled()) {
+    // @armada/sdk cutover: plan (unshield USDC → adapter + re-shield-bundle adaptParams) → prove
+    // off-thread → encode lendAndShield, and stash the calldata so submit-relayer dispatches it
+    // without re-proving. Survives a reload (persisted in the record).
+    const bf = broadcasterFeeFromRecord(record, usdcAddress)
+    const { to, data } = await buildYieldAdaptSdk({
+      mode: 'lend',
+      amount: record.meta.amount,
+      unshieldToken: usdcAddress as `0x${string}`,
+      shieldOutputToken: vaultAddress as `0x${string}`,
+      adapterAddress: adapterAddress as `0x${string}`,
+      railgunAddress,
+      broadcasterFee: bf ? { amount: bf.amount, recipientAddress: bf.recipientAddress } : null,
+      onProgress: progress.write,
+    })
+    if (ctx.signal.aborted) throw new Error('cancelled')
+    await ctx.upsert(advance(progress.latest(), 'submit-relayer', { yieldTx: { to, data, value: '0' } }))
+    return
+  }
+
   const built = await buildYieldAdaptTransaction({
     walletId,
     encryptionKey,

--- a/apps/armada-interface/src/features/yield-withdraw/handler.ts
+++ b/apps/armada-interface/src/features/yield-withdraw/handler.ts
@@ -17,6 +17,7 @@ import {
 import { refreshShieldedBalances } from '@/lib/railgun/sync'
 import { buildYieldAdaptTransaction, type BroadcasterFeeRecipient } from '@/lib/railgun/yield'
 import { runYieldDifferential, yieldDifferentialEnabled } from '@/lib/railgun/yield-differential'
+import { buildYieldAdaptSdk, sdkYieldEnabled } from '@/lib/railgun/yield-sdk'
 import { submitRelay } from '@/lib/relayer'
 import { handleRelaySubmitError } from '@/lib/tx/relaySubmit'
 import { advance, markFailed } from '@/lib/tx/reducer'
@@ -91,6 +92,27 @@ async function runBuildProof(
   if (ctx.signal.aborted) throw new Error('cancelled')
 
   const progress = createProofProgressWriter(record, ctx.signal)
+
+  if (sdkYieldEnabled()) {
+    // @armada/sdk cutover: plan (unshield shares → adapter + re-shield-bundle adaptParams) → prove
+    // off-thread → encode redeemAndShield, and stash the calldata + the fee note's random (#312) so
+    // submit-relayer dispatches it without re-proving. Survives a reload (persisted in the record).
+    const bf = broadcasterFeeFromRecord(record, usdcAddress)
+    const { to, data, feeShieldRandom } = await buildYieldAdaptSdk({
+      mode: 'redeem',
+      amount: record.meta.shares,
+      unshieldToken: yieldDeployment.contracts.armadaYieldVault as `0x${string}`,
+      shieldOutputToken: usdcAddress as `0x${string}`,
+      adapterAddress: yieldDeployment.contracts.armadaYieldAdapter as `0x${string}`,
+      railgunAddress,
+      broadcasterFee: bf ? { amount: bf.amount, recipientAddress: bf.recipientAddress } : null,
+      onProgress: progress.write,
+    })
+    if (ctx.signal.aborted) throw new Error('cancelled')
+    await ctx.upsert(advance(progress.latest(), 'submit-relayer', { yieldTx: { to, data, value: '0' }, feeShieldRandom }))
+    return
+  }
+
   const built = await buildYieldAdaptTransaction({
     walletId,
     encryptionKey,

--- a/apps/armada-interface/src/features/yield-withdraw/handler.ts
+++ b/apps/armada-interface/src/features/yield-withdraw/handler.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/railgun/keyManager'
 import { refreshShieldedBalances } from '@/lib/railgun/sync'
 import { buildYieldAdaptTransaction, type BroadcasterFeeRecipient } from '@/lib/railgun/yield'
+import { runYieldDifferential, yieldDifferentialEnabled } from '@/lib/railgun/yield-differential'
 import { submitRelay } from '@/lib/relayer'
 import { handleRelaySubmitError } from '@/lib/tx/relaySubmit'
 import { advance, markFailed } from '@/lib/tx/reducer'
@@ -109,6 +110,26 @@ async function runBuildProof(
   })
 
   if (ctx.signal.aborted) throw new Error('cancelled')
+
+  // Pre-cutover differential (opt-in, observe-only): build this withdraw with @armada/sdk and simulate
+  // it against the adapter — telemetry-reports whether the SDK proof + re-shield binding (user + fee
+  // notes) verifies on-chain. Fire-and-forget; never blocks or fails the withdraw.
+  const evmFrom = record.walletContext.evmAddress
+  if (yieldDifferentialEnabled() && evmFrom) {
+    const bf = broadcasterFeeFromRecord(record, usdcAddress)
+    void runYieldDifferential({
+      mode: 'redeem',
+      amount: record.meta.shares,
+      unshieldToken: yieldDeployment.contracts.armadaYieldVault as `0x${string}`,
+      shieldOutputToken: usdcAddress as `0x${string}`,
+      adapterAddress: yieldDeployment.contracts.armadaYieldAdapter as `0x${string}`,
+      railgunAddress,
+      broadcasterFee: bf ? { amount: bf.amount, recipientAddress: bf.recipientAddress } : null,
+      from: evmFrom as `0x${string}`,
+      chainId: getNetworkConfig().hub.chainId,
+    })
+  }
+
   await ctx.upsert(advance(progress.latest(), 'submit-relayer', {
     yieldTx: {
       to: built.transaction.to,

--- a/apps/armada-interface/src/lib/railgun/yield-differential.test.ts
+++ b/apps/armada-interface/src/lib/railgun/yield-differential.test.ts
@@ -1,0 +1,54 @@
+// ABOUTME: Unit test for runYieldDifferential — build the SDK yield op, simulate it, and report
+// ABOUTME: sdk.yieldDiff { mode, simulated }; never throws into the caller (observe-only).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({ buildYieldAdaptSdk: vi.fn(), simulateOrThrow: vi.fn() }))
+vi.mock('./yield-sdk', () => ({ buildYieldAdaptSdk: hoisted.buildYieldAdaptSdk }))
+vi.mock('@/lib/tx/simulate', () => ({ simulateOrThrow: hoisted.simulateOrThrow }))
+vi.mock('@/lib/telemetry', () => ({ track: vi.fn(), trackError: vi.fn() }))
+
+import { runYieldDifferential } from './yield-differential'
+import { track, trackError } from '@/lib/telemetry'
+
+const inputs = {
+  mode: 'lend' as const,
+  amount: 5n,
+  unshieldToken: '0xaaaa000000000000000000000000000000000000' as const,
+  shieldOutputToken: '0xbbbb000000000000000000000000000000000000' as const,
+  adapterAddress: '0xcccc000000000000000000000000000000000000' as const,
+  railgunAddress: '0zk_user',
+  broadcasterFee: { amount: 2n, recipientAddress: '0zk_relayer' },
+  from: '0xuser000000000000000000000000000000000000' as const,
+  chainId: 31337,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hoisted.buildYieldAdaptSdk.mockResolvedValue({ to: inputs.adapterAddress, data: '0xdead' })
+})
+
+describe('runYieldDifferential', () => {
+  it('reports simulated:true (with mode) when the SDK calldata passes on-chain simulation', async () => {
+    hoisted.simulateOrThrow.mockResolvedValue(undefined)
+    await runYieldDifferential(inputs)
+    expect(hoisted.simulateOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({ to: inputs.adapterAddress, data: '0xdead', account: inputs.from, chainId: 31337 }),
+    )
+    expect(track).toHaveBeenCalledWith('sdk.yieldDiff', { mode: 'lend', simulated: true })
+  })
+
+  it('reports simulated:false + trackError when the adapter rejects the SDK tx', async () => {
+    hoisted.simulateOrThrow.mockRejectedValue(new Error('execution reverted'))
+    await runYieldDifferential({ ...inputs, mode: 'redeem' })
+    expect(track).toHaveBeenCalledWith('sdk.yieldDiff', { mode: 'redeem', simulated: false })
+    expect(trackError).toHaveBeenCalledWith('sdk.yieldDiff.simulate', expect.any(Error), expect.any(Object))
+  })
+
+  it('never throws into the caller when the SDK build itself fails', async () => {
+    hoisted.buildYieldAdaptSdk.mockRejectedValue(new Error('plan/prove/bundle failed'))
+    await expect(runYieldDifferential(inputs)).resolves.toBeUndefined()
+    expect(trackError).toHaveBeenCalledWith('sdk.yieldDiff.build', expect.any(Error), expect.any(Object))
+    expect(track).not.toHaveBeenCalled()
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/yield-differential.ts
+++ b/apps/armada-interface/src/lib/railgun/yield-differential.ts
@@ -33,11 +33,13 @@ export async function runYieldDifferential(
       track('sdk.yieldDiff', { mode: inputs.mode, simulated: true })
     } catch (simErr) {
       // The SDK built calldata but the adapter rejected it — the load-bearing failure signal.
+      // trackError computes `message` from the error itself (the decoded revert reason) and spreads
+      // props AFTER it, so props must NOT carry `scope`/`message` or they clobber the real revert.
       track('sdk.yieldDiff', { mode: inputs.mode, simulated: false })
-      trackError('sdk.yieldDiff.simulate', simErr, { scope: 'shielded.yield', mode: inputs.mode, message: 'sdk yield failed on-chain simulation' })
+      trackError('sdk.yieldDiff.simulate', simErr, { mode: inputs.mode })
     }
   } catch (err) {
     // The SDK build itself failed (plan/prove/bundle/encode) — never surfaced to the yield flow.
-    trackError('sdk.yieldDiff.build', err, { scope: 'shielded.yield', mode: inputs.mode, message: 'sdk yield build failed' })
+    trackError('sdk.yieldDiff.build', err, { mode: inputs.mode })
   }
 }

--- a/apps/armada-interface/src/lib/railgun/yield-differential.ts
+++ b/apps/armada-interface/src/lib/railgun/yield-differential.ts
@@ -1,0 +1,43 @@
+// ABOUTME: Yield write-path differential — builds the lendAndShield/redeemAndShield calldata via @armada/sdk
+// ABOUTME: and validates it by SIMULATING against the adapter (the on-chain verifier is the arbiter). Observe-only.
+
+import { simulateOrThrow } from '@/lib/tx/simulate'
+import { track, trackError } from '@/lib/telemetry'
+import { buildYieldAdaptSdk, type SdkYieldInputs } from './yield-sdk'
+
+/**
+ * Opt-in gate (`VITE_SHADOW_SDK=1`) — NOT dev-default, because the differential runs a full Groth16
+ * proof on top of the engine's own. You turn it on to validate, not for every dev yield op. Retired
+ * once the yield cutover lands.
+ */
+export function yieldDifferentialEnabled(): boolean {
+  return import.meta.env.VITE_SHADOW_SDK === '1'
+}
+
+/**
+ * Build the yield op with `@armada/sdk` (plan unshield-to-adapter + re-shield-bundle adaptParams →
+ * prove → encode lendAndShield/redeemAndShield) and validate it by `eth_call`-simulating the calldata
+ * against the adapter. If the contract accepts it, the SDK produced a valid op — the proof, nullifiers,
+ * merkleRoot, and the adaptParams↔re-shield-bundle binding all verify on-chain. A proof-carrying tx
+ * can't be byte-compared to the engine's, so simulation is the correctness signal.
+ *
+ * Observe-only: never submits. Never throws into the caller; emits one `sdk.yieldDiff { mode, simulated }`.
+ */
+export async function runYieldDifferential(
+  inputs: SdkYieldInputs & { readonly from: `0x${string}`; readonly chainId: number },
+): Promise<void> {
+  try {
+    const { to, data } = await buildYieldAdaptSdk(inputs)
+    try {
+      await simulateOrThrow({ to, data, value: 0n, account: inputs.from, chainId: inputs.chainId })
+      track('sdk.yieldDiff', { mode: inputs.mode, simulated: true })
+    } catch (simErr) {
+      // The SDK built calldata but the adapter rejected it — the load-bearing failure signal.
+      track('sdk.yieldDiff', { mode: inputs.mode, simulated: false })
+      trackError('sdk.yieldDiff.simulate', simErr, { scope: 'shielded.yield', mode: inputs.mode, message: 'sdk yield failed on-chain simulation' })
+    }
+  } catch (err) {
+    // The SDK build itself failed (plan/prove/bundle/encode) — never surfaced to the yield flow.
+    trackError('sdk.yieldDiff.build', err, { scope: 'shielded.yield', mode: inputs.mode, message: 'sdk yield build failed' })
+  }
+}

--- a/apps/armada-interface/src/lib/railgun/yield-sdk.test.ts
+++ b/apps/armada-interface/src/lib/railgun/yield-sdk.test.ts
@@ -1,0 +1,132 @@
+// ABOUTME: Unit test for buildYieldAdaptSdk — plans an unshield-to-adapter with a re-shield-bundle adaptParams
+// ABOUTME: (deposit vs redeem), and encodes lendAndShield / redeemAndShield from the proved transaction tuple.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  planTransfer: vi.fn(),
+  prove: vi.fn(),
+  buildShieldRequest: vi.fn(),
+  generateShieldPrivateKey: vi.fn(() => new Uint8Array(32)),
+  encodeYieldDepositBinding: vi.fn(() => '0xdepositbinding'),
+  encodeYieldRedeemBinding: vi.fn(() => '0xredeembinding'),
+  transactionToTuple: vi.fn(() => ['TUPLE']),
+  encodeFunctionData: vi.fn(() => '0xcalldata'),
+}))
+vi.mock('@armada/sdk', () => ({
+  buildShieldRequest: hoisted.buildShieldRequest,
+  generateShieldPrivateKey: hoisted.generateShieldPrivateKey,
+  encodeYieldDepositBinding: hoisted.encodeYieldDepositBinding,
+  encodeYieldRedeemBinding: hoisted.encodeYieldRedeemBinding,
+  transactionToTuple: hoisted.transactionToTuple,
+}))
+vi.mock('ethers', () => ({
+  // A regular function (not arrow) so `new ethers.Interface(...)` works as a constructor.
+  ethers: { Interface: vi.fn(function () { return { encodeFunctionData: hoisted.encodeFunctionData } }) },
+}))
+vi.mock('./sdk-read', () => ({
+  getSdkWallet: async () => ({ planTransfer: hoisted.planTransfer, prove: hoisted.prove }),
+}))
+
+import { buildYieldAdaptSdk } from './yield-sdk'
+
+const USDC = '0xaaaa000000000000000000000000000000000000' as const
+const VAULT = '0xbbbb000000000000000000000000000000000000' as const
+const ADAPTER = '0xcccc000000000000000000000000000000000000' as const
+const NPK = `0x${'11'.repeat(32)}`
+const FEE_NPK = `0x${'22'.repeat(32)}`
+const BUNDLE: [string, string, string] = [`0x${'a1'.repeat(32)}`, `0x${'a2'.repeat(32)}`, `0x${'a3'.repeat(32)}`]
+const SHIELD_KEY = `0x${'bb'.repeat(32)}`
+
+function shieldReqReturning(npk: string, random: string) {
+  return {
+    shieldRequest: { preimage: { npk }, ciphertext: { encryptedBundle: BUNDLE, shieldKey: SHIELD_KEY } },
+    random,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hoisted.planTransfer.mockResolvedValue({ plan: true })
+  hoisted.prove.mockResolvedValue({ toTransactionData: () => ({ tx: 'data' }) })
+  hoisted.transactionToTuple.mockReturnValue(['TUPLE'])
+  hoisted.encodeFunctionData.mockReturnValue('0xcalldata')
+})
+
+describe('buildYieldAdaptSdk', () => {
+  it('deposit (lend): plans unshield USDC→adapter with the deposit binding + SDK fee leg, encodes lendAndShield', async () => {
+    hoisted.buildShieldRequest.mockResolvedValueOnce(shieldReqReturning(NPK, 'r-user'))
+    const r = await buildYieldAdaptSdk({
+      mode: 'lend',
+      amount: 5_000_000n,
+      unshieldToken: USDC,
+      shieldOutputToken: VAULT,
+      adapterAddress: ADAPTER,
+      railgunAddress: '0zk_user',
+      broadcasterFee: { amount: 20_000n, recipientAddress: '0zk_relayer' },
+    })
+    // Re-shield destination is the USER's 0zk in the OUTPUT token (ayUSDC shares).
+    expect(hoisted.buildShieldRequest).toHaveBeenCalledTimes(1)
+    expect(hoisted.buildShieldRequest.mock.calls[0]![0]).toEqual({ railgunAddress: '0zk_user', amount: 0n, tokenAddress: VAULT })
+    // Deposit binding over (npk, bundle, shieldKey).
+    expect(hoisted.encodeYieldDepositBinding).toHaveBeenCalledWith(BigInt(NPK), BUNDLE, SHIELD_KEY)
+    // Unshield goes TO the adapter (adaptContract = adapter), token = USDC, plus the SDK fee leg.
+    expect(hoisted.planTransfer).toHaveBeenCalledWith({
+      outputs: [],
+      unshield: { recipient: ADAPTER, amount: 5_000_000n, adaptContract: ADAPTER, adaptParams: '0xdepositbinding' },
+      tokenAddress: USDC,
+      fee: { schedule: { transfer: '20000' }, broadcasterRailgunAddress: '0zk_relayer', feesCacheId: '', expiresAt: 0 },
+    })
+    // lendAndShield(transaction tuple, npk, shieldCiphertext).
+    expect(hoisted.encodeFunctionData).toHaveBeenCalledWith('lendAndShield', [['TUPLE'], NPK, { encryptedBundle: BUNDLE, shieldKey: SHIELD_KEY }])
+    expect(r).toEqual({ to: ADAPTER, data: '0xcalldata' })
+    expect(r.feeShieldRandom).toBeUndefined() // deposit has no contract-side fee note
+  })
+
+  it('redeem: plans unshield shares→adapter, builds the fee re-shield bundle, encodes redeemAndShield + surfaces feeShieldRandom', async () => {
+    hoisted.buildShieldRequest
+      .mockResolvedValueOnce(shieldReqReturning(NPK, 'r-user'))   // user bundle
+      .mockResolvedValueOnce(shieldReqReturning(FEE_NPK, 'r-fee')) // relayer fee bundle
+    const r = await buildYieldAdaptSdk({
+      mode: 'redeem',
+      amount: 3_000_000n, // shares
+      unshieldToken: VAULT,
+      shieldOutputToken: USDC,
+      adapterAddress: ADAPTER,
+      railgunAddress: '0zk_user',
+      broadcasterFee: { amount: 15_000n, recipientAddress: '0zk_relayer' },
+    })
+    // Two bundles: user (USDC out) + relayer fee note (USDC out).
+    expect(hoisted.buildShieldRequest).toHaveBeenCalledTimes(2)
+    expect(hoisted.buildShieldRequest.mock.calls[1]![0]).toEqual({ railgunAddress: '0zk_relayer', amount: 0n, tokenAddress: USDC })
+    // Redeem binding covers user + fee bundle + feeAmount.
+    expect(hoisted.encodeYieldRedeemBinding).toHaveBeenCalledWith(BigInt(NPK), BUNDLE, SHIELD_KEY, BigInt(FEE_NPK), BUNDLE, SHIELD_KEY, 15_000n)
+    // Redeem plans with NO SDK fee leg (fee is contract-side), token = shares (ayUSDC).
+    expect(hoisted.planTransfer).toHaveBeenCalledWith({
+      outputs: [],
+      unshield: { recipient: ADAPTER, amount: 3_000_000n, adaptContract: ADAPTER, adaptParams: '0xredeembinding' },
+      tokenAddress: VAULT,
+      fee: { schedule: { transfer: '0' }, broadcasterRailgunAddress: '', feesCacheId: '', expiresAt: 0 },
+    })
+    expect(hoisted.encodeFunctionData).toHaveBeenCalledWith('redeemAndShield', [['TUPLE'], NPK, { encryptedBundle: BUNDLE, shieldKey: SHIELD_KEY }, FEE_NPK, { encryptedBundle: BUNDLE, shieldKey: SHIELD_KEY }, 15_000n])
+    expect(r.feeShieldRandom).toBe('r-fee') // #312 — surfaced for the relayer's npk-reconstruction check
+  })
+
+  it('redeem wallet-override (no broadcaster fee): zero fee bundle, no feeShieldRandom', async () => {
+    hoisted.buildShieldRequest.mockResolvedValueOnce(shieldReqReturning(NPK, 'r-user'))
+    const r = await buildYieldAdaptSdk({
+      mode: 'redeem',
+      amount: 3_000_000n,
+      unshieldToken: VAULT,
+      shieldOutputToken: USDC,
+      adapterAddress: ADAPTER,
+      railgunAddress: '0zk_user',
+      broadcasterFee: null,
+    })
+    // Only the user bundle; the fee slots are zeroed and feeAmount is 0.
+    expect(hoisted.buildShieldRequest).toHaveBeenCalledTimes(1)
+    const zero = `0x${'00'.repeat(32)}`
+    expect(hoisted.encodeYieldRedeemBinding).toHaveBeenCalledWith(BigInt(NPK), BUNDLE, SHIELD_KEY, BigInt(zero), [zero, zero, zero], zero, 0n)
+    expect(r.feeShieldRandom).toBeUndefined()
+  })
+})

--- a/apps/armada-interface/src/lib/railgun/yield-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/yield-sdk.ts
@@ -1,0 +1,155 @@
+// ABOUTME: SDK-backed yield adapter builder — planTransfer(unshield to adapter + re-shield-bundle adaptParams)
+// ABOUTME: → prove → transactionToTuple → encode lendAndShield / redeemAndShield. @armada/sdk analogue of buildYieldAdaptTransaction.
+
+import { ethers } from 'ethers'
+import {
+  buildShieldRequest,
+  generateShieldPrivateKey,
+  encodeYieldDepositBinding,
+  encodeYieldRedeemBinding,
+  transactionToTuple,
+} from '@armada/sdk'
+import { getSdkWallet } from './sdk-read'
+
+const ZERO_BYTES32 = `0x${'00'.repeat(32)}` as const
+
+/**
+ * Adapter entry points — the proved Transaction tuple + the user's re-shield destination (npk +
+ * ciphertext). `redeemAndShield` additionally takes the relayer's fee-shield destination + amount,
+ * all committed by `boundParams.adaptParams`. Mirrors contracts/yield/ArmadaYieldAdapter.sol; the same
+ * human-readable strings the engine builder used, via `ethers.Interface` (viem's parseAbi can't parse
+ * this depth of nested inline tuples). The Transaction is passed as a positional tuple.
+ */
+const ADAPTER_ABI = [
+  'function lendAndShield(tuple(tuple(tuple(uint256 x, uint256 y) a, tuple(uint256[2] x, uint256[2] y) b, tuple(uint256 x, uint256 y) c) proof, bytes32 merkleRoot, bytes32[] nullifiers, bytes32[] commitments, tuple(uint16 treeNumber, uint72 minGasPrice, uint8 unshield, uint64 chainID, address adaptContract, bytes32 adaptParams, tuple(bytes32[4] ciphertext, bytes32 blindedSenderViewingKey, bytes32 blindedReceiverViewingKey, bytes annotationData, bytes memo)[] commitmentCiphertext) boundParams, tuple(bytes32 npk, tuple(uint8 tokenType, address tokenAddress, uint256 tokenSubID) token, uint120 value) unshieldPreimage) _transaction, bytes32 _npk, tuple(bytes32[3] encryptedBundle, bytes32 shieldKey) _shieldCiphertext) returns (uint256)',
+  'function redeemAndShield(tuple(tuple(tuple(uint256 x, uint256 y) a, tuple(uint256[2] x, uint256[2] y) b, tuple(uint256 x, uint256 y) c) proof, bytes32 merkleRoot, bytes32[] nullifiers, bytes32[] commitments, tuple(uint16 treeNumber, uint72 minGasPrice, uint8 unshield, uint64 chainID, address adaptContract, bytes32 adaptParams, tuple(bytes32[4] ciphertext, bytes32 blindedSenderViewingKey, bytes32 blindedReceiverViewingKey, bytes annotationData, bytes memo)[] commitmentCiphertext) boundParams, tuple(bytes32 npk, tuple(uint8 tokenType, address tokenAddress, uint256 tokenSubID) token, uint120 value) unshieldPreimage) _transaction, bytes32 _npk, tuple(bytes32[3] encryptedBundle, bytes32 shieldKey) _shieldCiphertext, bytes32 _feeNpk, tuple(bytes32[3] encryptedBundle, bytes32 shieldKey) _feeShieldCiphertext, uint256 _feeAmount) returns (uint256)',
+]
+
+const as0x = (hex: string): `0x${string}` => {
+  if (!hex.startsWith('0x')) throw new Error('yield-sdk: expected a 0x-prefixed hex value')
+  return hex as `0x${string}`
+}
+
+/** A re-shield destination bound into adaptParams: npk (poseidon(mpk, random)) + the shield ECIES bundle. */
+interface ReshieldBundle {
+  readonly npk: `0x${string}`
+  readonly encryptedBundle: readonly [`0x${string}`, `0x${string}`, `0x${string}`]
+  readonly shieldKey: `0x${string}`
+  readonly random: string
+}
+
+/**
+ * Build a re-shield destination for `railgunAddress` in `tokenAddress` — the note the adapter shields
+ * back into the pool after the vault op. Value is 0 (the adapter fills the real output amount at
+ * runtime); only npk/encryptedBundle/shieldKey are bound into adaptParams, all value-independent.
+ */
+async function buildReshieldBundle(railgunAddress: string, tokenAddress: `0x${string}`): Promise<ReshieldBundle> {
+  const { shieldRequest, random } = await buildShieldRequest(
+    { railgunAddress, amount: 0n, tokenAddress },
+    generateShieldPrivateKey(),
+  )
+  return {
+    npk: as0x(shieldRequest.preimage.npk),
+    encryptedBundle: [
+      as0x(shieldRequest.ciphertext.encryptedBundle[0]),
+      as0x(shieldRequest.ciphertext.encryptedBundle[1]),
+      as0x(shieldRequest.ciphertext.encryptedBundle[2]),
+    ],
+    shieldKey: as0x(shieldRequest.ciphertext.shieldKey),
+    random,
+  }
+}
+
+export interface SdkYieldInputs {
+  readonly mode: 'lend' | 'redeem'
+  /** Unshield amount: USDC (lend) or vault shares (redeem) — the token spent to the adapter. */
+  readonly amount: bigint
+  /** Token spent to the adapter: USDC (lend) / ayUSDC shares (redeem). */
+  readonly unshieldToken: `0x${string}`
+  /** Token the adapter re-shields back to the user: ayUSDC shares (lend) / USDC (redeem). */
+  readonly shieldOutputToken: `0x${string}`
+  readonly adapterAddress: `0x${string}`
+  /** The user's 0zk address — recipient of the re-shielded output. */
+  readonly railgunAddress: string
+  /** Broadcaster (relayer) fee. On lend it's a shielded fee note (SDK fee leg); on redeem it's the
+   *  contract-side fee shielded to the relayer's 0zk from the redeemed USDC, bound into adaptParams. */
+  readonly broadcasterFee: { readonly amount: bigint; readonly recipientAddress: string } | null
+  readonly onProgress?: (fraction: number) => void
+}
+
+/**
+ * Build a yield adapter transaction via `@armada/sdk`. The proof unshields `amount` of `unshieldToken`
+ * TO the adapter (`adaptContract` = adapter), with the user's re-shield destination bound into
+ * `boundParams.adaptParams`; the adapter deposits into (lend) / redeems from (redeem) the vault and
+ * shields the result back to the user. Returns the encoded `lendAndShield`/`redeemAndShield` calldata.
+ *
+ * `feeShieldRandom` is surfaced on redeem so the relayer can recompute the fee note's npk =
+ * poseidon(itsMasterPublicKey, feeShieldRandom) and confirm the fee is addressed to itself (#312).
+ */
+export async function buildYieldAdaptSdk(
+  inputs: SdkYieldInputs,
+): Promise<{ to: `0x${string}`; data: `0x${string}`; feeShieldRandom?: string }> {
+  const isRedeem = inputs.mode === 'redeem'
+  const wallet = await getSdkWallet()
+
+  // The user's re-shield destination + the deposit/redeem binding.
+  const user = await buildReshieldBundle(inputs.railgunAddress, inputs.shieldOutputToken)
+
+  // The relayer fee re-shield destination (redeem only, when a broadcaster fee is charged).
+  let feeNpk: `0x${string}` = ZERO_BYTES32
+  let feeEncryptedBundle: readonly [`0x${string}`, `0x${string}`, `0x${string}`] = [ZERO_BYTES32, ZERO_BYTES32, ZERO_BYTES32]
+  let feeShieldKey: `0x${string}` = ZERO_BYTES32
+  let feeAmount = 0n
+  let feeShieldRandom: string | undefined
+  if (isRedeem && inputs.broadcasterFee && inputs.broadcasterFee.amount > 0n) {
+    const fee = await buildReshieldBundle(inputs.broadcasterFee.recipientAddress, inputs.shieldOutputToken)
+    feeNpk = fee.npk
+    feeEncryptedBundle = fee.encryptedBundle
+    feeShieldKey = fee.shieldKey
+    feeAmount = inputs.broadcasterFee.amount
+    feeShieldRandom = fee.random
+  }
+
+  const adaptParams = isRedeem
+    ? encodeYieldRedeemBinding(BigInt(user.npk), user.encryptedBundle, user.shieldKey, BigInt(feeNpk), feeEncryptedBundle, feeShieldKey, feeAmount)
+    : encodeYieldDepositBinding(BigInt(user.npk), user.encryptedBundle, user.shieldKey)
+
+  // Lend pays the relayer via the SDK fee leg (a shielded USDC output note); redeem does not (its fee
+  // is the contract-side re-shield above), so it plans with no fee output.
+  const fee = !isRedeem && inputs.broadcasterFee
+    ? {
+        schedule: { transfer: inputs.broadcasterFee.amount.toString() },
+        broadcasterRailgunAddress: inputs.broadcasterFee.recipientAddress,
+        feesCacheId: '',
+        expiresAt: 0,
+      }
+    : { schedule: { transfer: '0' }, broadcasterRailgunAddress: '', feesCacheId: '', expiresAt: 0 }
+
+  const plan = await wallet.planTransfer({
+    outputs: [],
+    unshield: { recipient: inputs.adapterAddress, amount: inputs.amount, adaptContract: inputs.adapterAddress, adaptParams },
+    tokenAddress: inputs.unshieldToken,
+    fee,
+  })
+  const handle = await wallet.prove(
+    plan,
+    inputs.onProgress ? { onProgress: (p) => inputs.onProgress?.(p.fraction) } : undefined,
+  )
+  const tuple = transactionToTuple(handle.toTransactionData())
+  const iface = new ethers.Interface(ADAPTER_ABI)
+
+  const data = (
+    isRedeem
+      ? iface.encodeFunctionData('redeemAndShield', [
+          tuple,
+          user.npk,
+          { encryptedBundle: user.encryptedBundle, shieldKey: user.shieldKey },
+          feeNpk,
+          { encryptedBundle: feeEncryptedBundle, shieldKey: feeShieldKey },
+          feeAmount,
+        ])
+      : iface.encodeFunctionData('lendAndShield', [tuple, user.npk, { encryptedBundle: user.encryptedBundle, shieldKey: user.shieldKey }])
+  ) as `0x${string}`
+
+  return { to: inputs.adapterAddress, data, ...(feeShieldRandom !== undefined ? { feeShieldRandom } : {}) }
+}

--- a/apps/armada-interface/src/lib/railgun/yield-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/yield-sdk.ts
@@ -30,6 +30,14 @@ const as0x = (hex: string): `0x${string}` => {
   return hex as `0x${string}`
 }
 
+/**
+ * Write-path cutover flag. When set, the yield handlers build + submit via `@armada/sdk`
+ * (`buildYieldAdaptSdk`) instead of the stock engine. Off by default; the engine drives.
+ */
+export function sdkYieldEnabled(): boolean {
+  return import.meta.env.VITE_SDK_YIELD === '1'
+}
+
 /** A re-shield destination bound into adaptParams: npk (poseidon(mpk, random)) + the shield ECIES bundle. */
 interface ReshieldBundle {
   readonly npk: `0x${string}`

--- a/apps/armada-interface/src/lib/telemetry.ts
+++ b/apps/armada-interface/src/lib/telemetry.ts
@@ -51,6 +51,12 @@ export type EventRegistry = {
   // means it resumed from the IndexedDB checkpoint. `scanned` false = head hadn't advanced (no work).
   'sdk.sync':                 { fromBlock: number; syncedThrough: number; scanned: boolean }
 
+  // @armada/sdk yield write-path differential — one line per SDK build+simulate (opt-in VITE_SHADOW_SDK).
+  // `simulated` true = the adapter's on-chain verifier accepted the SDK-built lendAndShield/redeemAndShield
+  // calldata (the arbiter — a proof-carrying tx can't be byte-compared, and it exercises the
+  // adaptParams↔re-shield-bundle binding). Observe-only; retired at the yield cutover.
+  'sdk.yieldDiff':            { mode: 'lend' | 'redeem'; simulated: boolean }
+
   'tx.submitted':             { id: string; kind: TxKind }
   'tx.transition':            { id: string; kind: TxKind; from: TxStage; to: TxStage; executionState: TxRecord['executionState'] }
   'tx.failed':                { id: string; kind: TxKind; errorCode?: string }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#0f1f3c2682fdf7788d0f155f0c28e12f0d78240a",
+        "@armada/sdk": "github:ship-armada/armada-sdk#12d6ffcf8f4a09c7d8258d67b9c56656e5371a85",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#0f1f3c2682fdf7788d0f155f0c28e12f0d78240a",
-      "integrity": "sha512-V2ne4uRCC28wyPIXLNCXynEI9ZoJafYTk3f49uwbqaicpojBBYk1PxGd8dRuod8WvT3kaAyeKwU+FfHmxxD6Qg==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#12d6ffcf8f4a09c7d8258d67b9c56656e5371a85",
+      "integrity": "sha512-Fr+HI+f86U+M0/t1PFjrEq1MS/300g/jDbWNQsPdtwjb05HwfHGLI3nXHJ3ax5gV4KSyplPHbv1kMHX9TfgZDw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#0f1f3c2682fdf7788d0f155f0c28e12f0d78240a",
+    "@armada/sdk": "github:ship-armada/armada-sdk#12d6ffcf8f4a09c7d8258d67b9c56656e5371a85",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",


### PR DESCRIPTION
Phase B, yield (last write-path surface). Builds both yield ops (`lendAndShield`/`redeemAndShield`) via `@armada/sdk`. Two things in one PR: the observe-only differential AND the flag-gated submission cutover (`VITE_SDK_YIELD=1`). Depends on armada-sdk#54 (multi-token spend + `adaptContract` threading — re-pinned here).

## What
- **`lib/railgun/yield-sdk.ts`** — `buildYieldAdaptSdk(mode, …)`: re-shield bundle via the SDK's `buildShieldRequest` (`preimage.npk` + `ciphertext.{encryptedBundle,shieldKey}` + `random`); `adaptParams` via `encodeYieldDepositBinding` / `encodeYieldRedeemBinding`; `planTransfer({ unshield: { recipient: adapter, amount, adaptContract: adapter, adaptParams }, tokenAddress, fee })` → prove → `transactionToTuple` → `ethers.Interface` encodes `lendAndShield`/`redeemAndShield`. Deposit spends USDC (SDK fee leg); redeem spends the ayUSDC share token (new per-request `tokenAddress`) with the contract-side fee bound in `adaptParams` and `feeShieldRandom` surfaced (#312). Flag: `sdkYieldEnabled()` = `VITE_SDK_YIELD === '1'` (opt-in).
- **`lib/railgun/yield-differential.ts`** — build via SDK, simulate against the adapter; `sdk.yieldDiff { mode, simulated }`. Runs when the flag is off (observe-only fallback).
- **Both handlers** — flag on → build via SDK, stash the calldata (+ `feeShieldRandom` on withdraw), advance; flag off → engine path + differential. Submit path unchanged (dispatches the stash verbatim).

## Validation status
- **Redeem differential: `simulated: true`** on-chain — validates the harder path (multi-token spend + two-bundle binding + contract-side fee).
- **Deposit differential: `simulated: false`** — the revert is `TransactModule: Note already spent`, i.e. the SDK reselected a USDC note the **engine** (the real submitter during the differential) had already spent; the SDK scan lagged. A dual-wallet contention artifact of the differential phase, **not a builder bug** (the proof was structurally valid; binding/adaptContract/token all correct). Confirmed the byte-parity of `YieldAdaptParams.encode` (contract) vs `encodeYieldDepositBinding` (SDK).
- The flag-gated cutover is how deposit gets validated cleanly: with `VITE_SDK_YIELD=1` the SDK is the sole submitter (no engine contention), it spends + self-tracks the note.
- Follow-up filed for the underlying in-flight-spend gap: **armada-sdk#55** (`spendableTxos` tracks only confirmed nullifiers; near-term hardening, affects all spend kinds).

## Testing
- New unit tests (6) — first-ever coverage for the yield builder: deposit binding + plan + `lendAndShield`; redeem two-bundle binding + no-fee-leg plan + `redeemAndShield` + `feeShieldRandom`; wallet-override zero-fee; plus differential true/false/never-throws. Typecheck clean; existing yield handler tests (3) green.
- **Runtime (Butters):** local stack + yield deployed, `VITE_SDK_YIELD=1`, run a deposit AND a withdraw end-to-end (relayer + A6 wallet-override) — confirm shares/USDC land and the record reaches `hub-confirmed`. Flag unset → engine path (+ observe-only differential).

Next after validation: default-flip (opt-out `VITE_SDK_YIELD=0`), then delete `yield.ts` + `normalizeTransactionForAdapter` + the differential + flag. Then the final teardown: engine init + balance-event bus.