### PR TITLE
fix(interface): atomic tx-storage OCC + guard SDK-instance builds vs mid-build teardown

### DIFF
--- a/apps/armada-interface/src/lib/cache.test.ts
+++ b/apps/armada-interface/src/lib/cache.test.ts
@@ -1,0 +1,46 @@
+// ABOUTME: Tests for cache.ts::cacheReadModifyWrite — atomic get→decide→put in one IDB transaction, so
+// ABOUTME: two concurrent same-key compare-and-sets can't both read a stale value and both write.
+
+import 'fake-indexeddb/auto'
+import { describe, it, expect } from 'vitest'
+import { cacheReadModifyWrite, cacheGet, cachePut } from './cache'
+
+describe('cacheReadModifyWrite', () => {
+  it('writes on { put } (returns true); skips on { skip } (returns false)', async () => {
+    const wrote = await cacheReadModifyWrite<number, number>('meta', 'k1', () => ({ put: 7 }))
+    expect(wrote).toBe(true)
+    expect(await cacheGet<number>('meta', 'k1')).toBe(7)
+
+    const skipped = await cacheReadModifyWrite<number, number>('meta', 'k1', () => ({ skip: true }))
+    expect(skipped).toBe(false)
+    expect(await cacheGet<number>('meta', 'k1')).toBe(7) // unchanged
+  })
+
+  it('decide sees the current stored value', async () => {
+    await cachePut('meta', 'k3', 41)
+    await cacheReadModifyWrite<number, number>('meta', 'k3', (v) => ({ put: (v ?? 0) + 1 }))
+    expect(await cacheGet<number>('meta', 'k3')).toBe(42)
+  })
+
+  it('is ATOMIC under concurrency — two same-key read-increments both apply (no lost update)', async () => {
+    await cachePut('meta', 'ctr', 0)
+    // Fire two RMWs concurrently; each reads the current value and writes value+1. With the old
+    // cacheGet-then-cachePut split (two transactions) both would read 0 and the store would end at 1.
+    // One transaction per call → IndexedDB serializes them, so the second reads the first's write → 2.
+    await Promise.all([
+      cacheReadModifyWrite<number, number>('meta', 'ctr', (v) => ({ put: (v ?? 0) + 1 })),
+      cacheReadModifyWrite<number, number>('meta', 'ctr', (v) => ({ put: (v ?? 0) + 1 })),
+    ])
+    expect(await cacheGet<number>('meta', 'ctr')).toBe(2)
+  })
+
+  it('aborts the transaction (no write) when decide throws', async () => {
+    await cachePut('meta', 'k2', 'orig')
+    await expect(
+      cacheReadModifyWrite<string, string>('meta', 'k2', () => {
+        throw new Error('boom')
+      }),
+    ).rejects.toThrow('boom')
+    expect(await cacheGet<string>('meta', 'k2')).toBe('orig') // unchanged
+  })
+})

--- a/apps/armada-interface/src/lib/cache.ts
+++ b/apps/armada-interface/src/lib/cache.ts
@@ -61,6 +61,55 @@ export async function cachePut<T>(store: StoreName, key: string, value: T): Prom
   })
 }
 
