### PR TITLE
feat(interface): unlock/lock/reset + nullifier cross-check + address off the engine; wire SDK-read quick-sync

### DIFF
--- a/apps/armada-interface/src/lib/address.ts
+++ b/apps/armada-interface/src/lib/address.ts
@@ -53,17 +53,21 @@ export function isShieldedAddress(value: string): boolean {
 }
 
 /**
- * Strict shielded-address validation via the Railgun SDK's `validateRailgunAddress` (bech32m +
- * checksum). Async + dynamic-imported: the SDK is heavy and crashes under jsdom at module load, so
- * it already ships as a lazy chunk (init.ts / wallet.ts) — this adds no entry-chunk weight. The
- * sync `isShieldedAddress` regex stays the per-keystroke fast path; call this once at the
- * form-validation / submit boundary to reject a 0zk recipient whose checksum doesn't validate
- * (a transposed character that the shape regex would otherwise wave funds through to).
+ * Strict shielded-address validation via `@armada/sdk`'s `decodeAddress` (bech32m checksum + `0zk`
+ * prefix + address version — it throws on any of those failing). The sync `isShieldedAddress` regex
+ * stays the per-keystroke fast path; call this once at the form-validation / submit boundary to
+ * reject a 0zk recipient whose checksum doesn't validate (a transposed character that the shape
+ * regex would otherwise wave funds through to).
  */
 export async function validateShieldedAddressStrict(value: string): Promise<boolean> {
   const v = value.trim()
-  // Fast pre-filter: avoid loading the SDK chunk for obviously-malformed input.
+  // Fast pre-filter: avoid the decode path for obviously-malformed input.
   if (!isShieldedAddress(v)) return false
-  const { validateRailgunAddress } = await import('@railgun-community/wallet')
-  return validateRailgunAddress(v)
+  const { decodeAddress } = await import('@armada/sdk/core')
+  try {
+    decodeAddress(v)
+    return true
+  } catch {
+    return false
+  }
 }

--- a/apps/armada-interface/src/lib/crypto/kdf.ts
+++ b/apps/armada-interface/src/lib/crypto/kdf.ts
@@ -103,6 +103,21 @@ export function deriveHistoryEncryptionKey(rootSecret: Uint8Array): Uint8Array {
   return hkdfExpand(sha256, rootSecret, HKDF_INFO_HISTORY_ENCRYPTION_V1, 32)
 }
 
