### PR TITLE
fix(interface): coalesce concurrent SDK read-instance creation on unlock

### DIFF
--- a/apps/armada-interface/src/lib/shielded/sdk-read.test.ts
+++ b/apps/armada-interface/src/lib/shielded/sdk-read.test.ts
@@ -1,20 +1,45 @@
 // ABOUTME: Unit test for sdk-read's syncTracked — asserts each wallet.sync() emits an sdk.sync
 // ABOUTME: telemetry line carrying the exact resume window, so resume-vs-rescan stays observable.
 
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // Stub the heavy @armada/sdk value imports so importing sdk-read doesn't pull the SDK/wasm into the
-// test — syncTracked only needs the wallet's `sync()` return, not any real SDK runtime.
+// test — syncTracked only needs the wallet's `sync()` return, not any real SDK runtime. `createArmadaSdk`
+// + `LocalSigner` are also exercised by the ensureInstance concurrency test below.
 vi.mock('@armada/sdk', () => ({
   createArmadaSdk: vi.fn(),
   IndexedDBStorageAdapter: class {},
+  LocalSigner: { fromRootSecret: vi.fn(async () => ({})) },
   getTokenDataERC20: vi.fn(),
   getTokenDataHash: vi.fn(),
 }))
 vi.mock('@/lib/telemetry', () => ({ track: vi.fn() }))
+// Mocks the ensureInstance path needs: a real keyManager throws when locked, and real deployments are
+// null in the test → both would block instance creation.
+vi.mock('./keyManager', () => ({
+  getShieldedAddress: () => '0zktest',
+  getRootSecret: () => new Uint8Array(32),
+  getCreationBlock: () => 0,
+}))
+vi.mock('../../config/deployments', () => ({
+  getCachedDeployments: () => ({
+    hub: { contracts: { privacyPool: '0x0000000000000000000000000000000000000001' }, deployBlock: 100 },
+  }),
+  getUsdcAddress: () => '0x0000000000000000000000000000000000000002',
+  loadYieldDeployment: async () => null,
+}))
+vi.mock('../../config/network', () => ({
+  getNetworkConfig: () => ({
+    hub: { chainId: 31337, rpcUrls: ['http://localhost:8545'] },
+    confirmationDepth: 0,
+    finalityThreshold: 0,
+    indexerUrl: null,
+  }),
+}))
 
-import { syncTracked } from './sdk-read'
+import { syncTracked, getSdkWallet, closeSdkRead } from './sdk-read'
 import { track } from '@/lib/telemetry'
