### PR TITLE
feat(interface): deposit (shield) flow redesign — new modal shell + mockup visuals (Phase 3b)

### DIFF
--- a/apps/armada-interface/index.html
+++ b/apps/armada-interface/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="dark">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
@@ -61,6 +61,50 @@
   gap: var(--primitives-spacing-2);
 }
 
+.balanceControls {
+  display: flex;
+  align-items: center;
+  gap: var(--primitives-spacing-3);
+  min-width: 0;
+}
+
+.pctPills {
+  display: flex;
+  align-items: center;
+  gap: var(--primitives-spacing-1);
+  flex-shrink: 0;
+}
+
+.pctPill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--primitives-spacing-5);
+  padding: 0 var(--primitives-spacing-2);
+  border: none;
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  background: var(--semantic-color-surface-raised);
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-weight: var(--primitives-fontWeight-medium);
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  color: var(--semantic-color-text-primary);
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+.pctPill:hover {
+  background: var(--semantic-color-surface-hover);
+}
+
+.pctPill:active {
+  transform: translateY(1px);
+}
+
+.pctPill:focus-visible {
+  outline: 2px solid var(--semantic-color-border-focus);
+  outline-offset: 1px;
+}
+
 .chainIconSlot,
 .tokenIconSlot {
   width: var(--primitives-spacing-8);

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
@@ -7,8 +7,8 @@
   gap: var(--primitives-spacing-8);
   width: 100%;
   padding: var(--primitives-spacing-5);
-  background: var(--semantic-color-surface-default);
-  border-radius: calc(var(--semantic-borderRadius-card) * 1px);
+  background: var(--semantic-color-surface-main);
+  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
   backdrop-filter: blur(15px);
   -webkit-backdrop-filter: blur(15px);
   box-sizing: border-box;
@@ -17,8 +17,9 @@
 .topRow,
 .bottomRow {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--primitives-spacing-4);
 }
 
 .chainRoot {
@@ -64,7 +65,9 @@
 .balanceControls {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--primitives-spacing-3);
+  width: 100%;
   min-width: 0;
 }
 
@@ -143,6 +146,40 @@
   gap: var(--primitives-spacing-1);
 }
 