+/**
+ * Atomic read-modify-write on ONE key in a SINGLE `readwrite` transaction. `decide` runs synchronously
+ * inside the transaction with the current stored value; return `{ put }` to write, or `{ skip: true }`
+ * to leave the store unchanged. Because get → decide → put all share one transaction, a compare-and-set
+ * (optimistic-concurrency / terminal-state guard) is atomic — two concurrent callers can't both read the
+ * same value, both pass the guard, and both write (the `cacheGet`-then-`cachePut` split can). Resolves
+ * to whether a write happened.
+ *
+ * `decide` MUST be synchronous — any `await` inside it lets IndexedDB auto-commit the transaction before
+ * the `put`, defeating the atomicity (and throwing on the late write).
+ */
+export async function cacheReadModifyWrite<T, V>(
+  store: StoreName,
+  key: string,
+  decide: (existing: T | undefined) => { put: V } | { skip: true },
+): Promise<boolean> {
+  const db = await openDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(store, 'readwrite')
+    const os = tx.objectStore(store)
+    const getReq = os.get(key)
+    let wrote = false
+    let settled = false
+    const done = (fn: () => void): void => {
+      if (!settled) {
+        settled = true
+        fn()
+      }
+    }
+    getReq.onsuccess = () => {
+      try {
+        const decision = decide(getReq.result as T | undefined)
+        if ('put' in decision) {
+          os.put(decision.put, key)
+          wrote = true
+        }
+      } catch (err) {
+        // A throw from decide() must not leave a half-applied state — abort the whole transaction.
+        tx.abort()
+        done(() => reject(err instanceof Error ? err : new Error(String(err))))
+      }
+    }
+    getReq.onerror = () => done(() => reject(getReq.error))
+    tx.oncomplete = () => done(() => resolve(wrote))
+    tx.onerror = () => done(() => reject(tx.error))
+    tx.onabort = () => done(() => reject(tx.error ?? new Error('cacheReadModifyWrite: transaction aborted')))
+  })
+}
+
 export async function cacheDelete(store: StoreName, key: string): Promise<void> {
   const db = await openDb()
   return new Promise((resolve, reject) => {

--- a/apps/armada-interface/src/lib/shielded/sdk-read.test.ts
+++ b/apps/armada-interface/src/lib/shielded/sdk-read.test.ts
@@ -99,10 +99,11 @@ describe('syncTracked', () => {
 })
 
 describe('ensureInstance — concurrency guard (getSdkWallet)', () => {
+  let fakeSdk: { wallet: { fromRootSecret: ReturnType<typeof vi.fn> }; close: ReturnType<typeof vi.fn> }
   beforeEach(async () => {
     await closeSdkRead() // reset the module singleton + any in-flight build between tests
     const fakeWallet = { on: vi.fn() }
-    const fakeSdk = { wallet: { fromRootSecret: vi.fn(async () => fakeWallet) }, close: vi.fn(async () => {}) }
+    fakeSdk = { wallet: { fromRootSecret: vi.fn(async () => fakeWallet) }, close: vi.fn(async () => {}) }
     vi.mocked(createArmadaSdk).mockReset()
     // A deliberately slow build so the concurrent callers genuinely overlap during creation — the exact
     // window the in-flight guard closes.
@@ -129,5 +130,18 @@ describe('ensureInstance — concurrency guard (getSdkWallet)', () => {
     await closeSdkRead()
     await getSdkWallet()
     expect(createArmadaSdk).toHaveBeenCalledTimes(2)
+  })
+
+  it('discards an in-flight build if a teardown lands mid-build — closes the SDK, no orphan/leak', async () => {
+    // WHY: a lock/account-switch during the (slow) createArmadaSdk build must not assign an orphan
+    // instance past closeSdkRead, nor leak the freshly-opened IndexedDB handle (which would block
+    // Settings → Reset's DB delete). The generation guard bumps on teardown; the build then bails.
+    const p = getSdkWallet() // build starts — createArmadaSdk is delaying
+    await new Promise((r) => setTimeout(r, 1)) // let createInstance reach the createArmadaSdk await
+    await closeSdkRead() // teardown mid-build → bumps the generation
+    await expect(p).rejects.toThrow(/superseded/)
+    expect(fakeSdk.close).toHaveBeenCalled() // the superseded build closed its freshly-opened SDK
+    // The singleton is clean afterward: a fresh unlock rebuilds normally.
+    await expect(getSdkWallet()).resolves.toBeDefined()
   })
 })

--- a/apps/armada-interface/src/lib/shielded/sdk-read.ts
+++ b/apps/armada-interface/src/lib/shielded/sdk-read.ts
@@ -97,6 +97,12 @@ let instance: SdkInstance | null = null
 // in-flight build so all concurrent callers for the same identity await one instance.
 let pendingInstance: { address: string; promise: Promise<SdkInstance> } | null = null
 
+// Bumped on every teardown (`closeSdkRead`). `createInstance` captures the generation at its start; if a
+// teardown lands during its awaits (lock / account-switch mid-build), the generation moves and the build
+// discards its freshly-opened SDK instead of assigning an orphan instance past the teardown or leaking
+// the open IndexedDB handle (a leaked handle would block Settings → Reset's DB delete).
+let generation = 0
+
 // IndexedDB database name for the SDK read instance's scan state, partitioned by the (hub chain id,
 // PrivacyPool address) pair that uniquely identifies a scan context. Chain id alone is insufficient:
 // two deployments on the same chain (different pool address — e.g. switching deployment instances)
@@ -149,6 +155,7 @@ async function ensureInstance(): Promise<SdkInstance> {
 }
 
 async function createInstance(engineAddress: string): Promise<SdkInstance> {
+  const gen = generation
   if (instance !== null) await instance.sdk.close()
 
   const cfg = await readPathConfig()
@@ -168,13 +175,28 @@ async function createInstance(engineAddress: string): Promise<SdkInstance> {
     // root-mismatch-fallback) through this sink, which the interface surfaces as `sdk.quicksync`.
     telemetry: sdkTelemetrySink,
   })
+  // A teardown (lock / account-switch) during the build above moves the generation. `createArmadaSdk`
+  // has already opened the read DB and the next `getRootSecret()` would throw (locked), so bail now and
+  // close the SDK rather than leak the open handle.
+  if (gen !== generation) {
+    await sdk.close().catch(() => {})
+    throw new Error('sdk-read: instance build superseded by teardown')
+  }
   // Attach a spend signer so the instance is write-capable (planTransfer/prove) — not just view-only.
   // Derived from the same in-memory rootSecret the viewing key comes from, so it adds no new secret
   // exposure; it only signs during prove(). Reads never invoke it.
-  const wallet = await sdk.wallet.fromRootSecret(keyManager.getRootSecret(), {
-    creationBlock: keyManager.getCreationBlock() ?? 0,
-    signer: await LocalSigner.fromRootSecret(keyManager.getRootSecret()),
-  })
+  let wallet: ReadWallet
+  try {
+    wallet = await sdk.wallet.fromRootSecret(keyManager.getRootSecret(), {
+      creationBlock: keyManager.getCreationBlock() ?? 0,
+      signer: await LocalSigner.fromRootSecret(keyManager.getRootSecret()),
+    })
+  } catch (err) {
+    // Close the freshly-opened SDK so a lock landing mid-build (getRootSecret throws) can't leak the
+    // open IndexedDB connection — a leaked handle blocks Settings → Reset's DB delete.
+    await sdk.close().catch(() => {})
+    throw err
+  }
   // Forward the wallet's scan/balance/note events onto the app buses — the SDK-native replacement for
   // the stock engine's global balance callback + merkletree-scan callback. Scan lifecycle drives the
   // sync banner/gate (scan-status bus); scan-complete/balance/note ping the balance bus (re-read
@@ -188,6 +210,13 @@ async function createInstance(engineAddress: string): Promise<SdkInstance> {
   wallet.on('scan:error', () => emitScanStatus({ status: 'failed', progress: 0 }))
   wallet.on('balance:updated', () => emitBalanceChange({ reason: 'balance' }))
   wallet.on('note:received', () => emitBalanceChange({ reason: 'note' }))
+  // Final gen-check right before the (synchronous) assign — a teardown during `fromRootSecret` above
+  // would otherwise assign an orphan instance past `closeSdkRead` (built from a possibly-zeroized
+  // rootSecret). No await between here and the assign, so a teardown can't interleave this window.
+  if (gen !== generation) {
+    await sdk.close().catch(() => {})
+    throw new Error('sdk-read: instance build superseded by teardown')
+  }
   instance = { sdk, wallet, address: engineAddress }
   return instance
 }
@@ -274,8 +303,9 @@ export async function readSdkHistory(sinceBlock?: number): Promise<HistoryEntry[
 
 /** Close the persistent instance (call on wallet lock). Idempotent. */
 export async function closeSdkRead(): Promise<void> {
-  // Drop any in-flight build marker so a lock mid-creation can't leave a stale pending promise that a
-  // later caller would await into a closed/orphaned instance.
+  // Supersede any in-flight build (bump the generation) and drop the pending marker, so a lock landing
+  // mid-creation can't strand a pending promise or let the build assign/leak an instance past teardown.
+  generation += 1
   pendingInstance = null
   if (instance !== null) {
     const closing = instance.sdk

--- a/apps/armada-interface/src/lib/tx/storage.test.ts
+++ b/apps/armada-interface/src/lib/tx/storage.test.ts
@@ -19,6 +19,22 @@ const hoisted = vi.hoisted(() => {
     cacheAll: vi.fn(async (_storeName: string) => {
       return Array.from(store.entries()).map(([key, value]) => ({ key, value }))
     }),
+    // Atomic get→decide→put on the in-memory store — mirrors the real single-transaction semantics
+    // (the whole op is synchronous here, so it's atomic just like the real IDB readwrite transaction).
+    cacheReadModifyWrite: vi.fn(
+      async (
+        _storeName: string,
+        key: string,
+        decide: (existing: unknown) => { put: unknown } | { skip: true },
+      ) => {
+        const decision = decide(store.get(key))
+        if ('put' in decision) {
+          store.set(key, decision.put)
+          return true
+        }
+        return false
+      },
+    ),
   }
 })
 
@@ -27,6 +43,7 @@ vi.mock('../cache', () => ({
   cachePut: hoisted.cachePut,
   cacheDelete: hoisted.cacheDelete,
   cacheAll: hoisted.cacheAll,
+  cacheReadModifyWrite: hoisted.cacheReadModifyWrite,
 }))
 
 import { putTxIfFresh, putTx, loadAllTx, deleteTx } from './storage'
@@ -122,11 +139,19 @@ describe('encrypted writes', () => {
       executionState: 'cancelled' as const,
       stage: 'submit-relayer' as const,
     }
-    // Zeroize the keyManager DURING the OCC read's await — exactly when lockWallet would.
-    hoisted.cacheGet.mockImplementationOnce(async () => {
-      clear()
-      return undefined
-    })
+    // Zeroize the keyManager DURING the OCC read-modify-write — exactly when lockWallet would. The
+    // envelope was already encrypted up-front (before this), so the write must still succeed.
+    hoisted.cacheReadModifyWrite.mockImplementationOnce(
+      async (_s: string, k: string, decide: (e: unknown) => { put: unknown } | { skip: true }) => {
+        clear()
+        const decision = decide(hoisted.store.get(k))
+        if ('put' in decision) {
+          hoisted.store.set(k, decision.put)
+          return true
+        }
+        return false
+      },
+    )
 
     await expect(putTxIfFresh(record)).resolves.toBe(true)
 

--- a/apps/armada-interface/src/lib/tx/storage.ts
+++ b/apps/armada-interface/src/lib/tx/storage.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tx record persistence with optimistic concurrency + at-rest AES-256-GCM encryption (V2 Phase 7) under a per-wallet historyEncryptionKey from keyManager.
 // ABOUTME: Stores envelopes of shape `{ nonce, ciphertext }` keyed by tx id; foreign-wallet records throw on unwrap and get silently skipped during hydration.
 
-import { cacheAll, cacheDelete, cacheGet, cachePut } from '../cache'
+import { cacheAll, cacheDelete, cachePut, cacheReadModifyWrite } from '../cache'
 import { isEncryptedBlob, unwrap, wrap, type EncryptedBlob } from '../crypto/cache-cipher'
 import { getHistoryEncryptionKey, isUnlocked } from '../shielded/keyManager'
 import { trackError } from '../telemetry'
@@ -68,39 +68,46 @@ export async function putTxIfFresh(record: TxRecord): Promise<boolean> {
   // instead of throwing at write time and silently losing the record (→ false INTERRUPTED). (W-5)
   const envelope = wrap(record, key)
   try {
-    const existingRaw = await cacheGet<unknown>(STORE, record.id)
-    if (existingRaw !== undefined) {
-      const existing = tryUnwrap(existingRaw, key)
-      // Terminal-state write guard (mirrors state/tx.ts::upsertTxAtom): refuse any write that
-      // would move a settled record back to a non-terminal state, regardless of updatedSeq, so a
-      // late poller/progress write can't resurrect a cancelled/failed/expired record on disk.
-      // Exceptions: terminal→terminal (history-recovery upgrade path) and terminal→`retrying` (an
-      // intentional retry). Stale writes only ever produce `active`/`waiting`, never `retrying`. (P0-3)
-      if (
-        existing
-        && isTerminalState(existing.executionState)
-        && !isTerminalState(record.executionState)
-        && record.executionState !== 'retrying'
-      ) {
-        trackError('tx.storage.terminal-write', new Error('terminal→non-terminal'), {
-          scope: 'tx.storage',
-          message: `refused terminal→non-terminal write for ${record.id}`,
-        })
-        return false
+    // Compare-and-set in ONE IndexedDB transaction so the OCC + terminal guards are atomic on disk. The
+    // prior `cacheGet` → guard → `cachePut` split spanned two transactions, so two concurrent same-id
+    // writers (a cancel's fire-and-forget `putTxIfFresh` racing an in-flight `ctx.upsert`, or a
+    // history-recovery reconcile vs the executor watcher) could both read the same value, both pass the
+    // guard, and both write — persisting a state the in-memory atom guard correctly rejected, which then
+    // resurrects on reload/resume. `decide` is synchronous (`wrap`/`unwrap` are @noble, no await) so the
+    // transaction stays open. (P0-3)
+    return await cacheReadModifyWrite<unknown, typeof envelope>(STORE, record.id, (existingRaw) => {
+      if (existingRaw !== undefined) {
+        const existing = tryUnwrap(existingRaw, key)
+        // Terminal-state write guard (mirrors state/tx.ts::upsertTxAtom): refuse any write that
+        // would move a settled record back to a non-terminal state, regardless of updatedSeq, so a
+        // late poller/progress write can't resurrect a cancelled/failed/expired record on disk.
+        // Exceptions: terminal→terminal (history-recovery upgrade path) and terminal→`retrying` (an
+        // intentional retry). Stale writes only ever produce `active`/`waiting`, never `retrying`. (P0-3)
+        if (
+          existing
+          && isTerminalState(existing.executionState)
+          && !isTerminalState(record.executionState)
+          && record.executionState !== 'retrying'
+        ) {
+          trackError('tx.storage.terminal-write', new Error('terminal→non-terminal'), {
+            scope: 'tx.storage',
+            message: `refused terminal→non-terminal write for ${record.id}`,
+          })
+          return { skip: true }
+        }
+        if (existing && existing.updatedSeq >= record.updatedSeq) {
+          trackError('tx.storage.stale-write', new Error('stale updatedSeq'), {
+            scope: 'tx.storage',
+            message: `stale write rejected for ${record.id}`,
+          })
+          return { skip: true }
+        }
+        // If existing is null here, the stored envelope was either foreign-wallet (couldn't
+        // decrypt under our key) or pre-Phase-7 plaintext. In either case the old value is
+        // unreadable garbage to us and overwriting it is correct.
       }
-      if (existing && existing.updatedSeq >= record.updatedSeq) {
-        trackError('tx.storage.stale-write', new Error('stale updatedSeq'), {
-          scope: 'tx.storage',
-          message: `stale write rejected for ${record.id}`,
-        })
-        return false
-      }
-      // If existing is null here, the stored envelope was either foreign-wallet (couldn't
-      // decrypt under our key) or pre-Phase-7 plaintext. In either case the old value is
-      // unreadable garbage to us and overwriting it is correct.
-    }
-    await cachePut(STORE, record.id, envelope)
-    return true
+      return { put: envelope }
+    })
   } catch (err) {
     trackError('tx.storage.putTxIfFresh', err, { scope: 'tx.storage', message: 'idb write failed' })
     throw err


### PR DESCRIPTION
Two concurrency findings from the interface-wide audit — both about **persisted/handle state** (live UI and funds are unaffected), both verified against the code, each with a regression test.

## 1. `putTxIfFresh` OCC was not atomic on disk
`lib/tx/storage.ts` + `lib/cache.ts`. The compare-and-set read (`cacheGet`, a `readonly` txn) and write (`cachePut`, a separate `readwrite` txn) ran with an `await` between, so two concurrent same-id writers — a cancel's fire-and-forget `putTxIfFresh` racing an in-flight `ctx.upsert`, or history-recovery reconcile vs the executor watcher — could **both** pass the `updatedSeq`/terminal guard and both commit. The persisted record then diverges from the (correct, synchronous) `upsertTxAtom` state and **resurrects on reload/resume** (a cancelled tx re-watched, a completed one back to `active`).

Fix: `cache.ts::cacheReadModifyWrite` does get → synchronous `decide` → put in **one** `readwrite` transaction (`wrap`/`unwrap` are `@noble`, synchronous, so the txn stays open); `putTxIfFresh` routes through it. IndexedDB serializes overlapping same-store readwrite transactions, so the CAS is now atomic.

## 2. SDK-instance build not guarded against mid-build teardown
`lib/shielded/sdk-read.ts` (hole in #472). #472 coalesced concurrent *builds* but not a lock/account-switch landing *during* one: `createArmadaSdk` has already opened the read DB, the next `getRootSecret()` throws (locked) with no `try/finally` to close it → **leaked IndexedDB handle → blocks Settings→Reset's DB delete**. Narrower case: a lock during `fromRootSecret` could assign an orphan instance (from a zeroized `rootSecret`) past `closeSdkRead`.

Fix: a module `generation` counter (bumped in `closeSdkRead`); `createInstance` captures it, re-checks after each `await` (incl. right before the synchronous assign), closes the freshly-built SDK, and bails if superseded.

## Tests
- `cache.test.ts` (new): `cacheReadModifyWrite` put/skip, decide-throw aborts the txn, and **atomic under concurrency** (two same-key read-increments → 2, not a lost update).
- `storage.test.ts`: updated the mock + W-5 zeroize test for the RMW path.
- `sdk-read.test.ts`: a teardown mid-build discards the SDK (`close` called, rejects `superseded`, no orphan).
- Full interface suite: **1143 passed / 8 skipped**; typecheck clean.

The remaining audit items were low/known (fire-and-forget write-failure swallowing, `useTxResume` leader-dep latency, cross-tab localStorage lost-update → redundant rescan, schema-migration `blocked`-but-marked, the inherent relayer request-sent/response-lost window) — left for a future pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)