### PR TITLE
chore(interface): log OCC/terminal write-rejections at info, not error

### DIFF
--- a/apps/armada-interface/src/lib/telemetry.ts
+++ b/apps/armada-interface/src/lib/telemetry.ts
@@ -61,6 +61,12 @@ export type EventRegistry = {
   'tx.interrupted':           { id: string; kind: TxKind }
   'tx.cancel-all':            { reason: string; count: number }
 
+  // The storage OCC / terminal-state guard dropped a write for `id` — an EXPECTED outcome (a
+  // superseded/duplicate write for a tx whose newer state already persisted; the guard keeps disk ==
+  // atom). Info-level (NOT `trackError`) so a benign concurrency drop doesn't masquerade as an error or
+  // ship to Sentry. `reason`: `stale` = lower/equal updatedSeq; `terminal` = would resurrect a settled record.
+  'tx.storage.write-rejected': { id: string; reason: 'stale' | 'terminal' }
+
   // Relayer-mediated submit (Phase A). Fired by handlers that delegate broadcast to the relayer
   // instead of sending from the user's wallet. errorCode on `rejected` is the typed RelayerErrorCode
   // (FEE_EXPIRED / FEE_TOO_LOW / etc.) so dashboards can split out fee-staleness from genuine

--- a/apps/armada-interface/src/lib/tx/storage.ts
+++ b/apps/armada-interface/src/lib/tx/storage.ts
@@ -4,7 +4,7 @@
 import { cacheAll, cacheDelete, cachePut, cacheReadModifyWrite } from '../cache'
 import { isEncryptedBlob, unwrap, wrap, type EncryptedBlob } from '../crypto/cache-cipher'
 import { getHistoryEncryptionKey, isUnlocked } from '../shielded/keyManager'
-import { trackError } from '../telemetry'
+import { track, trackError } from '../telemetry'
 import { historySortTime, isTerminalState } from './types'
 import type { TxRecord } from './types'
 
@@ -89,17 +89,14 @@ export async function putTxIfFresh(record: TxRecord): Promise<boolean> {
           && !isTerminalState(record.executionState)
           && record.executionState !== 'retrying'
         ) {
-          trackError('tx.storage.terminal-write', new Error('terminal→non-terminal'), {
-            scope: 'tx.storage',
-            message: `refused terminal→non-terminal write for ${record.id}`,
-          })
+          // Expected OCC outcome (a late write that would resurrect a settled record), NOT an error —
+          // info-level so it doesn't masquerade as an error / ship to Sentry.
+          track('tx.storage.write-rejected', { id: record.id, reason: 'terminal' })
           return { skip: true }
         }
         if (existing && existing.updatedSeq >= record.updatedSeq) {
-          trackError('tx.storage.stale-write', new Error('stale updatedSeq'), {
-            scope: 'tx.storage',
-            message: `stale write rejected for ${record.id}`,
-          })
+          // Expected OCC outcome (a superseded write whose newer state already persisted), NOT an error.
+          track('tx.storage.write-rejected', { id: record.id, reason: 'stale' })
           return { skip: true }
         }
         // If existing is null here, the stored envelope was either foreign-wallet (couldn't


### PR DESCRIPTION
Follow-up to #475. `putTxIfFresh`'s stale-`updatedSeq` and terminal-state guards fire in **normal operation** — a superseded/duplicate write (a receipt watcher or history-recovery reconcile racing a newer transition) is correctly dropped so the persisted record stays `== ` the atom. They were logged via `trackError`, so an **expected** concurrency drop surfaced as an `error` in the console (`stale write rejected for <ulid>`) and — with a Sentry DSN — as an error event.

Swap them for a new info-level `tx.storage.write-rejected` `{ id, reason: 'stale' | 'terminal' }`. Keeps the anomaly-spotting breadcrumb without masquerading as an error or polluting Sentry. The outer-catch `trackError` for genuine IDB write failures is unchanged.

No behavior change — guard logic + return values identical; `storage.test.ts` (17) green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)