### PR TITLE
fix(interface): single-flight the deployment manifest loaders

### DIFF
--- a/apps/armada-interface/src/config/deployments.test.ts
+++ b/apps/armada-interface/src/config/deployments.test.ts
@@ -1,0 +1,61 @@
+// ABOUTME: Tests for the deployment manifest loaders — single-flight dedup of concurrent calls (one
+// ABOUTME: fetch per burst) and preserved retry-on-transient-failure semantics.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// getNetworkConfig is the only import — a minimal local config (no clients → loadDeployments fetches
+// just the hub manifest, so the dedup assertion is a clean "called once").
+vi.mock('./network', () => ({
+  getNetworkConfig: () => ({ mode: 'local', clients: [] }),
+}))
+
+const okJson = (body: unknown) => ({ ok: true, json: async () => body })
+
+beforeEach(() => {
+  vi.resetModules() // fresh module-level cache/pending state per test
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('loadYieldDeployment — single-flight', () => {
+  it('coalesces concurrent calls into one fetch', async () => {
+    const fetchMock = vi.fn(async () => okJson({ contracts: { armadaYieldVault: '0xvault' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { loadYieldDeployment } = await import('./deployments')
+
+    const [a, b, c] = await Promise.all([loadYieldDeployment(), loadYieldDeployment(), loadYieldDeployment()])
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(a).toBe(b)
+    expect(b).toBe(c)
+    expect(a).not.toBeNull()
+  })
+
+  it('retries after a transient failure — a failure is not cached', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(okJson({ contracts: { armadaYieldVault: '0xvault' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { loadYieldDeployment } = await import('./deployments')
+
+    expect(await loadYieldDeployment()).toBeNull() // transient failure → null, not cached
+    expect(await loadYieldDeployment()).not.toBeNull() // next call re-fetches and succeeds
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('loadDeployments — single-flight', () => {
+  it('coalesces concurrent calls (hub manifest fetched once, not per caller)', async () => {
+    const fetchMock = vi.fn(async () => okJson({ contracts: {}, deployBlock: 1 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { loadDeployments } = await import('./deployments')
+
+    const [a, b, c] = await Promise.all([loadDeployments(), loadDeployments(), loadDeployments()])
+
+    expect(fetchMock).toHaveBeenCalledTimes(1) // clients: [] → only the hub manifest, once
+    expect(a).toBe(b)
+    expect(b).toBe(c)
+  })
+})

--- a/apps/armada-interface/src/config/deployments.ts
+++ b/apps/armada-interface/src/config/deployments.ts
@@ -96,22 +96,32 @@ async function fetchManifest<T>(name: string): Promise<T> {
 }
 
 let cached: ResolvedDeployments | null = null
+let pendingDeployments: Promise<ResolvedDeployments> | null = null
 
 export async function loadDeployments(): Promise<ResolvedDeployments> {
   if (cached) return cached
+  // Single-flight: coalesce concurrent callers onto ONE fetch so a burst (e.g. readPathConfig fired by
+  // several readers on unlock) doesn't re-request the same static manifests. The in-flight ref is cleared
+  // on settle, so a transient failure retries and a success falls through to `cached`.
+  if (pendingDeployments) return pendingDeployments
+  const p: Promise<ResolvedDeployments> = (async (): Promise<ResolvedDeployments> => {
+    const cfg = getNetworkConfig()
+    const hub = await fetchManifest<PrivacyPoolHubDeployment>(manifestName('hub'))
 
-  const cfg = getNetworkConfig()
-  const hub = await fetchManifest<PrivacyPoolHubDeployment>(manifestName('hub'))
+    // Two clients today (clientA + clientB). Mapped to the network config's `clients[]` order.
+    const clientNames: ReadonlyArray<'client' | 'clientB'> = ['client', 'clientB']
+    const clients: PrivacyPoolClientDeployment[] = []
+    for (const role of clientNames.slice(0, cfg.clients.length)) {
+      clients.push(await fetchManifest<PrivacyPoolClientDeployment>(manifestName(role)))
+    }
 
-  // Two clients today (clientA + clientB). Mapped to the network config's `clients[]` order.
-  const clientNames: ReadonlyArray<'client' | 'clientB'> = ['client', 'clientB']
-  const clients: PrivacyPoolClientDeployment[] = []
-  for (const role of clientNames.slice(0, cfg.clients.length)) {
-    clients.push(await fetchManifest<PrivacyPoolClientDeployment>(manifestName(role)))
-  }
-
-  cached = { hub, clients }
-  return cached
+    cached = { hub, clients }
+    return cached
+  })().finally(() => {
+    if (pendingDeployments === p) pendingDeployments = null
+  })
+  pendingDeployments = p
+  return p
 }
 
 export function getCachedDeployments(): ResolvedDeployments | null {
@@ -164,6 +174,7 @@ export interface YieldDeployment {
 }
 
 let yieldCached: YieldDeployment | null = null
+let pendingYield: Promise<YieldDeployment | null> | null = null
 
 /**
  * Fetch the yield deployment manifest. Returns null if the manifest isn't present (e.g., a
@@ -172,17 +183,27 @@ let yieldCached: YieldDeployment | null = null
  */
 export async function loadYieldDeployment(): Promise<YieldDeployment | null> {
   if (yieldCached) return yieldCached
-  const cfg = getNetworkConfig()
-  const suffix = cfg.mode === 'sepolia' ? '-sepolia' : ''
-  const name = `yield-hub${suffix}.json`
-  try {
-    const res = await fetch(`/api/deployments/${name}`)
-    if (!res.ok) return null
-    yieldCached = (await res.json()) as YieldDeployment
-    return yieldCached
-  } catch {
-    return null
-  }
+  // Single-flight — readPathConfig calls this twice (vault + adapter) across several readers on unlock,
+  // so coalesce concurrent callers onto one fetch. Cleared on settle: a failure (returns null without
+  // caching) retries next call; a success falls through to `yieldCached`.
+  if (pendingYield) return pendingYield
+  const p: Promise<YieldDeployment | null> = (async (): Promise<YieldDeployment | null> => {
+    const cfg = getNetworkConfig()
+    const suffix = cfg.mode === 'sepolia' ? '-sepolia' : ''
+    const name = `yield-hub${suffix}.json`
+    try {
+      const res = await fetch(`/api/deployments/${name}`)
+      if (!res.ok) return null
+      yieldCached = (await res.json()) as YieldDeployment
+      return yieldCached
+    } catch {
+      return null
+    }
+  })().finally(() => {
+    if (pendingYield === p) pendingYield = null
+  })
+  pendingYield = p
+  return p
 }
 
 export interface FeeModuleDeployment {
@@ -193,26 +214,36 @@ export interface FeeModuleDeployment {
 }
 
 let feeModuleCached: `0x${string}` | null | undefined
+let pendingFeeModule: Promise<`0x${string}` | null> | null = null
 
 /** ArmadaFeeModule proxy on the hub chain — used for on-chain shield fee quotes. */
 export async function loadFeeModuleAddress(): Promise<`0x${string}` | null> {
   if (feeModuleCached !== undefined) return feeModuleCached
-  const cfg = getNetworkConfig()
-  const suffix = cfg.mode === 'sepolia' ? '-sepolia' : ''
-  const name = `fee-module-hub${suffix}.json`
-  try {
-    const res = await fetch(`/api/deployments/${name}`)
-    if (!res.ok) {
+  // Single-flight: coalesce concurrent callers onto one fetch. `feeModuleCached` caches the failure
+  // (null) too, matching the prior behavior — a missing fee module is a stable answer, not a retry.
+  if (pendingFeeModule) return pendingFeeModule
+  const p: Promise<`0x${string}` | null> = (async (): Promise<`0x${string}` | null> => {
+    const cfg = getNetworkConfig()
+    const suffix = cfg.mode === 'sepolia' ? '-sepolia' : ''
+    const name = `fee-module-hub${suffix}.json`
+    try {
+      const res = await fetch(`/api/deployments/${name}`)
+      if (!res.ok) {
+        feeModuleCached = null
+        return null
+      }
+      const json = (await res.json()) as FeeModuleDeployment
+      const addr = json.contracts?.feeModuleProxy
+      feeModuleCached =
+        addr && /^0x[0-9a-fA-F]{40}$/.test(addr) ? (addr as `0x${string}`) : null
+      return feeModuleCached
+    } catch {
       feeModuleCached = null
       return null
     }
-    const json = (await res.json()) as FeeModuleDeployment
-    const addr = json.contracts?.feeModuleProxy
-    feeModuleCached =
-      addr && /^0x[0-9a-fA-F]{40}$/.test(addr) ? (addr as `0x${string}`) : null
-    return feeModuleCached
-  } catch {
-    feeModuleCached = null
-    return null
-  }
+  })().finally(() => {
+    if (pendingFeeModule === p) pendingFeeModule = null
+  })
+  pendingFeeModule = p
+  return p
 }


### PR DESCRIPTION
Follow-up hygiene from the balance-0-on-unlock audit (#472). Sweeping the interface's lazy async singletons for the same race pattern, the deployment manifest loaders were the only other instance — `loadDeployments` / `loadYieldDeployment` / `loadFeeModuleAddress` used null-check → `await fetch` → assign, so concurrent callers each re-fetched the same static manifests (`loadYieldDeployment` fires a few times per unlock via `readPathConfig`).

**Benign** (idempotent static JSON, browser-HTTP-cached — no corruption, unlike `ensureInstance`), but wasteful. Now single-flight: concurrent callers share one in-flight promise, cleared on settle so each loader keeps its existing semantics (`loadYieldDeployment` retries on transient failure; `loadFeeModuleAddress`/`loadDeployments` unchanged). Mirrors the correct pattern already in `lib/cache.ts::openDb`.

Audit outcome for the record: the prover worker (`createInterfaceProver`) and `getNetworkConfig` are synchronous (no race); `cache.ts::openDb` was already correct single-flight. `ensureInstance` (#472) was the only corruption-class instance.

## Tests
New `deployments.test.ts`: concurrent calls → one fetch; retry preserved after a transient failure. Full interface suite green (1138 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)