### PR TITLE
feat(interface): encrypt SDK read scan state at rest (closes Phase 2)

### DIFF
--- a/.claude/PLAN_INTERFACE_SDK_MIGRATION.md
+++ b/.claude/PLAN_INTERFACE_SDK_MIGRATION.md
@@ -2,9 +2,9 @@
 
 Status: **interface migration complete** (2026-08). The interface runs entirely on `@armada/sdk`; the
 stock `@railgun-community/*` engine is gone from the interface (no imports in `apps/armada-interface/src`).
-Gate 0, Phase A, Phase B, and most of Phase C are done and merged; the tail items (at-rest encryption,
-tree-wide Railgun removal, native value-types, the `railgunAddress` rename) are tracked under
-**Remaining** below. Read alongside `.claude/PLAN_ARMADA_INTERFACE.md` (the interface's own architecture doc).
+**Gate 0, Phase A, Phase B, and Phase C are all done and merged** — at-rest encryption + the
+`railgunAddress → shieldedAddress` rename landed, closing the last Phase-2 acceptance items. The
+remaining tail items (tree-wide Railgun removal, native value-types) are tracked under **Remaining** below. Read alongside `.claude/PLAN_ARMADA_INTERFACE.md` (the interface's own architecture doc).
 
 ## Guiding principle (locked)
 
@@ -33,7 +33,7 @@ When migrating an interface capability onto the SDK, build the **native** equiva
   - Broadcaster-fee output on `planTransfer`/`prove` (the `FeeRequest` path) — ✅.
 - **Phase A — read path:** ✅ `createArmadaSdk` instance + IndexedDB `StorageAdapter` + identity parity (`deriveKeyset`) + sync/balances via `SyncEventMap`. Shadow-differential → cutover done. (Sync-vs-read split later hardened to kill an amplification loop — see `sdk-read.ts`.)
 - **Phase B — write path:** ✅ shield → transfer → unshield-local → xchain-unshield → yield, all migrated + engine builders deleted; off-thread worker prover.
-- **Phase C — history + nullifier cross-check + at-rest encryption:** ⚠️ **partial** — history ✅, nullifier cross-check ✅ (`spendableNullifiers()`), **at-rest encryption still deferred** (see Remaining).
+- **Phase C — history + nullifier cross-check + at-rest encryption:** ✅ history ✅, nullifier cross-check ✅ (`spendableNullifiers()`), at-rest encryption ✅ (`EncryptedStore` wraps the read instance's `IndexedDBStorageAdapter`, AES-256-GCM under `deriveStorageKey(rootSecret)` held in-memory only).
 
 ## Railgun-removal end-state milestone
 
@@ -59,16 +59,17 @@ An explicit completion gate — the flags below are **transitional scaffolds**, 
 | Tx history | ✅ native `wallet.history()` — not ported from Railgun |
 | Proved struct for wrappers | ✅ `ProofHandle.toTransactionData()` |
 | Gas Type1/Type2 ceremony | 🗑️ deleted — `populate*` artifact, not needed natively |
-| At-rest encryption | ⚠️ **deferred** — StorageAdapter-level encryption (Option B); still plaintext-at-rest, at parity with the stock engine |
+| At-rest encryption | ✅ `EncryptedStore` (AES-256-GCM) wraps the read instance's `IndexedDBStorageAdapter`, keyed by `deriveStorageKey(rootSecret)` (in-memory only); DB holds ciphertext at rest |
 
-## Remaining (tail items — migration itself is done)
+## Remaining (tail items — the migration + all of Phase 2 are done)
 
-1. **At-rest encryption of the SDK read instance** (Phase C tail, "Option B"). The read instance's IndexedDB (`armada-sdk-shadow` — legacy name from the Phase-A shadow-differential) holds decrypted note plaintext unencrypted while unlocked, and unlike the stock engine we do **not** clear it on lock (`closeSdkRead` releases the instance but leaves the DB; only Reset deletes it). This is at parity with stock Railgun for the *encrypted wallet blob* (both encrypt the mnemonic) and *matches* Railgun's unencrypted decrypted-notes-at-rest — a lock-time clear is the one thing the engine did that we don't. Needs an encrypting `StorageAdapter` wrapper (and/or a cheap lock-time clear if the SDK exposes re-decrypt-from-tree). Deferred: PoC/testnet, no real funds, tracked.
-2. **Tree-wide Railgun removal** — gradual over future work (contract/relayer/deploy tooling); relayer v2 in a separate repo (armada-relayer#26).
-3. **Own the SDK's vendored value-types natively** — pinned to the **custom-circuits milestone** (when Armada's own ZK circuits + verifiers replace the vendored Railgun ones per `ARCHITECTURE_NOTES.md`; the value-types get redefined then anyway).
-4. **Rename `railgunAddress` → `shieldedAddress`** — cross-repo (SDK `Keyset`/`deriveKeyset` public field → interface `keyManager`/atoms/`ShieldedWalletState`). Internal identifier (not a runtime-emitted string, so not a naming-rule violation) — a clarity nicety tracked in SDK SPEC §4.2.
-5. **Future investigation** — push / new-block-driven sync trigger (armada-sdk#59). RPC scan stays the trust anchor; watcher optional + verified.
+Phase 2's last acceptance item (at-rest encryption) and the `railgunAddress → shieldedAddress` rename
+both landed; the interface is fully on the SDK with encrypted-at-rest scan state.
+
+1. **Tree-wide Railgun removal** — gradual over future work (contract/relayer/deploy tooling); relayer v2 in a separate repo (armada-relayer#26).
+2. **Own the SDK's vendored value-types natively** — pinned to the **custom-circuits milestone** (when Armada's own ZK circuits + verifiers replace the vendored Railgun ones per `ARCHITECTURE_NOTES.md`; the value-types get redefined then anyway).
+3. **Future investigation** — push / new-block-driven sync trigger (armada-sdk#59). RPC scan stays the trust anchor; watcher optional + verified.
 
 ## Key risks (retired)
 
-Identity/address parity, the native quicksync path (`/v2` + root verification), and native tx-history design all landed and are in production use in the interface. The remaining open risk is the at-rest encryption model (Remaining #1).
+Identity/address parity, the native quicksync path (`/v2` + root verification), native tx-history design, and at-rest encryption all landed and are in production use in the interface. No open migration risks remain.

--- a/apps/armada-interface/src/lib/shielded/CLAUDE.md
+++ b/apps/armada-interface/src/lib/shielded/CLAUDE.md
@@ -36,15 +36,17 @@ Privacy apps routinely leak through carelessly-written telemetry and dev logs. B
 
 3. **Encryption at rest.** Be precise about what the SDK encrypts vs. what it doesn't (verified against `@railgun-community/engine` 9.5.1):
    - **Shielded reads run through the `@armada/sdk` read instance** (`sdk-read.ts`), which persists its
-     scan state in its own IndexedDB database (`armada-sdk-shadow`), separate from the historical stock-engine
-     `armada-shielded` DB. The wallet blob (mnemonic / wallet record) is written encrypted under `sdkEncryptionKey`
-     (HKDF-Expand from `rootSecret`); the SDK handles salt + IV.
-   - **Decrypted note plaintext — NOT encrypted at rest.** The SDK writes decrypted receive-commitment plaintext
-     (value, recipient/sender 0zk address, memo) into `armada-sdk-shadow` while the instance exists. The former
-     engine-era mitigation (a `clearDecryptedBalances`-on-lock call) no longer exists — `lockWallet` now only
-     clears the in-memory `keyManager`, and the persistent read instance is torn down (`closeSdkRead`) on lock and
-     its whole database is deleted (`deleteSdkReadStorage`) on Settings → Reset. Full at-rest encryption of the
-     SDK's decrypted namespace remains deferred (WS7.2 Option B — an encrypting storage-adapter wrapper).
+     scan state in a per-deployment IndexedDB database (`armada-shielded-scan-e1-<chainId>-<pool>`),
+     separate from the historical stock-engine `armada-shielded` DB.
+   - **Decrypted note plaintext — encrypted at rest (§4.3, "Option B") ✅.** The read instance's
+     `IndexedDBStorageAdapter` is wrapped in the SDK's `EncryptedStore`, which AES-256-GCM-encrypts every
+     value under a key from `deriveStorageKey(rootSecret)` held **only in memory**. The DB therefore holds
+     only ciphertext at rest — a tab crash / disk read leaks no decrypted note data (value, recipient/sender
+     0zk, memo). Locking tears the instance down (`closeSdkRead`) → the key is dropped; Settings → Reset
+     deletes the DB (`deleteSdkReadStorage`). The pre-encryption plaintext DB (`armada-shielded-scan-<…>`,
+     no `-e1`) is best-effort deleted on the next unlock so no legacy plaintext lingers. This closes the
+     last Phase-2 acceptance gap — and goes further than the stock engine, which left decrypted notes
+     plaintext at rest.
    - **Tx history (V2 Phase 7) — encrypted.** Every `TxRecord` persisted by `lib/tx/storage.ts` is wrapped via `lib/crypto/cache-cipher.ts` as AES-256-GCM (`{ nonce: hex, ciphertext: hex }`) under `historyEncryptionKey` (HKDF-Expand from `rootSecret`, info=`'armada-tx-history:v1'`). Foreign-wallet records throw on `unwrap` and get silently skipped at hydration. The envelope deliberately carries no plaintext walletId — isolation is purely key-based.
 
 4. **Session-bound unlock.** Decrypted key material is held in memory for the active session only. **15-minute inactivity timeout** auto-locks (zeroizes). Lock also fires on tab unload (`beforeunload`), after a **5-minute tab-hidden grace period** (`visibilitychange`), and on EVM-account switch (V2 Phase 4 — `useWallet` compares wagmi's address against `keyManager.getEvmAddress()` and locks on mismatch). Reload requires re-signing.

--- a/apps/armada-interface/src/lib/shielded/sdk-read.ts
+++ b/apps/armada-interface/src/lib/shielded/sdk-read.ts
@@ -4,6 +4,8 @@
 import {
   createArmadaSdk,
   IndexedDBStorageAdapter,
+  EncryptedStore,
+  deriveStorageKey,
   LocalSigner,
   getTokenDataERC20,
   getTokenDataHash,
@@ -74,9 +76,31 @@ let instance: { sdk: ArmadaSdk; wallet: ReadWallet; address: string } | null = n
 // PrivacyPool address) pair that uniquely identifies a scan context. Chain id alone is insufficient:
 // two deployments on the same chain (different pool address — e.g. switching deployment instances)
 // must not share scan state, and the SDK's scan-state key is chain-agnostic (the 0zk address is the
-// same across chains), so a shared DB would let their checkpoints clobber each other.
+// same across chains), so a shared DB would let their checkpoints clobber each other. The `-e1` marks
+// the at-rest-encrypted schema (§4.3) — a distinct name from the pre-encryption plaintext DB, so the
+// EncryptedStore never tries to GCM-decrypt legacy plaintext (which would auth-fail).
 function dbNameFor(cfg: Awaited<ReturnType<typeof readPathConfig>>): string {
+  return `armada-shielded-scan-e1-${cfg.pool.chainId}-${cfg.pool.poolAddress.toLowerCase()}`
+}
+
+// The pre-encryption plaintext DB name (no `-e1`). Deleted on encrypted-instance creation so no
+// decrypted note plaintext lingers at rest after the migration — the whole point of §4.3.
+function legacyPlaintextDbName(cfg: Awaited<ReturnType<typeof readPathConfig>>): string {
   return `armada-shielded-scan-${cfg.pool.chainId}-${cfg.pool.poolAddress.toLowerCase()}`
+}
+
+/** Best-effort IndexedDB delete — never throws (a delete error must not block reset / migration). */
+function deleteDatabaseByName(name: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    try {
+      const req = indexedDB.deleteDatabase(name)
+      req.onsuccess = () => resolve()
+      req.onerror = () => resolve()
+      req.onblocked = () => resolve()
+    } catch {
+      resolve()
+    }
+  })
 }
 
 async function ensureInstance(): Promise<{ sdk: ArmadaSdk; wallet: ReadWallet; address: string }> {
@@ -86,9 +110,18 @@ async function ensureInstance(): Promise<{ sdk: ArmadaSdk; wallet: ReadWallet; a
   if (instance !== null) await instance.sdk.close()
 
   const cfg = await readPathConfig()
+  // Migration to at-rest encryption (§4.3): best-effort drop the pre-encryption plaintext DB so no
+  // decrypted note data lingers at rest. Fire-and-forget; the fresh encrypted DB re-scans from deploy.
+  void deleteDatabaseByName(legacyPlaintextDbName(cfg))
   const sdk = await createArmadaSdk({
     ...cfg,
-    storage: new IndexedDBStorageAdapter(dbNameFor(cfg)),
+    // At-rest AES-256-GCM under a rootSecret-derived key held only in memory (§4.3). Locking tears the
+    // instance down (`closeSdkRead`) → key dropped; the DB then holds only ciphertext, so a tab crash /
+    // disk read leaks no decrypted note plaintext.
+    storage: new EncryptedStore(
+      new IndexedDBStorageAdapter(dbNameFor(cfg)),
+      deriveStorageKey(keyManager.getRootSecret()),
+    ),
     prover: createInterfaceProver(),
     artifacts: createInterfaceArtifactSource(),
     // Quick-sync observability: the SDK emits its `sync.quicksync` outcome (served / tail-covered /
@@ -214,14 +247,5 @@ export async function deleteSdkReadStorage(): Promise<void> {
   } catch {
     return // deployments not loaded → nothing was ever opened, so nothing to delete
   }
-  await new Promise<void>((resolve) => {
-    try {
-      const req = indexedDB.deleteDatabase(name)
-      req.onsuccess = () => resolve()
-      req.onerror = () => resolve()
-      req.onblocked = () => resolve()
-    } catch {
-      resolve()
-    }
-  })
+  await deleteDatabaseByName(name)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#db28d28a7c9220094bb450fe9d39485fb5863855",
+        "@armada/sdk": "github:ship-armada/armada-sdk#07b611e48a1594ab69a0afdc3703df2c6e2cc50a",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -408,8 +408,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#db28d28a7c9220094bb450fe9d39485fb5863855",
-      "integrity": "sha512-ieRyIm3et4UCwY2l8ke/EhJTTAHGE22koAi7FJx8Nb+0fJHon9zrkluzLleJpPk+zIoj2DTGWOM5Am6LCeo9Wg==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#07b611e48a1594ab69a0afdc3703df2c6e2cc50a",
+      "integrity": "sha512-dqyk/jSLTDjapPrF3HwcqSJqX56U3a0gt5OyvnBnpwfz9QQs+O1YlS9xQSTJp+kXRtxGxDiBm3EnNgwKYSaHRw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#db28d28a7c9220094bb450fe9d39485fb5863855",
+    "@armada/sdk": "github:ship-armada/armada-sdk#07b611e48a1594ab69a0afdc3703df2c6e2cc50a",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",


### PR DESCRIPTION
Closes the **last Phase-2 acceptance item** — *"kill-the-tab-mid-scan leaves no plaintext note data at rest."* Consumes armada-sdk **#61** (which completed `EncryptedStore`).

### Change
`sdk-read.ts::ensureInstance` now wraps the read instance's storage:
```ts
storage: new EncryptedStore(
  new IndexedDBStorageAdapter(dbNameFor(cfg)),
  deriveStorageKey(keyManager.getRootSecret()),
)
```
- **AES-256-GCM at rest** under a `rootSecret`-derived key held **only in memory**. The IndexedDB holds ciphertext; a tab crash / disk read leaks no decrypted note data (value, recipient/sender 0zk, memo).
- **Key lifecycle:** locking tears the instance down (`closeSdkRead`) → the key is dropped. Nothing to scrub — there was never plaintext at rest.
- **Migration:** the DB name gains an `-e1` marker (encrypted schema), distinct from the pre-encryption plaintext DB, so `EncryptedStore` never tries to GCM-decrypt legacy plaintext. On the next unlock the old plaintext DB (`armada-shielded-scan-<…>`, no `-e1`) is **best-effort deleted** so no decrypted notes linger, and the fresh encrypted DB re-scans from deploy block (one-time slow scan; fine on testnet).

This goes *further* than the stock engine, which left decrypted notes plaintext at rest.

### Re-pin
`@armada/sdk` → `07b611e4` (includes #61's completed `EncryptedStore`).

### Tests
Crypto correctness is covered by the SDK's `EncryptedStore` tests (round-trip, wrong-key rejection, no-plaintext-at-rest, `list` decrypt). The interface change is config wiring (integration-heavy, not cleanly unit-testable) — interface typecheck clean, **full suite 1118 passed**, and the **root CI typecheck** is clean (no blast radius this time). Manual DevTools check: the `armada-shielded-scan-e1-*` IDB values are ciphertext.

### Notes
- One-time re-scan on first unlock after this ships (DB name change). No `relayer/` or `config/*.env` changes → no VPS restart.
- **Phase 2 of the SDK roadmap is now complete** — plan doc updated (`.claude/PLAN_INTERFACE_SDK_MIGRATION.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)