+/** Info string for the local wallet identifier. Versioned; domain-separated from the encryption keys. */
+const HKDF_INFO_WALLET_ID_V1 = utf8('armada-wallet-id:v1')
+
+/**
+ * Deterministic, engine-free wallet identifier — HKDF-Expand from root_secret (16 bytes → 32 hex),
+ * domain-separated from the encryption/history keys. Replaces the stock engine's opaque
+ * `sha256(mnemonicToSeed(...) ‖ index)` walletId now that the engine is gone. Non-secret: it's a
+ * one-way derivation used only to key local bookkeeping (the per-(EVM, account) maps + tx-history
+ * records); knowing it grants nothing (the at-rest wallet/history is encrypted under separate keys).
+ */
+export function deriveWalletId(rootSecret: Uint8Array): string {
+  assertRootSecret(rootSecret)
+  return bytesToHexNoPrefix(hkdfExpand(sha256, rootSecret, HKDF_INFO_WALLET_ID_V1, 16))
+}
+
 /**
  * Convert the 32-byte root_secret into a 24-word BIP-39 mnemonic for SDK consumption only.
  *

--- a/apps/armada-interface/src/lib/railgun/nullifierCrossCheck.test.ts
+++ b/apps/armada-interface/src/lib/railgun/nullifierCrossCheck.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const hoisted = vi.hoisted(() => ({
-  walletForID: vi.fn(),
+  getSdkWallet: vi.fn(),
   getNetworkConfig: vi.fn(),
   loadDeployments: vi.fn(),
   timeoutProvider: vi.fn(() => ({})),
@@ -14,10 +14,8 @@ const hoisted = vi.hoisted(() => ({
   trackError: vi.fn(),
 }))
 
-vi.mock('@railgun-community/wallet', () => ({ walletForID: hoisted.walletForID }))
-vi.mock('@railgun-community/shared-models', () => ({
-  TXIDVersion: { V2_PoseidonMerkle: 'V2_PoseidonMerkle' },
-}))
+// The cross-check now reads the wallet's spendable notes' (tree, nullifier) from @armada/sdk.
+vi.mock('./sdk-read', () => ({ getSdkWallet: hoisted.getSdkWallet }))
 vi.mock('ethers', () => ({
   ethers: {
     Contract: class {
@@ -31,10 +29,7 @@ vi.mock('ethers', () => ({
 vi.mock('@/config/network', () => ({ getNetworkConfig: hoisted.getNetworkConfig }))
 vi.mock('@/config/deployments', () => ({ loadDeployments: hoisted.loadDeployments }))
 vi.mock('@/lib/multicall3', () => ({ aggregate3: hoisted.aggregate3 }))
-vi.mock('./network', () => ({
-  timeoutProvider: hoisted.timeoutProvider,
-  getHubChainDescriptor: () => ({ type: 0, id: 31337 }),
-}))
+vi.mock('./network', () => ({ timeoutProvider: hoisted.timeoutProvider }))
 vi.mock('@/lib/telemetry', () => ({ trackError: hoisted.trackError }))
 
 import {
@@ -44,8 +39,9 @@ import {
   toNullifierBytes32,
 } from './nullifierCrossCheck'
 
-function txo(overrides: Record<string, unknown>) {
-  return { tree: 0, position: 0, nullifier: '0xnf', spendtxid: false as string | false, ...overrides }
+/** Stub the SDK wallet's `spendableNullifiers()` — the read the cross-check consumes. */
+function mockSpendable(refs: { tree: number; nullifier: bigint }[]): void {
+  hoisted.getSdkWallet.mockResolvedValue({ spendableNullifiers: () => refs })
 }
 
 beforeEach(() => {
@@ -92,26 +88,23 @@ describe('detectOmittedNullifiers (pure)', () => {
 })
 
 describe('getOwnUnspentNotes', () => {
-  it('returns only locally-unspent notes as {tree, nullifier}', async () => {
-    hoisted.walletForID.mockReturnValue({
-      TXOs: vi.fn(async () => [
-        txo({ tree: 0, nullifier: '0xunspent', spendtxid: false }),
-        txo({ tree: 0, nullifier: '0xspent', spendtxid: '0xsometx' }),
-        txo({ tree: 2, nullifier: '0xunspent2', spendtxid: false }),
-      ]),
-    })
-
-    const notes = await getOwnUnspentNotes('wallet-1')
+  it('maps the SDK\'s spendable (tree, nullifier) refs to {tree, nullifier-hex}', async () => {
+    // spendableNullifiers is already unspent-filtered by the SDK; the nullifier is a field bigint.
+    mockSpendable([
+      { tree: 0, nullifier: 0xdeadn },
+      { tree: 2, nullifier: 0xbeefn },
+    ])
+    const notes = await getOwnUnspentNotes()
     expect(notes).toEqual([
-      { tree: 0, nullifier: '0xunspent' },
-      { tree: 2, nullifier: '0xunspent2' },
+      { tree: 0, nullifier: (0xdeadn).toString(16) },
+      { tree: 2, nullifier: (0xbeefn).toString(16) },
     ])
   })
 })
 
 describe('toNullifierBytes32', () => {
-  it('0x-prefixes the engine\'s unprefixed 32-byte nullifier hex', () => {
-    const raw = 'ab'.repeat(32) // 64 hex chars, no 0x — exactly what the engine hands us
+  it('0x-prefixes an unprefixed 32-byte nullifier hex', () => {
+    const raw = 'ab'.repeat(32) // 64 hex chars, no 0x
     expect(toNullifierBytes32(raw)).toBe(`0x${raw}`)
   })
 
@@ -127,12 +120,10 @@ describe('toNullifierBytes32', () => {
 
 describe('checkOwnNullifiersOnChain (wired)', () => {
   it('flags omission-detected and batches a 0x-prefixed bytes32 into one aggregate3 call', async () => {
-    // The engine yields the nullifier UNPREFIXED; the wired check must normalize it before the
-    // ethers encode, else ethers throws "invalid BytesLike value" (the WI-5 fail-open regression).
+    // The SDK yields the nullifier as a field bigint; the wired check renders + normalizes it to a
+    // 0x-prefixed bytes32 before the ethers encode, else ethers throws "invalid BytesLike value".
     const rawNullifier = 'ab'.repeat(32)
-    hoisted.walletForID.mockReturnValue({
-      TXOs: vi.fn(async () => [txo({ tree: 0, nullifier: rawNullifier, spendtxid: false })]),
-    })
+    mockSpendable([{ tree: 0, nullifier: BigInt(`0x${rawNullifier}`) }])
     hoisted.aggregate3.mockResolvedValue([{ success: true, result: [true] }]) // chain says spent
 
     const r = await checkOwnNullifiersOnChain('wallet-1')
@@ -148,13 +139,11 @@ describe('checkOwnNullifiersOnChain (wired)', () => {
   })
 
   it('batches every unspent note into a single aggregate3 call', async () => {
-    hoisted.walletForID.mockReturnValue({
-      TXOs: vi.fn(async () => [
-        txo({ tree: 0, nullifier: '0xa', spendtxid: false }),
-        txo({ tree: 1, nullifier: '0xb', spendtxid: false }),
-        txo({ tree: 2, nullifier: '0xc', spendtxid: false }),
-      ]),
-    })
+    mockSpendable([
+      { tree: 0, nullifier: 0xan },
+      { tree: 1, nullifier: 0xbn },
+      { tree: 2, nullifier: 0xcn },
+    ])
     hoisted.aggregate3.mockResolvedValue([
       { success: true, result: [false] },
       { success: true, result: [false] },
@@ -169,9 +158,7 @@ describe('checkOwnNullifiersOnChain (wired)', () => {
   })
 
   it('returns ok when the chain agrees the notes are unspent', async () => {
-    hoisted.walletForID.mockReturnValue({
-      TXOs: vi.fn(async () => [txo({ tree: 0, nullifier: '0xa', spendtxid: false })]),
-    })
+    mockSpendable([{ tree: 0, nullifier: 0xan }])
     hoisted.aggregate3.mockResolvedValue([{ success: true, result: [false] }])
 
     const r = await checkOwnNullifiersOnChain('wallet-1')
@@ -179,12 +166,10 @@ describe('checkOwnNullifiersOnChain (wired)', () => {
   })
 
   it('treats an unreadable sub-call as not-spent (fail-open per note)', async () => {
-    hoisted.walletForID.mockReturnValue({
-      TXOs: vi.fn(async () => [
-        txo({ tree: 0, nullifier: '0xa', spendtxid: false }),
-        txo({ tree: 1, nullifier: '0xb', spendtxid: false }),
-      ]),
-    })
+    mockSpendable([
+      { tree: 0, nullifier: 0xan },
+      { tree: 1, nullifier: 0xbn },
+    ])
     // First note unreadable (success:false), second reads unspent → no omission flagged.
     hoisted.aggregate3.mockResolvedValue([
       { success: false, result: undefined },
@@ -196,7 +181,7 @@ describe('checkOwnNullifiersOnChain (wired)', () => {
   })
 
   it('short-circuits (no RPC) when the wallet has no unspent notes', async () => {
-    hoisted.walletForID.mockReturnValue({ TXOs: vi.fn(async () => []) })
+    mockSpendable([])
 
     const r = await checkOwnNullifiersOnChain('wallet-1')
     expect(r).toEqual({ checked: 0, omissionDetected: false })
@@ -204,9 +189,7 @@ describe('checkOwnNullifiersOnChain (wired)', () => {
   })
 
   it('fails open (no false block) and logs when the on-chain query errors', async () => {
-    hoisted.walletForID.mockReturnValue({
-      TXOs: vi.fn(async () => [txo({ tree: 0, nullifier: '0xa', spendtxid: false })]),
-    })
+    mockSpendable([{ tree: 0, nullifier: 0xan }])
     hoisted.aggregate3.mockRejectedValue(new Error('rpc down'))
 
     const r = await checkOwnNullifiersOnChain('wallet-1')

--- a/apps/armada-interface/src/lib/railgun/nullifierCrossCheck.ts
+++ b/apps/armada-interface/src/lib/railgun/nullifierCrossCheck.ts
@@ -6,30 +6,21 @@ import { getNetworkConfig } from '@/config/network'
 import { loadDeployments } from '@/config/deployments'
 import { trackError } from '@/lib/telemetry'
 import { aggregate3, type AggregateCall } from '@/lib/multicall3'
-import { timeoutProvider, getHubChainDescriptor } from './network'
+import { timeoutProvider } from './network'
+import { getSdkWallet } from './sdk-read'
 
 // PrivacyPoolStorage.sol: mapping(uint256 => mapping(bytes32 => bool)) public nullifiers → this
 // auto getter. Set in TransactModule.sol when a note is spent. No SDK read helper exists.
 const NULLIFIERS_ABI = ['function nullifiers(uint256,bytes32) view returns (bool)']
 
 /**
- * Normalize a TXO nullifier for the `bytes32` ABI arg. The engine stores it as an UNPREFIXED,
- * zero-padded 32-byte hex string (`ByteUtils.nToHex(nullifier, ByteLength.UINT_256)`), but ethers'
- * `bytes32` encoder requires a `0x`-prefixed BytesLike — passing the raw value throws
- * "invalid BytesLike value". Idempotent: tolerates an already-prefixed or short-trimmed value.
+ * Normalize a nullifier for the `bytes32` ABI arg. `@armada/sdk` gives the nullifier as a field-
+ * element `bigint`, rendered here as unprefixed hex; ethers' `bytes32` encoder requires a `0x`-
+ * prefixed, zero-padded 32-byte value. Idempotent: tolerates an already-prefixed or short value.
  */
 export function toNullifierBytes32(nullifier: string): string {
   const raw = nullifier.startsWith('0x') ? nullifier.slice(2) : nullifier
   return `0x${raw.padStart(64, '0')}`
-}
-
-// The Railgun SDK crashes on module-load under jsdom (circomlibjs) — defer to call time, same
-// pattern as sync.ts / wallet.ts. One import per session.
-async function railgunSdk() {
-  return import('@railgun-community/wallet')
-}
-async function sharedModels() {
-  return import('@railgun-community/shared-models')
 }
 
 /** An own note the wallet believes is unspent, identified for its on-chain nullifier lookup. */
@@ -46,17 +37,14 @@ export interface NullifierCrossCheckResult {
 }
 
 /**
- * The wallet's own notes it believes are unspent, as `{tree, nullifier}`. Each TXO already carries
- * its computed `nullifier` and `tree`; `spendtxid === false` means locally-unspent. V2 only — our
- * PrivacyPool implements the V2 UTXO tree.
+ * The wallet's own locally-unspent notes as `{tree, nullifier}`, from the @armada/sdk read wallet's
+ * `spendableNullifiers()` (the SDK-native replacement for the engine's `TXOs(...)` + `spendtxid`
+ * filter). `_walletId` is accepted for call-site compatibility but ignored — the read instance is the
+ * unlocked wallet. V2 only — our PrivacyPool implements the V2 UTXO tree.
  */
-export async function getOwnUnspentNotes(walletId: string): Promise<OwnUnspentNote[]> {
-  const [{ walletForID }, { TXIDVersion }] = await Promise.all([railgunSdk(), sharedModels()])
-  const wallet = walletForID(walletId)
-  const txos = await wallet.TXOs(TXIDVersion.V2_PoseidonMerkle, getHubChainDescriptor())
-  return txos
-    .filter((txo) => txo.spendtxid === false)
-    .map((txo) => ({ tree: txo.tree, nullifier: txo.nullifier }))
+export async function getOwnUnspentNotes(_walletId?: string): Promise<OwnUnspentNote[]> {
+  const wallet = await getSdkWallet()
+  return wallet.spendableNullifiers().map((n) => ({ tree: n.tree, nullifier: n.nullifier.toString(16) }))
 }
 
 /**

--- a/apps/armada-interface/src/lib/railgun/sdk-read.ts
+++ b/apps/armada-interface/src/lib/railgun/sdk-read.ts
@@ -23,7 +23,7 @@ async function vaultTokenAddress(): Promise<`0x${string}` | undefined> {
   return yieldDeployment?.contracts.armadaYieldVault as `0x${string}` | undefined
 }
 
-/** Assemble the SDK config from the same deployment + network config the engine uses. */
+/** Assemble the SDK config from the same deployment + network config the app uses. */
 async function readPathConfig(): Promise<{
   pool: {
     chainId: number
@@ -33,6 +33,7 @@ async function readPathConfig(): Promise<{
     additionalTokens?: `0x${string}`[]
   }
   rpc: { urls: string[] }
+  indexer?: { url: string }
 }> {
   const deployments = getCachedDeployments()
   if (deployments === null) throw new Error('sdk-read: deployments not loaded')
@@ -44,6 +45,10 @@ async function readPathConfig(): Promise<{
   }
   // Scan the yield-vault share token too, so the SDK can report shielded ayUSDC shares.
   const vault = await vaultTokenAddress()
+  // Quick-sync fast path: when a watcher URL is configured, the SDK uses the native `/v2/quick-sync`
+  // indexer as the primary event source (RPC covers the tail + verifies against the on-chain root).
+  // Unset → RPC-only slow scan. Parity with the engine's former quickSync path.
+  const indexerUrl = getNetworkConfig().indexerUrl
   return {
     pool: {
       chainId: hub.chainId,
@@ -53,6 +58,7 @@ async function readPathConfig(): Promise<{
       ...(vault ? { additionalTokens: [vault] } : {}),
     },
     rpc: { urls: [...hub.rpcUrls] },
+    ...(indexerUrl ? { indexer: { url: indexerUrl } } : {}),
   }
 }
 
@@ -173,4 +179,23 @@ export async function closeSdkRead(): Promise<void> {
     instance = null
     await closing.close()
   }
+}
+
+/**
+ * Wipe the SDK read instance's persisted scan state (Settings → Reset wallet). Closes the instance
+ * first (releasing the IndexedDB handle), then deletes the whole read database so the next unlock
+ * re-scans from the deploy block. Best-effort: a delete error must never block the reset.
+ */
+export async function deleteSdkReadStorage(): Promise<void> {
+  await closeSdkRead()
+  await new Promise<void>((resolve) => {
+    try {
+      const req = indexedDB.deleteDatabase(READ_DB_NAME)
+      req.onsuccess = () => resolve()
+      req.onerror = () => resolve()
+      req.onblocked = () => resolve()
+    } catch {
+      resolve()
+    }
+  })
 }

--- a/apps/armada-interface/src/lib/railgun/wallet.test.ts
+++ b/apps/armada-interface/src/lib/railgun/wallet.test.ts
@@ -1,51 +1,22 @@
-// ABOUTME: Tests for lib/railgun/wallet — enroll/unlock/lock/reset paths with a mocked Railgun SDK.
-// ABOUTME: Real engine init is exercised in commit 3 (init.ts port); here we verify our wallet.ts plumbs the SDK calls + keyManager correctly.
+// ABOUTME: Tests for lib/railgun/wallet — enroll/unlock/lock/reset. Identity is derived locally now
+// ABOUTME: (deriveWalletId + the SDK's deriveKeyset 0zk); no stock engine. We verify the keyManager + localStorage plumbing.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// Mock the Railgun SDK at the module boundary so we don't need a live engine to test our wrapper.
-// We capture the per-test mock impls below for assertion.
-// Shared spy for the per-wallet decrypted-balance clear (WS7.2 Option A) so tests can assert it.
-const sdkHooks = vi.hoisted(() => ({
-  clearDecryptedBalances: vi.fn(async () => {}),
+const h = vi.hoisted(() => ({
+  railgunAddress: '0zk1qexampleaddressvalue00000000000000000000000000000000000000000000',
+  deriveKeyset: vi.fn(),
+  deleteSdkReadStorage: vi.fn(async () => {}),
 }))
 
-vi.mock('@railgun-community/wallet', () => ({
-  createRailgunWallet: vi.fn(),
-  loadWalletByID: vi.fn(),
-  unloadWalletByID: vi.fn(),
-  deleteWalletByID: vi.fn(),
-  walletForID: vi.fn(() => ({
-    clearDecryptedBalancesAllTXIDVersions: sdkHooks.clearDecryptedBalances,
-  })),
-}))
+// Identity comes from the SDK's keyset derivation (mocked — the real one needs poseidon/ed25519 init,
+// and this suite tests the wallet.ts lifecycle plumbing, not the crypto).
+vi.mock('@armada/sdk', () => ({ deriveKeyset: h.deriveKeyset }))
+// Reset wipes the SDK read instance's IDB scan state.
+vi.mock('./sdk-read', () => ({ deleteSdkReadStorage: h.deleteSdkReadStorage }))
+// wallet.ts only reads the current hub block (creation-block seed); return null so it's undefined.
+vi.mock('./network', () => ({ getCurrentHubBlock: vi.fn(async () => null) }))
 
-// Also mock our engine bootstrap modules — they eagerly import the SDK at top-level, which
-// would trigger jsdom's circomlibjs init crash. Tests for these modules will live alongside
-// them (init.test.ts / network.test.ts) once the engine plumbing has a real test surface.
-vi.mock('./init', () => ({
-  initRailgunEngine: vi.fn(async () => {}),
-  isRailgunEngineInitialized: vi.fn(() => true),
-  getRailgunInitError: vi.fn(() => null),
-  resetInitState: vi.fn(),
-}))
-vi.mock('./network', () => ({
-  loadHubNetwork: vi.fn(async () => {}),
-  isHubNetworkLoaded: vi.fn(() => true),
-  resetNetworkLoaderState: vi.fn(),
-  getHubChainDescriptor: vi.fn(() => ({ type: 0 as const, id: 31337 })),
-  // Returns null so wallet.ts passes undefined to createRailgunWallet — same as the prior
-  // behavior before Phase 1.4 added creationBlockNumbers wiring. Tests don't exercise the
-  // creation-block side of things; that's a runtime optimization verified on testnet.
-  getCurrentHubBlock: vi.fn(async () => null),
-}))
-
-import {
-  createRailgunWallet,
-  loadWalletByID,
-  unloadWalletByID,
-  deleteWalletByID,
-} from '@railgun-community/wallet'
 import {
   enrollFromSignature,
   unlockFromRootSecret,
@@ -55,33 +26,28 @@ import {
   MismatchedRecoverySecretError,
 } from './wallet'
 import { isUnlocked, getWalletId, getRailgunAddress, clear as clearKeyManager } from './keyManager'
-import { encryptBackup, deriveRootSecret } from '@/lib/crypto/kdf'
+import { encryptBackup, deriveRootSecret, deriveWalletId } from '@/lib/crypto/kdf'
 
-const mockCreate = createRailgunWallet as unknown as ReturnType<typeof vi.fn>
-const mockLoad = loadWalletByID as unknown as ReturnType<typeof vi.fn>
-const mockUnload = unloadWalletByID as unknown as ReturnType<typeof vi.fn>
-const mockDelete = deleteWalletByID as unknown as ReturnType<typeof vi.fn>
-
-const SAMPLE_WALLET_ID = '0d3a8e7c'
-const SAMPLE_RAILGUN_ADDRESS = '0zk1qexample…'
 const SAMPLE_EVM = '0xabcdef0123456789abcdef0123456789abcdef01' as `0x${string}`
 const SAMPLE_EVM_LC = SAMPLE_EVM.toLowerCase()
 
-// Helpers for seeding/reading the per-(EVM, account) localStorage map that wallet.ts uses now.
+/** The deterministic walletId wallet.ts derives for a given signature seed. */
+function expectedWalletId(seed = 0): string {
+  return deriveWalletId(deriveRootSecret(fixedSig(seed)))
+}
+
 function seedStoredWalletId(walletId: string, evmAddress: `0x${string}` = SAMPLE_EVM, account = '0'): void {
   const key = 'armada.shielded.walletIds'
   const raw = window.localStorage.getItem(key)
   const map = raw ? JSON.parse(raw) : {}
-  const evm = evmAddress.toLowerCase()
-  map[evm] = { ...(map[evm] ?? {}), [account]: walletId }
+  map[evmAddress.toLowerCase()] = { ...(map[evmAddress.toLowerCase()] ?? {}), [account]: walletId }
   window.localStorage.setItem(key, JSON.stringify(map))
 }
 function seedStoredChecksum(checksum: string, evmAddress: `0x${string}` = SAMPLE_EVM, account = '0'): void {
   const key = 'armada.shielded.checksums'
   const raw = window.localStorage.getItem(key)
   const map = raw ? JSON.parse(raw) : {}
-  const evm = evmAddress.toLowerCase()
-  map[evm] = { ...(map[evm] ?? {}), [account]: checksum }
+  map[evmAddress.toLowerCase()] = { ...(map[evmAddress.toLowerCase()] ?? {}), [account]: checksum }
   window.localStorage.setItem(key, JSON.stringify(map))
 }
 function readStoredMap(key: string): Record<string, Record<string, string>> {
@@ -97,223 +63,130 @@ function fixedSig(seed = 0): Uint8Array {
 }
 
 beforeEach(() => {
-  mockCreate.mockReset()
-  mockLoad.mockReset()
-  mockUnload.mockReset()
-  mockDelete.mockReset()
   clearKeyManager()
   window.localStorage.clear()
-
-  // Default happy path: createRailgunWallet returns a fixed wallet info.
-  mockCreate.mockResolvedValue({ id: SAMPLE_WALLET_ID, railgunAddress: SAMPLE_RAILGUN_ADDRESS })
-  mockLoad.mockResolvedValue({ id: SAMPLE_WALLET_ID, railgunAddress: SAMPLE_RAILGUN_ADDRESS })
+  h.deriveKeyset.mockReset()
+  h.deriveKeyset.mockResolvedValue({ railgunAddress: h.railgunAddress })
+  h.deleteSdkReadStorage.mockClear()
 })
 
 describe('enrollFromSignature', () => {
-  it('derives root_secret from the normalized signature and creates an SDK wallet', async () => {
+  it('derives a deterministic identity (walletId + 0zk) from the signature, no engine wallet', async () => {
     const sig = fixedSig()
     const { rootSecret, state } = await enrollFromSignature(sig)
 
     expect(rootSecret.length).toBe(32)
-    expect(state.id).toBe(SAMPLE_WALLET_ID)
+    expect(state.id).toBe(expectedWalletId())
+    expect(state.id).toMatch(/^[0-9a-f]{32}$/) // 16-byte HKDF wallet id
     expect(state.status).toBe('unlocked')
-    expect(state.railgunAddress).toBe(SAMPLE_RAILGUN_ADDRESS)
+    expect(state.railgunAddress).toBe(h.railgunAddress)
     expect(state.checksum).toMatch(/^[0-9a-f]{4} [0-9a-f]{4} [0-9a-f]{4}$/)
     expect(state.unlockedAt).toBeTypeOf('number')
-
-    // SDK was called with (encryptionKey, mnemonic, undefined, 0) — derivationIndex = 0.
-    expect(mockCreate).toHaveBeenCalledTimes(1)
-    const args = mockCreate.mock.calls[0]!
-    expect(args[0]).toMatch(/^[0-9a-f]{64}$/) // encryption key — 64 hex chars
-    expect(typeof args[1]).toBe('string') // mnemonic
-    expect((args[1] as string).split(' ').length).toBe(24)
-    expect(args[2]).toBeUndefined() // creationBlockNumbers
-    expect(args[3]).toBe(0) // derivation index
+    expect(h.deriveKeyset).toHaveBeenCalledTimes(1)
   })
 
   it('marks the keyManager unlocked + persists walletId to the per-(EVM,account) localStorage map', async () => {
     await enrollFromSignature(fixedSig(), { evmAddress: SAMPLE_EVM, account: 0n })
     expect(isUnlocked()).toBe(true)
-    expect(getWalletId()).toBe(SAMPLE_WALLET_ID)
-    expect(getRailgunAddress()).toBe(SAMPLE_RAILGUN_ADDRESS)
-    const map = readStoredMap('armada.shielded.walletIds')
-    expect(map[SAMPLE_EVM_LC]?.['0']).toBe(SAMPLE_WALLET_ID)
+    expect(getWalletId()).toBe(expectedWalletId())
+    expect(getRailgunAddress()).toBe(h.railgunAddress)
+    expect(readStoredMap('armada.shielded.walletIds')[SAMPLE_EVM_LC]?.['0']).toBe(expectedWalletId())
   })
 
-  it('skips the localStorage binding when no evmAddress is supplied (no-wallet-connected fallback)', async () => {
+  it('skips the localStorage binding when no evmAddress is supplied', async () => {
     await enrollFromSignature(fixedSig())
     expect(isUnlocked()).toBe(true)
-    expect(getWalletId()).toBe(SAMPLE_WALLET_ID)
-    // No entries in the map because we didn't pass an evmAddress.
     expect(readStoredMap('armada.shielded.walletIds')).toEqual({})
   })
 
-  it('is deterministic — same signature → same root_secret → same checksum', async () => {
+  it('is deterministic — same signature → same root_secret → same id + checksum', async () => {
     const a = await enrollFromSignature(fixedSig(0))
-    // Snapshot a.rootSecret BEFORE clearKeyManager() zeroizes it — both `a` and the keyManager
-    // share the buffer reference (intentional, see keyManager.setUnlocked docs).
     const aRootCopy = new Uint8Array(a.rootSecret)
     const aChecksum = a.state.checksum
+    const aId = a.state.id
     clearKeyManager()
     window.localStorage.clear()
-    mockCreate.mockClear()
     const b = await enrollFromSignature(fixedSig(0))
     expect(b.state.checksum).toBe(aChecksum)
+    expect(b.state.id).toBe(aId)
     expect(b.rootSecret).toEqual(aRootCopy)
   })
 
-  it('different signatures produce different checksums', async () => {
+  it('different signatures produce different ids + checksums', async () => {
     const a = await enrollFromSignature(fixedSig(0))
     clearKeyManager()
     window.localStorage.clear()
     const b = await enrollFromSignature(fixedSig(1))
     expect(b.state.checksum).not.toBe(a.state.checksum)
+    expect(b.state.id).not.toBe(a.state.id)
   })
 
   it('rejects signatures of the wrong length', async () => {
     await expect(enrollFromSignature(new Uint8Array(64))).rejects.toThrow()
   })
 
-  it('try-loads an existing SDK wallet when a walletId is cached for this (EVM,account) tuple', async () => {
-    // Simulates "Sign in" on UnlockFlow's primary tab: same signature, but a walletId from a
-    // prior session is already in the map. Must call loadWalletByID, not createRailgunWallet,
-    // so the SDK preserves its scan cursor + UTXO set (otherwise shielded balance shows 0
-    // after reload).
-    seedStoredWalletId(SAMPLE_WALLET_ID)
-    const { state } = await enrollFromSignature(fixedSig(), { evmAddress: SAMPLE_EVM, account: 0n })
-    expect(mockLoad).toHaveBeenCalledTimes(1)
-    expect(mockCreate).not.toHaveBeenCalled()
-    expect(state.id).toBe(SAMPLE_WALLET_ID)
-    expect(state.railgunAddress).toBe(SAMPLE_RAILGUN_ADDRESS)
-  })
-
-  it('falls back to createRailgunWallet when the cached walletId fails to load (cleared IDB)', async () => {
-    seedStoredWalletId(SAMPLE_WALLET_ID)
-    mockLoad.mockRejectedValueOnce(new Error('Could not load RAILGUN wallet'))
-    const { state } = await enrollFromSignature(fixedSig(), { evmAddress: SAMPLE_EVM, account: 0n })
-    expect(mockLoad).toHaveBeenCalledTimes(1)
-    expect(mockCreate).toHaveBeenCalledTimes(1)
-    expect(state.id).toBe(SAMPLE_WALLET_ID)
-  })
-
-  it('zeroes the input signature buffer after HKDF derivation (signature-discipline guarantee)', async () => {
-    // Per V2 amendment §"Signature discipline" — the caller's reference to the signature
-    // buffer must point to all-zeros after enrollFromSignature returns, even on the happy
-    // path. This is best-effort (JS gives no zeroization guarantees), but the in-place
-    // .fill(0) closes the window during which a heap scrape could recover the bytes.
+  it('zeroes the input signature buffer after HKDF derivation', async () => {
     const sig = fixedSig(0)
-    // Sanity: the signature is non-zero going in, so the post-call assertion is meaningful.
-    expect(Array.from(sig).some(b => b !== 0)).toBe(true)
+    expect(Array.from(sig).some((b) => b !== 0)).toBe(true)
     await enrollFromSignature(sig)
-    expect(Array.from(sig).every(b => b === 0)).toBe(true)
+    expect(Array.from(sig).every((b) => b === 0)).toBe(true)
   })
 
   it('zeroes the input signature buffer even when derivation throws (try/finally guarantee)', async () => {
-    // A 64-byte input fails the length assertion inside deriveRootSecret. The signature
-    // buffer must still be zeroed before the exception propagates.
     const badSig = new Uint8Array(64)
     for (let i = 0; i < 64; i++) badSig[i] = 0xab
     await expect(enrollFromSignature(badSig)).rejects.toThrow()
-    expect(Array.from(badSig).every(b => b === 0)).toBe(true)
+    expect(Array.from(badSig).every((b) => b === 0)).toBe(true)
   })
 
   it('throws NonDeterministicSignerError when the re-sign derives a different identity than the cached one', async () => {
-    // Simulate the post-Phase-2a returning-user determinism check: the previous session
-    // stored a checksum for identity A; the user re-signs but the wallet now produces a
-    // signature for identity B. The cached-checksum-mismatch guard catches this before any
-    // identity is bound to the device, and surfaces a typed error the UI can render as a
-    // dedicated screen (rather than a generic toast).
-    seedStoredWalletId(SAMPLE_WALLET_ID)
-    seedStoredChecksum('aaaa bbbb cccc') // identity A
+    seedStoredWalletId(expectedWalletId())
+    seedStoredChecksum('aaaa bbbb cccc') // identity A — differs from the signature's derived checksum
     let captured: unknown
     try {
       await enrollFromSignature(fixedSig(0), { evmAddress: SAMPLE_EVM, account: 0n })
     } catch (err) {
       captured = err
     }
-    expect(captured).toBeDefined()
     const errObj = captured as { kind?: string; reason?: string }
     expect(errObj.kind).toBe('NonDeterministicSignerError')
     expect(errObj.reason).toBe('cached-checksum-mismatch')
-    // Critical: must NOT have called the SDK at all (no wallet bound on this device).
-    expect(mockCreate).not.toHaveBeenCalled()
-    expect(mockLoad).not.toHaveBeenCalled()
+    // No identity bound: the keyManager stays locked.
+    expect(isUnlocked()).toBe(false)
   })
 
-  it('the cached-checksum mismatch is scoped to (evmAddress, account) — a different EVM address gets a fresh enrollment, not a mismatch', async () => {
-    // Phase 4 guarantee: switching EVM addresses lets a user enroll a fresh shielded identity
-    // for the new address without tripping the cached-mismatch guard tied to the old address.
-    seedStoredWalletId(SAMPLE_WALLET_ID, SAMPLE_EVM)
+  it('the cached-checksum mismatch is scoped to (evmAddress, account) — a different EVM address enrolls fresh', async () => {
+    seedStoredWalletId(expectedWalletId(), SAMPLE_EVM)
     seedStoredChecksum('aaaa bbbb cccc', SAMPLE_EVM)
     const otherEvm = '0x1234567890abcdef1234567890abcdef12345678' as `0x${string}`
-    // Different EVM address → no entry for the (otherEvm, 0) tuple → fresh-create path runs.
     const { state } = await enrollFromSignature(fixedSig(0), { evmAddress: otherEvm, account: 0n })
-    expect(state.id).toBe(SAMPLE_WALLET_ID)
-    expect(mockCreate).toHaveBeenCalledTimes(1)
+    expect(state.id).toBe(expectedWalletId())
+    expect(isUnlocked()).toBe(true)
   })
 })
 
 describe('unlockFromRootSecret', () => {
-  it('fast-paths via loadWalletByID when a walletId is cached for the (EVM, account) tuple', async () => {
-    seedStoredWalletId(SAMPLE_WALLET_ID)
+  it('unlocks + derives the identity + writes the binding on a fresh device', async () => {
     const root = deriveRootSecret(fixedSig())
     const state = await unlockFromRootSecret(root, { evmAddress: SAMPLE_EVM, account: 0n })
-
-    expect(mockLoad).toHaveBeenCalledTimes(1)
-    expect(mockCreate).not.toHaveBeenCalled()
-    expect(state.id).toBe(SAMPLE_WALLET_ID)
-    expect(state.railgunAddress).toBe(SAMPLE_RAILGUN_ADDRESS)
-    expect(state.checksum).toMatch(/^[0-9a-f]{4} [0-9a-f]{4} [0-9a-f]{4}$/)
+    expect(state.id).toBe(deriveWalletId(root))
+    expect(state.railgunAddress).toBe(h.railgunAddress)
     expect(isUnlocked()).toBe(true)
-  })
-
-  it('falls back to createRailgunWallet when loadWalletByID throws (wallet missing on this device)', async () => {
-    seedStoredWalletId(SAMPLE_WALLET_ID)
-    mockLoad.mockRejectedValueOnce(new Error('Could not load RAILGUN wallet'))
-    const root = deriveRootSecret(fixedSig())
-    const state = await unlockFromRootSecret(root, { evmAddress: SAMPLE_EVM, account: 0n })
-
-    expect(mockLoad).toHaveBeenCalledTimes(1)
-    expect(mockCreate).toHaveBeenCalledTimes(1)
-    expect(state.id).toBe(SAMPLE_WALLET_ID)
-  })
-
-  it('creates a fresh wallet when no walletId is cached', async () => {
-    const root = deriveRootSecret(fixedSig())
-    const state = await unlockFromRootSecret(root)
-
-    expect(mockLoad).not.toHaveBeenCalled()
-    expect(mockCreate).toHaveBeenCalledTimes(1)
-    expect(state.id).toBe(SAMPLE_WALLET_ID)
+    expect(readStoredMap('armada.shielded.checksums')[SAMPLE_EVM_LC]?.['0']).toBe(state.checksum)
   })
 
   it('rejects rootSecret of the wrong length', async () => {
     await expect(unlockFromRootSecret(new Uint8Array(16))).rejects.toThrow()
   })
 
-  // P1-13: a wrong pasted secret (or a backup for a different wallet) must NOT silently rebind the
-  // device. Refuse with a typed error and leave the binding maps untouched so the next correct
-  // sign-in doesn't hit the scary cached-checksum-mismatch.
-  it('refuses when the derived identity differs from the device binding, without rebinding', async () => {
-    seedStoredChecksum('aaaa bbbb cccc') // device bound to a different identity for (EVM, account)
+  it('refuses when the derived identity differs from the device binding, without rebinding (P1-13)', async () => {
+    seedStoredChecksum('aaaa bbbb cccc')
     const root = deriveRootSecret(fixedSig())
-
     await expect(
       unlockFromRootSecret(root, { evmAddress: SAMPLE_EVM, account: 0n }),
     ).rejects.toBeInstanceOf(MismatchedRecoverySecretError)
-
-    // Binding maps untouched, no SDK work attempted, wallet stays locked.
     expect(readStoredMap('armada.shielded.checksums')[SAMPLE_EVM_LC]?.['0']).toBe('aaaa bbbb cccc')
-    expect(mockCreate).not.toHaveBeenCalled()
-    expect(mockLoad).not.toHaveBeenCalled()
     expect(isUnlocked()).toBe(false)
-  })
-
-  it('unlocks + writes the binding on a fresh device (no stored checksum)', async () => {
-    const root = deriveRootSecret(fixedSig())
-    const state = await unlockFromRootSecret(root, { evmAddress: SAMPLE_EVM, account: 0n })
-    expect(isUnlocked()).toBe(true)
-    expect(readStoredMap('armada.shielded.checksums')[SAMPLE_EVM_LC]?.['0']).toBe(state.checksum)
   })
 
   it('unlocks when the pasted secret matches the device binding (re-paste of the same secret)', async () => {
@@ -321,6 +194,7 @@ describe('unlockFromRootSecret', () => {
     clearKeyManager()
     const again = await unlockFromRootSecret(deriveRootSecret(fixedSig()), { evmAddress: SAMPLE_EVM, account: 0n })
     expect(again.checksum).toBe(first.checksum)
+    expect(again.id).toBe(first.id)
     expect(isUnlocked()).toBe(true)
   })
 })
@@ -331,7 +205,7 @@ describe('unlockFromBackup', () => {
     const blob = await encryptBackup({ rootSecret: root, creationBlock: 0 }, 'passphrase-here', { iterations: 1000 })
     const state = await unlockFromBackup(blob, 'passphrase-here')
     expect(state.status).toBe('unlocked')
-    expect(state.id).toBe(SAMPLE_WALLET_ID)
+    expect(state.id).toBe(deriveWalletId(root))
     expect(isUnlocked()).toBe(true)
   })
 
@@ -343,52 +217,28 @@ describe('unlockFromBackup', () => {
 })
 
 describe('lockWallet', () => {
-  it('clears the keyManager and calls SDK unloadWalletByID', async () => {
+  it('clears the keyManager (in-memory secrets); does not touch the SDK read storage', async () => {
     await enrollFromSignature(fixedSig())
     expect(isUnlocked()).toBe(true)
     await lockWallet('whatever-id-arg-is-ignored')
     expect(isUnlocked()).toBe(false)
-    expect(mockUnload).toHaveBeenCalledWith(SAMPLE_WALLET_ID)
+    // Lock releases secrets only — the SDK read instance is torn down separately (useShieldedBalanceSync).
+    expect(h.deleteSdkReadStorage).not.toHaveBeenCalled()
   })
 
   it('is a no-op when no wallet is unlocked', async () => {
     expect(isUnlocked()).toBe(false)
     await lockWallet('whatever')
-    expect(mockUnload).not.toHaveBeenCalled()
-  })
-
-  it('clears decrypted balances before unloading the wallet (WS7.2 Option A)', async () => {
-    // WHY: the Railgun engine persists decrypted note plaintext (value, 0zk addresses, memo)
-    // unencrypted under wallet:<id>. On lock we wipe it so it doesn't sit at rest while locked;
-    // it must run while the SDK wallet handle is still loaded (i.e. before unloadWalletByID).
-    sdkHooks.clearDecryptedBalances.mockClear()
-    await enrollFromSignature(fixedSig())
-    await lockWallet('ignored')
-    expect(sdkHooks.clearDecryptedBalances).toHaveBeenCalledTimes(1)
-    expect(mockUnload).toHaveBeenCalledWith(SAMPLE_WALLET_ID)
-    // Ordering: the clear resolves before the unload is invoked.
-    expect(sdkHooks.clearDecryptedBalances.mock.invocationCallOrder[0]!).toBeLessThan(
-      mockUnload.mock.invocationCallOrder[0]!,
-    )
-  })
-
-  it('does not block the lock when the decrypted-balance clear throws', async () => {
-    // WHY: best-effort — a clear failure (wallet not loaded, SDK hiccup) must never strand the
-    // user in an unlocked state. The keyManager is already zeroized synchronously regardless.
-    sdkHooks.clearDecryptedBalances.mockRejectedValueOnce(new Error('clear failed'))
-    await enrollFromSignature(fixedSig())
-    await lockWallet('ignored')
     expect(isUnlocked()).toBe(false)
-    expect(mockUnload).toHaveBeenCalledWith(SAMPLE_WALLET_ID)
   })
 })
 
 describe('resetWallet', () => {
-  it('deletes the SDK wallet and clears the entire per-(EVM,account) map', async () => {
+  it('wipes the SDK read storage and clears the entire per-(EVM,account) map', async () => {
     await enrollFromSignature(fixedSig(), { evmAddress: SAMPLE_EVM, account: 0n })
-    expect(readStoredMap('armada.shielded.walletIds')[SAMPLE_EVM_LC]?.['0']).toBe(SAMPLE_WALLET_ID)
+    expect(readStoredMap('armada.shielded.walletIds')[SAMPLE_EVM_LC]?.['0']).toBe(expectedWalletId())
     await resetWallet('whatever-id-arg-is-ignored')
-    expect(mockDelete).toHaveBeenCalledWith(SAMPLE_WALLET_ID)
+    expect(h.deleteSdkReadStorage).toHaveBeenCalledTimes(1)
     expect(window.localStorage.getItem('armada.shielded.walletIds')).toBeNull()
     expect(window.localStorage.getItem('armada.shielded.checksums')).toBeNull()
     expect(isUnlocked()).toBe(false)
@@ -401,14 +251,7 @@ describe('resetWallet', () => {
   it('uses the cached walletId when locked but a previous session left state', async () => {
     seedStoredWalletId('cached-id-xyz')
     await resetWallet('whatever')
-    expect(mockDelete).toHaveBeenCalledWith('cached-id-xyz')
-    expect(window.localStorage.getItem('armada.shielded.walletIds')).toBeNull()
-  })
-
-  it('still clears localStorage even if SDK delete throws', async () => {
-    await enrollFromSignature(fixedSig(), { evmAddress: SAMPLE_EVM, account: 0n })
-    mockDelete.mockRejectedValueOnce(new Error('wallet not found'))
-    await resetWallet('whatever')
+    expect(h.deleteSdkReadStorage).toHaveBeenCalledTimes(1)
     expect(window.localStorage.getItem('armada.shielded.walletIds')).toBeNull()
   })
 })

--- a/apps/armada-interface/src/lib/railgun/wallet.ts
+++ b/apps/armada-interface/src/lib/railgun/wallet.ts
@@ -1,58 +1,31 @@
 // ABOUTME: Signature-derived Railgun wallet lifecycle per specs/TX_SIGNING.md + TX_SIGNING_V2_AMENDMENT.md.
 // ABOUTME: enrollFromSignature / unlockFromRootSecret / unlockFromBackup / lockWallet / resetWallet route through a shared applyRootSecret helper. Internal mnemonic shim hidden inside this module.
 
-// The Railgun SDK pulls a chunky transitive dep graph (circomlibjs, etc.) that has trouble
-// loading in jsdom. We `import()` the SDK at call time so vitest can load this module without
-// instantiating the engine's polyfill surface — pure unit tests stub the SDK at the import
-// boundary. Production code pays the dynamic import cost once per session on first call.
-type RailgunSdk = typeof import('@railgun-community/wallet')
-async function railgunSdk(): Promise<RailgunSdk> {
-  return import('@railgun-community/wallet')
-}
+import { deriveKeyset } from '@armada/sdk'
 import {
   antiPhishChecksumBytes,
   assertEntropyFloor,
   decryptBackup,
   deriveHistoryEncryptionKey,
-  deriveInternalMnemonic,
   deriveRootSecret,
   deriveSdkEncryptionKeyHex,
   deriveSpendingKeyBytes,
   deriveViewingKeyBytes,
+  deriveWalletId,
   formatChecksumDisplay,
   type BackupBlob,
 } from '@/lib/crypto/kdf'
 import { NonDeterministicSignerError } from '@/lib/crypto/determinism'
-import { track, trackError } from '@/lib/telemetry'
+import { track } from '@/lib/telemetry'
 import {
   clear as clearKeyManager,
-  getSdkEncryptionKey as kmGetSdkEncryptionKey,
   getWalletId as kmGetWalletId,
   setUnlocked,
 } from './keyManager'
 import { loadDeployments } from '@/config/deployments'
-import { getNetworkConfig } from '@/config/network'
 import { clearHistoryCheckpoint } from './history-checkpoint'
-import { initRailgunEngine } from './init'
-import { getCurrentHubBlock, loadHubNetwork } from './network'
-
-/**
- * Ensure the Railgun engine is initialized + the hub network is loaded before issuing an SDK
- * call. Both are idempotent — first call does the work, subsequent calls return immediately.
- * loadHubNetwork failure is non-fatal during enrollment (the wallet can still be created
- * without a network; balance scanning just won't work until the network is loaded).
- */
-async function ensureRailgunReady(): Promise<void> {
-  await initRailgunEngine()
-  try {
-    await loadHubNetwork()
-  } catch (err) {
-    // Surface but don't block — wallet creation/load doesn't strictly need the network.
-    // Balance scans + tx submission will fail downstream until the user fixes the underlying
-    // problem (RPC down, contracts not deployed, etc.).
-    trackError('shielded.network.load', err, { scope: 'shielded.unlock', message: 'hub network load failed' })
-  }
-}
+import { deleteSdkReadStorage } from './sdk-read'
+import { getCurrentHubBlock } from './network'
 
 /**
  * Public state shape exposed to React (atoms / hooks). No secrets — just identity + status.
@@ -324,41 +297,19 @@ async function applyRootSecret(
     ? readStoredWalletIdFor(opts.evmAddress, account)
     : null
 
-  let walletId: string
-  let railgunAddress: string
-  let newlyCreated: boolean
-  // `effectiveCreationBlock` mirrors what we stash into keyManager.creationBlock so a later
-  // `exportBackup` can write a meaningful value. null = "not known in this session": the load-
-  // fast-path doesn't tell us, since the SDK already has the canonical value in walletDetails.
-  let effectiveCreationBlock: number | null = opts.creationBlock ?? null
-
-  if (cachedWalletId) {
-    try {
-      const { loadWalletByID } = await railgunSdk()
-      const info = await loadWalletByID(sdkEncryptionKey, cachedWalletId, false /* isViewOnlyWallet */)
-      walletId = cachedWalletId
-      railgunAddress = info.railgunAddress
-      newlyCreated = false
-    } catch (err) {
-      // Cached id but no entry in this device's IDB (cleared / new device / corrupted state, or
-      // the cached id belonged to a different identity and this rootSecret's sdkEncryptionKey
-      // can't decrypt it). Recreate the wallet — same rootSecret deterministically yields the
-      // same walletId per the BIP-39 mnemonic shim, so this is idempotent.
-      trackError('shielded.wallet.loadByID', err, {
-        scope: 'shielded.unlock',
-        message: 'load failed, recreating',
-      })
-      const recreated = await createSdkWalletFromRoot(rootSecret, opts.creationBlock)
-      walletId = recreated.walletId
-      railgunAddress = recreated.railgunAddress
-      newlyCreated = true
-    }
-  } else {
-    const recreated = await createSdkWalletFromRoot(rootSecret, opts.creationBlock)
-    walletId = recreated.walletId
-    railgunAddress = recreated.railgunAddress
-    newlyCreated = true
-  }
+  // Identity is derived locally — no engine wallet to create or load. `walletId` is a deterministic
+  // function of rootSecret; the 0zk address comes from the SDK's keyset derivation (byte-identical to
+  // what the read instance derives via `fromRootSecret`). The actual wallet is the persistent
+  // @armada/sdk read instance, created lazily on first balance read (sdk-read.ts).
+  const walletId = deriveWalletId(rootSecret)
+  const railgunAddress = (await deriveKeyset(rootSecret)).railgunAddress
+  // "Newly created" (telemetry) = first sign-in on this device for the tuple (no cached id). It no
+  // longer implies an engine wallet was created; the identity is purely derived.
+  const newlyCreated = cachedWalletId === null
+  // Mirrors what we stash into keyManager.creationBlock so a later `exportBackup` can write a
+  // meaningful value. null = not known in this session (the SDK read instance resumes from its own
+  // persisted checkpoint regardless).
+  const effectiveCreationBlock: number | null = opts.creationBlock ?? null
 
   if (opts.evmAddress) {
     setStoredWalletId(opts.evmAddress, account, walletId)
@@ -403,9 +354,9 @@ async function applyRootSecret(
  * backup-export ceremony. The keyManager retains the authoritative copy until lock or reset; the
  * caller must NOT mutate or `fill(0)` the returned buffer.
  *
- * Phase 1 compromise: `deriveInternalMnemonic` (called inside `applyRootSecret`'s recreate path)
- * produces a deterministic 24-word BIP-39 from root_secret; we hand it to `createRailgunWallet`
- * and never expose it. Phase 2 drops the shim by going through the lower-level engine package.
+ * Identity is derived entirely locally now — `applyRootSecret` computes the walletId + 0zk address
+ * from root_secret (no engine wallet). The actual scanning wallet is the persistent @armada/sdk read
+ * instance, created lazily on first balance read.
  */
 /**
  * Caller-supplied identity binding for sign-in / unlock entry points. Threading these through
@@ -428,7 +379,6 @@ export async function enrollFromSignature(
   rootSecret: Uint8Array
   state: ShieldedWalletState
 }> {
-  await ensureRailgunReady()
   let rootSecret: Uint8Array
   try {
     rootSecret = deriveRootSecret(signatureBytes)
@@ -523,7 +473,6 @@ export async function unlockFromRootSecret(
   if (rootSecret.length !== 32) {
     throw new Error('unlockFromRootSecret: rootSecret must be 32 bytes')
   }
-  await ensureRailgunReady()
   const { state } = await applyRootSecret(rootSecret, opts)
   track('shielded.unlock', { walletId: state.id })
   return state
@@ -548,11 +497,13 @@ export async function unlockFromBackup(
 }
 
 /**
- * Drop the unlocked-session state. Does NOT delete the SDK wallet from IDB — only releases
- * the in-memory copies. The user can re-unlock at any time with the same root_secret.
+ * Drop the unlocked-session state. Does NOT delete the SDK read instance's persisted scan state —
+ * only releases the in-memory secrets. The user can re-unlock at any time with the same root_secret;
+ * the @armada/sdk read instance is torn down separately by `useShieldedBalanceSync` on the active-
+ * wallet change (which calls `closeSdkRead`). `_id` is accepted for API compatibility with callers.
  *
- * Async because we await the SDK's in-memory wallet unload. `_id` is accepted for API
- * consistency with the legacy signature; we always lock whichever wallet is currently unlocked.
+ * Kept synchronous-first: the tab-unload (`beforeunload`) lock path relies on the rootSecret buffer
+ * being zeroized before the page tears down, so `clearKeyManager()` must run before any await.
  */
 export async function lockWallet(_id: string): Promise<void> {
   const id = (() => {
@@ -562,40 +513,8 @@ export async function lockWallet(_id: string): Promise<void> {
       return null
     }
   })()
-  // Clear the keyManager FIRST and synchronously — the tab-unload (`beforeunload`) lock path
-  // relies on the rootSecret buffer being zeroized before the page tears down; an `await` ahead of
-  // this would orphan that guarantee. Clearing our keys does not unload the SDK's wallet handle.
   clearKeyManager()
-  if (!id) return
-  // WS7.2 Option A: wipe the SDK's decrypted note plaintext (value, 0zk addresses, memo) from IDB
-  // while the wallet handle is still loaded and before we unload it, so it doesn't persist at rest
-  // while locked. The public merkletree is left intact — the next unlock re-decrypts locally from
-  // it (no network rescan). Best-effort: a failure must never block the lock; abrupt termination
-  // (tab kill) skips it, which is the accepted limitation of this mitigation.
-  await clearDecryptedBalancesOnLock(id)
-  try {
-    const { unloadWalletByID } = await railgunSdk()
-    unloadWalletByID(id)
-  } catch {
-    /* SDK throws if the wallet isn't loaded; ignore. */
-  }
-  track('shielded.locked', { walletId: id })
-}
-
-/**
- * Best-effort clear of a wallet's decrypted balances (note plaintext + scan heights) from IDB.
- * Leaves the public merkletree. See `lockWallet` for why this runs on lock (WS7.2 Option A).
- */
-async function clearDecryptedBalancesOnLock(id: string): Promise<void> {
-  try {
-    const { walletForID } = await railgunSdk()
-    const wallet = walletForID(id)
-    // ChainType.EVM === 0; mirror the chain shape network.ts patches into NETWORK_CONFIG.
-    const chain = { type: 0, id: getNetworkConfig().hub.chainId }
-    await wallet.clearDecryptedBalancesAllTXIDVersions(chain)
-  } catch {
-    /* wallet not loaded / SDK unavailable — nothing to clear */
-  }
+  if (id) track('shielded.locked', { walletId: id })
 }
 
 /**
@@ -616,30 +535,13 @@ export async function resetWallet(_id: string): Promise<void> {
   if (!id) {
     throw new Error('resetWallet: no wallet to reset')
   }
-  const sdkEncryptionKey = (() => {
-    try {
-      return kmGetSdkEncryptionKey()
-    } catch {
-      return null
-    }
-  })()
   clearKeyManager()
-  // sdkEncryptionKey is captured pre-clear so the SDK delete can run after we've locked the
-  // key manager. We don't actually need it for the delete call (SDK signature takes id only)
-  // but reading it confirms the session was authenticated. If absent, we still proceed —
-  // there's no auth surface on delete to guard.
-  void sdkEncryptionKey
-  try {
-    const { deleteWalletByID } = await railgunSdk()
-    await deleteWalletByID(id)
-  } catch (err) {
-    // Surface but don't block — the wallet may already be absent.
-    trackError('shielded.wallet.deleteByID', err, { scope: 'shielded.reset', message: 'delete failed' })
-  }
+  // Wipe the @armada/sdk read instance's persisted scan state (closes it, deletes the read DB) so the
+  // next enrollment re-scans from the deploy block. Best-effort — a delete error must not block reset.
+  await deleteSdkReadStorage()
   clearStoredWalletIdentity()
-  // Drop the history-scan checkpoint so a future re-enrollment on this device walks chain
-  // history from the hub deploy block again, not from a stale block that pre-dates the new
-  // wallet's first observable activity.
+  // Drop the history-scan checkpoint so a future re-enrollment on this device walks chain history
+  // from the hub deploy block again, not from a stale block that pre-dates the new wallet's activity.
   clearHistoryCheckpoint(id)
   track('shielded.reset', { walletId: id })
 }
@@ -663,47 +565,4 @@ async function resolveCreationBlock(): Promise<number | undefined> {
     // Manifest load failed (offline, dev plugin down) — fall through to head-block fallback.
   }
   return (await getCurrentHubBlock()) ?? undefined
-}
-
-/**
- * Internal helper: derive the internal mnemonic + encryption key from root_secret and hand
- * them to the Railgun SDK. The mnemonic exists only on this function's stack frame; the SDK
- * encrypts it before returning. We do not retain the string reference beyond the await.
- *
- * Phase 1 compromise documented in lib/crypto/CLAUDE.md.
- */
-async function createSdkWalletFromRoot(
-  rootSecret: Uint8Array,
-  creationBlock: number | undefined,
-): Promise<{
-  walletId: string
-  railgunAddress: string
-}> {
-  const sdkEncryptionKey = deriveSdkEncryptionKeyHex(rootSecret)
-  const mnemonic = deriveInternalMnemonic(rootSecret)
-  // creationBlockNumbers is the SDK's hint for where to begin the merkletree commitment scan.
-  // Per the engine source (abstract-wallet.js::getCreationTreeAndPosition), it resolves to a
-  // `(creationTree, creationTreeHeight)` position from which the scan walks forward. Pass the
-  // TRUE creation block when known (first-enrollment, or restored from v2 backup); pass
-  // undefined for restore paths where it's unknown (paste-secret, post-load-failure recovery)
-  // and accept the slower full-genesis rescan.
-  //
-  // Keyed by SDK NetworkName, not chain id. We patch NETWORK_CONFIG.Hardhat to mean our hub
-  // chain (see lib/railgun/network.ts), so the key here is literally 'Hardhat'.
-  const creationBlockNumbers = creationBlock != null ? { Hardhat: creationBlock } : undefined
-  try {
-    const { createRailgunWallet } = await railgunSdk()
-    const info = await createRailgunWallet(
-      sdkEncryptionKey,
-      mnemonic,
-      creationBlockNumbers,
-      0, // railgunWalletDerivationIndex — fixed at 0 for Phase 1 (one identity per spec)
-    )
-    return { walletId: info.id, railgunAddress: info.railgunAddress }
-  } finally {
-    // JS strings are immutable; we can't overwrite the buffer. Best we can do is drop the
-    // reference. V8 will reclaim it on the next GC cycle. Phase 2 (engine-level) avoids the
-    // mnemonic string entirely by writing key bytes directly.
-    void mnemonic
-  }
 }

--- a/apps/armada-interface/src/test/integration/shielded-wallet-lifecycle.test.tsx
+++ b/apps/armada-interface/src/test/integration/shielded-wallet-lifecycle.test.tsx
@@ -45,6 +45,17 @@ vi.mock('@railgun-community/wallet', () => ({
   deleteWalletByID: hoisted.deleteWalletByID,
 }))
 
+// wallet.ts derives the 0zk address via the SDK's `deriveKeyset`; the real one needs ed25519/poseidon
+// crypto that jsdom can't run, and this test exercises the record/atom lifecycle, not keyset crypto.
+// Override just `deriveKeyset`, keep the rest of @armada/sdk real (sdk-read + handlers import it).
+vi.mock('@armada/sdk', async (importActual) => {
+  const actual = await importActual<typeof import('@armada/sdk')>()
+  return {
+    ...actual,
+    deriveKeyset: vi.fn(async () => ({ railgunAddress: '0zk1qtestlifecycleaddr000000000000000000000000000000000000000000' })),
+  }
+})
+
 vi.mock('@/lib/railgun/init', () => ({
   initRailgunEngine: vi.fn(async () => {}),
   isRailgunEngineInitialized: vi.fn(() => true),
@@ -178,8 +189,7 @@ describe('V2 shielded-wallet lifecycle integration', () => {
       await capture.shielded!.signIn()
     })
 
-    // SDK was called once to create the wallet (first-time path); active id atom is populated.
-    expect(hoisted.createRailgunWallet).toHaveBeenCalledTimes(1)
+    // Identity is derived locally (no engine wallet); the unlock populates the active id atom.
     expect(isUnlocked()).toBe(true)
     const activeWalletId = store.get(activeRailgunWalletIdAtom)
     expect(activeWalletId).toBeTruthy()

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#363fd31864a785505a31d7f099bb6b8f60d0788e",
+        "@armada/sdk": "github:ship-armada/armada-sdk#d6e4a9b9b93a278d461711b156f79ba9e6a3e534",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -411,8 +411,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#363fd31864a785505a31d7f099bb6b8f60d0788e",
-      "integrity": "sha512-xx/L9WCJVPFJjUNZnv9yeKkcz4bnre6sEMGZuQScvD5rEviAfmi6RAmQ3otZQru6pDOQ8kVnA/M4Y5bhW5IljQ==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#d6e4a9b9b93a278d461711b156f79ba9e6a3e534",
+      "integrity": "sha512-8F8XPhmvf1YVWEi8Ewn9Kv6lFhbM9FYhMfBC9GK/IXkUJIvHeYi6gROaennCeYwY390c1VZezpGW2ZKJrKi7QA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#363fd31864a785505a31d7f099bb6b8f60d0788e",
+    "@armada/sdk": "github:ship-armada/armada-sdk#d6e4a9b9b93a278d461711b156f79ba9e6a3e534",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",


### PR DESCRIPTION
Teardown step 3 (b + c). Migrates the last three engine tenants in the wallet/read path off `@railgun-community/wallet` onto `@armada/sdk`, and wires quick-sync into the SDK read (re-pins armada-sdk#57). After this the engine is only reachable through `init.ts` (the balance-event producer + sync banner), which step 4 removes. No data to migrate (pre-prod/testnet), so identity uses a clean SDK-native derivation — no engine walletId replication.

## 3b — off the engine
- **`wallet.ts`** — unlock/lock/reset no longer call `createRailgunWallet` / `loadWalletByID` / `unloadWalletByID` / `walletForID` / `deleteWalletByID` / `initRailgunEngine`. Identity is derived locally: `walletId` = `deriveWalletId(rootSecret)` (new HKDF helper, engine-free, domain-separated), 0zk address = the SDK's `deriveKeyset(rootSecret).railgunAddress` (byte-identical to what the read instance derives). The scanning wallet is the persistent `@armada/sdk` read instance (already lazily created). Lock just releases secrets; **reset** wipes the SDK read IDB via the new `deleteSdkReadStorage()` (closes the instance + `indexedDB.deleteDatabase`).
- **`nullifierCrossCheck.ts`** — `walletForID(id).TXOs()` + `spendtxid` filter → `getSdkWallet().spendableNullifiers()` (armada-sdk#57). Same Multicall3 on-chain nullifier check; still fail-open.
- **`address.ts`** — `validateRailgunAddress` → `@armada/sdk/core`'s `decodeAddress` (bech32m + `0zk` prefix + version, throws on bad).

## 3c — quick-sync parity (folded in)
- **`sdk-read.ts::readPathConfig`** now passes `indexer: { url }` to `createArmadaSdk` when `VITE_INDEXER_URL` is set, so the SDK read uses the watcher's native `/v2/quick-sync` as the primary source (RPC covers the tail + verifies against the on-chain root). This restores the quick-sync parity we'd otherwise lose when the engine's `quickSync.ts` goes in step 4. The watcher already implements `/v2/quick-sync` (ship-armada/armada-relayer).

## Naming
The `railgunAddress` → `shieldedAddress` public-API rename is tracked in the SDK SPEC (§4.2, via armada-sdk#57) as a deferred scoped pass — deliberately not folded in here to keep this diff about mechanics.

## Testing
- Interface typecheck clean; **690 tests pass** across `lib` + `hooks` + integration.
- `wallet.test.ts` rewritten for the SDK-native identity model (deterministic `deriveWalletId`, mocked `deriveKeyset` + `deleteSdkReadStorage`; dropped the obsolete engine-call assertions). `nullifierCrossCheck.test.ts` repointed onto `spendableNullifiers`. Lifecycle integration test mocks `deriveKeyset` (jsdom can't run ed25519).
- **Runtime (Butters):** sign in (fresh + returning) → funds + history appear; lock/unlock; Settings → Reset wallet → re-sign re-scans from deploy block; send to a mistyped 0zk → rejected at submit. With `VITE_INDEXER_URL` set, confirm the initial scan is fast (quick-sync) and grep the console for `sdk.sync` resuming from a high `fromBlock`.

Step 4 next: delete `init.ts` + `prover.ts` + `quickSync.ts` + `database.ts` + the `loadHubNetwork`/`NETWORK_CONFIG` patch, and move the sync-progress banner (`syncStateAtom`) onto the SDK scan events — which is when the merkletree write-queue error finally goes away.