### PR TITLE
feat(interface): default yield to @armada/sdk (opt out via VITE_SDK_YIELD=0)

### DIFF
--- a/apps/armada-interface/src/lib/railgun/yield-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/yield-sdk.ts
@@ -31,11 +31,12 @@ const as0x = (hex: string): `0x${string}` => {
 }
 
 /**
- * Write-path cutover flag. When set, the yield handlers build + submit via `@armada/sdk`
- * (`buildYieldAdaptSdk`) instead of the stock engine. Off by default; the engine drives.
+ * Write-path cutover flag. The yield handlers build + submit via `@armada/sdk` (`buildYieldAdaptSdk`)
+ * by default; set `VITE_SDK_YIELD=0` to fall back to the stock engine (escape hatch, retained until
+ * the engine yield builder is deleted).
  */
 export function sdkYieldEnabled(): boolean {
-  return import.meta.env.VITE_SDK_YIELD === '1'
+  return import.meta.env.VITE_SDK_YIELD !== '0'
 }
 
 /** A re-shield destination bound into adaptParams: npk (poseidon(mpk, random)) + the shield ECIES bundle. */


### PR DESCRIPTION
Phase B, yield slice B — flips the default. Deposit + withdraw now build + submit via `@armada/sdk` for everyone; `VITE_SDK_YIELD=0` is the escape hatch back to the stock engine (retained until the engine builder is deleted in slice C). Mirrors the unshield/xchain default-flips.

Validated in #458 with the flag on: both lend and withdraw went end-to-end (shares/USDC land, records reach `hub-confirmed`). One-line change: `sdkYieldEnabled()` from `=== '1'` to `!== '0'`.

## Testing
- Interface typecheck clean; yield tests unaffected (they mock the build path directly).
- **Runtime (Butters):** with no flag set, run a deposit + withdraw and confirm they take the SDK path (`hub-confirmed`). Set `VITE_SDK_YIELD=0` and confirm engine fallback.

Next (slice C): delete `lib/railgun/yield.ts` (`buildYieldAdaptTransaction` + `normalizeTransactionForAdapter` + the inline encoders/ABI), the differential + `sdk.yieldDiff`, and the flag — yield becomes engine-free. Then the final teardown: engine init + the stock-engine balance-event bus (repoint onto the SDK's native scan events — also silences the merkletree error).