+import { createArmadaSdk } from '@armada/sdk'
 
 describe('syncTracked', () => {
   it('emits sdk.sync with the exact { fromBlock, syncedThrough, scanned } sync returned', async () => {
@@ -70,5 +95,39 @@ describe('syncTracked', () => {
     // The next caller still runs (the chain caught the rejection).
     await expect(syncTracked(wallet)).resolves.toBeUndefined()
     expect(wallet.sync).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('ensureInstance — concurrency guard (getSdkWallet)', () => {
+  beforeEach(async () => {
+    await closeSdkRead() // reset the module singleton + any in-flight build between tests
+    const fakeWallet = { on: vi.fn() }
+    const fakeSdk = { wallet: { fromRootSecret: vi.fn(async () => fakeWallet) }, close: vi.fn(async () => {}) }
+    vi.mocked(createArmadaSdk).mockReset()
+    // A deliberately slow build so the concurrent callers genuinely overlap during creation — the exact
+    // window the in-flight guard closes.
+    vi.mocked(createArmadaSdk).mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      return fakeSdk as unknown as Awaited<ReturnType<typeof createArmadaSdk>>
+    })
+  })
+
+  it('coalesces concurrent unlock-time callers onto a SINGLE SDK instance', async () => {
+    // WHY: on unlock the initial scan + sync poll + the balance reads + history recovery all call
+    // ensureInstance near-simultaneously. Without the guard each builds its own SDK instance against the
+    // same IndexedDB DB, and the concurrent wallets clobber each other's scan state — the observed
+    // "dashboard balance reads 0 until a later sync." The guard must fold them onto one build.
+    const [a, b, c] = await Promise.all([getSdkWallet(), getSdkWallet(), getSdkWallet()])
+    expect(createArmadaSdk).toHaveBeenCalledTimes(1)
+    expect(a).toBe(b)
+    expect(b).toBe(c)
+  })
+
+  it('rebuilds after closeSdkRead — a fresh unlock creates a new instance', async () => {
+    await getSdkWallet()
+    expect(createArmadaSdk).toHaveBeenCalledTimes(1)
+    await closeSdkRead()
+    await getSdkWallet()
+    expect(createArmadaSdk).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/armada-interface/src/lib/shielded/sdk-read.ts
+++ b/apps/armada-interface/src/lib/shielded/sdk-read.ts
@@ -82,10 +82,20 @@ async function readPathConfig(): Promise<{
 
 type ReadWallet = Awaited<ReturnType<ArmadaSdk['wallet']['fromRootSecret']>>
 
+type SdkInstance = { sdk: ArmadaSdk; wallet: ReadWallet; address: string }
+
 // A PERSISTENT SDK instance for the session — IndexedDB-backed, so the scan state survives across reads
 // and page reloads (the first sync scans from deployBlock; later ones are
 // incremental). Recreated when the unlocked wallet changes; closed on lock via `closeSdkRead`.
-let instance: { sdk: ArmadaSdk; wallet: ReadWallet; address: string } | null = null
+let instance: SdkInstance | null = null
+
+// In-flight creation guard. `ensureInstance` is called near-simultaneously on unlock by several flows
+// (initial scan, the sync poll's mount fetch, the three balance reads, history recovery). Without
+// coalescing, each races past the null check and builds its OWN SDK instance + wallet against the SAME
+// IndexedDB scan-state DB — multiple wallets then scan and write one encrypted DB concurrently and
+// clobber each other, so early reads see 0 owned notes until the survivors settle. This holds the single
+// in-flight build so all concurrent callers for the same identity await one instance.
+let pendingInstance: { address: string; promise: Promise<SdkInstance> } | null = null
 
 // IndexedDB database name for the SDK read instance's scan state, partitioned by the (hub chain id,
 // PrivacyPool address) pair that uniquely identifies a scan context. Chain id alone is insufficient:
@@ -122,10 +132,23 @@ function deleteDatabaseByName(name: string): Promise<void> {
   })
 }
 
-async function ensureInstance(): Promise<{ sdk: ArmadaSdk; wallet: ReadWallet; address: string }> {
+async function ensureInstance(): Promise<SdkInstance> {
   const engineAddress = keyManager.getShieldedAddress()
+  // Fast path: a ready instance for this identity.
   if (instance !== null && instance.address === engineAddress) return instance
+  // Coalesce concurrent creations for the same identity onto one in-flight build (see `pendingInstance`).
+  if (pendingInstance !== null && pendingInstance.address === engineAddress) return pendingInstance.promise
+  const promise = createInstance(engineAddress)
+  pendingInstance = { address: engineAddress, promise }
+  try {
+    return await promise
+  } finally {
+    // Clear the marker only if still ours — a later identity change may have replaced it mid-build.
+    if (pendingInstance !== null && pendingInstance.promise === promise) pendingInstance = null
+  }
+}
 
+async function createInstance(engineAddress: string): Promise<SdkInstance> {
   if (instance !== null) await instance.sdk.close()
 
   const cfg = await readPathConfig()
@@ -251,6 +274,9 @@ export async function readSdkHistory(sinceBlock?: number): Promise<HistoryEntry[
 
 /** Close the persistent instance (call on wallet lock). Idempotent. */
 export async function closeSdkRead(): Promise<void> {
+  // Drop any in-flight build marker so a lock mid-creation can't leave a stale pending promise that a
+  // later caller would await into a closed/orphaned instance.
+  pendingInstance = null
   if (instance !== null) {
     const closing = instance.sdk
     instance = null


### PR DESCRIPTION
## Symptom
On unlock the dashboard showed a shielded balance of **0** for ~15s (until the next sync poll), on both cold load and resume — even though all notes were at old blocks and no new activity occurred.

## Root cause
`sdk-read.ts::ensureInstance` had no in-flight guard. On unlock, several flows call it near-simultaneously — the initial scan (`refreshShieldedBalances`), `useShieldedSyncPoll`'s mount fetch, the three balance reads in `refreshAll`, and `useHistoryRecovery`. While `instance` is still `null`, each races past the null check and builds its **own** SDK instance + wallet against the **same** IndexedDB scan-state DB. Multiple wallets then scan/write one encrypted DB concurrently and clobber each other's state, so early reads see **0 owned notes** until the survivors settle and a later poll re-syncs.

Diagnosed by instrumenting the read path: the first scan reported `ownedNotes=0` (covering all note blocks), a later sync reported `ownedNotes=4` — and a forced crypto warmup delay had no effect, ruling out a timing/WASM race and pointing at duplicate instances.

## Fix
Add an in-flight guard so `ensureInstance` builds **exactly one** instance — concurrent callers for the same identity await a single `pendingInstance` promise; a genuine identity change still rebuilds. `closeSdkRead` clears the marker so a lock mid-build can't strand it.

## Tests
`sdk-read.test.ts`: 3 concurrent `getSdkWallet()` → `createArmadaSdk` called once; fresh build after `closeSdkRead`. Full interface suite green (1133 passed); typecheck clean. Verified live: balance appears on the first scan, cold and resume.

Interface-only; root cause was not in `@armada/sdk` (no re-pin). No relayer/VPS impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)