### PR TITLE
interface: decouple prep — explicit deps + remote fee-module fetch

### DIFF
--- a/apps/armada-interface/netlify.toml
+++ b/apps/armada-interface/netlify.toml
@@ -47,7 +47,7 @@
     curl -sfL -o public/api/deployments/privacy-pool-client-sepolia.json  "${BASE}/base-sepolia/privacy-pool.json" && \
     curl -sfL -o public/api/deployments/privacy-pool-clientB-sepolia.json "${BASE}/arbitrum-sepolia/privacy-pool.json" && \
     curl -sfL -o public/api/deployments/yield-hub-sepolia.json            "${BASE}/sepolia/yield.json" && \
-    cp ../../deployments/fee-module-hub-sepolia.json public/api/deployments/fee-module-hub-sepolia.json && \
+    curl -sfL -o public/api/deployments/fee-module-hub-sepolia.json       "${BASE}/sepolia/fee-module.json" && \
     npm run prepare:artifacts && \
     cd ../.. && \
     npm run build --workspace=@armada/interface

--- a/apps/armada-interface/package.json
+++ b/apps/armada-interface/package.json
@@ -14,6 +14,7 @@
     "prepare:artifacts": "node scripts/prepare-artifacts.mjs"
   },
   "dependencies": {
+    "@armada/sdk": "github:ship-armada/armada-sdk#67c1aab47cb9df940db78e46822ec0d82aa5fef8",
     "@armada/ui": "*",
     "@heroicons/react": "^2.2.0",
     "@noble/ciphers": "^0.4.1",
@@ -22,6 +23,7 @@
     "@scure/bip39": "^1.3.0",
     "@sentry/react": "^8.55.0",
     "@tanstack/react-query": "^5.96.0",
+    "@web3icons/react": "^4.1.17",
     "clsx": "^2.1.1",
     "ethers": "^6.15.0",
     "jotai": "^2.15.1",

--- a/apps/armada-interface/scripts/fetch-sepolia-deployments.sh
+++ b/apps/armada-interface/scripts/fetch-sepolia-deployments.sh
@@ -27,7 +27,6 @@ curl -sfL -o "${OUT}/privacy-pool-hub-sepolia.json" "${BASE}/sepolia/privacy-poo
 curl -sfL -o "${OUT}/privacy-pool-client-sepolia.json" "${BASE}/base-sepolia/privacy-pool.json"
 curl -sfL -o "${OUT}/privacy-pool-clientB-sepolia.json" "${BASE}/arbitrum-sepolia/privacy-pool.json"
 curl -sfL -o "${OUT}/yield-hub-sepolia.json" "${BASE}/sepolia/yield.json"
-# Fee module lives in armada-poc deployments/ (not armada-deployments remote yet).
-cp "$(cd "${ROOT}/../.." && pwd)/deployments/fee-module-hub-sepolia.json" "${OUT}/fee-module-hub-sepolia.json"
+curl -sfL -o "${OUT}/fee-module-hub-sepolia.json" "${BASE}/sepolia/fee-module.json"
 
 echo "Done."

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
       "name": "@armada/interface",
       "version": "0.1.0",
       "dependencies": {
+        "@armada/sdk": "github:ship-armada/armada-sdk#67c1aab47cb9df940db78e46822ec0d82aa5fef8",
         "@armada/ui": "*",
         "@heroicons/react": "^2.2.0",
         "@noble/ciphers": "^0.4.1",
@@ -76,6 +77,7 @@
         "@scure/bip39": "^1.3.0",
         "@sentry/react": "^8.55.0",
         "@tanstack/react-query": "^5.96.0",
+        "@web3icons/react": "^4.1.17",
         "clsx": "^2.1.1",
         "ethers": "^6.15.0",
         "jotai": "^2.15.1",


### PR DESCRIPTION
Two small decoupling fixes ahead of spinning `apps/armada-interface` out into its own repo (the carve itself is deferred until after the incoming visual redesign). Both are correct today regardless of extraction — testnet only, no external users.

## Explicit dependency declarations
The app imports `@armada/sdk` (16 files) and `@web3icons/react` (5 components) **directly** but was free-riding on root workspace hoisting — neither was in its own `package.json`. Declared both (`@armada/sdk` pinned to the same SHA as root). Lockfile reconciled offline (`--package-lock-only`); 2-line delta, no resolution churn.

## Fee-module manifest: fetch from remote, not the monorepo
The sepolia build fetched every manifest from `ship-armada/armada-deployments` **except** the fee module, which it `cp`'d from the monorepo `deployments/` dir (hardcoded to one deployment). Switched both build sites (`fetch-sepolia-deployments.sh`, `netlify.toml`; Vercel runs the script) to `curl ${BASE}/sepolia/fee-module.json`.

- Removes the **last** monorepo file-dependency in the build path — sepolia builds are now fully remote-sourced.
- Fixes a latent **instance mismatch**: the default (`demo1`) build shipped demo2's fee module (`config.privacyPool` pointed at the wrong pool). Now instance-matched.
- The remote already carries `sepolia/fee-module.json` for both full-privacy-pool instances (`demo1`/`demo2`), so this is safe — nothing needed pushing there. The stale "not in remote yet" comment is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)