### PR TITLE
chore(interface): re-pin @armada/sdk to #77 (crypto-ready gate + IndexedDB lock)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#278b5de9defdd2a56eca3c734a395a2120aa0e9a",
+        "@armada/sdk": "github:ship-armada/armada-sdk#67c1aab47cb9df940db78e46822ec0d82aa5fef8",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -408,8 +408,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#278b5de9defdd2a56eca3c734a395a2120aa0e9a",
-      "integrity": "sha512-hHJlEBq9pFG9aBZzCjgP9W+7AEnGJ1sLVeESm/hhkuXjBFU58Se5d1MjA+k2kK3U+WS7decIPYkTjug1V7bEBg==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#67c1aab47cb9df940db78e46822ec0d82aa5fef8",
+      "integrity": "sha512-0+gFMBWUwFOtz7VlegLvSzSpDT+w94Z3AqlCyLDgk2/yyPNpbFDOnIMAIBeoHjUmzdv+E1M/GbWZvQbUuBxcMg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#278b5de9defdd2a56eca3c734a395a2120aa0e9a",
+    "@armada/sdk": "github:ship-armada/armada-sdk#67c1aab47cb9df940db78e46822ec0d82aa5fef8",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",


### PR DESCRIPTION
Adopts [armada-sdk #77](https://github.com/ship-armada/armada-sdk/pull/77) — bumps the `@armada/sdk` git-SHA pin `278b5de…` → `67c1aab…`:

- `createArmadaSdk` now awaits the curve25519 WASM init (not just Poseidon), so the first scan can't trial-decrypt against un-ready WASM.
- `IndexedDBStorageAdapter.open()` takes an origin-scoped exclusive Web Lock on its DB name → `StorageConflictError` on a second same-DB instance.

Both are defense-in-depth from the balance-0-on-unlock diagnosis; the live bug was already fixed by #472.

## Blast-radius check (re-pin touches root consumers too)
- Root `tsc --project tsconfig.ci.json` — clean
- `test:sdk-backend` — 4/4 (0zk derivation parity holds)
- Interface typecheck — clean
- Interface suite — 1138 passed / 8 skipped

Additive SDK changes (an extra `await` + a feature-detected lock), no API/wire-shape change — confirmed by the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)