### PR TITLE
cleanup(interface): dead code + stale comments + partition SDK scan DB (PR 1/4)

### DIFF
--- a/apps/armada-interface/src/features/shield-xchain/handler.ts
+++ b/apps/armada-interface/src/features/shield-xchain/handler.ts
@@ -91,9 +91,9 @@ const PRIVACY_POOL_CLIENT_SHIELD_ABI = [
 
 /**
  * Stage map for `shield-xchain`:
- *   1. `build-proof`              — sign RAILGUN_SHIELD, derive shieldPrivateKey, build the
- *                                    ShieldRequest off-chain (keyed to the HUB USDC address — the
- *                                    shield commitment lives on the hub once delivered).
+ *   1. `build-proof`              — generate a random shieldPrivateKey, build the ShieldRequest
+ *                                    off-chain (keyed to the HUB USDC address — the shield commitment
+ *                                    lives on the hub once delivered). No signature (random key).
  *   2. `submit-relayer`           — on the CLIENT chain: ensure USDC allowance for the
  *                                    PrivacyPoolClient, then call crossChainShield. The contract
  *                                    handles depositForBurnWithHook internally, emitting a CCTP
@@ -112,7 +112,7 @@ const PRIVACY_POOL_CLIENT_SHIELD_ABI = [
  */
 export const shieldXchainHandler: StageHandler<'shield-xchain'> = {
   kind: 'shield-xchain',
-  // Iris/hub polling can be resumed; pre-receipt stages can't (RAILGUN_SHIELD sig + on-chain submit).
+  // Iris/hub polling can be resumed; pre-receipt stages can't (ephemeral shield build + any permit sig + on-chain submit).
   resumableFrom: ['submit-relayer', 'iris-attestation-pending'],
 
   async run(record, ctx) {
@@ -167,8 +167,8 @@ async function runBuildProof(
 
   if (ctx.signal.aborted) throw new Error('cancelled')
 
-  // RAILGUN_SHIELD is chain-agnostic (plain personal_sign of a constant string), but for UX we
-  // still want the wallet on the source client chain so the prompt shows the right network and
+  // The shield key is random (no signature), but for UX we still want the wallet on the source
+  // client chain so any build-proof prompt (the gasless EIP-2612 permit) shows the right network and
   // the subsequent submit-relayer step doesn't have to switch a second time. Same pattern the
   // same-chain shield handler uses with meta.fromChainId.
   await ensureChain(record.meta.fromChainId)
@@ -458,8 +458,8 @@ async function runDirectSubmit(
  * client chain id, wait for the source-chain receipt, then continue with the same CCTP nonce
  * extraction + hub-block snapshot the direct path uses.
  *
- * Zero EVM wallet prompts in this stage — the user already signed RAILGUN_SHIELD + USDC permit
- * during build-proof. The relayer broadcasts on the user's behalf and pays gas in the source
+ * Zero EVM wallet prompts in this stage — the user already signed the USDC permit during
+ * build-proof. The relayer broadcasts on the user's behalf and pays gas in the source
  * chain's native token; the wrapper pulls `amount + fee` USDC from the user via the permit
  * and reimburses the relayer.
  */

--- a/apps/armada-interface/src/features/shield/handler.ts
+++ b/apps/armada-interface/src/features/shield/handler.ts
@@ -93,9 +93,10 @@ const PRIVACY_POOL_SHIELD_ABI = [
  * always produces the ShieldRequest from the user's signature, and `submit-relayer` then either
  * routes through the user's EVM wallet (direct) or the relayer-mediated wrapper (gasless).
  *
- *   1. `build-proof`    — sign 'RAILGUN_SHIELD' → derive shieldPrivateKey → build ShieldRequest.
- *                         When gasless: ALSO sign an EIP-2612 USDC permit for `amount + fee` to
- *                         the wrapper address. Both prompts surface to the user in succession.
+ *   1. `build-proof`    — generate a random shieldPrivateKey → build ShieldRequest (no signature —
+ *                         see lib/railgun/shield.ts for why the shield key is random, not derived).
+ *                         When gasless: sign an EIP-2612 USDC permit for `amount + fee` to the
+ *                         wrapper address — the only wallet prompt on this path.
  *   2. `submit-relayer` — direct path: approve USDC + writeContract(PrivacyPool.shield).
  *                         gasless path: encode `gaslessShield(...)` calldata + POST /relay +
  *                         poll /status. No EVM wallet prompts after build-proof on this branch.
@@ -458,8 +459,8 @@ async function runDirectSubmit(
 /**
  * Phase B3 gasless-shield path: encode `gaslessShield(...)` calldata from the permit signature
  * + ShieldRequest captured in build-proof, POST to /relay, poll /status. Zero EVM wallet
- * prompts here — the user already signed both the RAILGUN_SHIELD message and the USDC permit
- * during build-proof, so this stage is purely network-side work.
+ * prompts here — the user already signed the USDC permit during build-proof (the shield key is
+ * random, so there's no signature for it), so this stage is purely network-side work.
  */
 async function runGaslessSubmit(
   record: TxRecord<'shield'>,

--- a/apps/armada-interface/src/lib/crypto/CLAUDE.md
+++ b/apps/armada-interface/src/lib/crypto/CLAUDE.md
@@ -7,22 +7,22 @@ Pure-logic crypto primitives for the signature-derived key system. No React, no 
 | File | Purpose |
 |---|---|
 | `eip712.ts` | Enrollment typed-data builder + signature normalization (65-byte r‖s‖v, EIP-2098 compact expansion, v∈{0,1}→{27,28}). |
-| `kdf.ts` | HKDF-SHA-256 derivation (root + spend/view subkeys), anti-phish checksum, internal-mnemonic shim (Phase 1 SDK compat), AES-256-GCM backup encryption with PBKDF2-SHA-256@600k, `bytesToBigIntBE`, IC-2 entropy floor canary. |
+| `kdf.ts` | HKDF-SHA-256 derivation (root + spend/view subkeys), anti-phish checksum, AES-256-GCM backup encryption with PBKDF2-SHA-256@600k, `bytesToBigIntBE`, IC-2 entropy floor canary. |
 | `boundary-vectors.test.ts` | The 6 bytes-to-scalar boundary vectors from spec §"Bytes to Field Element Mapping" (Vector 1 zero, r exactly, r−1, r+1, 0xFF…FF, 2r+42). |
 
 ## Hard rules
 
-- **No `console.log` / `console.debug` of derived secrets.** This includes `root_secret`, spending/viewing key bytes, the internal mnemonic, the SDK encryption key, the user passphrase, and anything derived from them. Secret-leak prevention. (Same rule as `lib/railgun/` from the root CLAUDE.md.)
+- **No `console.log` / `console.debug` of derived secrets.** This includes `root_secret`, spending/viewing key bytes, the SDK encryption key, the user passphrase, and anything derived from them. Secret-leak prevention. (Same rule as `lib/railgun/` from the root CLAUDE.md.)
 - **IC-1: No JavaScript `Number` in derivation paths.** All byte-to-scalar conversions use `bigint`. The boundary vector test catches accidental float truncation. Avoid `parseInt` on key material; use `bytesToBigIntBE` or the byte-array forms directly.
 - **IC-3: Opaque byte passthrough.** Raw signature bytes are passed to HKDF as a `Uint8Array`. Do not parse (r, s, v) components through numeric intermediates before HKDF input — `eip712.ts::normalizeSignature` returns the canonical 65 bytes ready for HKDF.
 - **Identity-determining constants are frozen.** `eip712.ts` exports `VERIFYING_CONTRACT`, `DOMAIN_NAME`, `MESSAGE_PURPOSE`, `MESSAGE_VERSION`. Changing any of these — even formatting — forks every user's shielded identity. The four together are a governance-frozen tuple per the spec.
 - **No HMAC, no symmetric ciphers other than what's listed above.** Phase 1 is fixed at HKDF-SHA-256 + AES-256-GCM + PBKDF2-SHA-256@600k. Phase 2 adds Argon2id as the preferred KDF (parsers already validate `kdf: 'argon2id' | 'scrypt' | 'pbkdf2-sha256'` per the spec's interop contract).
 
-## Phase 1 compromise (read once)
+## Identity derivation (`root_secret` → shielded keys)
 
-The Railgun wallet SDK's public entry point is mnemonic-based. `deriveInternalMnemonic(rootSecret)` derives a deterministic 24-word BIP-39 mnemonic from `root_secret` so we can call `createRailgunWallet(encryptionKey, mnemonic, ...)`. The mnemonic is never displayed, never returned to UI, never exported. It exists only in the call stack between `deriveInternalMnemonic` and the SDK call. Phase 2 drops this shim entirely by going through the lower-level engine package.
+Identity comes from `@armada/sdk`'s `deriveKeyset(root_secret)` — it consumes the 32-byte `root_secret` directly and returns the shielded (0zk) address + keyset. There is no mnemonic in the path: the earlier engine-era `deriveInternalMnemonic` → `createRailgunWallet` shim has been removed. The interface's own `deriveSpendingKeyBytes` / `deriveViewingKeyBytes` (HKDF-Expand) survive **only** as inputs to the IC-2 entropy-floor canary (`assertEntropyFloor` in `lib/railgun/wallet.ts`) — they are NOT the keys the SDK spends with.
 
-This compromise means **Phase 1 keys are NOT interoperable with Phase 2 keys.** Same `root_secret`, different derived spending/viewing key bytes (BIP-32 vs direct HKDF-Expand). The plan accepts this — testnet identity is disposable, mainnet starts fresh.
+**Key-material stability:** identity is a pure function of `root_secret` (→ `deriveKeyset`), so a given `root_secret` always reproduces the same 0zk address. A future protocol change (custom circuits — see `ARCHITECTURE_NOTES.md`) could redefine the derivation; those keys would not be interoperable with today's. Accepted: testnet identity is disposable, mainnet starts fresh.
 
 ## What this folder will gain in Phase 2
 

--- a/apps/armada-interface/src/lib/crypto/kdf.test.ts
+++ b/apps/armada-interface/src/lib/crypto/kdf.test.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Tests for lib/crypto/kdf — HKDF derivation determinism, anti-phish checksum, internal mnemonic shim, AES-GCM backup round-trip, IC-2 canary.
+// ABOUTME: Tests for lib/crypto/kdf — HKDF derivation determinism, anti-phish checksum, AES-GCM backup round-trip, IC-2 canary.
 
 import { describe, it, expect } from 'vitest'
 import {
@@ -7,7 +7,6 @@ import {
   deriveViewingKeyBytes,
   deriveSdkEncryptionKeyHex,
   deriveHistoryEncryptionKey,
-  deriveInternalMnemonic,
   antiPhishChecksumBytes,
   formatChecksumDisplay,
   assertEntropyFloor,
@@ -27,8 +26,6 @@ import {
  * from dominating the suite runtime. The encryption shape is bit-identical regardless.
  */
 const TEST_OPTS: EncryptOptions = { iterations: 1000 }
-import { validateMnemonic } from '@scure/bip39'
-import { wordlist } from '@scure/bip39/wordlists/english'
 
 /** Deterministic 65-byte signature fixture. */
 function fixedSignature(seed: number = 0): Uint8Array {
@@ -127,27 +124,6 @@ describe('deriveHistoryEncryptionKey', () => {
   it('rejects bad input lengths (assertRootSecret)', () => {
     expect(() => deriveHistoryEncryptionKey(new Uint8Array(31))).toThrow()
     expect(() => deriveHistoryEncryptionKey(new Uint8Array(33))).toThrow()
-  })
-})
-
-describe('deriveInternalMnemonic', () => {
-  it('returns a 24-word BIP-39 mnemonic', () => {
-    const root = deriveRootSecret(fixedSignature())
-    const m = deriveInternalMnemonic(root)
-    const words = m.split(' ')
-    expect(words.length).toBe(24)
-    expect(validateMnemonic(m, wordlist)).toBe(true)
-  })
-
-  it('is deterministic from root_secret', () => {
-    const root = deriveRootSecret(fixedSignature())
-    expect(deriveInternalMnemonic(root)).toBe(deriveInternalMnemonic(root))
-  })
-
-  it('two different root_secrets produce two different mnemonics', () => {
-    const a = deriveInternalMnemonic(deriveRootSecret(fixedSignature(0)))
-    const b = deriveInternalMnemonic(deriveRootSecret(fixedSignature(1)))
-    expect(a).not.toBe(b)
   })
 })
 

--- a/apps/armada-interface/src/lib/crypto/kdf.ts
+++ b/apps/armada-interface/src/lib/crypto/kdf.ts
@@ -5,8 +5,6 @@ import { hkdf } from '@noble/hashes/hkdf'
 import { expand as hkdfExpand } from '@noble/hashes/hkdf'
 import { sha256 } from '@noble/hashes/sha2'
 import { gcm } from '@noble/ciphers/aes'
-import { entropyToMnemonic } from '@scure/bip39'
-import { wordlist } from '@scure/bip39/wordlists/english'
 import { bytesToHexNoPrefix, hexToBytesNoPrefix } from './hex'
 
 // ============================================================================
@@ -63,8 +61,10 @@ export function deriveRootSecret(signatureBytes: Uint8Array): Uint8Array {
  * a 32-byte pseudorandom key.
  *
  * Note: these are 32-byte HKDF outputs, NOT yet reduced to a Baby Jubjub scalar. The field-element
- * conversion (mod r vs mod l) is pending Andrew's confirmation and lands in Phase 2. In Phase 1
- * these bytes are not handed to Railgun directly — see `deriveInternalMnemonic` for the shim.
+ * conversion (mod r vs mod l) is pending Andrew's confirmation and lands in Phase 2. These bytes
+ * are not the identity keys the SDK actually spends with (`@armada/sdk` derives those from
+ * `root_secret` via `deriveKeyset`); the interface computes them only to run the IC-2 entropy-floor
+ * canary (`assertEntropyFloor` in wallet.ts).
  */
 export function deriveSpendingKeyBytes(rootSecret: Uint8Array): Uint8Array {
   assertRootSecret(rootSecret)
@@ -116,23 +116,6 @@ const HKDF_INFO_WALLET_ID_V1 = utf8('armada-wallet-id:v1')
 export function deriveWalletId(rootSecret: Uint8Array): string {
   assertRootSecret(rootSecret)
   return bytesToHexNoPrefix(hkdfExpand(sha256, rootSecret, HKDF_INFO_WALLET_ID_V1, 16))
-}
-
-/**
- * Convert the 32-byte root_secret into a 24-word BIP-39 mnemonic for SDK consumption only.
- *
- * Phase 1 compromise: the Railgun wallet SDK's public entry point is mnemonic-based. We derive
- * a deterministic mnemonic from root_secret and feed it to `createRailgunWallet`. The mnemonic
- * is NEVER displayed, NEVER exported, NEVER returned to UI code. Callers are expected to zeroize
- * the returned string by going out of scope quickly — JS strings are immutable so explicit
- * zeroization isn't possible, but limiting the lifetime helps. Phase 2 removes this entirely.
- *
- * 24 words = 256 bits, matching root_secret's full entropy (vs the legacy 12-word/128-bit form).
- */
-export function deriveInternalMnemonic(rootSecret: Uint8Array): string {
-  assertRootSecret(rootSecret)
-  // BIP-39 with 32 bytes of entropy = 24 words. @scure/bip39 handles the checksum.
-  return entropyToMnemonic(rootSecret, wordlist)
 }
 
 // ============================================================================

--- a/apps/armada-interface/src/lib/railgun/sdk-read.ts
+++ b/apps/armada-interface/src/lib/railgun/sdk-read.ts
@@ -70,10 +70,14 @@ type ReadWallet = Awaited<ReturnType<ArmadaSdk['wallet']['fromRootSecret']>>
 // incremental). Recreated when the unlocked wallet changes; closed on lock via `closeSdkRead`.
 let instance: { sdk: ArmadaSdk; wallet: ReadWallet; address: string } | null = null
 
-// Separate IDB database from the engine's (`armada-shielded`) so the SDK read instance keeps its
-// own scan state. The value retains the legacy `-shadow` name so existing users' persisted scan
-// state isn't orphaned by the rename (a changed name would force a full re-scan on next unlock).
-const READ_DB_NAME = 'armada-sdk-shadow'
+// IndexedDB database name for the SDK read instance's scan state, partitioned by the (hub chain id,
+// PrivacyPool address) pair that uniquely identifies a scan context. Chain id alone is insufficient:
+// two deployments on the same chain (different pool address — e.g. switching deployment instances)
+// must not share scan state, and the SDK's scan-state key is chain-agnostic (the 0zk address is the
+// same across chains), so a shared DB would let their checkpoints clobber each other.
+function dbNameFor(cfg: Awaited<ReturnType<typeof readPathConfig>>): string {
+  return `armada-shielded-scan-${cfg.pool.chainId}-${cfg.pool.poolAddress.toLowerCase()}`
+}
 
 async function ensureInstance(): Promise<{ sdk: ArmadaSdk; wallet: ReadWallet; address: string }> {
   const engineAddress = keyManager.getRailgunAddress()
@@ -84,7 +88,7 @@ async function ensureInstance(): Promise<{ sdk: ArmadaSdk; wallet: ReadWallet; a
   const cfg = await readPathConfig()
   const sdk = await createArmadaSdk({
     ...cfg,
-    storage: new IndexedDBStorageAdapter(READ_DB_NAME),
+    storage: new IndexedDBStorageAdapter(dbNameFor(cfg)),
     prover: createInterfaceProver(),
     artifacts: createInterfaceArtifactSource(),
     // Quick-sync observability: the SDK emits its `sync.quicksync` outcome (served / tail-covered /
@@ -202,9 +206,17 @@ export async function closeSdkRead(): Promise<void> {
  */
 export async function deleteSdkReadStorage(): Promise<void> {
   await closeSdkRead()
+  let name: string
+  try {
+    // Deletes only the current deployment's DB (the (chain, pool) the app is pointed at) — other
+    // deployments are separate scan contexts and keep their own state.
+    name = dbNameFor(await readPathConfig())
+  } catch {
+    return // deployments not loaded → nothing was ever opened, so nothing to delete
+  }
   await new Promise<void>((resolve) => {
     try {
-      const req = indexedDB.deleteDatabase(READ_DB_NAME)
+      const req = indexedDB.deleteDatabase(name)
       req.onsuccess = () => resolve()
       req.onerror = () => resolve()
       req.onblocked = () => resolve()

--- a/apps/armada-interface/src/lib/railgun/transfer-sdk.ts
+++ b/apps/armada-interface/src/lib/railgun/transfer-sdk.ts
@@ -20,8 +20,7 @@ export interface SdkTransferInputs {
  * spendable notes, proves it (Groth16), and the proved struct is serialized into `transact(...)`
  * calldata. Returns `{ to, data }` (value is always 0 — a shielded tx carries no native value).
  *
- * Proving runs on the instance's prover (same-thread today; worker follow-on). The caller decides
- * whether to submit the result or (differential) only simulate it.
+ * Proving runs on the instance's off-thread worker prover. Returns `{ to, data }` for the caller to submit.
  */
 export async function buildTransferSdk(
   inputs: SdkTransferInputs,

--- a/apps/armada-interface/src/lib/railgun/wallet.ts
+++ b/apps/armada-interface/src/lib/railgun/wallet.ts
@@ -105,9 +105,9 @@ function writeMap(key: string, value: unknown): void {
 
 /**
  * Read the cached walletId for a specific (EVM address, account) tuple. Returns null when no
- * sign-in has happened for that pair on this device. Used by the sign-in fast path to skip
- * `createRailgunWallet` and call `loadWalletByID` directly, preserving the SDK's merkle scan
- * cursor + UTXO set across reloads.
+ * sign-in has happened for that pair on this device. The sign-in fast path uses it to reuse the
+ * existing walletId (the tx-history key + scan checkpoint) rather than treating a returning user
+ * as newly created — preserving history + the SDK's scan cursor across reloads.
  */
 export function readStoredWalletIdFor(
   evmAddress: `0x${string}`,
@@ -195,9 +195,10 @@ export function clearStoredWalletIdentity(): void {
 
 /**
  * Shared post-derivation pipeline used by the three rootSecret-bearing entry points
- * (enrollFromSignature / unlockFromRootSecret / unlockFromBackup). Runs IC-2 canaries,
- * fast-paths `loadWalletByID` if a cached id matches, else (re)creates the SDK wallet, persists
- * walletId + checksum to localStorage, and hands the live key material to the keyManager.
+ * (enrollFromSignature / unlockFromRootSecret / unlockFromBackup). Runs IC-2 canaries, resolves the
+ * walletId (reusing a cached id for a returning user, else deriving a fresh one), derives the 0zk
+ * address, persists walletId + checksum to localStorage, and hands the live key material to the
+ * keyManager. The SDK read/write instance is created lazily on first use (sdk-read.ts).
  *
  * Telemetry is the caller's responsibility — `applyRootSecret` reports back via `newlyCreated`
  * so each caller can emit the right `shielded.created` vs `shielded.unlock` semantics. (Why not

--- a/apps/armada-interface/src/lib/tx/shieldWalletSteps.ts
+++ b/apps/armada-interface/src/lib/tx/shieldWalletSteps.ts
@@ -45,9 +45,9 @@ export function shieldWalletSteps(
 ): WalletStep[] {
   const amountLabel = formatUsdcAmount(amount)
 
-  // Gasless path: the only wallet prompts (RAILGUN_SHIELD + EIP-2612 permit) happen during
-  // build-proof; the relayer broadcasts the submit, so there's no separate approve/submit prompt.
-  // Collapse to a single "Authorize deposit" row, done once build-proof has captured the signatures.
+  // Gasless path: the only wallet prompt (the EIP-2612 permit) happens during build-proof; the
+  // relayer broadcasts the submit, so there's no separate approve/submit prompt. Collapse to a
+  // single "Authorize deposit" row, done once build-proof has captured the signature.
   const useGasless = record ? (record.meta as { useGasless?: boolean }).useGasless === true : false
   if (useGasless) {
     const authorized = Boolean(record?.stagesCompleted.includes('build-proof'))

--- a/apps/armada-interface/src/lib/tx/types.ts
+++ b/apps/armada-interface/src/lib/tx/types.ts
@@ -408,8 +408,8 @@ export interface ArtifactsXchain extends ArtifactsCommon {
 
 /**
  * Shield-specific artifacts. The `build-proof` stage stashes its outputs here so the next stage
- * (and any post-reload resume) can submit the on-chain shield tx without re-signing RAILGUN_SHIELD
- * or re-computing the engine-side request. `value` is stringified for IDB serializability.
+ * (and any post-reload resume) can submit the on-chain shield tx without re-generating the random
+ * shield key or re-building the ShieldRequest. `value` is stringified for IDB serializability.
  */
 export interface ArtifactsShield extends ArtifactsCommon {
   privacyPoolAddress?: string


### PR DESCRIPTION
First of the comprehensive post-migration cleanup (PR 1 of 4 — the self-contained, no-cross-repo-dep one). No behavior change except the DB partitioning.

### Dead code
- Delete `deriveInternalMnemonic` (kdf.ts) — the engine-era `rootSecret → BIP-39 mnemonic → createRailgunWallet` shim, now **zero runtime callers** (identity comes from `@armada/sdk`'s `deriveKeyset(rootSecret)`). Removed its test + the now-unused `@scure/bip39` imports. `deriveSpendingKeyBytes`/`deriveViewingKeyBytes` stay — they're still used as the IC-2 entropy-floor canary.

### Stale comments (describe things that no longer exist)
- `createRailgunWallet`/`loadWalletByID` references in `wallet.ts` + `crypto/CLAUDE.md` (rewrote the "Phase 1 compromise" section as "Identity derivation" — no mnemonic in the path).
- `transfer-sdk.ts`: dropped the `(differential) only simulate` remnant + the "same-thread today; worker follow-on" line (the off-thread worker prover landed).
- **`RAILGUN_SHIELD` cluster** — the shield flow uses a **random** `shieldPrivateKey` (see `shield.ts`); there is no `personal_sign('RAILGUN_SHIELD')` anywhere. Fixed ~6 comments across `shield/handler.ts`, `shield-xchain/handler.ts`, `shieldWalletSteps.ts`, `tx/types.ts` that described a signing step / wallet prompt that doesn't happen. Kept the two correct "why random instead of RAILGUN_SHIELD" explanations.

### SDK scan DB — rename + partition (the one behavior change)
- `armada-sdk-shadow` (legacy name from the Phase-A shadow-differential) → **`armada-shielded-scan-${hubChainId}-${poolAddress}`**.
- Partitioned by **(chain id, pool address)**, not chain id alone: the SDK's scan-state key is chain-agnostic (the 0zk address is identical across chains), so a shared DB lets checkpoints from different deployments clobber each other. Chain id fixes local↔sepolia; the pool address also covers switching deployment instances on the same chain. `deleteSdkReadStorage` (Reset) wipes only the current deployment's DB. Not publicly deployed → no migration.

### Tests
Typecheck clean; full interface suite **1115 passed / 8 skipped** (= prior 1118 minus the 3 deleted mnemonic-shim tests).

Follow-ups (this cleanup, later PRs): PR 2 = SDK `railgunAddress → shieldedAddress` (§4.2) + re-pin; PR 3 = interface identifier sweep; PR 4 = `lib/railgun/` → `lib/shielded/` directory rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)