+/* Fee row (mockup style): its own inset "card" below the balance controls — a muted, rounded,
+   fixed-height pill (the translucent fill stacks on the translucent card so it reads as inset).
+   "Fee" label left, mono value right. */
+.feeRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: calc(var(--primitives-spacing-10) - var(--primitives-spacing-1));
+  padding-inline: var(--primitives-spacing-3);
+  border-radius: calc(var(--primitives-borderRadius-sm) * 1px + 1px);
+  background: color-mix(in srgb, var(--primitives-color-neutral-50) 40%, transparent);
+}
+
+.feeLabel {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-weight: var(--primitives-fontWeight-regular);
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  color: var(--semantic-color-text-secondary);
+}
+
+.feeValueGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--primitives-spacing-1);
+}
+
+.feeValue {
+  font-family: var(--primitives-fontFamily-mono), ui-monospace, monospace;
+  font-weight: var(--primitives-fontWeight-medium);
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  color: var(--semantic-color-text-primary);
+}
+
 .feeText,
 .chainOptionLabel {
   font-family: var(--primitives-fontFamily-ui), sans-serif;
@@ -199,9 +236,33 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: var(--primitives-spacing-3);
   width: 100%;
   min-height: calc(var(--primitives-fontSize-4xl) * 1.2 * 1px);
   cursor: text;
+}
+
+/* USDC coin sits directly beside the amount (mockup places the token glyph next to the number,
+   not as a separate top-right label). */
+.amountTokenIcon {
+  width: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* The web3icons `size` prop doesn't reliably drive the rendered svg in this app (see .tokenIconSlot),
+   so size the coin via CSS: render it oversized (24/18 of the 40px badge) and let the badge's
+   overflow:hidden clip the glyph's built-in padding so the coin fills the circle — matches the mockup. */
+.amountTokenIcon :global(svg) {
+  width: calc(var(--primitives-spacing-10) * 24 / 18);
+  height: calc(var(--primitives-spacing-10) * 24 / 18);
+  display: block;
+  flex-shrink: 0;
 }
 
 .amountField {
@@ -212,9 +273,9 @@
 
 .amountDisplay,
 .amountInput {
-  font-family: var(--primitives-fontFamily-ui), sans-serif;
-  font-size: calc(var(--primitives-fontSize-4xl) * 1px);
-  font-weight: var(--primitives-fontWeight-regular);
+  font-family: var(--primitives-fontFamily-mono), ui-monospace, monospace;
+  font-size: var(--primitives-spacing-10);
+  font-weight: var(--primitives-fontWeight-medium);
   line-height: var(--primitives-lineHeight-snug);
   font-variant-numeric: tabular-nums;
 }
@@ -228,7 +289,7 @@
 }
 
 .amountDisplayActive {
-  color: var(--semantic-color-brand-lavender);
+  color: var(--semantic-color-text-primary);
 }
 
 .amountInput {

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
@@ -12,6 +12,10 @@ import type { DisplayFees } from '@/lib/fees/displayFees'
 import styles from './DepositAmountCard.module.css'
 
 const ICON_SIZE = 32
+// USDC coin beside the amount: rendered oversized inside a 40px clipped badge (matches the mockup —
+// the web3icons glyph carries padding, so scaling up + clipping makes it fill the circle).
+const AMOUNT_TOKEN_BADGE_PX = 40
+const AMOUNT_TOKEN_ICON_SIZE = Math.round((AMOUNT_TOKEN_BADGE_PX * 24) / 18)
 
 export interface DepositChainOption {
   chainId: number
@@ -166,16 +170,13 @@ export function DepositAmountCard({
           ) : null}
         </div>
 
-        <div className={styles.tokenGroup}>
-          <span className={styles.tokenIconSlot} aria-hidden>
-            <TokenUSDC size={ICON_SIZE} variant="branded" />
-          </span>
-          <span className={styles.tokenName}>{token}</span>
-        </div>
       </div>
 
       <label className={styles.amountWrapper} htmlFor={amountInputId}>
         <span className={styles.visuallyHidden}>{amountAriaLabel}</span>
+        <span className={styles.amountTokenIcon} aria-hidden>
+          <TokenUSDC size={AMOUNT_TOKEN_ICON_SIZE} variant="branded" />
+        </span>
         <span
           className={[styles.amountField, showActiveAmount && styles.amountFieldHasValue]
             .filter(Boolean)
@@ -242,21 +243,24 @@ export function DepositAmountCard({
             </button>
           ) : null}
         </div>
-        {displayFees ? (
-          <span className={styles.feeGroup}>
-            <span className={styles.feeText}>
-              FEE {formatUsdcPlain(displayFees.totalFee + (flowBreakdown?.broadcasterFee ?? 0n) + (flowBreakdown?.cctpFee ?? 0n))}{' '}
-              {token}
+        {/* Fee surfaces only once an amount is entered (mockup behavior). The info tooltip with the
+            full breakdown is kept even though the mockup has no tooltip. */}
+        {showActiveAmount && displayFees ? (
+          <div className={styles.feeRow}>
+            <span className={styles.feeLabel}>Fee</span>
+            <span className={styles.feeValueGroup}>
+              <span className={styles.feeValue}>
+                {formatUsdcPlain(displayFees.totalFee + (flowBreakdown?.broadcasterFee ?? 0n) + (flowBreakdown?.cctpFee ?? 0n))}{' '}
+                {token}
+              </span>
+              <FeeBreakdownTooltip
+                fees={displayFees}
+                isLoading={feeLoading}
+                flowBreakdown={flowBreakdown}
+              />
             </span>
-            <FeeBreakdownTooltip
-              fees={displayFees}
-              isLoading={feeLoading}
-              flowBreakdown={flowBreakdown}
-            />
-          </span>
-        ) : (
-          <span className={styles.feeText}>FEE — {token}</span>
-        )}
+          </div>
+        ) : null}
       </div>
     </div>
   )

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
@@ -39,6 +39,12 @@ export interface DepositAmountCardProps {
    */
   flowBreakdown?: FlowFeeBreakdown
   onMax?: () => void
+  /**
+   * Raw 6-decimal cap the amount input accepts. When provided, the balance row renders
+   * 25% / 50% / 75% / Max percentage pills (each sets the amount to that fraction of `maxInput`);
+   * when omitted the card falls back to the single `Max` button (driven by `onMax`).
+   */
+  maxInput?: bigint
   error?: string
   /** Accessible name for the amount field (e.g. "Deposit amount", "Withdrawal amount"). */
   amountAriaLabel?: string
@@ -73,6 +79,7 @@ export function DepositAmountCard({
   feeLoading = false,
   flowBreakdown,
   onMax,
+  maxInput,
   error,
   amountAriaLabel = 'Amount',
 }: DepositAmountCardProps) {
@@ -103,6 +110,14 @@ export function DepositAmountCard({
   function handleAmountInput(raw: string) {
     const next = sanitizeAmountInput(raw)
     onAmountChange(hasActiveAmount(next) ? next : '')
+  }
+
+  // Percentage pills set the amount to a fraction of the raw input cap. Integer bigint math keeps
+  // full 6-decimal precision (no float rounding); Max reuses the caller's `onMax` when supplied so
+  // fee-on-top paths keep their exact cap, else it falls back to the full `maxInput`.
+  function applyPercent(percent: bigint) {
+    if (maxInput === undefined) return
+    onAmountChange(formatUsdcPlain((maxInput * percent) / 100n))
   }
 
   const showActiveAmount = hasActiveAmount(amount)
@@ -194,13 +209,34 @@ export function DepositAmountCard({
       ) : null}
 
       <div className={styles.bottomRow}>
-        <div className={styles.balanceGroup}>
-          <WalletIcon className={styles.walletIcon} aria-hidden />
-          <span className={styles.balanceText}>
-            {balance}
-            {pendingBalance ? ` · ${pendingBalance} pending` : ''}
-          </span>
-          {onMax ? (
+        <div className={styles.balanceControls}>
+          <div className={styles.balanceGroup}>
+            <WalletIcon className={styles.walletIcon} aria-hidden />
+            <span className={styles.balanceText}>
+              {balance}
+              {pendingBalance ? ` · ${pendingBalance} pending` : ''}
+            </span>
+          </div>
+          {maxInput !== undefined ? (
+            <div className={styles.pctPills}>
+              <button type="button" className={styles.pctPill} onClick={() => applyPercent(25n)}>
+                25%
+              </button>
+              <button type="button" className={styles.pctPill} onClick={() => applyPercent(50n)}>
+                50%
+              </button>
+              <button type="button" className={styles.pctPill} onClick={() => applyPercent(75n)}>
+                75%
+              </button>
+              <button
+                type="button"
+                className={styles.pctPill}
+                onClick={onMax ?? (() => applyPercent(100n))}
+              >
+                Max
+              </button>
+            </div>
+          ) : onMax ? (
             <button type="button" className={styles.maxBtn} onClick={onMax}>
               Max
             </button>

--- a/apps/armada-interface/src/components/deposit/DepositReviewSummary/DepositReviewSummary.module.css
+++ b/apps/armada-interface/src/components/deposit/DepositReviewSummary/DepositReviewSummary.module.css
@@ -1,0 +1,83 @@
+/* ABOUTME: DepositReviewSummary layout — borderless summary table (network / addresses / deposit amount / fees) + total row. */
+/* ABOUTME: Mirrors the deposit-review reference; shared by ShieldReviewStep and ShieldCompleteStep. */
+
+/* Borderless summary table — deposit-review reference. */
+.summary {
+  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.summaryBody {
+  padding: var(--primitives-spacing-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-4);
+  background: var(--semantic-color-surface-main);
+}
+
+.summaryRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  /* Match the mockup's measured 21px row height. Our body-sm line-box is 13px × 1.4 = 18.2px, so
+     pin the row so the vertical rhythm matches. */
+  min-height: 21px;
+  gap: var(--primitives-spacing-3);
+}
+
+.summaryTotalRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--primitives-spacing-3);
+  padding: var(--primitives-spacing-5);
+  background: var(--semantic-color-surface-default);
+}
+
+.summaryLabel {
+  composes: bodySm from '../../../design/styles/typographyComposites.module.css';
+  color: var(--semantic-color-text-muted);
+  flex-shrink: 0;
+}
+
+.summaryValue {
+  composes: bodySmMedium from '../../../design/styles/typographyComposites.module.css';
+  color: var(--semantic-color-text-primary);
+  text-align: right;
+  min-width: 0;
+}
+
+.valueWithIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--primitives-spacing-2);
+  min-width: 0;
+}
+
+.valueWithIcon > span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.armadaIcon {
+  width: var(--primitives-spacing-4);
+  height: var(--primitives-spacing-4);
+  flex-shrink: 0;
+  display: block;
+}
+
+.summaryTotalLabel,
+.summaryTotalValue {
+  composes: bodySmSemibold from '../../../design/styles/typographyComposites.module.css';
+  color: var(--semantic-color-brand-deep);
+}
+
+.summaryTotalValue {
+  text-align: right;
+}

--- a/apps/armada-interface/src/components/deposit/DepositReviewSummary/DepositReviewSummary.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositReviewSummary/DepositReviewSummary.tsx
@@ -1,0 +1,103 @@
+// ABOUTME: DepositReviewSummary — borderless deposit summary table (network / wallet / shielded account / amount / fees) with a "You'll receive" total.
+// ABOUTME: Shared by ShieldReviewStep and ShieldCompleteStep; an optional confirmedAt adds a leading "Date and time" row for confirmations.
+
+import { ArmadaLogo } from '@/design'
+import { WalletProviderIcon } from '@/components/ui/WalletProviderIcon'
+import { formatTransactionDateTime, formatUsdcAmount, truncateAddress } from '@/lib/format'
+import { getChainById } from '@/config/network'
+import usdcAmount from '@/design/styles/usdcAmount.module.css'
+import styles from './DepositReviewSummary.module.css'
+
+const ROW_ICON_PX = 16
+
+export interface DepositReviewSummaryProps {
+  fromChainId: number
+  amount: bigint
+  fee: bigint | null
+  netAmount: bigint
+  /** Connected EVM wallet address — rendered (truncated) as the "From your wallet" row when present. */
+  walletAddress?: string
+  /** Connected wallet provider name (wagmi connector) — drives the "From your wallet" brand glyph. */
+  walletProvider?: string
+  /** Shielded (Armada) destination address — rendered (truncated) as the "To your private account" row when present. */
+  shieldedAddress?: string
+  /** Completion timestamp (ms) — when present, adds a leading "Date and time" row for confirmations. */
+  confirmedAt?: number
+}
+
+export function DepositReviewSummary({
+  fromChainId,
+  amount,
+  fee,
+  netAmount,
+  walletAddress,
+  walletProvider,
+  shieldedAddress,
+  confirmedAt,
+}: DepositReviewSummaryProps) {
+  const fromChain = getChainById(fromChainId)
+  const feeValue = fee ?? 0n
+  return (
+    <div className={styles.summary}>
+      <div className={styles.summaryBody}>
+        {confirmedAt !== undefined ? (
+          <div className={styles.summaryRow}>
+            <span className={styles.summaryLabel}>Date and time</span>
+            <span className={styles.summaryValue}>{formatTransactionDateTime(confirmedAt)}</span>
+          </div>
+        ) : null}
+        <div className={styles.summaryRow}>
+          <span className={styles.summaryLabel}>Network</span>
+          <span className={styles.summaryValue}>
+            {fromChain?.name ?? `Chain ${fromChainId}`}
+          </span>
+        </div>
+        {walletAddress ? (
+          <div className={styles.summaryRow}>
+            <span className={styles.summaryLabel}>From your wallet</span>
+            <span className={styles.summaryValue}>
+              <span className={styles.valueWithIcon}>
+                <WalletProviderIcon provider={walletProvider} size={ROW_ICON_PX} />
+                <span>{truncateAddress(walletAddress)}</span>
+              </span>
+            </span>
+          </div>
+        ) : null}
+        {shieldedAddress ? (
+          <div className={styles.summaryRow}>
+            <span className={styles.summaryLabel}>To your private account</span>
+            <span className={styles.summaryValue}>
+              <span className={styles.valueWithIcon}>
+                <ArmadaLogo variant="mark" className={styles.armadaIcon} />
+                <span>{truncateAddress(shieldedAddress)}</span>
+              </span>
+            </span>
+          </div>
+        ) : null}
+        <div className={styles.summaryRow}>
+          <span className={styles.summaryLabel}>Deposit amount</span>
+          <span className={[styles.summaryValue, usdcAmount.font].join(' ')}>
+            {formatUsdcAmount(amount)} USDC
+          </span>
+        </div>
+        <div className={styles.summaryRow}>
+          <span className={styles.summaryLabel}>Fees</span>
+          <span className={[styles.summaryValue, usdcAmount.font].join(' ')}>
+            {fee === null ? '—' : `${formatUsdcAmount(feeValue)} USDC`}
+          </span>
+        </div>
+      </div>
+      {/* Deposit fees are inclusive: the wallet is charged `amount` and the shielded pool receives
+          `amount - fees`. Show that net figure (not a fee-on-top total, which would overstate the charge). */}
+      <div className={styles.summaryTotalRow}>
+        {/* Past tense once confirmed (confirmedAt is only set on the confirmation step). */}
+        <span className={styles.summaryTotalLabel}>
+          {confirmedAt !== undefined ? 'You received' : "You'll receive"}
+        </span>
+        <span className={[styles.summaryTotalValue, usdcAmount.font].join(' ')}>
+          {formatUsdcAmount(netAmount)} USDC
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/armada-interface/src/components/deposit/DepositReviewSummary/index.ts
+++ b/apps/armada-interface/src/components/deposit/DepositReviewSummary/index.ts
@@ -1,0 +1,5 @@
+// ABOUTME: Barrel for DepositReviewSummary — shared deposit summary table used by the shield review + complete steps.
+// ABOUTME: Re-exports the component and its prop type so consumers don't have to know the filename.
+
+export { DepositReviewSummary } from './DepositReviewSummary'
+export type { DepositReviewSummaryProps } from './DepositReviewSummary'

--- a/apps/armada-interface/src/components/flow/FlowShell/FlowShell.module.css
+++ b/apps/armada-interface/src/components/flow/FlowShell/FlowShell.module.css
@@ -2,6 +2,9 @@
 /* ABOUTME: ModalShell's content is full-width; the mockup relies on each step owning a column, so we center one here. */
 
 .stepColumn {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-8);
   width: 100%;
   max-width: 27.25rem; /* ~436px — the mockup's step column width */
   margin-inline: auto;

--- a/apps/armada-interface/src/components/flow/FlowShell/FlowShell.module.css
+++ b/apps/armada-interface/src/components/flow/FlowShell/FlowShell.module.css
@@ -1,0 +1,8 @@
+/* ABOUTME: FlowShell layout — constrains step content to a centered column (matches the mockup's ~434px step width). */
+/* ABOUTME: ModalShell's content is full-width; the mockup relies on each step owning a column, so we center one here. */
+
+.stepColumn {
+  width: 100%;
+  max-width: 27.25rem; /* ~436px — the mockup's step column width */
+  margin-inline: auto;
+}

--- a/apps/armada-interface/src/components/flow/FlowShell/FlowShell.tsx
+++ b/apps/armada-interface/src/components/flow/FlowShell/FlowShell.tsx
@@ -3,6 +3,7 @@
 
 import type { ReactNode } from 'react'
 import { FlowModalOverlay, ModalShell } from '@/design'
+import styles from './FlowShell.module.css'
 
 /** Default 3-step deposit/action progress labels (Amount → Review → Confirm). */
 const DEFAULT_STEPS = ['Amount', 'Review', 'Confirm']
@@ -38,7 +39,7 @@ export function FlowShell({
         flowLabel={flowLabel}
         onClose={onClose}
       >
-        {children}
+        <div className={styles.stepColumn}>{children}</div>
       </ModalShell>
     </FlowModalOverlay>
   )

--- a/apps/armada-interface/src/components/flow/FlowShell/FlowShell.tsx
+++ b/apps/armada-interface/src/components/flow/FlowShell/FlowShell.tsx
@@ -1,0 +1,45 @@
+// ABOUTME: FlowShell — action-flow modal chrome wrapping the vendored FlowModalOverlay + ModalShell.
+// ABOUTME: Replaces DepositOverlayShell for the redesigned flows; renders the logo + Steps progress + close + backdrop/focus-trap.
+
+import type { ReactNode } from 'react'
+import { FlowModalOverlay, ModalShell } from '@/design'
+
+/** Default 3-step deposit/action progress labels (Amount → Review → Confirm). */
+const DEFAULT_STEPS = ['Amount', 'Review', 'Confirm']
+
+export interface FlowShellProps {
+  open: boolean
+  onClose: () => void
+  flowLabel?: string
+  steps?: string[]
+  /** 1-based active step. */
+  currentStep: number
+  status?: 'default' | 'confirmed' | 'error'
+  children: ReactNode
+}
+
+export function FlowShell({
+  open,
+  onClose,
+  flowLabel = 'Deposit',
+  steps = DEFAULT_STEPS,
+  currentStep,
+  status = 'default',
+  children,
+}: FlowShellProps) {
+  if (!open) return null
+
+  return (
+    <FlowModalOverlay label={flowLabel} onClose={onClose}>
+      <ModalShell
+        steps={steps}
+        currentStep={currentStep}
+        status={status}
+        flowLabel={flowLabel}
+        onClose={onClose}
+      >
+        {children}
+      </ModalShell>
+    </FlowModalOverlay>
+  )
+}

--- a/apps/armada-interface/src/components/flow/FlowShell/index.ts
+++ b/apps/armada-interface/src/components/flow/FlowShell/index.ts
@@ -1,0 +1,3 @@
+// ABOUTME: Barrel for FlowShell — the action-flow modal chrome.
+export { FlowShell } from './FlowShell'
+export type { FlowShellProps } from './FlowShell'

--- a/apps/armada-interface/src/components/shield/CLAUDE.md
+++ b/apps/armada-interface/src/components/shield/CLAUDE.md
@@ -6,7 +6,7 @@ The deposit (public → private) flow. Owned by `ShieldModal`, opened via `setOp
 
 | Component | Purpose |
 |---|---|
-| `ShieldModal` | Orchestrator. Owns `step` + form state, wires `useTx({kind:'shield'})`, renders ActionFlowShell. |
+| `ShieldModal` | Orchestrator. Owns `step` + form state, wires `useTx({kind:'shield'})`, renders `FlowShell` (FlowModalOverlay + ModalShell) with the redesigned step screens. |
 | `ShieldInputStep` | From-chain `ChainSelect` + `AmountInput` (display variant) + `FeeSummary`. Validates amount > 0 and ≤ max. |
 | `ShieldReviewStep` | Read-only echo with the big-numeral amount + From chain row + FeeSummary + Confirm CTA. |
 | `ShieldCompleteStep` | Success panel ("Success — you've deposited X USDC") + Done CTA. |

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.module.css
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.module.css
@@ -1,39 +1,63 @@
-/* ABOUTME: ShieldCompleteStep layout — centered success icon, serif headline, body, flush footer. */
-/* ABOUTME: Mirrors the onboarding CompleteStep proportions so success states feel consistent across the app. */
+/* ABOUTME: ShieldCompleteStep layout — centered serif title, coin+amount block, flush footer. */
+/* ABOUTME: Mirrors the deposit-confirmed reference so success states feel consistent across the app. */
 
 .root {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: var(--primitives-spacing-3);
-  text-align: center;
-}
-
-.icon {
-  width: 72px;
-  height: 72px;
-  border-radius: 50%;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(52, 211, 153, 0.12);
-  color: var(--semantic-color-status-success);
-  margin-bottom: var(--primitives-spacing-2);
+  align-items: stretch;
+  gap: var(--primitives-spacing-8);
 }
 
 .title {
-  font-family: "Charis SIL", serif;
-  font-size: calc(var(--primitives-fontSize-2xl) * 1px);
-  line-height: var(--primitives-lineHeight-tight);
-  font-weight: var(--primitives-fontWeight-regular);
-  color: var(--semantic-color-text-primary);
+  composes: displayLg from '../../design/styles/displayLgTitle.module.css';
   margin: 0;
+  width: 100%;
+  color: var(--semantic-color-text-primary);
+  text-align: center;
 }
 
-.body {
-  color: var(--semantic-color-text-muted);
-  max-width: 46ch;
-  margin: 0;
+.amountRow {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+}
+
+.amountGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--primitives-spacing-2);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
+}
+
+.tokenBadge {
+  width: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tokenBadgeIcon {
+  flex-shrink: 0;
+  display: block;
+}
+
+.tokenBadgeIcon :global(svg) {
+  display: block;
+}
+
+.amountValue {
+  display: block;
+  font-weight: var(--primitives-fontWeight-medium);
+  font-size: var(--primitives-spacing-10);
+  line-height: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  color: var(--semantic-color-text-primary);
 }
 
 .footer {

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.module.css
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.module.css
@@ -1,4 +1,4 @@
-/* ABOUTME: ShieldCompleteStep layout — centered serif title, coin+amount block, flush footer. */
+/* ABOUTME: ShieldCompleteStep layout — centered serif title, coin+amount block, shared summary table, two-button CTA row. */
 /* ABOUTME: Mirrors the deposit-confirmed reference so success states feel consistent across the app. */
 
 .root {
@@ -60,7 +60,14 @@
   color: var(--semantic-color-text-primary);
 }
 
-.footer {
-  align-self: stretch;
-  margin: var(--primitives-spacing-6) calc(var(--primitives-spacing-6) * -1) calc(var(--primitives-spacing-6) * -1);
+/* Two-button CTA row — deposit-confirmed mockup: equal-width View on explorer / Go to dashboard, no divider above. */
+.buttonRow {
+  display: flex;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+}
+
+.buttonRow > * {
+  flex: 1;
+  max-width: 211px;
 }

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.test.tsx
@@ -1,20 +1,51 @@
-// ABOUTME: Tests for ShieldCompleteStep — renders the confirmed headline, the deposited amount, and dispatches onDone.
+// ABOUTME: Tests for ShieldCompleteStep — renders the confirmed headline, the deposited amount, the date/time row, and dispatches the explorer/dashboard CTAs.
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ShieldCompleteStep } from './ShieldCompleteStep'
 
+function setup(overrides?: { explorerUrl?: string }) {
+  const onViewExplorer = vi.fn()
+  const onGoToDashboard = vi.fn()
+  render(
+    <ShieldCompleteStep
+      fromChainId={31337}
+      amount={250_500_000n}
+      fee={null}
+      netAmount={250_500_000n}
+      confirmedAt={Date.parse('2026-01-05T15:42:00Z')}
+      explorerUrl={'explorerUrl' in (overrides ?? {}) ? overrides?.explorerUrl : 'https://example.com/tx/0xabc'}
+      onViewExplorer={onViewExplorer}
+      onGoToDashboard={onGoToDashboard}
+    />,
+  )
+  return { onViewExplorer, onGoToDashboard }
+}
+
 describe('<ShieldCompleteStep>', () => {
-  it('renders the headline and the net amount in the coin+amount block', () => {
-    render(<ShieldCompleteStep netAmount={250_500_000n} onDone={() => {}} />)
+  it('renders the headline, the amount in the coin+amount block, and the chain name', () => {
+    setup()
     expect(screen.getByRole('heading', { name: 'Deposit confirmed' })).toBeInTheDocument()
-    expect(screen.getByText('250.50')).toBeInTheDocument()
+    // Gross amount renders full-precision in the coin block; net amount ("250.50 USDC") is the
+    // summary Total row, a distinct node — so the exact-text query still resolves the block.
+    expect(screen.getByText('250.5')).toBeInTheDocument()
+    expect(screen.getByText(/Anvil Hub/)).toBeInTheDocument()
   })
 
-  it('fires onDone when the Done CTA is clicked', () => {
-    const onDone = vi.fn()
-    render(<ShieldCompleteStep netAmount={1_000_000n} onDone={onDone} />)
-    fireEvent.click(screen.getByRole('button', { name: /Done/ }))
-    expect(onDone).toHaveBeenCalledTimes(1)
+  it('fires onGoToDashboard when the primary CTA is clicked', () => {
+    const { onGoToDashboard } = setup()
+    fireEvent.click(screen.getByRole('button', { name: /Go to dashboard/ }))
+    expect(onGoToDashboard).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onViewExplorer when the secondary CTA is clicked', () => {
+    const { onViewExplorer } = setup()
+    fireEvent.click(screen.getByRole('button', { name: /View on explorer/ }))
+    expect(onViewExplorer).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the explorer CTA when no explorerUrl is provided', () => {
+    setup({ explorerUrl: undefined })
+    expect(screen.getByRole('button', { name: /View on explorer/ })).toBeDisabled()
   })
 })

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.test.tsx
@@ -1,14 +1,14 @@
-// ABOUTME: Tests for ShieldCompleteStep — renders the success headline, the deposited amount, and dispatches onDone.
+// ABOUTME: Tests for ShieldCompleteStep — renders the confirmed headline, the deposited amount, and dispatches onDone.
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ShieldCompleteStep } from './ShieldCompleteStep'
 
 describe('<ShieldCompleteStep>', () => {
-  it('renders the headline and the net amount in the body copy', () => {
+  it('renders the headline and the net amount in the coin+amount block', () => {
     render(<ShieldCompleteStep netAmount={250_500_000n} onDone={() => {}} />)
-    expect(screen.getByRole('heading', { name: 'Success' })).toBeInTheDocument()
-    expect(screen.getByText(/You've deposited 250\.50 USDC/)).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Deposit confirmed' })).toBeInTheDocument()
+    expect(screen.getByText('250.50')).toBeInTheDocument()
   })
 
   it('fires onDone when the Done CTA is clicked', () => {

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.tsx
@@ -1,10 +1,15 @@
-// ABOUTME: Shield complete step — celebratory success panel with the deposited amount and a Done CTA.
-// ABOUTME: Matches the WelcomeStep/CompleteStep style (centered icon + serif headline + body + footer).
+// ABOUTME: Shield complete step — serif "Deposit confirmed" title, USDC coin + deposited-amount block, and a Done CTA.
+// ABOUTME: Mirrors the deposit-confirmed reference (centered serif title + coin/amount block + flush footer).
 
-import { CheckCircle2 } from 'lucide-react'
+import TokenUSDC from '@web3icons/react/icons/tokens/TokenUSDC'
 import { FlowFooter } from '@/components/flow/FlowFooter'
 import { formatUsdcAmount } from '@/lib/format'
+import usdcAmount from '@/design/styles/usdcAmount.module.css'
 import styles from './ShieldCompleteStep.module.css'
+
+const TOKEN_BADGE_PX = 40
+/** @web3icons branded assets use an 18px circle in a 24px viewBox — scale up to fill the badge. */
+const TOKEN_ICON_SIZE = Math.round((TOKEN_BADGE_PX * 24) / 18)
 
 export interface ShieldCompleteStepProps {
   /** Net amount deposited (post-fee), raw 6-decimal USDC. */
@@ -15,13 +20,19 @@ export interface ShieldCompleteStepProps {
 export function ShieldCompleteStep({ netAmount, onDone }: ShieldCompleteStepProps) {
   return (
     <div className={styles.root}>
-      <div className={styles.icon} aria-hidden="true">
-        <CheckCircle2 size={40} />
+      <h1 className={styles.title}>Deposit confirmed</h1>
+
+      <div className={styles.amountRow}>
+        <div className={styles.amountGroup}>
+          <span className={styles.tokenBadge} aria-hidden="true">
+            <TokenUSDC size={TOKEN_ICON_SIZE} variant="branded" className={styles.tokenBadgeIcon} />
+          </span>
+          <span className={[styles.amountValue, usdcAmount.font].join(' ')}>
+            {formatUsdcAmount(netAmount)}
+          </span>
+        </div>
       </div>
-      <h3 className={styles.title}>Success</h3>
-      <p className={styles.body}>
-        You've deposited {formatUsdcAmount(netAmount)} USDC.
-      </p>
+
       <FlowFooter
         className={styles.footer}
         primary={{ label: 'Done', onClick: onDone }}

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.tsx
@@ -1,9 +1,10 @@
-// ABOUTME: Shield complete step — serif "Deposit confirmed" title, USDC coin + deposited-amount block, and a Done CTA.
-// ABOUTME: Mirrors the deposit-confirmed reference (centered serif title + coin/amount block + flush footer).
+// ABOUTME: Shield complete step — serif "Deposit confirmed" title, USDC coin + deposited-amount block, shared DepositReviewSummary (with date/time), and explorer/dashboard CTAs.
+// ABOUTME: Mirrors the deposit-confirmed reference — no divider between the summary card and the button row.
 
 import TokenUSDC from '@web3icons/react/icons/tokens/TokenUSDC'
-import { FlowFooter } from '@/components/flow/FlowFooter'
-import { formatUsdcAmount } from '@/lib/format'
+import { Button } from '@/design'
+import { DepositReviewSummary } from '@/components/deposit/DepositReviewSummary'
+import { formatUsdcPlain } from '@/lib/format'
 import usdcAmount from '@/design/styles/usdcAmount.module.css'
 import styles from './ShieldCompleteStep.module.css'
 
@@ -12,12 +13,36 @@ const TOKEN_BADGE_PX = 40
 const TOKEN_ICON_SIZE = Math.round((TOKEN_BADGE_PX * 24) / 18)
 
 export interface ShieldCompleteStepProps {
-  /** Net amount deposited (post-fee), raw 6-decimal USDC. */
+  fromChainId: number
+  /** Gross amount deposited (pre-fee), raw 6-decimal USDC — shown full-precision in the coin block. */
+  amount: bigint
+  fee: bigint | null
+  /** Net amount deposited (post-fee), raw 6-decimal USDC — the summary's "You'll receive". */
   netAmount: bigint
-  onDone: () => void
+  walletAddress?: string
+  walletProvider?: string
+  shieldedAddress?: string
+  /** Completion timestamp (ms) — drives the summary's "Date and time" row. */
+  confirmedAt: number
+  /** Source-chain explorer URL for the deposit tx; absent disables the "View on explorer" button. */
+  explorerUrl?: string
+  onViewExplorer: () => void
+  onGoToDashboard: () => void
 }
 
-export function ShieldCompleteStep({ netAmount, onDone }: ShieldCompleteStepProps) {
+export function ShieldCompleteStep({
+  fromChainId,
+  amount,
+  fee,
+  netAmount,
+  walletAddress,
+  walletProvider,
+  shieldedAddress,
+  confirmedAt,
+  explorerUrl,
+  onViewExplorer,
+  onGoToDashboard,
+}: ShieldCompleteStepProps) {
   return (
     <div className={styles.root}>
       <h1 className={styles.title}>Deposit confirmed</h1>
@@ -28,15 +53,39 @@ export function ShieldCompleteStep({ netAmount, onDone }: ShieldCompleteStepProp
             <TokenUSDC size={TOKEN_ICON_SIZE} variant="branded" className={styles.tokenBadgeIcon} />
           </span>
           <span className={[styles.amountValue, usdcAmount.font].join(' ')}>
-            {formatUsdcAmount(netAmount)}
+            {formatUsdcPlain(amount)}
           </span>
         </div>
       </div>
 
-      <FlowFooter
-        className={styles.footer}
-        primary={{ label: 'Done', onClick: onDone }}
+      <DepositReviewSummary
+        fromChainId={fromChainId}
+        amount={amount}
+        fee={fee}
+        netAmount={netAmount}
+        walletAddress={walletAddress}
+        walletProvider={walletProvider}
+        shieldedAddress={shieldedAddress}
+        confirmedAt={confirmedAt}
       />
+
+      <div className={styles.buttonRow}>
+        <Button
+          variant="secondary"
+          size="lg"
+          label="View on explorer"
+          showIcon={false}
+          onClick={onViewExplorer}
+          disabled={!explorerUrl}
+        />
+        <Button
+          variant="primary"
+          size="lg"
+          label="Go to dashboard"
+          showIcon={false}
+          onClick={onGoToDashboard}
+        />
+      </div>
     </div>
   )
 }

--- a/apps/armada-interface/src/components/shield/ShieldInputStep.module.css
+++ b/apps/armada-interface/src/components/shield/ShieldInputStep.module.css
@@ -5,6 +5,16 @@
   width: 100%;
 }
 
+/* Serif display title for the shield amount step (matches the deposit-flow mockup). */
+.title {
+  composes: displayLg from '../../design/styles/displayLgTitle.module.css';
+  margin: 0;
+  width: 100%;
+  color: var(--semantic-color-text-primary);
+  text-align: center;
+}
+
+/* Sans question label — reused by the Send / Withdraw / Earn amount steps via shieldStyles.question. */
 .question {
   font-family: var(--primitives-fontFamily-ui), sans-serif;
   font-weight: var(--primitives-fontWeight-medium);

--- a/apps/armada-interface/src/components/shield/ShieldInputStep.module.css
+++ b/apps/armada-interface/src/components/shield/ShieldInputStep.module.css
@@ -1,7 +1,7 @@
 .contentZone {
   display: flex;
   flex-direction: column;
-  gap: var(--primitives-spacing-6);
+  gap: var(--primitives-spacing-8);
   width: 100%;
 }
 

--- a/apps/armada-interface/src/components/shield/ShieldInputStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldInputStep.tsx
@@ -90,7 +90,7 @@ export function ShieldInputStepContent({
 
   return (
     <div className={styles.contentZone}>
-      <p className={styles.question}>How much USDC do you want to deposit?</p>
+      <h1 className={styles.title}>How much do you want to deposit?</h1>
       <DepositAmountCard
         chains={chains}
         chainId={fromChainId}
@@ -102,6 +102,7 @@ export function ShieldInputStepContent({
         flowBreakdown={flowBreakdown}
         feeLoading={feeLoading}
         onMax={() => onAmountChange(formatUsdcPlain(maxInput))}
+        maxInput={maxInput}
         error={errorMessage}
         amountAriaLabel="Deposit amount"
       />

--- a/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
@@ -51,6 +51,13 @@ vi.mock('@/hooks/useDisplayFees', () => ({
   }),
 }))
 
+// ShieldModal reads the connected EVM address via wagmi's useAccount for the review-step summary;
+// these tests don't mount a WagmiProvider, so stub it with a fixed address.
+vi.mock('wagmi', async (importOriginal) => ({
+  ...await importOriginal<typeof import('wagmi')>(),
+  useAccount: () => ({ address: '0xabc' }),
+}))
+
 // useGasBalanceWarning calls wagmi's useAccount/useBalance — same provider requirement.
 // "No warning" keeps the GasBalanceNotice hidden; gasless-mode branching is asserted in
 // ShieldInputStep.test.tsx by directly setting gaslessMode (no integration concern here).
@@ -122,8 +129,8 @@ describe('<ShieldModal>', () => {
     renderModal({ open: true, max: 10_000_000n })
     fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
-    expect(screen.getByText('Review your deposit')).toBeInTheDocument()
-    // 5.00 appears in both the hero numeral and the FeeSummary net-amount row.
+    expect(screen.getByRole('heading', { name: 'Review' })).toBeInTheDocument()
+    // 5.00 renders in the coin+amount block (the summary Total row is "5.00 USDC", a distinct node).
     expect(screen.getAllByText('5.00').length).toBeGreaterThanOrEqual(1)
   })
 

--- a/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
@@ -129,9 +129,10 @@ describe('<ShieldModal>', () => {
     renderModal({ open: true, max: 10_000_000n })
     fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
-    expect(screen.getByRole('heading', { name: 'Review' })).toBeInTheDocument()
-    // 5.00 renders in the coin+amount block (the summary Total row is "5.00 USDC", a distinct node).
-    expect(screen.getAllByText('5.00').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByRole('heading', { name: 'Review your deposit' })).toBeInTheDocument()
+    // Amount renders full-precision ("5") in the coin+amount block and 2dp in the summary rows
+    // ("5.00 USDC"); match the summary rows.
+    expect(screen.getAllByText(/5\.00/).length).toBeGreaterThanOrEqual(1)
   })
 
   it('Back from review returns to the input step', () => {

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -58,7 +58,7 @@ export function ShieldModal() {
 
   // Review-step summary addresses: the connected EVM wallet (source) + the shielded destination.
   // Both are optional — the review rows render only when a value is present.
-  const { address: evmAddress } = useAccount()
+  const { address: evmAddress, connector } = useAccount()
   const shieldedWallet = useAtomValue(shieldedWalletAtom)
 
   // Form state.
@@ -382,6 +382,7 @@ export function ShieldModal() {
           fee={fee + protocolFee + cctpFee}
           netAmount={netAmount}
           walletAddress={evmAddress}
+          walletProvider={connector?.name}
           shieldedAddress={shieldedWallet.shieldedAddress}
           isSubmitting={isSubmitting}
           duplicateWarning={duplicateWarning}
@@ -390,7 +391,26 @@ export function ShieldModal() {
         />
       )}
       {step === 'progress' && <ProgressStep record={record} />}
-      {step === 'complete' && <ShieldCompleteStep netAmount={netAmount} onDone={close} />}
+      {step === 'complete' && (
+        <ShieldCompleteStep
+          fromChainId={fromChainId}
+          amount={amount}
+          // Same inclusive fee expression passed to ShieldReviewStep — broadcaster + on-chain
+          // protocol fee + CCTP — so the confirmation echoes the number that derived `netAmount`.
+          fee={fee + protocolFee + cctpFee}
+          netAmount={netAmount}
+          walletAddress={evmAddress}
+          walletProvider={connector?.name}
+          shieldedAddress={shieldedWallet.shieldedAddress}
+          confirmedAt={record?.updatedAt ?? Date.now()}
+          explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, displayTxHash(record))}
+          onViewExplorer={() => {
+            const url = txExplorerUrl(record?.walletContext.sourceChainId, displayTxHash(record))
+            if (url) window.open(url, '_blank', 'noopener,noreferrer')
+          }}
+          onGoToDashboard={close}
+        />
+      )}
       {step === 'error' && (
         <ErrorStep
           error={record?.artifacts.error ?? null}

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -1,10 +1,12 @@
-// ABOUTME: ShieldModal — orchestrator for the shield (deposit) action flow. Owns step + form state; renders DepositOverlayShell with InputStep/ReviewStep/ProgressStep/CompleteStep/ErrorStep.
+// ABOUTME: ShieldModal — orchestrator for the shield (deposit) action flow. Owns step + form state; renders FlowShell with InputStep/ReviewStep/ProgressStep/CompleteStep/ErrorStep.
 // ABOUTME: Dispatches between same-chain shield (hub source) and cross-chain shield-xchain (client source) based on fromChainId; B3 routes hub shield through GaslessShieldWrapper when available.
 
 import { useEffect, useRef, useState } from 'react'
 import { useAtom, useAtomValue } from 'jotai'
+import { useAccount } from 'wagmi'
 import { useQuery } from '@tanstack/react-query'
 import { openModalAtom } from '@/state/ui'
+import { shieldedWalletAtom } from '@/state/wallet'
 import { preferencesAtom } from '@/state/preferences'
 import { useTx } from '@/hooks/useTx'
 import { useFees } from '@/hooks/useFees'
@@ -25,7 +27,7 @@ import {
   type FlowStep,
   type FlowVisibleStep,
 } from '@/components/flow'
-import { DepositOverlayShell } from '@/components/deposit/DepositOverlayShell/DepositOverlayShell'
+import { FlowShell } from '@/components/flow/FlowShell'
 import { RelayerStatusBanner } from '@/components/RelayerStatusBanner'
 import { ShieldInputStepContent, ShieldInputStepFooter } from './ShieldInputStep'
 import { ShieldReviewStep } from './ShieldReviewStep'
@@ -53,6 +55,11 @@ export function ShieldModal() {
   const [openModal, setOpenModal] = useAtom(openModalAtom)
   const isOpen = openModal === 'shield'
   const prefs = useAtomValue(preferencesAtom)
+
+  // Review-step summary addresses: the connected EVM wallet (source) + the shielded destination.
+  // Both are optional — the review rows render only when a value is present.
+  const { address: evmAddress } = useAccount()
+  const shieldedWallet = useAtomValue(shieldedWalletAtom)
 
   // Form state.
   const hubChainId = getNetworkConfig().hub.chainId
@@ -324,7 +331,7 @@ export function ShieldModal() {
 
   if (!isOpen) return null
 
-  // DepositOverlayShell renders a 3-segment indicator (Amount/Review/Confirm) — `progress`,
+  // FlowShell's ModalShell renders a 3-segment Steps indicator (Amount/Review/Confirm) — `progress`,
   // `complete`, and `error` all map to segment 3. `overlayIndicatorStatus` flips the bar green
   // on `complete` and red on `error`. Lavender otherwise. errorAtStep is no longer surfaced
   // through the shell (the legacy 4-segment bar used it); instead the ErrorStep itself owns
@@ -333,10 +340,9 @@ export function ShieldModal() {
   const indicatorStatus = overlayIndicatorStatus(step)
 
   return (
-    <DepositOverlayShell
+    <FlowShell
       open={isOpen}
       onClose={close}
-      dismissible={true}
       flowLabel="Deposit"
       currentStep={indicatorStep}
       status={indicatorStatus}
@@ -375,6 +381,8 @@ export function ShieldModal() {
           // the amount card already breaks it out into individual rows.
           fee={fee + protocolFee + cctpFee}
           netAmount={netAmount}
+          walletAddress={evmAddress}
+          shieldedAddress={shieldedWallet.shieldedAddress}
           isSubmitting={isSubmitting}
           duplicateWarning={duplicateWarning}
           onBack={() => setStep('input')}
@@ -423,6 +431,6 @@ export function ShieldModal() {
         />
       )}
       <RelayerStatusBanner isOpen={isOpen} />
-    </DepositOverlayShell>
+    </FlowShell>
   )
 }

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.module.css
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.module.css
@@ -1,62 +1,123 @@
-/* ABOUTME: ShieldReviewStep layout — centered big amount, From facts row, fee summary, footer. */
-/* ABOUTME: Matches the visual rhythm of the input step so the user's mental anchor (the big number) stays stable. */
+/* ABOUTME: ShieldReviewStep layout — serif title, coin+amount block, borderless deposit summary table, flush footer. */
+/* ABOUTME: Summary table mirrors the deposit-review reference (network / addresses / fees / total). */
 
 .root {
   display: flex;
   flex-direction: column;
-  gap: var(--primitives-spacing-4);
+  gap: var(--primitives-spacing-8);
 }
 
-.headline {
-  color: var(--semantic-color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: var(--primitives-letterSpacing-wider);
-  font-size: calc(var(--primitives-fontSize-xs) * 1px);
+.title {
+  composes: displayLg from '../../design/styles/displayLgTitle.module.css';
+  margin: 0;
+  width: 100%;
+  color: var(--semantic-color-text-primary);
   text-align: center;
 }
 
-.amountBlock {
+.amountRow {
   display: flex;
-  align-items: baseline;
   justify-content: center;
-  gap: var(--primitives-spacing-3);
+  align-items: center;
+  width: 100%;
 }
 
-.amount {
+.amountGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--primitives-spacing-2);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
+}
+
+.tokenBadge {
+  width: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tokenBadgeIcon {
+  flex-shrink: 0;
+  display: block;
+}
+
+.tokenBadgeIcon :global(svg) {
+  display: block;
+}
+
+.amountValue {
+  display: block;
+  font-weight: var(--primitives-fontWeight-medium);
+  font-size: var(--primitives-spacing-10);
+  line-height: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
   color: var(--semantic-color-text-primary);
-  font-family: "Charis SIL", serif;
-  font-size: calc(var(--primitives-fontSize-5xl) * 1px);
-  line-height: var(--primitives-lineHeight-tight);
-  font-weight: var(--primitives-fontWeight-regular);
-  font-variant-numeric: tabular-nums;
 }
 
-.unit {
-  color: var(--semantic-color-text-muted);
-  font-size: calc(var(--primitives-fontSize-lg) * 1px);
-}
-
-.facts {
+/* Borderless summary table — deposit-review reference. */
+.summary {
+  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  gap: var(--primitives-spacing-2);
-  margin: 0;
+  width: 100%;
+  box-sizing: border-box;
 }
 
-.facts > div {
+.summaryBody {
+  padding: var(--primitives-spacing-5);
   display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-4);
+  background: var(--semantic-color-surface-main);
+}
+
+.summaryRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: var(--primitives-spacing-4);
+  gap: var(--primitives-spacing-3);
+}
+
+.summaryTotalRow {
+  display: flex;
+  align-items: center;
   justify-content: space-between;
   gap: var(--primitives-spacing-3);
-  padding: var(--primitives-spacing-2) 0;
-  border-bottom: 1px solid var(--semantic-color-border-default);
+  padding: var(--primitives-spacing-5);
+  background: var(--semantic-color-surface-default);
 }
 
-.facts dt {
+.summaryLabel {
+  composes: bodySm from '../../design/styles/typographyComposites.module.css';
   color: var(--semantic-color-text-muted);
+  flex-shrink: 0;
 }
 
-.facts dd {
+.summaryValue {
+  composes: bodySmMedium from '../../design/styles/typographyComposites.module.css';
   color: var(--semantic-color-text-primary);
+  text-align: right;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.summaryTotalLabel,
+.summaryTotalValue {
+  composes: bodySmSemibold from '../../design/styles/typographyComposites.module.css';
+  color: var(--semantic-color-brand-deep);
+}
+
+.summaryTotalValue {
+  text-align: right;
 }
 
 /* S-L7: non-blocking caution when an unresolved same-amount deposit may still be on-chain. */

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.module.css
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.module.css
@@ -1,5 +1,5 @@
-/* ABOUTME: ShieldReviewStep layout — serif title, coin+amount block, borderless deposit summary table, flush footer. */
-/* ABOUTME: Summary table mirrors the deposit-review reference (network / addresses / fees / total). */
+/* ABOUTME: ShieldReviewStep layout — serif title, coin+amount block, non-blocking duplicate caution, two-button CTA row. */
+/* ABOUTME: The deposit summary table itself lives in the shared DepositReviewSummary component. */
 
 .root {
   display: flex;
@@ -59,67 +59,6 @@
   color: var(--semantic-color-text-primary);
 }
 
-/* Borderless summary table — deposit-review reference. */
-.summary {
-  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.summaryBody {
-  padding: var(--primitives-spacing-5);
-  display: flex;
-  flex-direction: column;
-  gap: var(--primitives-spacing-4);
-  background: var(--semantic-color-surface-main);
-}
-
-.summaryRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  min-height: var(--primitives-spacing-4);
-  gap: var(--primitives-spacing-3);
-}
-
-.summaryTotalRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--primitives-spacing-3);
-  padding: var(--primitives-spacing-5);
-  background: var(--semantic-color-surface-default);
-}
-
-.summaryLabel {
-  composes: bodySm from '../../design/styles/typographyComposites.module.css';
-  color: var(--semantic-color-text-muted);
-  flex-shrink: 0;
-}
-
-.summaryValue {
-  composes: bodySmMedium from '../../design/styles/typographyComposites.module.css';
-  color: var(--semantic-color-text-primary);
-  text-align: right;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.summaryTotalLabel,
-.summaryTotalValue {
-  composes: bodySmSemibold from '../../design/styles/typographyComposites.module.css';
-  color: var(--semantic-color-brand-deep);
-}
-
-.summaryTotalValue {
-  text-align: right;
-}
-
 /* S-L7: non-blocking caution when an unresolved same-amount deposit may still be on-chain. */
 .caution {
   display: flex;
@@ -137,7 +76,14 @@
   margin-top: 2px;
 }
 
-.footer {
-  align-self: stretch;
-  margin: var(--primitives-spacing-4) calc(var(--primitives-spacing-6) * -1) calc(var(--primitives-spacing-6) * -1);
+/* Two-button CTA row — deposit-review mockup: equal-width Back / Confirm, no divider above. */
+.buttonRow {
+  display: flex;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+}
+
+.buttonRow > * {
+  flex: 1;
+  max-width: 211px;
 }

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.test.tsx
@@ -23,10 +23,9 @@ function setup() {
 describe('<ShieldReviewStep>', () => {
   it('renders the amount and chain name', () => {
     setup()
-    // Amount renders in the coin+amount block; the summary Total row ("100.50 USDC") is a
-    // distinct node, so an exact-text query still resolves the block. Chain name is the
-    // summary's Network row.
-    expect(screen.getAllByText('100.50').length).toBeGreaterThanOrEqual(1)
+    // Amount renders full-precision in the coin+amount block ("100.5") and 2dp in the summary
+    // "Deposit amount" row ("100.50 USDC"); a regex resolves either. Chain name is the Network row.
+    expect(screen.getAllByText(/100\.5/).length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText(/Anvil Hub/)).toBeInTheDocument()
   })
 

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.test.tsx
@@ -23,8 +23,9 @@ function setup() {
 describe('<ShieldReviewStep>', () => {
   it('renders the amount and chain name', () => {
     setup()
-    // Amount appears in the hero numeral AND in the FeeSummary's net-amount row (fee=null →
-    // netAmount=amount in this test). Use getAllByText since both spots match.
+    // Amount renders in the coin+amount block; the summary Total row ("100.50 USDC") is a
+    // distinct node, so an exact-text query still resolves the block. Chain name is the
+    // summary's Network row.
     expect(screen.getAllByText('100.50').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText(/Anvil Hub/)).toBeInTheDocument()
   })

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.tsx
@@ -1,18 +1,27 @@
-// ABOUTME: Shield review step — read-only echo of the deposit summary with Confirm + Back CTAs.
-// ABOUTME: Renders the same big Charis-SIL numeral as the input step so the user sees their amount in the same visual context.
+// ABOUTME: Shield review step — serif title, USDC coin + amount block, borderless deposit summary table, Confirm/Back CTAs.
+// ABOUTME: Summary rows (network, wallet/shielded addresses, fees, total) replace the prior FeeSummary; duplicate caution + FlowFooter behavior preserved.
 
 import { AlertTriangle } from 'lucide-react'
+import TokenUSDC from '@web3icons/react/icons/tokens/TokenUSDC'
 import { FlowFooter } from '@/components/flow/FlowFooter'
-import { FeeSummary } from '@/components/ui'
-import { formatUsdcAmount } from '@/lib/format'
+import { formatUsdcAmount, truncateAddress } from '@/lib/format'
 import { getChainById } from '@/config/network'
+import usdcAmount from '@/design/styles/usdcAmount.module.css'
 import styles from './ShieldReviewStep.module.css'
+
+const TOKEN_BADGE_PX = 40
+/** @web3icons branded assets use an 18px circle in a 24px viewBox — scale up to fill the badge. */
+const TOKEN_ICON_SIZE = Math.round((TOKEN_BADGE_PX * 24) / 18)
 
 export interface ShieldReviewStepProps {
   fromChainId: number
   amount: bigint
   fee: bigint | null
   netAmount: bigint
+  /** Connected EVM wallet address — rendered (truncated) as the "From your wallet" row when present. */
+  walletAddress?: string
+  /** Shielded (Armada) destination address — rendered (truncated) as the "To Armada" row when present. */
+  shieldedAddress?: string
   /** True while a submit is in flight — disables Confirm so a double-click can't create two txs. */
   isSubmitting?: boolean
   /** S-L7: an unresolved same-amount deposit may still be on-chain — surface a non-blocking caution. */
@@ -26,26 +35,68 @@ export function ShieldReviewStep({
   amount,
   fee,
   netAmount,
+  walletAddress,
+  shieldedAddress,
   isSubmitting,
   duplicateWarning,
   onBack,
   onConfirm,
 }: ShieldReviewStepProps) {
   const fromChain = getChainById(fromChainId)
+  const feeValue = fee ?? 0n
   return (
     <div className={styles.root}>
-      <div className={styles.headline}>Review your deposit</div>
-      <div className={styles.amountBlock}>
-        <span className={styles.amount}>{formatUsdcAmount(amount)}</span>
-        <span className={styles.unit}>USDC</span>
-      </div>
-      <dl className={styles.facts}>
-        <div>
-          <dt>From</dt>
-          <dd>{fromChain?.name ?? `Chain ${fromChainId}`}</dd>
+      <h1 className={styles.title}>Review</h1>
+
+      <div className={styles.amountRow}>
+        <div className={styles.amountGroup}>
+          <span className={styles.tokenBadge} aria-hidden="true">
+            <TokenUSDC size={TOKEN_ICON_SIZE} variant="branded" className={styles.tokenBadgeIcon} />
+          </span>
+          <span className={[styles.amountValue, usdcAmount.font].join(' ')}>
+            {formatUsdcAmount(amount)}
+          </span>
         </div>
-      </dl>
-      <FeeSummary fee={fee} netAmount={netAmount} netLabel="You'll deposit" />
+      </div>
+
+      <div className={styles.summary}>
+        <div className={styles.summaryBody}>
+          <div className={styles.summaryRow}>
+            <span className={styles.summaryLabel}>Network</span>
+            <span className={styles.summaryValue}>
+              {fromChain?.name ?? `Chain ${fromChainId}`}
+            </span>
+          </div>
+          {walletAddress ? (
+            <div className={styles.summaryRow}>
+              <span className={styles.summaryLabel}>From your wallet</span>
+              <span className={styles.summaryValue}>{truncateAddress(walletAddress)}</span>
+            </div>
+          ) : null}
+          {shieldedAddress ? (
+            <div className={styles.summaryRow}>
+              <span className={styles.summaryLabel}>To Armada</span>
+              <span className={styles.summaryValue}>{truncateAddress(shieldedAddress)}</span>
+            </div>
+          ) : null}
+          <div className={styles.summaryRow}>
+            <span className={styles.summaryLabel}>Fees</span>
+            <span className={[styles.summaryValue, usdcAmount.font].join(' ')}>
+              {fee === null ? '—' : `${formatUsdcAmount(feeValue)} USDC`}
+            </span>
+          </div>
+        </div>
+        {/* Fees are inclusive (fee-from-recipient): the wallet is debited `amount` and the shielded
+            pool receives `amount - fees`. Show that net figure — the honest "what lands in your
+            account" — as the emphasized row, not a misleading amount+fee total. */}
+        <div className={styles.summaryTotalRow}>
+          <span className={styles.summaryTotalLabel}>You'll deposit</span>
+          <span className={[styles.summaryTotalValue, usdcAmount.font].join(' ')}>
+            {formatUsdcAmount(netAmount)} USDC
+          </span>
+        </div>
+      </div>
+
       {duplicateWarning ? (
         <div className={styles.caution} role="alert">
           <AlertTriangle size={16} className={styles.cautionIcon} aria-hidden="true" />
@@ -55,6 +106,7 @@ export function ShieldReviewStep({
           </span>
         </div>
       ) : null}
+
       <FlowFooter
         className={styles.footer}
         primary={{ label: 'Confirm deposit', onClick: onConfirm, disabled: isSubmitting }}

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.tsx
@@ -1,11 +1,11 @@
-// ABOUTME: Shield review step — serif title, USDC coin + amount block, borderless deposit summary table, Confirm/Back CTAs.
-// ABOUTME: Summary rows (network, wallet/shielded addresses, fees, total) replace the prior FeeSummary; duplicate caution + FlowFooter behavior preserved.
+// ABOUTME: Shield review step — serif title, USDC coin + full-precision amount block, shared DepositReviewSummary table, Confirm/Back CTAs.
+// ABOUTME: Delegates the summary rows (network, wallet/shielded addresses, deposit amount, fees, total) to DepositReviewSummary; duplicate caution preserved.
 
 import { AlertTriangle } from 'lucide-react'
 import TokenUSDC from '@web3icons/react/icons/tokens/TokenUSDC'
-import { FlowFooter } from '@/components/flow/FlowFooter'
-import { formatUsdcAmount, truncateAddress } from '@/lib/format'
-import { getChainById } from '@/config/network'
+import { Button } from '@/design'
+import { DepositReviewSummary } from '@/components/deposit/DepositReviewSummary'
+import { formatUsdcPlain } from '@/lib/format'
 import usdcAmount from '@/design/styles/usdcAmount.module.css'
 import styles from './ShieldReviewStep.module.css'
 
@@ -20,7 +20,9 @@ export interface ShieldReviewStepProps {
   netAmount: bigint
   /** Connected EVM wallet address — rendered (truncated) as the "From your wallet" row when present. */
   walletAddress?: string
-  /** Shielded (Armada) destination address — rendered (truncated) as the "To Armada" row when present. */
+  /** Connected wallet provider name (wagmi connector) — drives the "From your wallet" brand glyph. */
+  walletProvider?: string
+  /** Shielded (Armada) destination address — rendered (truncated) as the "To your private account" row when present. */
   shieldedAddress?: string
   /** True while a submit is in flight — disables Confirm so a double-click can't create two txs. */
   isSubmitting?: boolean
@@ -36,17 +38,16 @@ export function ShieldReviewStep({
   fee,
   netAmount,
   walletAddress,
+  walletProvider,
   shieldedAddress,
   isSubmitting,
   duplicateWarning,
   onBack,
   onConfirm,
 }: ShieldReviewStepProps) {
-  const fromChain = getChainById(fromChainId)
-  const feeValue = fee ?? 0n
   return (
     <div className={styles.root}>
-      <h1 className={styles.title}>Review</h1>
+      <h1 className={styles.title}>Review your deposit</h1>
 
       <div className={styles.amountRow}>
         <div className={styles.amountGroup}>
@@ -54,48 +55,20 @@ export function ShieldReviewStep({
             <TokenUSDC size={TOKEN_ICON_SIZE} variant="branded" className={styles.tokenBadgeIcon} />
           </span>
           <span className={[styles.amountValue, usdcAmount.font].join(' ')}>
-            {formatUsdcAmount(amount)}
+            {formatUsdcPlain(amount)}
           </span>
         </div>
       </div>
 
-      <div className={styles.summary}>
-        <div className={styles.summaryBody}>
-          <div className={styles.summaryRow}>
-            <span className={styles.summaryLabel}>Network</span>
-            <span className={styles.summaryValue}>
-              {fromChain?.name ?? `Chain ${fromChainId}`}
-            </span>
-          </div>
-          {walletAddress ? (
-            <div className={styles.summaryRow}>
-              <span className={styles.summaryLabel}>From your wallet</span>
-              <span className={styles.summaryValue}>{truncateAddress(walletAddress)}</span>
-            </div>
-          ) : null}
-          {shieldedAddress ? (
-            <div className={styles.summaryRow}>
-              <span className={styles.summaryLabel}>To Armada</span>
-              <span className={styles.summaryValue}>{truncateAddress(shieldedAddress)}</span>
-            </div>
-          ) : null}
-          <div className={styles.summaryRow}>
-            <span className={styles.summaryLabel}>Fees</span>
-            <span className={[styles.summaryValue, usdcAmount.font].join(' ')}>
-              {fee === null ? '—' : `${formatUsdcAmount(feeValue)} USDC`}
-            </span>
-          </div>
-        </div>
-        {/* Fees are inclusive (fee-from-recipient): the wallet is debited `amount` and the shielded
-            pool receives `amount - fees`. Show that net figure — the honest "what lands in your
-            account" — as the emphasized row, not a misleading amount+fee total. */}
-        <div className={styles.summaryTotalRow}>
-          <span className={styles.summaryTotalLabel}>You'll deposit</span>
-          <span className={[styles.summaryTotalValue, usdcAmount.font].join(' ')}>
-            {formatUsdcAmount(netAmount)} USDC
-          </span>
-        </div>
-      </div>
+      <DepositReviewSummary
+        fromChainId={fromChainId}
+        amount={amount}
+        fee={fee}
+        netAmount={netAmount}
+        walletAddress={walletAddress}
+        walletProvider={walletProvider}
+        shieldedAddress={shieldedAddress}
+      />
 
       {duplicateWarning ? (
         <div className={styles.caution} role="alert">
@@ -107,11 +80,17 @@ export function ShieldReviewStep({
         </div>
       ) : null}
 
-      <FlowFooter
-        className={styles.footer}
-        primary={{ label: 'Confirm deposit', onClick: onConfirm, disabled: isSubmitting }}
-        secondary={{ label: 'Back', onClick: onBack }}
-      />
+      <div className={styles.buttonRow}>
+        <Button variant="secondary" size="lg" label="Back" showIcon={false} onClick={onBack} />
+        <Button
+          variant="primary"
+          size="lg"
+          label="Confirm deposit"
+          showIcon={false}
+          onClick={onConfirm}
+          disabled={isSubmitting}
+        />
+      </div>
     </div>
   )
 }

--- a/apps/armada-interface/src/components/ui/WalletProviderIcon/WalletProviderIcon.tsx
+++ b/apps/armada-interface/src/components/ui/WalletProviderIcon/WalletProviderIcon.tsx
@@ -1,0 +1,20 @@
+// ABOUTME: Renders the connected wallet provider's brand glyph (MetaMask / Phantom / WalletConnect).
+// ABOUTME: Provider name is matched case-insensitively by substring so wagmi connector names resolve loosely; falls back to a generic wallet icon.
+
+import { WalletIcon } from '@heroicons/react/24/outline'
+import WalletMetamask from '@web3icons/react/icons/wallets/WalletMetamask'
+import WalletPhantom from '@web3icons/react/icons/wallets/WalletPhantom'
+import WalletWalletConnect from '@web3icons/react/icons/wallets/WalletWalletConnect'
+
+export interface WalletProviderIconProps {
+  provider?: string
+  size?: number
+}
+
+export function WalletProviderIcon({ provider, size = 16 }: WalletProviderIconProps) {
+  const name = provider?.toLowerCase() ?? ''
+  if (name.includes('metamask')) return <WalletMetamask size={size} aria-hidden />
+  if (name.includes('phantom')) return <WalletPhantom size={size} aria-hidden />
+  if (name.includes('walletconnect')) return <WalletWalletConnect size={size} aria-hidden />
+  return <WalletIcon width={size} height={size} aria-hidden />
+}

--- a/apps/armada-interface/src/components/ui/WalletProviderIcon/index.ts
+++ b/apps/armada-interface/src/components/ui/WalletProviderIcon/index.ts
@@ -1,0 +1,5 @@
+// ABOUTME: WalletProviderIcon barrel export — brand glyph for the connected wallet provider.
+// ABOUTME: Re-exports the component and its prop types.
+
+export { WalletProviderIcon } from './WalletProviderIcon'
+export type { WalletProviderIconProps } from './WalletProviderIcon'

--- a/apps/armada-interface/src/design/components/Button/Button.module.css
+++ b/apps/armada-interface/src/design/components/Button/Button.module.css
@@ -116,9 +116,10 @@
 .primary:disabled { background: var(--semantic-component-button-primary-bg-disabled); color: var(--semantic-component-button-primary-text-disabled); }
 
 /* Secondary */
-.secondary { background: transparent; color: var(--semantic-component-button-secondary-text); border-color: var(--semantic-component-button-secondary-border); }
-.secondary:hover:not(:disabled) { background: var(--semantic-component-button-secondary-bg-hover); border-color: var(--semantic-component-button-secondary-border-hover); }
+.secondary { background: var(--semantic-component-button-secondary-bg); color: var(--semantic-component-button-secondary-text); border-color: transparent; }
+.secondary:hover:not(:disabled) { background: var(--semantic-component-button-secondary-bg-hover); border-color: transparent; }
 .secondary:active:not(:disabled) { background: var(--semantic-component-button-secondary-bg-active); }
+:global([data-theme='light']) .secondary:active:not(:disabled) { background: var(--semantic-color-surface-hover); }
 .secondary:disabled { color: var(--semantic-component-button-secondary-text-disabled); }
 
 /* Ghost — text matches secondary (no border) */

--- a/apps/armada-interface/src/design/components/FlowModalOverlay/FlowModalOverlay.module.css
+++ b/apps/armada-interface/src/design/components/FlowModalOverlay/FlowModalOverlay.module.css
@@ -1,0 +1,66 @@
+/* ABOUTME: Styles for FlowModalOverlay — fixed blurred backdrop, dialog surface, and enter/exit fade keyframes.
+   ABOUTME: Ported from the armada-app design mockup. */
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  overflow: auto;
+}
+
+.overlay::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background: color-mix(in srgb, var(--primitives-color-amber-300) 30%, transparent);
+  backdrop-filter: blur(100px);
+  -webkit-backdrop-filter: blur(100px);
+  opacity: 1;
+  animation: flowModalOverlayEnter 240ms ease-out both;
+}
+
+.overlayExiting::before {
+  animation: flowModalOverlayFadeOut var(--modal-overlay-exit-ms, 180ms) ease-out
+    var(--modal-overlay-exit-delay, 440ms) forwards;
+}
+
+.dialog {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  min-height: 100dvh;
+  box-sizing: border-box;
+}
+
+@keyframes flowModalOverlayEnter {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes flowModalOverlayFadeOut {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay::before {
+    animation: none;
+    opacity: 1;
+  }
+
+  .overlayExiting::before {
+    animation: none;
+    opacity: 0;
+  }
+}

--- a/apps/armada-interface/src/design/components/FlowModalOverlay/FlowModalOverlay.tsx
+++ b/apps/armada-interface/src/design/components/FlowModalOverlay/FlowModalOverlay.tsx
@@ -1,0 +1,63 @@
+// ABOUTME: Portaled, blurred backdrop dialog wrapper for flow modals — scroll lock, focus trap, escape, restore focus.
+// ABOUTME: Ported from the armada-app design mockup.
+import { useEffect, useRef, type CSSProperties, type ReactNode, type RefObject } from 'react'
+import { createPortal } from 'react-dom'
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
+import { useEscapeKey } from '@/hooks/useEscapeKey'
+import { useFocusTrap } from '@/hooks/useFocusTrap'
+import { useNestedDialogCount } from '@/hooks/nestedDialog'
+import { useRestoreFocus } from '@/hooks/useRestoreFocus'
+import styles from './FlowModalOverlay.module.css'
+
+export interface FlowModalOverlayProps {
+  /** Accessible name for the dialog (e.g. "Deposit", "Send"). */
+  label: string
+  exiting?: boolean
+  onClose: () => void
+  initialFocusRef?: RefObject<HTMLElement | null>
+  style?: CSSProperties
+  children: ReactNode
+}
+
+export function FlowModalOverlay({
+  label,
+  exiting = false,
+  onClose,
+  initialFocusRef,
+  style,
+  children,
+}: FlowModalOverlayProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const nestedDialogCount = useNestedDialogCount()
+  const focusTrapActive = nestedDialogCount === 0
+
+  useBodyScrollLock(true)
+  useRestoreFocus(true)
+  useEscapeKey(onClose, !exiting)
+  useFocusTrap(dialogRef, focusTrapActive && !exiting)
+
+  useEffect(() => {
+    if (exiting || !focusTrapActive) return
+    const target = initialFocusRef?.current ?? dialogRef.current
+    target?.focus({ preventScroll: true })
+  }, [exiting, focusTrapActive, initialFocusRef])
+
+  const overlayClassName = [styles.overlay, exiting && styles.overlayExiting].filter(Boolean).join(' ')
+
+  return createPortal(
+    <div className={overlayClassName} style={style}>
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={label}
+        aria-hidden={nestedDialogCount > 0 ? true : undefined}
+        className={styles.dialog}
+        tabIndex={-1}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/apps/armada-interface/src/design/components/FlowModalOverlay/index.ts
+++ b/apps/armada-interface/src/design/components/FlowModalOverlay/index.ts
@@ -1,0 +1,3 @@
+// ABOUTME: Barrel for the FlowModalOverlay component and its props type.
+// ABOUTME: Ported from the armada-app design mockup.
+export { FlowModalOverlay, type FlowModalOverlayProps } from './FlowModalOverlay'

--- a/apps/armada-interface/src/design/components/ModalShell/ModalShell.module.css
+++ b/apps/armada-interface/src/design/components/ModalShell/ModalShell.module.css
@@ -1,0 +1,352 @@
+/* ABOUTME: Styles for ModalShell — header/content layout, enter/exit keyframes, simple + immersive chrome variants.
+   ABOUTME: Ported from the armada-app design mockup. */
+.shell {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  min-height: 100dvh;
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: var(--primitives-spacing-5);
+  box-sizing: border-box;
+}
+
+.shellSimple {
+  padding-top: calc(var(--primitives-spacing-4) + var(--mobile-safe-area-top, 0px));
+  padding-bottom: 0;
+  height: 100dvh;
+  min-height: 100dvh;
+  max-height: 100dvh;
+  overflow: hidden;
+}
+
+/* EXCEPTION — brand gradient fills the processing beat on mobile keypad deposit. */
+.shellImmersive {
+  background: linear-gradient(
+    165deg,
+    var(--semantic-color-brand-lavender) 0%,
+    var(--semantic-color-brand-amber) 100%
+  );
+  padding-bottom: calc(var(--primitives-spacing-5) + var(--mobile-safe-area-bottom, 0px));
+}
+
+.headerImmersive .headerTitle,
+.headerImmersive .back,
+.headerImmersive .closeImmersive {
+  color: var(--semantic-component-tag-label);
+}
+
+.closeImmersive:hover {
+  background: color-mix(in srgb, var(--semantic-component-tag-label) 14%, transparent);
+}
+
+.contentImmersive {
+  margin-top: var(--primitives-spacing-4);
+  flex: 1;
+  min-height: 0;
+}
+
+.contentExit {
+  opacity: 1;
+  transform: translateY(0);
+  animation: modalContentExit var(--modal-content-exit-ms, 260ms)
+    var(--modal-exit-easing, cubic-bezier(0.22, 1, 0.36, 1)) forwards;
+}
+
+.contentExit .stepBodyEnter,
+.contentExit .actionRowEnter > * {
+  animation: none !important;
+  opacity: 1;
+  transform: none;
+}
+
+.headerExit {
+  opacity: 1;
+  transform: translateY(0);
+  animation: modalHeaderExit var(--modal-header-exit-ms, 260ms)
+    var(--modal-exit-easing, cubic-bezier(0.22, 1, 0.36, 1)) var(--modal-header-exit-delay, 180ms)
+    forwards !important;
+}
+
+@keyframes modalHeaderExit {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(var(--primitives-spacing-10));
+  }
+}
+
+@keyframes modalContentExit {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(var(--primitives-spacing-10));
+  }
+}
+
+.header {
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  height: calc(var(--primitives-spacing-11) + var(--primitives-spacing-1) * 0.5);
+  animation: modalHeaderEnter 500ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.headerSimple {
+  display: grid;
+  grid-template-columns:
+    var(--mobile-touch-target-min, var(--primitives-spacing-11))
+    minmax(0, 1fr)
+    var(--mobile-touch-target-min, var(--primitives-spacing-11));
+  align-items: center;
+  justify-content: unset;
+  height: var(--mobile-touch-target-min, var(--primitives-spacing-11));
+}
+
+.headerSideSlot {
+  width: var(--mobile-touch-target-min, var(--primitives-spacing-11));
+  height: var(--mobile-touch-target-min, var(--primitives-spacing-11));
+}
+
+.headerTitle {
+  margin: 0;
+  justify-self: center;
+  text-align: center;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-xl) * 1px);
+  font-weight: var(--primitives-fontWeight-semibold);
+  line-height: var(--primitives-lineHeight-tight);
+  letter-spacing: var(--primitives-letterSpacing-normal);
+  color: var(--semantic-color-text-primary);
+}
+
+.back {
+  width: var(--mobile-touch-target-min, var(--primitives-spacing-11));
+  height: var(--mobile-touch-target-min, var(--primitives-spacing-11));
+  margin-inline-start: calc(var(--primitives-spacing-2) * -1);
+  border: none;
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  padding: 0;
+  color: var(--semantic-color-text-primary);
+  transition: background 0.15s ease;
+}
+
+.back:hover {
+  background: var(--semantic-component-button-secondary-bg-hover);
+}
+
+.back:focus-visible {
+  outline: calc(var(--primitives-borderWidth-default) * 1px) solid var(--semantic-color-border-focus);
+  outline-offset: calc(var(--primitives-spacing-1) * 1px);
+}
+
+.backIcon {
+  width: var(--primitives-spacing-6);
+  height: var(--primitives-spacing-6);
+}
+
+@keyframes modalHeaderEnter {
+  from {
+    opacity: 0;
+    transform: translateY(var(--primitives-spacing-10));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes modalContentEnter {
+  from {
+    opacity: 0;
+    transform: translateY(var(--primitives-spacing-10));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes modalActionButtonEnter {
+  0% {
+    opacity: 0;
+    transform: translateY(0);
+  }
+
+  48% {
+    opacity: 1;
+    transform: translateY(calc(var(--primitives-spacing-3) * -1));
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.headerNoSteps {
+  justify-content: space-between;
+}
+
+.logoSlot {
+  flex-shrink: 0;
+  padding-top: 3px;
+}
+
+.logo {
+  width: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  display: block;
+  color: var(--semantic-color-brand-deep);
+}
+
+.stepsWrap {
+  flex: 1;
+  max-width: calc(var(--primitives-spacing-20) * 4 + var(--primitives-spacing-10));
+  margin-inline: auto;
+}
+
+.close {
+  width: calc(var(--primitives-spacing-11) + var(--primitives-spacing-1) * 0.5);
+  height: calc(var(--primitives-spacing-11) + var(--primitives-spacing-1) * 0.5);
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  border: calc(var(--primitives-borderWidth-default) * 1px) solid
+    var(--semantic-component-button-secondary-border);
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  padding: 0;
+  color: var(--semantic-color-text-primary);
+  transition: background 0.15s ease;
+}
+
+.closeGhost {
+  width: var(--mobile-touch-target-min, var(--primitives-spacing-11));
+  height: var(--mobile-touch-target-min, var(--primitives-spacing-11));
+  margin-inline-end: calc(var(--primitives-spacing-2) * -1);
+  border: none;
+  background: transparent;
+}
+
+.closeGhost .closeIcon {
+  width: var(--primitives-spacing-6);
+  height: var(--primitives-spacing-6);
+}
+
+.closeGhost:hover {
+  background: var(--semantic-component-button-secondary-bg-hover);
+}
+
+.close:hover {
+  background: var(--semantic-component-button-secondary-bg-hover);
+}
+
+.close:focus-visible {
+  outline: calc(var(--primitives-borderWidth-default) * 1px) solid var(--semantic-color-border-focus);
+  outline-offset: calc(var(--primitives-spacing-1) * 1px);
+}
+
+.closeIcon {
+  width: calc(var(--primitives-spacing-4) + var(--primitives-spacing-1) * 0.5);
+  height: calc(var(--primitives-spacing-4) + var(--primitives-spacing-1) * 0.5);
+}
+
+.content {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--primitives-spacing-8);
+  margin-top: calc(var(--primitives-spacing-16) + var(--primitives-spacing-2));
+}
+
+.contentSimple {
+  flex: 1;
+  min-height: 0;
+  margin-top: var(--primitives-spacing-5);
+  gap: 0;
+  align-items: stretch;
+}
+
+.stepShell {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.contentSimple .stepShell {
+  flex: 1;
+  min-height: 0;
+  align-items: stretch;
+}
+
+.stepBodyEnter {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--primitives-spacing-8);
+  opacity: 0;
+  animation: modalContentEnter 360ms cubic-bezier(0.22, 1, 0.36, 1) 360ms both;
+}
+
+.actionRowEnter > * {
+  opacity: 0;
+  animation: modalActionButtonEnter 520ms cubic-bezier(0.34, 1.15, 0.64, 1) both;
+}
+
+.actionRowEnter > *:nth-child(1) {
+  animation-delay: 720ms;
+}
+
+.actionRowEnter > *:nth-child(2) {
+  animation-delay: 790ms;
+}
+
+.actionRowEnter > *:nth-child(3) {
+  animation-delay: 860ms;
+}
+
+.actionRowEnter > *:nth-child(4) {
+  animation-delay: 930ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header,
+  .stepBodyEnter,
+  .actionRowEnter > * {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .contentExit,
+  .headerExit {
+    animation: none !important;
+    opacity: 0;
+    transform: none;
+  }
+}

--- a/apps/armada-interface/src/design/components/ModalShell/ModalShell.tsx
+++ b/apps/armada-interface/src/design/components/ModalShell/ModalShell.tsx
@@ -1,0 +1,147 @@
+// ABOUTME: Flow-modal chrome — header (logo/steps or simple back+title), close control, and animated content slot.
+// ABOUTME: Ported from the armada-app design mockup.
+import { useRef, type ReactNode, type Ref } from 'react'
+import { ArrowLeftIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { ArmadaLogo } from '@/design'
+import { Steps } from '@/design'
+import { MODAL_EXIT_TIMING_VARS } from './modalExitMotion'
+import styles from './ModalShell.module.css'
+
+export const modalActionRowEnter = styles.actionRowEnter
+export const modalStepShell = styles.stepShell
+export const modalStepBodyEnter = styles.stepBodyEnter
+
+export type ModalShellChrome = 'default' | 'simple'
+export type ModalShellSurface = 'default' | 'immersive'
+
+export interface ModalShellProps {
+  steps: string[]
+  currentStep: number
+  status?: 'default' | 'confirmed' | 'error'
+  flowLabel?: string
+  hideStepCount?: boolean
+  hideSteps?: boolean
+  /** `simple` = back + centered title + ghost close (no logo/steps). Mobile keypad chrome. */
+  chrome?: ModalShellChrome
+  /** `immersive` = full-bleed brand gradient (mobile keypad processing). */
+  surface?: ModalShellSurface
+  /** Centered header title when `chrome="simple"`. */
+  headerTitle?: string
+  /** Back control for `chrome="simple"` (always shown when provided). */
+  onBack?: () => void
+  exiting?: boolean
+  onClose: () => void
+  closeButtonRef?: Ref<HTMLButtonElement>
+  children: ReactNode
+}
+
+export function ModalShell({
+  steps,
+  currentStep,
+  status = 'default',
+  flowLabel = 'Deposit',
+  hideStepCount = false,
+  hideSteps = false,
+  chrome = 'default',
+  surface = 'default',
+  headerTitle,
+  onBack,
+  exiting = false,
+  onClose,
+  closeButtonRef,
+  children,
+}: ModalShellProps) {
+  const fallbackCloseRef = useRef<HTMLButtonElement>(null)
+  const resolvedCloseRef = closeButtonRef ?? fallbackCloseRef
+  const isSimple = chrome === 'simple'
+  const isImmersive = surface === 'immersive'
+  const headerClassName = [
+    styles.header,
+    (hideSteps || isSimple) && styles.headerNoSteps,
+    isSimple && styles.headerSimple,
+    isImmersive && styles.headerImmersive,
+    exiting && styles.headerExit,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const shellClassName = [
+    styles.shell,
+    isSimple && styles.shellSimple,
+    isImmersive && styles.shellImmersive,
+  ]
+    .filter(Boolean)
+    .join(' ')
+  const contentClassName = [
+    styles.content,
+    isSimple && styles.contentSimple,
+    isImmersive && styles.contentImmersive,
+    exiting && styles.contentExit,
+  ]
+    .filter(Boolean)
+    .join(' ')
+  const closeClassName = [
+    styles.close,
+    isSimple && styles.closeGhost,
+    isImmersive && styles.closeImmersive,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <div className={shellClassName} style={exiting ? MODAL_EXIT_TIMING_VARS : undefined}>
+      <header className={headerClassName}>
+        {isSimple ? (
+          <>
+            {onBack ? (
+              <button type="button" className={styles.back} onClick={onBack} aria-label="Back">
+                <ArrowLeftIcon className={styles.backIcon} strokeWidth={1.5} aria-hidden />
+              </button>
+            ) : (
+              <span className={styles.headerSideSlot} aria-hidden />
+            )}
+            <h1 className={styles.headerTitle}>
+              {headerTitle !== undefined ? headerTitle : flowLabel}
+            </h1>
+            <button
+              ref={resolvedCloseRef}
+              type="button"
+              className={closeClassName}
+              onClick={onClose}
+              aria-label="Close"
+            >
+              <XMarkIcon className={styles.closeIcon} strokeWidth={1.5} aria-hidden />
+            </button>
+          </>
+        ) : (
+          <>
+            <div className={styles.logoSlot}>
+              <ArmadaLogo variant="mark" markTone="white" className={styles.logo} />
+            </div>
+            {hideSteps ? null : (
+              <div className={styles.stepsWrap}>
+                <Steps
+                  steps={steps}
+                  currentStep={currentStep}
+                  status={status}
+                  flowLabel={status === 'confirmed' ? undefined : flowLabel}
+                  hideStepCount={hideStepCount}
+                />
+              </div>
+            )}
+            <button
+              ref={resolvedCloseRef}
+              type="button"
+              className={styles.close}
+              onClick={onClose}
+              aria-label="Close"
+            >
+              <XMarkIcon className={styles.closeIcon} strokeWidth={1.5} aria-hidden />
+            </button>
+          </>
+        )}
+      </header>
+      <div className={contentClassName}>{children}</div>
+    </div>
+  )
+}

--- a/apps/armada-interface/src/design/components/ModalShell/index.ts
+++ b/apps/armada-interface/src/design/components/ModalShell/index.ts
@@ -1,0 +1,4 @@
+// ABOUTME: Barrel for the ModalShell component and its exported style-class + type helpers.
+// ABOUTME: Ported from the armada-app design mockup.
+export { ModalShell, modalActionRowEnter, modalStepBodyEnter, modalStepShell } from './ModalShell'
+export type { ModalShellProps, ModalShellChrome } from './ModalShell'

--- a/apps/armada-interface/src/design/components/ModalShell/modalExitMotion.ts
+++ b/apps/armada-interface/src/design/components/ModalShell/modalExitMotion.ts
@@ -1,0 +1,27 @@
+// ABOUTME: Shared exit-animation timing constants + CSS custom-property vars for the modal close choreography.
+// ABOUTME: Ported from the armada-app design mockup.
+import type { CSSProperties } from 'react'
+
+/**
+ * Close order: content → header → backdrop.
+ * Timings mirror enter (header 500ms, body 360ms @ 360ms, overlay 240ms) at ~72% scale
+ * so total exit (~700ms) matches perceived open speed (~720ms body reveal).
+ */
+export const MODAL_CONTENT_EXIT_MS = 260
+export const MODAL_HEADER_EXIT_MS = 260
+export const MODAL_HEADER_EXIT_DELAY_MS = 180
+export const MODAL_OVERLAY_EXIT_MS = 180
+export const MODAL_OVERLAY_EXIT_DELAY_MS = MODAL_HEADER_EXIT_DELAY_MS + MODAL_HEADER_EXIT_MS
+
+export const MODAL_EXIT_TOTAL_MS = MODAL_OVERLAY_EXIT_DELAY_MS + MODAL_OVERLAY_EXIT_MS
+
+export const MODAL_EXIT_EASING = 'cubic-bezier(0.22, 1, 0.36, 1)'
+
+export const MODAL_EXIT_TIMING_VARS = {
+  '--modal-content-exit-ms': `${MODAL_CONTENT_EXIT_MS}ms`,
+  '--modal-header-exit-ms': `${MODAL_HEADER_EXIT_MS}ms`,
+  '--modal-header-exit-delay': `${MODAL_HEADER_EXIT_DELAY_MS}ms`,
+  '--modal-overlay-exit-ms': `${MODAL_OVERLAY_EXIT_MS}ms`,
+  '--modal-overlay-exit-delay': `${MODAL_OVERLAY_EXIT_DELAY_MS}ms`,
+  '--modal-exit-easing': MODAL_EXIT_EASING,
+} as CSSProperties

--- a/apps/armada-interface/src/design/components/Steps/Steps.module.css
+++ b/apps/armada-interface/src/design/components/Steps/Steps.module.css
@@ -1,0 +1,57 @@
+/* ABOUTME: Styles for the Steps progress indicator — header row typography and segmented progress-bar states.
+   ABOUTME: Ported from the armada-app design mockup. */
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+}
+
+.headerRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.stepName {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-weight: var(--primitives-fontWeight-medium);
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  letter-spacing: var(--primitives-letterSpacing-wide);
+  text-transform: uppercase;
+  color: var(--semantic-color-text-primary);
+}
+
+.stepCount {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-weight: var(--primitives-fontWeight-medium);
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  letter-spacing: var(--primitives-letterSpacing-wide);
+  text-transform: uppercase;
+  color: var(--semantic-color-text-muted);
+}
+
+.progressBar {
+  display: flex;
+  gap: var(--primitives-spacing-1);
+  width: 100%;
+}
+
+.segment {
+  flex: 1;
+  height: calc(var(--primitives-borderWidth-default) * 3px);
+  border-radius: calc(var(--primitives-borderWidth-default) * 2px);
+  background-color: var(--semantic-color-border-default);
+}
+
+.segment.active {
+  background-color: var(--semantic-color-brand-lavender);
+}
+
+.segment.error {
+  background-color: var(--semantic-color-status-error);
+}
+
+.segment.confirmed {
+  background-color: var(--semantic-color-status-success);
+}

--- a/apps/armada-interface/src/design/components/Steps/Steps.tsx
+++ b/apps/armada-interface/src/design/components/Steps/Steps.tsx
@@ -1,0 +1,54 @@
+// ABOUTME: Progress indicator for multi-step flows — step name/count header row plus a segmented progress bar.
+// ABOUTME: Ported from the armada-app design mockup.
+import styles from './Steps.module.css'
+
+export interface StepsProps {
+  steps: string[]
+  currentStep: number
+  status?: 'default' | 'error' | 'confirmed'
+  /** Fixed flow title (e.g. "Deposit") — when set, shown left instead of the active step name. */
+  flowLabel?: string
+  hideStepCount?: boolean
+}
+
+export function Steps({
+  steps,
+  currentStep,
+  status = 'default',
+  flowLabel,
+  hideStepCount = false,
+}: StepsProps) {
+  const stepName = flowLabel
+    ? flowLabel.toUpperCase()
+    : status === 'confirmed'
+      ? 'CONFIRMATION'
+      : (steps[currentStep - 1]?.toUpperCase() ?? '')
+  const stepCount =
+    status === 'confirmed'
+      ? `STEP ${steps.length} OF ${steps.length}`
+      : `STEP ${currentStep} OF ${steps.length}`
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.headerRow}>
+        <span className={styles.stepName}>{stepName}</span>
+        {hideStepCount ? null : <span className={styles.stepCount}>{stepCount}</span>}
+      </div>
+      <div className={styles.progressBar}>
+        {steps.map((_, index) => {
+          const isActive = index < currentStep
+          const className = [
+            styles.segment,
+            status === 'confirmed' && styles.confirmed,
+            status === 'error' && isActive && styles.error,
+            status === 'default' && isActive && styles.active,
+          ]
+            .filter(Boolean)
+            .join(' ')
+
+          return <div key={index} className={className} />
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/armada-interface/src/design/components/Steps/index.ts
+++ b/apps/armada-interface/src/design/components/Steps/index.ts
@@ -1,0 +1,4 @@
+// ABOUTME: Barrel for the Steps progress-indicator component and its props type.
+// ABOUTME: Ported from the armada-app design mockup.
+export { Steps } from './Steps'
+export type { StepsProps } from './Steps'

--- a/apps/armada-interface/src/design/index.ts
+++ b/apps/armada-interface/src/design/index.ts
@@ -30,3 +30,11 @@ export type { IconButtonProps, IconButtonVariant } from './components/IconButton
 export { default as Tooltip } from './components/Tooltip/Tooltip'
 export { BottomSheet, afterBottomSheetHandoff, BOTTOM_SHEET_EXIT_MS, BOTTOM_SHEET_HANDOFF_MS } from './components/BottomSheet'
 export type { BottomSheetProps } from './components/BottomSheet'
+
+export { ModalShell, modalActionRowEnter, modalStepBodyEnter, modalStepShell } from './components/ModalShell'
+export type { ModalShellProps, ModalShellChrome } from './components/ModalShell'
+export { MODAL_EXIT_TIMING_VARS, MODAL_EXIT_TOTAL_MS, MODAL_EXIT_EASING } from './components/ModalShell/modalExitMotion'
+export { FlowModalOverlay } from './components/FlowModalOverlay'
+export type { FlowModalOverlayProps } from './components/FlowModalOverlay'
+export { Steps } from './components/Steps'
+export type { StepsProps } from './components/Steps'

--- a/apps/armada-interface/src/design/styles/displayLgTitle.module.css
+++ b/apps/armada-interface/src/design/styles/displayLgTitle.module.css
@@ -1,0 +1,11 @@
+/* ABOUTME: display-lg composite — Charis SIL 32px modal/flow headlines via composes. */
+/* ABOUTME: Ported verbatim from the armada-app design mockup. */
+
+/* display-lg composite — Charis SIL 32px modal headlines */
+.displayLg {
+  font-family: var(--semantic-typography-display-lg-font-family), serif;
+  font-weight: var(--semantic-typography-display-lg-font-weight);
+  font-size: var(--semantic-typography-display-lg-font-size);
+  line-height: var(--semantic-typography-display-lg-line-height);
+  letter-spacing: var(--semantic-typography-display-lg-letter-spacing);
+}

--- a/apps/armada-interface/src/hooks/nestedDialog.ts
+++ b/apps/armada-interface/src/hooks/nestedDialog.ts
@@ -1,0 +1,33 @@
+// ABOUTME: Global nested-dialog counter store so parent modals pause their focus trap while a child dialog is open.
+// ABOUTME: Ported from the armada-app design mockup.
+import { useSyncExternalStore } from 'react'
+
+let nestedDialogCount = 0
+const listeners = new Set<() => void>()
+
+function subscribe(listener: () => void) {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+function getSnapshot() {
+  return nestedDialogCount
+}
+
+function notify() {
+  listeners.forEach((listener) => listener())
+}
+
+/** Register a nested dialog (e.g. MockMetaMask) so parent modals pause focus trap. */
+export function registerNestedDialog() {
+  nestedDialogCount += 1
+  notify()
+  return () => {
+    nestedDialogCount = Math.max(0, nestedDialogCount - 1)
+    notify()
+  }
+}
+
+export function useNestedDialogCount() {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}

--- a/apps/armada-interface/src/hooks/useFocusTrap.ts
+++ b/apps/armada-interface/src/hooks/useFocusTrap.ts
@@ -1,0 +1,52 @@
+// ABOUTME: React hook that traps keyboard Tab focus within a container element while active.
+// ABOUTME: Ported from the armada-app design mockup.
+import { useEffect, type RefObject } from 'react'
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+function getFocusableElements(container: HTMLElement) {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (element) => !element.hasAttribute('disabled') && element.tabIndex !== -1,
+  )
+}
+
+/** Keep keyboard focus inside `containerRef` while `active`. */
+export function useFocusTrap(containerRef: RefObject<HTMLElement | null>, active = true) {
+  useEffect(() => {
+    if (!active) return
+
+    const container = containerRef.current
+    if (!container) return
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== 'Tab' || !containerRef.current) return
+
+      const focusable = getFocusableElements(containerRef.current)
+      if (focusable.length === 0) {
+        event.preventDefault()
+        return
+      }
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      const activeElement = document.activeElement
+
+      if (event.shiftKey) {
+        if (activeElement === first || !containerRef.current.contains(activeElement)) {
+          event.preventDefault()
+          last?.focus()
+        }
+        return
+      }
+
+      if (activeElement === last) {
+        event.preventDefault()
+        first?.focus()
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [active, containerRef])
+}

--- a/apps/armada-interface/src/hooks/useRestoreFocus.ts
+++ b/apps/armada-interface/src/hooks/useRestoreFocus.ts
@@ -1,0 +1,21 @@
+// ABOUTME: React hook that returns focus to the previously-active element when a modal/dialog closes.
+// ABOUTME: Ported from the armada-app design mockup.
+import { useEffect, useRef } from 'react'
+
+/** Return focus to the element that was active when `active` became true. */
+export function useRestoreFocus(active: boolean) {
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    if (!active) return
+
+    previousFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null
+
+    return () => {
+      const target = previousFocusRef.current
+      if (!target || !document.contains(target)) return
+      target.focus({ preventScroll: true })
+    }
+  }, [active])
+}

--- a/apps/armada-interface/src/index.css
+++ b/apps/armada-interface/src/index.css
@@ -68,7 +68,9 @@ body {
   background-attachment: fixed;
   font-family: var(--primitives-fontFamily-ui);
   font-size: 15px;
-  line-height: 1.5;
+  /* Match the mockup's global line-height (140%) — was hardcoded 1.5, which slightly inflated
+     inherited line-boxes app-wide vs the design. */
+  line-height: var(--primitives-lineHeight-normal);
   color: var(--semantic-color-text-primary);
 }
 

--- a/apps/armada-interface/src/lib/format.ts
+++ b/apps/armada-interface/src/lib/format.ts
@@ -104,6 +104,23 @@ export function usdcInputErrorMessage(error: UsdcInputError | undefined): string
   }
 }
 
+const TRANSACTION_DATE_FORMAT = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+})
+
+const TRANSACTION_TIME_FORMAT = new Intl.DateTimeFormat('en-US', {
+  hour: 'numeric',
+  minute: '2-digit',
+})
+
+/** Single-line absolute date and time for transaction confirmations, e.g. "Jan 5, 2026 · 3:42 PM". */
+export function formatTransactionDateTime(ms: number): string {
+  const date = new Date(ms)
+  return `${TRANSACTION_DATE_FORMAT.format(date)} · ${TRANSACTION_TIME_FORMAT.format(date)}`
+}
+
 /** Truncate an Ethereum address to "0x1234...abcd" (mockup convention: 6 chars before, 4 after). */
 export function truncateAddress(address: string): string {
   if (address.length <= 10) return address

--- a/apps/armada-interface/src/main.tsx
+++ b/apps/armada-interface/src/main.tsx
@@ -11,6 +11,7 @@ import { Toaster } from 'sonner'
 
 import { wagmiConfig } from '@/config/wagmi'
 import { installBisectingGetLogs } from '@/lib/rpc-bisecting'
+import { getSavedTheme, setTheme } from '@/design/utils/theme'
 import { AppErrorBoundary } from '@/components/AppErrorBoundary'
 import { initSentry } from '@/lib/sentry'
 import { trackError } from '@/lib/telemetry'
@@ -28,6 +29,12 @@ initSentry()
 // SDK's 499-block scan chunks. Idempotent + prototype-level, so all ethers
 // providers in the process (including the SDK's internal PollingJsonRpcProvider) pick it up.
 installBisectingGetLogs()
+
+// Apply the persisted theme, defaulting to light to match the design mockup. Runs before render
+// so the WalletPillMenu dark/light toggle survives reloads. index.html sets data-theme="light"
+// pre-paint to avoid a flash; this reconciles it with any saved choice.
+setTheme(getSavedTheme() ?? 'light')
+
 import { Dashboard } from '@/pages/Dashboard'
 import { History } from '@/pages/History'
 import { Settings } from '@/pages/Settings'


### PR DESCRIPTION
## What
Rebuilds the deposit (shield) flow onto the mockup's modal shell and restyles its steps; `ShieldModal` logic/seams intact (presentation swap + restyle, all functionality preserved).

## Shell
New `FlowShell` (`FlowModalOverlay` + `ModalShell` + `Steps` → `@/design`; `useFocusTrap`/`useRestoreFocus`/`nestedDialog` → `@/hooks`) replaces `DepositOverlayShell` **for shield only** (unshield/send/earn unchanged). Armada mark + 3-seg Steps bar + blurred backdrop + focus trap.

## Steps
- **Amount** — serif prompt; `DepositAmountCard` restyled (surface-main card, coin beside amount, mono `text-primary` amount, 25/50/75/Max pills, fee revealed on input in an inset row; tooltip kept).
- **Review** — "Review your deposit", full-precision amount, shared `DepositReviewSummary` (Network / From your wallet [+glyph] / To your private account [+Armada mark] / Deposit amount / Fees / **You'll receive** = net).
- **Confirmed** — "Deposit confirmed", tx-details card (+ "Date and time"; total **You received**), View on explorer / Go to dashboard; no rule.
- New shared `DepositReviewSummary` + `WalletProviderIcon`; `formatTransactionDateTime` added to `lib/format`.

## App-wide (surfaced here)
- Default theme → **light** (matches mockup; respects saved toggle).
- `body` line-height → `lineHeight-normal` (was hardcoded 1.5).
- Shared secondary Button filled (not outlined) — affects all secondary buttons.

## Fee semantics
Deposit fees are inclusive (wallet charged `amount`; receive `amount − fees`) → review/confirmed show net, not a fee-on-top total.

## Deferred
In-flight/progress display (shared, redesign once); form-validation UX (shared pass); mobile keypad; exit-motion.

## Verification
Typecheck clean · **1133 tests pass** / 8 skipped. Visuals verified in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)