### PR TITLE
style(interface): restyle shared transfer flow onto FlowShell + mockup visuals (PR2)

### DIFF
--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
@@ -14,6 +14,12 @@
   box-sizing: border-box;
 }
 
+/* Chain-less card (Send flow): the amount is the top element, so the top padding is enlarged
+   to match the mockup, where the chain row's absence is compensated with extra headroom. */
+.cardNoChain {
+  padding-top: calc(var(--primitives-spacing-12) + var(--primitives-spacing-3));
+}
+
 .topRow,
 .bottomRow {
   display: flex;
@@ -144,6 +150,18 @@
   display: inline-flex;
   align-items: center;
   gap: var(--primitives-spacing-1);
+}
+
+/* Available-balance text — full match to the mockup (mono, base size, regular weight, secondary
+   color); without the explicit size it would inherit the larger 15px body baseline. Shared by the
+   deposit + send amount cards. */
+.balanceText {
+  font-family: var(--primitives-fontFamily-mono), ui-monospace, monospace;
+  font-weight: var(--primitives-fontWeight-regular);
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  color: var(--semantic-color-text-secondary);
+  white-space: nowrap;
+  letter-spacing: 0;
 }
 
 /* Fee row (mockup style): its own inset "card" below the balance controls — a muted, rounded,

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
@@ -5,7 +5,7 @@ import { useEffect, useId, useRef, useState } from 'react'
 import { ChevronDownIcon, WalletIcon } from '@heroicons/react/24/solid'
 import TokenUSDC from '@web3icons/react/icons/tokens/TokenUSDC'
 import { hasActiveAmount, sanitizeAmountInput } from '@/utils/amountInput'
-import { chainIconForChainId } from '@/components/deposit/depositChainIcons'
+import { chainIconForChainId } from '@/components/ui/chainIcons'
 import { FeeBreakdownTooltip, type FlowFeeBreakdown } from '@/components/ui/FeeBreakdownTooltip'
 import { formatUsdcPlain } from '@/lib/format'
 import type { DisplayFees } from '@/lib/fees/displayFees'
@@ -26,6 +26,8 @@ export interface DepositAmountCardProps {
   chains: ReadonlyArray<DepositChainOption>
   chainId: number
   onChainIdChange?: (chainId: number) => void
+  /** Hide the chain row entirely (e.g. the Send flow, where the chain is chosen on a prior step). */
+  showChain?: boolean
   token?: string
   amount: string
   onAmountChange: (value: string) => void
@@ -74,6 +76,7 @@ export function DepositAmountCard({
   chains,
   chainId,
   onChainIdChange,
+  showChain = true,
   token = 'USDC',
   amount,
   onAmountChange,
@@ -127,7 +130,8 @@ export function DepositAmountCard({
   const showActiveAmount = hasActiveAmount(amount)
 
   return (
-    <div className={styles.card}>
+    <div className={[styles.card, !showChain && styles.cardNoChain].filter(Boolean).join(' ')}>
+      {showChain ? (
       <div className={styles.topRow}>
         <div className={styles.chainRoot} ref={chainRootRef}>
           {chainSelectable ? (
@@ -171,6 +175,7 @@ export function DepositAmountCard({
         </div>
 
       </div>
+      ) : null}
 
       <label className={styles.amountWrapper} htmlFor={amountInputId}>
         <span className={styles.visuallyHidden}>{amountAriaLabel}</span>

--- a/apps/armada-interface/src/components/payments/SendCompleteStep.module.css
+++ b/apps/armada-interface/src/components/payments/SendCompleteStep.module.css
@@ -1,54 +1,73 @@
-/* ABOUTME: SendCompleteStep layout — matches Shield/Unshield CompleteStep proportions. */
-/* ABOUTME: Icon uses status-success green; copy adapts to private vs external via inline JSX. */
+/* ABOUTME: SendCompleteStep layout — centered serif title, coin+amount block, shared summary table, two-button CTA row. */
+/* ABOUTME: Mirrors the send-confirmed reference so success states feel consistent across the app. */
 
 .root {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: var(--primitives-spacing-3);
-  text-align: center;
-}
-
-.icon {
-  width: 72px;
-  height: 72px;
-  border-radius: 50%;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(52, 211, 153, 0.12);
-  color: var(--semantic-color-status-success);
-  margin-bottom: var(--primitives-spacing-2);
+  align-items: stretch;
+  gap: var(--primitives-spacing-8);
 }
 
 .title {
-  font-family: "Charis SIL", serif;
-  font-size: calc(var(--primitives-fontSize-2xl) * 1px);
-  line-height: var(--primitives-lineHeight-tight);
-  font-weight: var(--primitives-fontWeight-regular);
+  composes: displayLg from '../../design/styles/displayLgTitle.module.css';
+  margin: 0;
+  width: 100%;
   color: var(--semantic-color-text-primary);
-  margin: 0;
+  text-align: center;
 }
 
-.body {
-  color: var(--semantic-color-text-muted);
-  max-width: 46ch;
-  margin: 0;
+.amountRow {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
 }
 
-.explorerLink {
+.amountGroup {
   display: inline-flex;
   align-items: center;
-  gap: var(--primitives-spacing-1);
-  color: var(--semantic-color-text-accent);
-  text-decoration: none;
+  gap: var(--primitives-spacing-2);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
 }
 
-.explorerLink:hover {
-  text-decoration: underline;
+.tokenBadge {
+  width: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.footer {
-  align-self: stretch;
-  margin: var(--primitives-spacing-6) calc(var(--primitives-spacing-6) * -1) calc(var(--primitives-spacing-6) * -1);
+.tokenBadgeIcon {
+  flex-shrink: 0;
+  display: block;
+}
+
+.tokenBadgeIcon :global(svg) {
+  display: block;
+}
+
+.amountValue {
+  display: block;
+  font-weight: var(--primitives-fontWeight-medium);
+  font-size: var(--primitives-spacing-10);
+  line-height: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  color: var(--semantic-color-text-primary);
+}
+
+/* Two-button CTA row — send-confirmed mockup: equal-width View on explorer / Go to dashboard, no divider above. */
+.buttonRow {
+  display: flex;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+}
+
+.buttonRow > * {
+  flex: 1;
+  max-width: 211px;
 }

--- a/apps/armada-interface/src/components/payments/SendCompleteStep.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendCompleteStep.test.tsx
@@ -1,74 +1,71 @@
-// ABOUTME: Tests for SendCompleteStep — copy adapts to private vs public + variant, Done dispatches onDone.
+// ABOUTME: Tests for SendCompleteStep — title + privacy/network summary rows by recipient format + variant, CTA wiring.
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { SendCompleteStep } from './SendCompleteStep'
+import { SendCompleteStep, type SendCompleteStepProps } from './SendCompleteStep'
 
 const VALID_EVM = '0xabcdef1234567890abcdef1234567890abcdef12'
 const VALID_0ZK = '0zkabcdefghijklmnopqrstuvwxyz0123456789aaaa'
 
+function renderComplete(extras?: Partial<SendCompleteStepProps>) {
+  const props: SendCompleteStepProps = {
+    variant: extras?.variant ?? 'send',
+    recipient: extras?.recipient ?? VALID_0ZK,
+    armadaAddress: extras?.armadaAddress,
+    amount: extras?.amount ?? 100_000_000n,
+    fee: extras?.fee ?? null,
+    totalDeducted: extras?.totalDeducted ?? 100_000_000n,
+    networkName: extras?.networkName,
+    confirmedAt: extras?.confirmedAt ?? Date.now(),
+    explorerUrl: extras?.explorerUrl,
+    onViewExplorer: extras?.onViewExplorer ?? vi.fn(),
+    onGoToDashboard: extras?.onGoToDashboard ?? vi.fn(),
+  }
+  render(<SendCompleteStep {...props} />)
+  return props
+}
+
 describe('<SendCompleteStep>', () => {
-  it("private: renders the 'sent privately' copy", () => {
-    render(
-      <SendCompleteStep
-        variant="send"
-        isPrivate
-        destChainId={31337}
-        recipient={VALID_0ZK}
-        recipientReceives={100_000_000n}
-        totalDeducted={100_000_000n}
-        onDone={() => {}}
-      />,
-    )
-    expect(screen.getByText(/privately/)).toBeInTheDocument()
-    expect(screen.getByText(/100\.00 USDC/)).toBeInTheDocument()
+  it('send: renders the "Send confirmed" title + a "Private" privacy row', () => {
+    renderComplete({ recipient: VALID_0ZK })
+    expect(screen.getByText('Send confirmed')).toBeInTheDocument()
+    expect(screen.getByText('Private')).toBeInTheDocument()
+    expect(screen.getAllByText(/100\.00 USDC/).length).toBeGreaterThan(0)
   })
 
-  it('public: renders the chain name in the copy', () => {
-    render(
-      <SendCompleteStep
-        variant="send"
-        isPrivate={false}
-        destChainId={31337}
-        recipient={VALID_EVM}
-        recipientReceives={50_000_000n}
-        totalDeducted={50_000_000n}
-        onDone={() => {}}
-      />,
-    )
-    expect(screen.getByText(/Anvil Hub/)).toBeInTheDocument()
-    expect(screen.getByText(/50\.00 USDC/)).toBeInTheDocument()
+  it('public: renders the network row + a "Public" privacy row', () => {
+    renderComplete({
+      recipient: VALID_EVM,
+      networkName: 'Anvil Hub (local)',
+      amount: 50_000_000n,
+      totalDeducted: 50_000_000n,
+    })
+    expect(screen.getByText('Anvil Hub (local)')).toBeInTheDocument()
+    expect(screen.getByText('Public')).toBeInTheDocument()
+    expect(screen.getAllByText(/50\.00 USDC/).length).toBeGreaterThan(0)
   })
 
   it('withdraw variant: uses the "Withdrawal complete" title', () => {
-    render(
-      <SendCompleteStep
-        variant="withdraw"
-        isPrivate={false}
-        destChainId={31337}
-        recipient={VALID_EVM}
-        recipientReceives={50_000_000n}
-        totalDeducted={50_000_000n}
-        onDone={() => {}}
-      />,
-    )
+    renderComplete({ variant: 'withdraw', recipient: VALID_EVM, networkName: 'Anvil Hub (local)' })
     expect(screen.getByText('Withdrawal complete')).toBeInTheDocument()
   })
 
-  it('fires onDone when the CTA is clicked', () => {
-    const onDone = vi.fn()
-    render(
-      <SendCompleteStep
-        variant="send"
-        isPrivate
-        destChainId={31337}
-        recipient={VALID_0ZK}
-        recipientReceives={1_000_000n}
-        totalDeducted={1_000_000n}
-        onDone={onDone}
-      />,
-    )
-    fireEvent.click(screen.getByRole('button', { name: /Done/ }))
-    expect(onDone).toHaveBeenCalledTimes(1)
+  it('disables "View on explorer" when no explorer URL is provided', () => {
+    renderComplete()
+    expect(screen.getByRole('button', { name: /View on explorer/ })).toBeDisabled()
+  })
+
+  it('fires onGoToDashboard when the primary CTA is clicked', () => {
+    const onGoToDashboard = vi.fn()
+    renderComplete({ onGoToDashboard })
+    fireEvent.click(screen.getByRole('button', { name: /Go to dashboard/ }))
+    expect(onGoToDashboard).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onViewExplorer when a URL is present', () => {
+    const onViewExplorer = vi.fn()
+    renderComplete({ explorerUrl: 'https://example.test/tx/0xabc', onViewExplorer })
+    fireEvent.click(screen.getByRole('button', { name: /View on explorer/ }))
+    expect(onViewExplorer).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/armada-interface/src/components/payments/SendCompleteStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendCompleteStep.tsx
@@ -1,72 +1,101 @@
-// ABOUTME: Send complete step — success copy adapts to private vs external mode + chain (when external).
-// ABOUTME: Mirrors the Shield/Unshield CompleteStep shape so success states across flows feel consistent.
+// ABOUTME: Send/Withdraw complete step — serif "Send confirmed"/"Withdrawal complete" title, USDC coin + amount block, shared TransferReviewSummary (with date/time), and explorer/dashboard CTAs.
+// ABOUTME: Mirrors the send-confirmed reference — no divider between the summary card and the button row.
 
-import { CheckCircle2, ExternalLink } from 'lucide-react'
-import { FlowFooter } from '@/components/flow/FlowFooter'
-import { formatUsdcAmount, truncateAddress } from '@/lib/format'
-import { getChainById } from '@/config/network'
+import TokenUSDC from '@web3icons/react/icons/tokens/TokenUSDC'
+import { Button } from '@/design'
+import { TransferReviewSummary } from './TransferReviewSummary'
+import { formatUsdcPlain } from '@/lib/format'
+import usdcAmount from '@/design/styles/usdcAmount.module.css'
 import type { SendFlowVariant } from './SendRecipientStep'
 import styles from './SendCompleteStep.module.css'
 
+const TOKEN_BADGE_PX = 40
+/** @web3icons branded assets use an 18px circle in a 24px viewBox — scale up to fill the badge. */
+const TOKEN_ICON_SIZE = Math.round((TOKEN_BADGE_PX * 24) / 18)
+
 export interface SendCompleteStepProps {
   variant: SendFlowVariant
-  /** True when the recipient is a shielded 0zk address (private transfer); false for public 0x. */
-  isPrivate: boolean
-  destChainId: number
   recipient: string
-  /** USDC the recipient actually received on chain. See SendModal's per-kind comment. */
-  recipientReceives: bigint
-  /** USDC actually deducted from the user's shielded balance. Render a second line when this
-   *  exceeds `recipientReceives` (the unshield-local relayer-fee path); skip when they're equal. */
+  /** The user's own shielded (Armada) address — rendered as the summary's "From your private account" row. */
+  armadaAddress?: string
+  /** Gross amount sent/withdrawn (raw 6-decimal USDC) — shown full-precision in the coin block. */
+  amount: bigint
+  /** Inclusive Fee total — broadcaster + protocol + CCTP. Rendered as "—" when null. */
+  fee: bigint | null
+  /** USDC deducted from the user's shielded balance — `amount + fee`; the summary's Total row. */
   totalDeducted: bigint
-  /** Explorer URL for the hub-chain tx. Undefined for local Anvil; hidden when unset. */
+  /** Destination chain name — shown on the summary's Network row for public (0x) recipients. */
+  networkName?: string
+  /** Wallet provider name for a public recipient's brand glyph (only when it's the user's own wallet). */
+  recipientWalletProvider?: string
+  /** Completion timestamp (ms) — drives the summary's "Date and time" row. */
+  confirmedAt: number
+  /** Source-chain explorer URL for the tx; absent disables the "View on explorer" button. */
   explorerUrl?: string
-  onDone: () => void
+  onViewExplorer: () => void
+  onGoToDashboard: () => void
 }
 
 export function SendCompleteStep({
   variant,
-  isPrivate,
-  destChainId,
   recipient,
-  recipientReceives,
+  armadaAddress,
+  amount,
+  fee,
   totalDeducted,
+  networkName,
+  recipientWalletProvider,
+  confirmedAt,
   explorerUrl,
-  onDone,
+  onViewExplorer,
+  onGoToDashboard,
 }: SendCompleteStepProps) {
-  const destChain = isPrivate ? null : getChainById(destChainId)
-  const short = recipient.startsWith('0zk') && recipient.length > 14
-    ? `${recipient.slice(0, 7)}…${recipient.slice(-4)}`
-    : truncateAddress(recipient)
-  const title = variant === 'withdraw' ? 'Withdrawal complete' : 'Sent'
+  const title = variant === 'withdraw' ? 'Withdrawal complete' : 'Send confirmed'
 
   return (
     <div className={styles.root}>
-      <div className={styles.icon} aria-hidden="true">
-        <CheckCircle2 size={40} />
+      <h1 className={styles.title}>{title}</h1>
+
+      <div className={styles.amountRow}>
+        <div className={styles.amountGroup}>
+          <span className={styles.tokenBadge} aria-hidden="true">
+            <TokenUSDC size={TOKEN_ICON_SIZE} variant="branded" className={styles.tokenBadgeIcon} />
+          </span>
+          <span className={[styles.amountValue, usdcAmount.font].join(' ')}>
+            {formatUsdcPlain(amount)}
+          </span>
+        </div>
       </div>
-      <h3 className={styles.title}>{title}</h3>
-      <p className={styles.body}>
-        {isPrivate
-          ? <>Sent {formatUsdcAmount(recipientReceives)} USDC privately to {short}.</>
-          : <>Sent {formatUsdcAmount(recipientReceives)} USDC to {short} on {destChain?.name ?? `chain ${destChainId}`}.</>}
-      </p>
-      {totalDeducted !== recipientReceives ? (
-        <p className={styles.body}>
-          Total deducted from your private balance: {formatUsdcAmount(totalDeducted)} USDC.
-        </p>
-      ) : null}
-      {explorerUrl ? (
-        <p className={styles.body}>
-          <a href={explorerUrl} target="_blank" rel="noreferrer noopener" className={styles.explorerLink}>
-            View transaction <ExternalLink size={14} aria-hidden="true" />
-          </a>
-        </p>
-      ) : null}
-      <FlowFooter
-        className={styles.footer}
-        primary={{ label: 'Done', onClick: onDone }}
+
+      <TransferReviewSummary
+        recipient={recipient}
+        armadaAddress={armadaAddress}
+        amount={amount}
+        fee={fee}
+        totalDeducted={totalDeducted}
+        variant={variant}
+        networkName={networkName}
+        recipientWalletProvider={recipientWalletProvider}
+        confirmedAt={confirmedAt}
       />
+
+      <div className={styles.buttonRow}>
+        <Button
+          variant="secondary"
+          size="lg"
+          label="View on explorer"
+          showIcon={false}
+          onClick={onViewExplorer}
+          disabled={!explorerUrl}
+        />
+        <Button
+          variant="primary"
+          size="lg"
+          label="Go to dashboard"
+          showIcon={false}
+          onClick={onGoToDashboard}
+        />
+      </div>
     </div>
   )
 }

--- a/apps/armada-interface/src/components/payments/SendInputStep.module.css
+++ b/apps/armada-interface/src/components/payments/SendInputStep.module.css
@@ -4,8 +4,17 @@
 .sendContent {
   display: flex;
   flex-direction: column;
-  gap: var(--primitives-spacing-6);
+  gap: var(--primitives-spacing-8);
   width: 100%;
+}
+
+/* Serif display title for the send/withdraw amount step (matches the flow mockup). */
+.title {
+  composes: displayLg from '../../design/styles/displayLgTitle.module.css';
+  margin: 0;
+  width: 100%;
+  color: var(--semantic-color-text-primary);
+  text-align: center;
 }
 
 .amountGroup {

--- a/apps/armada-interface/src/components/payments/SendInputStep.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendInputStep.test.tsx
@@ -1,4 +1,4 @@
-// ABOUTME: Tests for SendInputStep (amount step) — static chain display, amount gating, xchain notice, variant copy, Back/Review actions.
+// ABOUTME: Tests for SendInputStep (amount step) — no chain row, percent pills, amount gating, xchain notice, variant copy, Back/Review actions.
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
@@ -44,22 +44,35 @@ function setup(extras?: Partial<SendInputStepProps>) {
 }
 
 describe('<SendInputStep>', () => {
-  it('renders the send amount question', () => {
+  it('renders the amount question', () => {
     setup()
-    expect(screen.getByText(/How much USDC do you want to send/)).toBeInTheDocument()
+    expect(screen.getByText('How much USDC?')).toBeInTheDocument()
   })
 
-  it('withdraw variant: uses withdraw copy + the "Withdrawal amount" field', () => {
+  it('withdraw variant: keeps the static title + exposes the "Withdrawal amount" field', () => {
     setup({ variant: 'withdraw' })
-    expect(screen.getByText(/How much USDC do you want to withdraw/)).toBeInTheDocument()
+    expect(screen.getByText('How much USDC?')).toBeInTheDocument()
     expect(screen.getByLabelText('Withdrawal amount')).toBeInTheDocument()
   })
 
-  it('renders the chain statically (no interactive chain dropdown here)', () => {
-    setup()
-    // Chain is chosen on the recipient step; DepositAmountCard gets no onChainIdChange → static.
+  it('hides the chain row entirely (chosen on the recipient step; not in the mockup)', () => {
+    setup({ destChainId: 31337 })
+    // No chain name, no dropdown — the send amount card has no chain row.
+    expect(screen.queryByText(/Anvil Hub/)).toBeNull()
     expect(screen.queryByRole('listbox')).toBeNull()
-    expect(screen.queryByRole('button', { name: /Network/i })).toBeNull()
+  })
+
+  it('renders the 25% / 50% / 75% / Max percent pills', () => {
+    setup()
+    for (const label of ['25%', '50%', '75%', 'Max']) {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument()
+    }
+  })
+
+  it('a percent pill sets the amount to that fraction of the input cap', () => {
+    const props = setup({ maxInput: 5_000_000n, max: 5_000_000n })
+    fireEvent.click(screen.getByRole('button', { name: '50%' }))
+    expect(props.onAmountChange).toHaveBeenCalledWith('2.5')
   })
 
   it('gates Review on the amount — too much shows an error and disables Review', () => {

--- a/apps/armada-interface/src/components/payments/SendInputStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendInputStep.tsx
@@ -1,4 +1,4 @@
-// ABOUTME: Send/Withdraw amount step — DepositAmountCard (chain shown statically; chosen on the recipient step) + gas notice.
+// ABOUTME: Send/Withdraw amount step — DepositAmountCard (no chain row; chosen on the recipient step) + percent pills + gas notice.
 // ABOUTME: Recipient + chain live on the preceding recipient step, so this step gates only on the amount.
 
 import { useMemo } from 'react'
@@ -12,7 +12,6 @@ import { useGasBalanceWarning } from '@/hooks/useGasBalanceWarning'
 import { getAllChainIdentities } from '@/config/network'
 import { formatUsdcPlain, parseUsdcInput, usdcInputErrorMessage } from '@/lib/format'
 import { hasActiveAmount } from '@/utils/amountInput'
-import shieldStyles from '@/components/shield/ShieldInputStep.module.css'
 import type { SendFlowVariant } from './SendRecipientStep'
 import styles from './SendInputStep.module.css'
 
@@ -88,20 +87,15 @@ export function SendInputStepContent({
   const amountError = usdcInputErrorMessage(parseError)
     ?? (tooMuch ? 'Amount exceeds your private balance after fees.' : undefined)
 
-  const question =
-    variant === 'withdraw'
-      ? 'How much USDC do you want to withdraw?'
-      : 'How much USDC do you want to send?'
-
   return (
     <div className={styles.sendContent}>
-      <p className={shieldStyles.question}>{question}</p>
+      <h1 className={styles.title}>How much USDC?</h1>
       <div className={styles.amountGroup}>
         <DepositAmountCard
           chains={allChains}
           chainId={destChainId}
-          // No onChainIdChange — the chain is chosen on the recipient step, so it renders as
-          // static text here.
+          // The chain is chosen on the recipient step; the mockup's send amount card has no chain row.
+          showChain={false}
           amount={amountStr}
           onAmountChange={onAmountChange}
           balance={formatUsdcPlain(max)}
@@ -109,6 +103,8 @@ export function SendInputStepContent({
           displayFees={displayFees}
           flowBreakdown={flowBreakdown}
           feeLoading={feeLoading}
+          // maxInput drives the 25% / 50% / 75% / Max percent pills; onMax keeps the exact fee-aware cap.
+          maxInput={maxInput}
           onMax={() => onAmountChange(formatUsdcPlain(maxInput))}
           error={amountError}
           amountAriaLabel={variant === 'withdraw' ? 'Withdrawal amount' : 'Send amount'}

--- a/apps/armada-interface/src/components/payments/SendModal.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.test.tsx
@@ -12,6 +12,7 @@ import {
   shieldedUsdcSpendableAtom,
 } from '@/state/wallet'
 import { feeQuoteAtom, feeQuoteFetchedAtAtom } from '@/state/fees'
+import { getChainById } from '@/config/network'
 import { withTestQueryClient } from '@/test-utils/queryClient'
 
 // useDisplayFees + useGasBalanceWarning hit wagmi hooks that require a WagmiProvider; these
@@ -20,6 +21,13 @@ import { withTestQueryClient } from '@/test-utils/queryClient'
 vi.mock('@/lib/tx/executor', async (importActual) => ({
   ...await importActual<typeof import('@/lib/tx/executor')>(),
   getIsLeader: () => true,
+}))
+
+// SendModal reads the connected wallet's connector via wagmi's useAccount to brand the recipient
+// row glyph; these tests don't mount a WagmiProvider, so stub it with a MetaMask connector.
+vi.mock('wagmi', async (importOriginal) => ({
+  ...await importOriginal<typeof import('wagmi')>(),
+  useAccount: () => ({ connector: { name: 'MetaMask' } }),
 }))
 
 vi.mock('@/hooks/useDisplayFees', () => ({
@@ -100,11 +108,14 @@ function renderModal(opts?: {
   return store
 }
 
-/** Advance the recipient step: type an address, (optionally) pick a chain, click Continue. */
+/** Advance the recipient step: type an address, (optionally) pick a chain via the popover, click Continue. */
 function completeRecipientStep(recipient: string, chainValue?: string) {
   fireEvent.change(screen.getByLabelText('Recipient address'), { target: { value: recipient } })
   if (chainValue !== undefined) {
-    fireEvent.change(screen.getByLabelText('Destination chain'), { target: { value: chainValue } })
+    // Open the styled chain popover and click the option whose label matches the chainId.
+    fireEvent.click(screen.getByLabelText('Destination chain'))
+    const name = getChainById(Number(chainValue))?.name ?? chainValue
+    fireEvent.click(screen.getByRole('option', { name }))
   }
   fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
 }
@@ -121,12 +132,13 @@ describe('<SendModal>', () => {
     expect(screen.getByLabelText('Recipient address')).toBeInTheDocument()
   })
 
-  it('Continue is disabled until the recipient is a valid address', () => {
+  it('Continue reveals only once the recipient is a valid address', () => {
     renderModal({ open: 'payment', shielded: 10_000_000n })
-    expect(screen.getByRole('button', { name: /Continue/ })).toBeDisabled()
+    // Empty + invalid: no footer, so no Continue button at all (matches the mockup).
+    expect(screen.queryByRole('button', { name: /Continue/ })).toBeNull()
     fireEvent.change(screen.getByLabelText('Recipient address'), { target: { value: 'not-an-address' } })
     expect(screen.getByRole('alert')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Continue/ })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: /Continue/ })).toBeNull()
     fireEvent.change(screen.getByLabelText('Recipient address'), { target: { value: VALID_0ZK } })
     expect(screen.getByRole('button', { name: /Continue/ })).not.toBeDisabled()
   })
@@ -143,29 +155,30 @@ describe('<SendModal>', () => {
     expect(screen.getByLabelText('Destination chain')).toBeInTheDocument()
   })
 
-  it('0zk recipient → transfer-shielded: review shows "Private transfer"', () => {
+  it('0zk recipient → transfer-shielded: review shows the "Private" privacy row + no network row', () => {
     renderModal({ open: 'payment', shielded: 10_000_000n })
     completeRecipientStep(VALID_0ZK)
     fireEvent.change(screen.getByLabelText('Send amount'), { target: { value: '3' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
-    expect(screen.getByText('Private transfer')).toBeInTheDocument()
+    expect(screen.getByText('Private')).toBeInTheDocument()
+    expect(screen.queryByText('Network')).toBeNull()
   })
 
-  it('0x recipient to hub → unshield-local: review shows "External wallet", no cross-chain tag', () => {
+  it('0x recipient to hub → unshield-local: review shows the "Public" privacy row + hub network', () => {
     renderModal({ open: 'payment', shielded: 10_000_000n })
     completeRecipientStep(VALID_EVM, '31337')
     fireEvent.change(screen.getByLabelText('Send amount'), { target: { value: '3' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
-    expect(screen.getByText('External wallet')).toBeInTheDocument()
-    expect(screen.queryByText('cross-chain')).toBeNull()
+    expect(screen.getByText('Public')).toBeInTheDocument()
+    expect(screen.getByText(/Anvil Hub/)).toBeInTheDocument()
   })
 
-  it('0x recipient to a client chain → unshield-xchain: review shows the cross-chain tag', () => {
+  it('0x recipient to a client chain → unshield-xchain: review shows the client network name', () => {
     renderModal({ open: 'payment', shielded: 10_000_000n })
     completeRecipientStep(VALID_EVM, '31338')
     fireEvent.change(screen.getByLabelText('Send amount'), { target: { value: '3' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
-    expect(screen.getByText('cross-chain')).toBeInTheDocument()
+    expect(screen.getByText(/Anvil Client A/)).toBeInTheDocument()
   })
 
   it('transfer-shielded Confirm advances to the progress step', async () => {
@@ -207,9 +220,9 @@ describe('<SendModal>', () => {
     })
   })
 
-  it('Cancel on the recipient step closes the modal', () => {
+  it('the close button closes the modal', () => {
     const store = renderModal({ open: 'payment', shielded: 10_000_000n })
-    fireEvent.click(screen.getByRole('button', { name: /Cancel/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
     expect(store.get(openModalAtom)).toBeNull()
   })
 
@@ -218,15 +231,15 @@ describe('<SendModal>', () => {
     completeRecipientStep(VALID_0ZK)
     // On the amount step now — go Back.
     fireEvent.click(screen.getByRole('button', { name: /Back/ }))
-    // Recipient input is editable again and retains the typed value.
-    expect(screen.getByLabelText('Recipient address')).toHaveValue(VALID_0ZK)
+    // Recipient input retains the address (shown middle-truncated when blurred; full value in `title`).
+    expect(screen.getByLabelText('Recipient address')).toHaveAttribute('title', VALID_0ZK)
   })
 
   describe('withdraw variant', () => {
     it('opens with the "Withdraw" title and prefills the connected wallet', () => {
       renderModal({ open: 'withdraw', shielded: 10_000_000n, evm: VALID_EVM })
       expect(screen.getByRole('dialog', { name: 'Withdraw' })).toBeInTheDocument()
-      expect(screen.getByLabelText('Recipient address')).toHaveValue(VALID_EVM)
+      expect(screen.getByLabelText('Recipient address')).toHaveAttribute('title', VALID_EVM)
     })
 
     it('the prefilled recipient is editable — can withdraw to any other 0x address', async () => {

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -2,14 +2,20 @@
 // ABOUTME: One variant-driven modal (send | withdraw). Mounts three useTx hooks (transfer-shielded / unshield-local / unshield-xchain); submitted-kind state locks the subscription for the rest of the flow.
 
 import { useEffect, useRef, useState } from 'react'
+import { useAccount } from 'wagmi'
 import { useAtom, useAtomValue } from 'jotai'
 import { openModalAtom } from '@/state/ui'
 import { preferencesAtom } from '@/state/preferences'
-import { evmAddressAtom, shieldedUsdcAtom, shieldedUsdcSpendableAtom } from '@/state/wallet'
+import {
+  evmAddressAtom,
+  shieldedUsdcAtom,
+  shieldedUsdcSpendableAtom,
+  shieldedWalletAtom,
+} from '@/state/wallet'
 import { useTx } from '@/hooks/useTx'
 import { useFees } from '@/hooks/useFees'
 import { useSpendableSyncGate } from '@/hooks/useSpendableSyncGate'
-import { getNetworkConfig } from '@/config/network'
+import { getChainById, getNetworkConfig } from '@/config/network'
 import {
   findDeploymentForChain,
   loadDeployments,
@@ -23,14 +29,12 @@ import { canRetryTx } from '@/lib/tx/executor'
 import { trackError } from '@/lib/telemetry'
 import { assertSpendableForFeeOnTop } from '@/lib/tx/spendable'
 import {
-  overlayIndicatorStep,
-  overlayIndicatorStatus,
   ProgressStep,
   ErrorStep,
   type FlowStep,
   type FlowVisibleStep,
 } from '@/components/flow'
-import { DepositOverlayShell } from '@/components/deposit/DepositOverlayShell/DepositOverlayShell'
+import { FlowShell } from '@/components/flow/FlowShell'
 import { SendRecipientStep, type SendFlowVariant } from './SendRecipientStep'
 import { SendInputStepContent, SendInputStepFooter } from './SendInputStep'
 import { useDisplayFees } from '@/hooks/useDisplayFees'
@@ -57,9 +61,16 @@ export function SendModal() {
   // A6 — frozen into the record's meta at submit-time so a mid-flight toggle doesn't strand the handler.
   const prefs = useAtomValue(preferencesAtom)
 
+  // The user's own shielded (Armada) address — rendered as the review/complete summary's
+  // "From your private account" row. Optional; the row is omitted when locked/absent.
+  const shieldedWallet = useAtomValue(shieldedWalletAtom)
+
   // Form state
   const hubChainId = getNetworkConfig().hub.chainId
   const connectedEvm = useAtomValue(evmAddressAtom)
+  // Connected wallet provider name (wagmi connector) — brands the recipient row glyph when the
+  // recipient is the user's own wallet (e.g. withdraw-to-self); mirrors the deposit "From your wallet" row.
+  const { connector } = useAccount()
   const [destChainId, setDestChainId] = useState<number>(hubChainId)
   const [recipient, setRecipient] = useState<string>('')
   const [amountStr, setAmountStr] = useState<string>('')
@@ -317,20 +328,38 @@ export function SendModal() {
 
   if (!isOpen) return null
 
-  // The recipient step precedes the 3-segment indicator (Amount / Review / Confirm); it maps to
-  // step 1 for now. The restyle PR adds a dedicated Recipient segment.
-  const indicatorStep = step === 'recipient' ? 1 : overlayIndicatorStep(step)
-  const indicatorStatus = step === 'recipient' ? 'default' : overlayIndicatorStatus(step)
+  // FlowShell renders a 4-segment Steps indicator (Recipient / Amount / Review / Confirm).
+  // progress / complete / error all map to the final Confirm segment; the ErrorStep itself owns
+  // the retry button + copy.
+  const currentStep =
+    step === 'recipient' ? 1
+    : step === 'input' ? 2
+    : step === 'review' ? 3
+    : 4
+  const status: 'default' | 'confirmed' | 'error' =
+    step === 'complete' ? 'confirmed'
+    : step === 'error' ? 'error'
+    : 'default'
   const flowLabel = variant === 'withdraw' ? 'Withdraw' : 'Send'
+  // Destination chain name for the summary's Network row — public (0x) recipients only; a private
+  // (0zk) transfer has no destination-chain concept.
+  const networkName = isPrivate ? undefined : getChainById(destChainId)?.name
+  // Brand the public recipient's glyph only when it's the user's own connected wallet — for an
+  // arbitrary recipient we don't know their provider, so the summary shows a generic wallet glyph.
+  const recipientIsConnectedWallet =
+    !isPrivate &&
+    connectedEvm != null &&
+    recipient.trim().toLowerCase() === connectedEvm.toLowerCase()
+  const recipientWalletProvider = recipientIsConnectedWallet ? connector?.name : undefined
 
   return (
-    <DepositOverlayShell
-      open
+    <FlowShell
+      open={isOpen}
       onClose={close}
-      dismissible={true}
       flowLabel={flowLabel}
-      currentStep={indicatorStep}
-      status={indicatorStatus}
+      steps={['Recipient', 'Amount', 'Review', 'Confirm']}
+      currentStep={currentStep}
+      status={status}
     >
       <RelayerStatusBanner isOpen={isOpen} />
       {step === 'recipient' && (
@@ -341,7 +370,6 @@ export function SendModal() {
           destChainId={destChainId}
           onDestChainIdChange={setDestChainId}
           destDeploymentError={destDeploymentError}
-          onCancel={close}
           onContinue={() => setStep('input')}
         />
       )}
@@ -378,13 +406,13 @@ export function SendModal() {
       {step === 'review' && (
         <SendReviewStep
           variant={variant}
-          isPrivate={isPrivate}
-          destChainId={destChainId}
           recipient={recipient}
+          armadaAddress={shieldedWallet.shieldedAddress}
           amount={amount}
           fee={displayedFee}
           totalDeducted={totalDeducted}
-          isXchain={isXchain}
+          networkName={networkName}
+          recipientWalletProvider={recipientWalletProvider}
           submitBlockedReason={syncGate.reason}
           onBack={() => setStep('input')}
           isSubmitting={isSubmitting}
@@ -395,15 +423,22 @@ export function SendModal() {
       {step === 'complete' && (
         <SendCompleteStep
           variant={variant}
-          isPrivate={isPrivate}
-          destChainId={destChainId}
           recipient={recipient}
-          recipientReceives={recipientReceives}
+          armadaAddress={shieldedWallet.shieldedAddress}
+          amount={amount}
+          fee={displayedFee}
           totalDeducted={totalDeducted}
+          networkName={networkName}
+          recipientWalletProvider={recipientWalletProvider}
+          confirmedAt={record?.updatedAt ?? Date.now()}
           // Hub-chain explorer link for the on-chain submission. The destination delivery for
           // xchain is a separate event tracked elsewhere; this is the source-chain action.
           explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, displayTxHash(record))}
-          onDone={close}
+          onViewExplorer={() => {
+            const url = txExplorerUrl(record?.walletContext.sourceChainId, displayTxHash(record))
+            if (url) window.open(url, '_blank', 'noopener,noreferrer')
+          }}
+          onGoToDashboard={close}
         />
       )}
       {step === 'error' && (
@@ -445,6 +480,6 @@ export function SendModal() {
           }
         />
       )}
-    </DepositOverlayShell>
+    </FlowShell>
   )
 }

--- a/apps/armada-interface/src/components/payments/SendRecipientStep.module.css
+++ b/apps/armada-interface/src/components/payments/SendRecipientStep.module.css
@@ -1,14 +1,123 @@
-/* ABOUTME: SendRecipientStep layout — question, recipient field, privacy indicator, optional chain selector. */
+/* ABOUTME: Send/Withdraw recipient step — serif prompt, neutral-50 address pill (Paste/Clear), and a reveal footer (privacy badge + Continue). */
+/* ABOUTME: Ported from the armada-app SendRecipientScreen mockup. */
 
 .root {
   display: flex;
   flex-direction: column;
-  gap: var(--primitives-spacing-6);
+  gap: var(--primitives-spacing-8);
   width: 100%;
 }
 
-.privacyIndicator {
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-8);
+  width: 100%;
+}
+
+.title {
+  composes: displayLg from '../../design/styles/displayLgTitle.module.css';
+  margin: 0;
+  width: 100%;
+  color: var(--semantic-color-text-primary);
+  text-align: center;
+}
+
+.addressBlock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+}
+
+.addressField {
+  display: flex;
+  align-items: center;
+  gap: var(--primitives-spacing-5);
+  width: 100%;
+  height: var(--primitives-spacing-16);
+  padding: 0 var(--primitives-spacing-5);
+  border-radius: calc(var(--primitives-spacing-5) / 2);
+  background: var(--primitives-color-neutral-50);
+  box-sizing: border-box;
+}
+
+.addressInput {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-family: var(--primitives-fontFamily-mono), ui-monospace, monospace;
+  /* ≥16px prevents iOS Safari zoom-on-focus */
+  font-size: calc(var(--primitives-fontSize-lg) * 1px);
+  font-weight: var(--primitives-fontWeight-medium);
+  color: var(--semantic-color-text-primary);
+  outline: none;
+  height: 100%;
+  overflow: hidden;
+  text-overflow: clip;
+}
+
+.addressInput::placeholder {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-weight: var(--primitives-fontWeight-regular);
+  color: var(--semantic-color-text-muted);
+}
+
+.pasteButton {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--primitives-spacing-8);
+  padding: 0 var(--primitives-spacing-4);
+  border: none;
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  background: var(--semantic-color-brand-lavender);
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  font-weight: var(--primitives-fontWeight-medium);
+  color: var(--semantic-color-text-primary);
+  cursor: pointer;
+  transition: transform 0.1s ease, opacity 0.15s ease;
+}
+
+.pasteButton:hover {
+  opacity: 0.92;
+}
+
+.pasteButton:active {
+  transform: translateY(1px);
+}
+
+.clearButton {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--primitives-spacing-8);
+  height: var(--primitives-spacing-8);
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  background: var(--semantic-color-surface-hover);
   color: var(--semantic-color-text-secondary);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.clearButton:hover {
+  color: var(--semantic-color-text-primary);
+  background: var(--semantic-color-surface-raised);
+}
+
+.clearIcon {
+  width: var(--primitives-spacing-4);
+  height: var(--primitives-spacing-4);
+  display: block;
 }
 
 .chainSlot {
@@ -16,9 +125,110 @@
 }
 
 .destError {
-  background: rgba(248, 113, 113, 0.08);
-  border: 1px solid rgba(248, 113, 113, 0.24);
-  border-radius: calc(var(--semantic-borderRadius-input) * 1px);
-  padding: var(--primitives-spacing-3) var(--primitives-spacing-4);
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
   color: var(--semantic-color-status-error);
+}
+
+/* Reveal footer — appears once the address is valid. */
+.footer {
+  flex-shrink: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--primitives-spacing-5);
+  box-sizing: border-box;
+}
+
+.actionRowReveal {
+  opacity: 0;
+  animation: recipientActionEnter 360ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  will-change: opacity, transform;
+}
+
+@keyframes recipientActionEnter {
+  from {
+    opacity: 0;
+    transform: translate3d(0, var(--primitives-spacing-2), 0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+.privacyBadge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+  min-width: 0;
+}
+
+.privacyIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  color: var(--semantic-component-tag-label);
+}
+
+.brandBadge {
+  border-radius: calc(var(--semantic-borderRadius-button) * 1px);
+  background: linear-gradient(
+    to bottom,
+    var(--semantic-component-button-gradient-default-from),
+    var(--semantic-component-button-gradient-default-to)
+  );
+}
+
+.brandMark {
+  width: var(--primitives-spacing-5);
+  height: var(--primitives-spacing-5);
+  color: var(--semantic-component-tag-label);
+}
+
+.privacyIconPublic {
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  background: var(--semantic-color-text-primary);
+}
+
+.privacyIconSvg {
+  width: var(--primitives-spacing-5);
+  height: var(--primitives-spacing-5);
+}
+
+.privacyCopy {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--primitives-spacing-1);
+  min-width: 0;
+  text-align: center;
+}
+
+.privacyTitle {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  font-weight: var(--primitives-fontWeight-semibold);
+  line-height: var(--primitives-lineHeight-tight);
+  color: var(--semantic-color-text-primary);
+}
+
+.privacySubtitle {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  font-weight: var(--primitives-fontWeight-regular);
+  line-height: var(--primitives-lineHeight-tight);
+  color: var(--semantic-color-text-secondary);
+}
+
+.continueButton {
+  width: 100%;
+  max-width: none;
 }

--- a/apps/armada-interface/src/components/payments/SendRecipientStep.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendRecipientStep.test.tsx
@@ -1,4 +1,5 @@
-// ABOUTME: Tests for SendRecipientStep — address validity gating, private/public indicator, chain selector visibility, deployment-error gating, actions.
+// ABOUTME: Tests for SendRecipientStep — address validity, private/public reveal badge, chain-selector visibility, deployment-error gating, Continue.
+// ABOUTME: The footer (privacy badge + Continue) reveals only once the address is valid — matches the mockup (no persistent buttons).
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
@@ -15,7 +16,6 @@ function setup(extras?: Partial<SendRecipientStepProps>) {
     destChainId: extras?.destChainId ?? 31337,
     onDestChainIdChange: extras?.onDestChainIdChange ?? vi.fn(),
     destDeploymentError: extras?.destDeploymentError,
-    onCancel: extras?.onCancel ?? vi.fn(),
     onContinue: extras?.onContinue ?? vi.fn(),
   }
   render(<SendRecipientStep {...props} />)
@@ -23,49 +23,48 @@ function setup(extras?: Partial<SendRecipientStepProps>) {
 }
 
 describe('<SendRecipientStep>', () => {
-  it('send variant: asks who to send to', () => {
+  it('prompts "Where do you want to send your USDC?" (both variants)', () => {
     setup()
-    expect(screen.getByText(/Who do you want to send USDC to/)).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Where do you want to/ })).toBeInTheDocument()
   })
 
-  it('withdraw variant: asks where to withdraw', () => {
-    setup({ variant: 'withdraw' })
-    expect(screen.getByText(/Where do you want to withdraw your USDC/)).toBeInTheDocument()
-  })
-
-  it('disables Continue while the recipient is empty', () => {
+  it('shows no Continue button while the recipient is empty', () => {
     setup()
-    expect(screen.getByRole('button', { name: /Continue/ })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: /Continue/ })).toBeNull()
   })
 
-  it('shows an error and disables Continue for a malformed address', () => {
+  it('shows an error and no Continue for a malformed address', () => {
     setup({ recipient: 'nonsense' })
     expect(screen.getByRole('alert')).toHaveTextContent(/valid shielded .* or public wallet/i)
-    expect(screen.getByRole('button', { name: /Continue/ })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: /Continue/ })).toBeNull()
   })
 
-  it('0zk recipient: private indicator, no chain selector, Continue enabled', () => {
+  it('0zk recipient: private badge, no chain selector, Continue enabled', () => {
     setup({ recipient: VALID_0ZK })
-    expect(screen.getByText(/Private transfer/)).toBeInTheDocument()
+    expect(screen.getByText('Private address')).toBeInTheDocument()
     expect(screen.queryByLabelText('Destination chain')).toBeNull()
     expect(screen.getByRole('button', { name: /Continue/ })).not.toBeDisabled()
   })
 
-  it('0x recipient: public indicator + chain selector, Continue enabled', () => {
+  it('0x recipient: public badge + chain selector, Continue enabled', () => {
     setup({ recipient: VALID_EVM })
-    expect(screen.getByText(/Public transfer/)).toBeInTheDocument()
+    expect(screen.getByText('Public address')).toBeInTheDocument()
     expect(screen.getByLabelText('Destination chain')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Continue/ })).not.toBeDisabled()
   })
 
   it('fires onDestChainIdChange when the chain selection changes', () => {
     const props = setup({ recipient: VALID_EVM })
-    fireEvent.change(screen.getByLabelText('Destination chain'), { target: { value: '31338' } })
+    fireEvent.click(screen.getByLabelText('Destination chain'))
+    fireEvent.click(screen.getByRole('option', { name: /Anvil Client A/ }))
     expect(props.onDestChainIdChange).toHaveBeenCalledWith(31338)
   })
 
   it('gates Continue + surfaces the deployment error when the chosen chain has no manifest', () => {
-    setup({ recipient: VALID_EVM, destDeploymentError: 'This destination chain has no deployment manifest. Pick another chain.' })
+    setup({
+      recipient: VALID_EVM,
+      destDeploymentError: 'This destination chain has no deployment manifest. Pick another chain.',
+    })
     expect(screen.getByRole('alert')).toHaveTextContent(/no deployment manifest/i)
     expect(screen.getByRole('button', { name: /Continue/ })).toBeDisabled()
   })
@@ -74,11 +73,5 @@ describe('<SendRecipientStep>', () => {
     const props = setup({ recipient: VALID_0ZK })
     fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
     expect(props.onContinue).toHaveBeenCalledTimes(1)
-  })
-
-  it('fires onCancel from the Cancel button', () => {
-    const props = setup()
-    fireEvent.click(screen.getByRole('button', { name: /Cancel/ }))
-    expect(props.onCancel).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/armada-interface/src/components/payments/SendRecipientStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendRecipientStep.tsx
@@ -1,11 +1,13 @@
-// ABOUTME: Send/Withdraw recipient step — editable address (0zk or 0x) + a destination-chain selector shown only for public 0x recipients.
-// ABOUTME: Address format drives the flow kind downstream; a privacy indicator tells the user whether this send stays shielded (0zk) or exits to a public wallet (0x).
+// ABOUTME: Send/Withdraw recipient step — serif prompt, a pill address input (0zk or 0x) with Paste/Clear,
+// ABOUTME: a public-only destination-chain selector, and a reveal footer (privacy badge + Continue) once the address is valid.
 
-import { Button } from '@/design'
-import { depositOverlayShellStyles } from '@/components/deposit/DepositOverlayShell/DepositOverlayShell'
-import { ChainSelect, RecipientInput } from '@/components/ui'
+import { useState } from 'react'
+import { XMarkIcon, GlobeAltIcon } from '@heroicons/react/24/outline'
+import { ArmadaLogo, Button } from '@/design'
+import { modalStepBodyEnter } from '@/design'
+import { ChainSelect } from '@/components/ui'
 import { isShieldedAddress, validateEvmAddress } from '@/lib/address'
-import shieldStyles from '@/components/shield/ShieldInputStep.module.css'
+import { truncateAddress } from '@/lib/format'
 import styles from './SendRecipientStep.module.css'
 
 /** Which flow the shared Send/Withdraw modal is running as — drives minimal copy differences. */
@@ -19,89 +21,146 @@ export interface SendRecipientStepProps {
   onDestChainIdChange: (chainId: number) => void
   /** Surfaced when the chosen public destination chain has no deployment manifest. */
   destDeploymentError?: string
-  onCancel: () => void
   onContinue: () => void
 }
 
 export function SendRecipientStep({
-  variant,
+  // `variant` is retained on the props (the modal passes it) but the prompt is intentionally
+  // "Where do you want to send your USDC?" for both send + withdraw (per design).
   recipient,
   onRecipientChange,
   destChainId,
   onDestChainIdChange,
   destDeploymentError,
-  onCancel,
   onContinue,
 }: SendRecipientStepProps) {
+  const [inputFocused, setInputFocused] = useState(false)
+
   const recipientTrimmed = recipient.trim()
+  const hasInput = recipientTrimmed.length > 0
   const isPrivate = isShieldedAddress(recipientTrimmed)
   const evmValidation = validateEvmAddress(recipientTrimmed)
   // A public recipient is a valid 0x address that is NOT a shielded 0zk address.
   const isPublic = !isPrivate && evmValidation.valid
   const recipientValid = isPrivate || isPublic
-  const recipientInvalid = recipientTrimmed.length > 0 && !recipientValid
+  const recipientInvalid = hasInput && !recipientValid
   const recipientError = recipientInvalid
     ? evmValidation.error === 'checksum'
       ? 'Address checksum mismatch — double-check for typos.'
       : 'Enter a valid shielded (0zk…) or public wallet (0x…) address.'
     : undefined
 
-  const question =
-    variant === 'withdraw'
-      ? 'Where do you want to withdraw your USDC?'
-      : 'Who do you want to send USDC to?'
+  // Full address while focused/editing; middle-truncated when blurred so long addresses stay legible.
+  const inputDisplayValue = inputFocused || !hasInput ? recipient : truncateAddress(recipientTrimmed)
+
+  async function handlePaste() {
+    try {
+      const text = await navigator.clipboard.readText()
+      if (text.trim()) onRecipientChange(text.trim())
+    } catch {
+      // Clipboard read blocked/unavailable — no-op; the user can still type/paste manually.
+    }
+  }
 
   const canContinue = recipientValid && !destDeploymentError
 
   return (
     <div className={styles.root}>
-      <p className={shieldStyles.question}>{question}</p>
-      <RecipientInput
-        label="Recipient address"
-        value={recipient}
-        onValueChange={onRecipientChange}
-        error={recipientError}
-        placeholder="0zk… or 0x…"
-      />
-      {recipientValid ? (
-        <div className={styles.privacyIndicator} role="status">
-          {isPrivate
-            ? 'Private transfer — stays inside the shielded pool.'
-            : 'Public transfer — funds leave the shielded pool to a wallet address.'}
+      <div className={[styles.body, modalStepBodyEnter].join(' ')}>
+        <h1 className={styles.title}>
+          Where do you want to
+          <br />
+          send your USDC?
+        </h1>
+
+        <div className={styles.addressBlock}>
+          <div className={styles.addressField}>
+            <input
+              className={styles.addressInput}
+              type="text"
+              value={inputDisplayValue}
+              title={recipientTrimmed || undefined}
+              onChange={(e) => onRecipientChange(e.target.value)}
+              onFocus={() => setInputFocused(true)}
+              onBlur={() => setInputFocused(false)}
+              placeholder="Enter address"
+              spellCheck={false}
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              aria-label="Recipient address"
+              aria-invalid={recipientInvalid || undefined}
+            />
+            {!hasInput ? (
+              <button type="button" className={styles.pasteButton} onClick={() => void handlePaste()}>
+                Paste
+              </button>
+            ) : (
+              <button
+                type="button"
+                className={styles.clearButton}
+                aria-label="Clear address"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => onRecipientChange('')}
+              >
+                <XMarkIcon className={styles.clearIcon} strokeWidth={2} aria-hidden />
+              </button>
+            )}
+          </div>
+
+          {/* Chain selection only applies to public 0x recipients; a 0zk transfer stays on the hub. */}
+          {isPublic ? (
+            <div className={styles.chainSlot}>
+              <ChainSelect label="Destination chain" value={destChainId} onChange={onDestChainIdChange} />
+            </div>
+          ) : null}
+
+          {recipientError ? (
+            <div className={styles.destError} role="alert">
+              {recipientError}
+            </div>
+          ) : null}
+          {destDeploymentError ? (
+            <div className={styles.destError} role="alert">
+              {destDeploymentError}
+            </div>
+          ) : null}
         </div>
-      ) : null}
-      {/* Chain selection only applies to public 0x recipients; a 0zk transfer stays on the hub. */}
-      {isPublic ? (
-        <div className={styles.chainSlot}>
-          <ChainSelect
-            label="Destination chain"
-            value={destChainId}
-            onChange={onDestChainIdChange}
+      </div>
+
+      {/* Footer reveals only once the address is valid (matches the mockup — no persistent buttons). */}
+      {recipientValid ? (
+        <div className={[styles.footer, styles.actionRowReveal].join(' ')}>
+          <div className={styles.privacyBadge}>
+            <span
+              className={[styles.privacyIcon, isPrivate ? styles.brandBadge : styles.privacyIconPublic]
+                .join(' ')}
+              aria-hidden
+            >
+              {isPrivate ? (
+                <ArmadaLogo variant="mark" markTone="white" className={styles.brandMark} />
+              ) : (
+                <GlobeAltIcon className={styles.privacyIconSvg} strokeWidth={1.75} />
+              )}
+            </span>
+            <div className={styles.privacyCopy}>
+              <span className={styles.privacyTitle}>{isPrivate ? 'Private address' : 'Public address'}</span>
+              <span className={styles.privacySubtitle}>
+                {isPrivate ? 'Transaction will be fully private' : "Transfer won't be fully private"}
+              </span>
+            </div>
+          </div>
+          <Button
+            variant="primary"
+            size="lg"
+            label="Continue"
+            showIcon={false}
+            className={styles.continueButton}
+            disabled={!canContinue}
+            onClick={onContinue}
           />
         </div>
       ) : null}
-      {destDeploymentError ? (
-        <div className={styles.destError} role="alert">
-          {destDeploymentError}
-        </div>
-      ) : null}
-      <div className={depositOverlayShellStyles.buttonRow}>
-        <Button
-          variant="secondary"
-          size="lg"
-          label="Cancel"
-          showIcon={false}
-          onClick={onCancel}
-        />
-        <Button
-          variant="primary"
-          size="lg"
-          label="Continue"
-          showIcon={false}
-          disabled={!canContinue}
-          onClick={onContinue}
-        />
-      </div>
     </div>
   )
 }

--- a/apps/armada-interface/src/components/payments/SendReviewStep.module.css
+++ b/apps/armada-interface/src/components/payments/SendReviewStep.module.css
@@ -1,82 +1,65 @@
-/* ABOUTME: SendReviewStep styling — matches UnshieldReviewStep proportions (hero numeral + facts grid + footer). */
-/* ABOUTME: Cross-chain tag reuses the amber accent so the visual vocabulary stays consistent across flows. */
+/* ABOUTME: SendReviewStep layout — serif title, coin+amount block, sync-gate notice, two-button CTA row. */
+/* ABOUTME: The send/withdraw summary table itself lives in the shared TransferReviewSummary component. */
 
 .root {
   display: flex;
   flex-direction: column;
-  gap: var(--primitives-spacing-4);
+  gap: var(--primitives-spacing-8);
 }
 
-.headline {
-  color: var(--semantic-color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: var(--primitives-letterSpacing-wider);
-  font-size: calc(var(--primitives-fontSize-xs) * 1px);
+.title {
+  composes: displayLg from '../../design/styles/displayLgTitle.module.css';
+  margin: 0;
+  width: 100%;
+  color: var(--semantic-color-text-primary);
   text-align: center;
 }
 
-.amountBlock {
+.amountRow {
   display: flex;
-  align-items: baseline;
   justify-content: center;
-  gap: var(--primitives-spacing-3);
+  align-items: center;
+  width: 100%;
 }
 
-.amount {
-  color: var(--semantic-color-text-primary);
-  font-family: "Charis SIL", serif;
-  font-size: calc(var(--primitives-fontSize-5xl) * 1px);
-  line-height: var(--primitives-lineHeight-tight);
-  font-weight: var(--primitives-fontWeight-regular);
-  font-variant-numeric: tabular-nums;
+.amountGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--primitives-spacing-2);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
 }
 
-.unit {
-  color: var(--semantic-color-text-muted);
-  font-size: calc(var(--primitives-fontSize-lg) * 1px);
-}
-
-.facts {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  margin: 0;
-}
-
-.facts > div {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: var(--primitives-spacing-3);
-  padding: var(--primitives-spacing-2) 0;
-  border-bottom: 1px solid var(--semantic-color-border-default);
-}
-
-.facts dt {
-  color: var(--semantic-color-text-muted);
-}
-
-.facts dd {
-  color: var(--semantic-color-text-primary);
-}
-
-.xchainTag {
-  display: inline-block;
-  margin-left: var(--primitives-spacing-2);
-  padding: 2px 8px;
-  background: rgba(243, 208, 160, 0.12);
-  border: 1px solid var(--semantic-color-border-amber);
-  color: var(--semantic-color-text-amber);
+.tokenBadge {
+  width: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
   border-radius: calc(var(--primitives-borderRadius-full) * 1px);
-  text-transform: uppercase;
-  letter-spacing: var(--primitives-letterSpacing-wider);
-  font-size: calc(var(--primitives-fontSize-xs) * 1px);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.recipient {
-  font-family: "Geist Mono", monospace;
+.tokenBadgeIcon {
+  flex-shrink: 0;
+  display: block;
 }
 
+.tokenBadgeIcon :global(svg) {
+  display: block;
+}
+
+.amountValue {
+  display: block;
+  font-weight: var(--primitives-fontWeight-medium);
+  font-size: var(--primitives-spacing-10);
+  line-height: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  color: var(--semantic-color-text-primary);
+}
+
+/* Non-blocking notice while the initial shielded-balance sync is still completing. */
 .syncNotice {
   background: rgba(196, 145, 229, 0.08);
   border: 1px solid var(--semantic-color-border-lavender);
@@ -85,7 +68,14 @@
   color: var(--semantic-color-text-secondary);
 }
 
-.footer {
-  align-self: stretch;
-  margin: var(--primitives-spacing-4) calc(var(--primitives-spacing-6) * -1) calc(var(--primitives-spacing-6) * -1);
+/* Two-button CTA row — send-review mockup: equal-width Back / Confirm, no divider above. */
+.buttonRow {
+  display: flex;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+}
+
+.buttonRow > * {
+  flex: 1;
+  max-width: 211px;
 }

--- a/apps/armada-interface/src/components/payments/SendReviewStep.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendReviewStep.test.tsx
@@ -1,111 +1,75 @@
-// ABOUTME: Tests for SendReviewStep — mode label by isPrivate, optional chain row, cross-chain tag, variant copy, recipient truncation.
+// ABOUTME: Tests for SendReviewStep — privacy row by recipient format, optional network row, variant copy, recipient truncation, CTAs.
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { SendReviewStep } from './SendReviewStep'
+import { SendReviewStep, type SendReviewStepProps } from './SendReviewStep'
 
 const VALID_EVM = '0x1234567890abcdef1234567890abcdef12345678'
 const VALID_0ZK = '0zkabcdefghijklmnopqrstuvwxyz0123456789aaaa'
 
-function renderPrivate() {
-  const onBack = vi.fn()
-  const onConfirm = vi.fn()
-  render(
-    <SendReviewStep
-      variant="send"
-      isPrivate
-      destChainId={31337}
-      recipient={VALID_0ZK}
-      amount={5_000_000n}
-      fee={null}
-      totalDeducted={5_000_000n}
-      isXchain={false}
-      onBack={onBack}
-      onConfirm={onConfirm}
-    />,
-  )
-  return { onBack, onConfirm }
+function renderReview(extras?: Partial<SendReviewStepProps>) {
+  const props: SendReviewStepProps = {
+    variant: extras?.variant ?? 'send',
+    recipient: extras?.recipient ?? VALID_0ZK,
+    armadaAddress: extras?.armadaAddress,
+    amount: extras?.amount ?? 5_000_000n,
+    fee: extras?.fee ?? null,
+    totalDeducted: extras?.totalDeducted ?? 5_000_000n,
+    networkName: extras?.networkName,
+    submitBlockedReason: extras?.submitBlockedReason,
+    isSubmitting: extras?.isSubmitting,
+    onBack: extras?.onBack ?? vi.fn(),
+    onConfirm: extras?.onConfirm ?? vi.fn(),
+  }
+  render(<SendReviewStep {...props} />)
+  return props
 }
 
 describe('<SendReviewStep>', () => {
-  it('private: shows "Private transfer" mode and no chain row', () => {
-    renderPrivate()
-    expect(screen.getByText('Private transfer')).toBeInTheDocument()
-    expect(screen.queryByText('To chain')).toBeNull()
+  it('private: shows the "Private" privacy row and no network row', () => {
+    renderReview({ recipient: VALID_0ZK })
+    expect(screen.getByText('Private')).toBeInTheDocument()
+    expect(screen.queryByText('Network')).toBeNull()
   })
 
-  it('private: truncates 0zk recipient with leading 0zk + ellipsis + last 4 chars', () => {
-    renderPrivate()
-    // 0zkabcd…aaaa
-    expect(screen.getByText(/^0zkabcd…/)).toBeInTheDocument()
+  it('private: truncates the 0zk recipient (6 chars + ellipsis + last 4)', () => {
+    renderReview({ recipient: VALID_0ZK })
+    // truncateAddress → "0zkabc...aaaa"
+    expect(screen.getByText('0zkabc...aaaa')).toBeInTheDocument()
   })
 
-  it('public: shows the chain row and an EVM-style truncated recipient', () => {
-    render(
-      <SendReviewStep
-        variant="send"
-        isPrivate={false}
-        destChainId={31337}
-        recipient={VALID_EVM}
-        amount={5_000_000n}
-        fee={null}
-        totalDeducted={5_000_000n}
-        isXchain={false}
-        onBack={() => {}}
-        onConfirm={() => {}}
-      />,
-    )
-    expect(screen.getByText('To chain')).toBeInTheDocument()
-    expect(screen.getByText(/Anvil Hub/)).toBeInTheDocument()
+  it('public: shows the network row + an EVM-style truncated recipient', () => {
+    renderReview({
+      recipient: VALID_EVM,
+      networkName: 'Anvil Hub (local)',
+    })
+    expect(screen.getByText('Network')).toBeInTheDocument()
+    expect(screen.getByText('Anvil Hub (local)')).toBeInTheDocument()
+    expect(screen.getByText('Public')).toBeInTheDocument()
     expect(screen.getByText('0x1234...5678')).toBeInTheDocument()
   })
 
-  it('public + xchain: shows the cross-chain tag', () => {
-    render(
-      <SendReviewStep
-        variant="send"
-        isPrivate={false}
-        destChainId={31338}
-        recipient={VALID_EVM}
-        amount={5_000_000n}
-        fee={null}
-        totalDeducted={5_000_000n}
-        isXchain
-        onBack={() => {}}
-        onConfirm={() => {}}
-      />,
-    )
-    expect(screen.getByText('cross-chain')).toBeInTheDocument()
-  })
-
-  it('withdraw variant: uses the withdrawal headline + confirm label', () => {
-    render(
-      <SendReviewStep
-        variant="withdraw"
-        isPrivate={false}
-        destChainId={31337}
-        recipient={VALID_EVM}
-        amount={5_000_000n}
-        fee={null}
-        totalDeducted={5_000_000n}
-        isXchain={false}
-        onBack={() => {}}
-        onConfirm={() => {}}
-      />,
-    )
+  it('withdraw variant: uses the withdrawal title + confirm label', () => {
+    renderReview({ variant: 'withdraw', recipient: VALID_EVM, networkName: 'Anvil Hub (local)' })
     expect(screen.getByText('Review your withdrawal')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Confirm withdrawal/ })).toBeInTheDocument()
   })
 
-  it('send variant: fires onConfirm on the primary CTA', () => {
-    const { onConfirm } = renderPrivate()
+  it('send variant: uses the transfer title + fires onConfirm on the primary CTA', () => {
+    const { onConfirm } = renderReview()
+    expect(screen.getByText('Review transfer')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /Confirm send/ }))
     expect(onConfirm).toHaveBeenCalledTimes(1)
   })
 
   it('fires onBack on the secondary CTA', () => {
-    const { onBack } = renderPrivate()
+    const { onBack } = renderReview()
     fireEvent.click(screen.getByRole('button', { name: /^Back/ }))
     expect(onBack).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables Confirm while a submit is in flight', () => {
+    renderReview({ isSubmitting: true })
+    expect(screen.getByRole('button', { name: /Confirm send/ })).toBeDisabled()
   })
 })

--- a/apps/armada-interface/src/components/payments/SendReviewStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendReviewStep.tsx
@@ -1,26 +1,32 @@
-// ABOUTME: Send review step — surfaces the resolved kind label (Private transfer / External wallet ± cross-chain) so the user understands what they're confirming.
-// ABOUTME: Renders the same hero-numeral + facts-grid layout as Shield/Unshield review for consistency across flows.
+// ABOUTME: Send/Withdraw review step — serif title, USDC coin + full-precision amount block, shared TransferReviewSummary table, Confirm/Back CTAs.
+// ABOUTME: Delegates the summary rows (network, private account, recipient, privacy, amount, fees, total) to TransferReviewSummary; keeps the sync-gate notice + submit disabling.
 
-import { FlowFooter } from '@/components/flow/FlowFooter'
-import { FeeSummary } from '@/components/ui'
-import { formatUsdcAmount } from '@/lib/format'
-import { getChainById } from '@/config/network'
-import { truncateAddress } from '@/lib/format'
+import TokenUSDC from '@web3icons/react/icons/tokens/TokenUSDC'
+import { Button } from '@/design'
+import { TransferReviewSummary } from './TransferReviewSummary'
+import { formatUsdcPlain } from '@/lib/format'
+import usdcAmount from '@/design/styles/usdcAmount.module.css'
 import type { SendFlowVariant } from './SendRecipientStep'
 import styles from './SendReviewStep.module.css'
 
+const TOKEN_BADGE_PX = 40
+/** @web3icons branded assets use an 18px circle in a 24px viewBox — scale up to fill the badge. */
+const TOKEN_ICON_SIZE = Math.round((TOKEN_BADGE_PX * 24) / 18)
+
 export interface SendReviewStepProps {
   variant: SendFlowVariant
-  /** True when the recipient is a shielded 0zk address (private transfer); false for public 0x. */
-  isPrivate: boolean
-  destChainId: number
   recipient: string
+  /** The user's own shielded (Armada) address — rendered as the summary's "From your private account" row. */
+  armadaAddress?: string
   amount: bigint
   /** Inclusive Fee total — broadcaster + protocol + CCTP. Tooltip breaks it down on the input card. */
   fee: bigint | null
   /** USDC deducted from the user's shielded balance — `amount + fee` across all three kinds. */
   totalDeducted: bigint
-  isXchain: boolean
+  /** Destination chain name — shown on the summary's Network row for public (0x) recipients. */
+  networkName?: string
+  /** Wallet provider name for a public recipient's brand glyph (only when it's the user's own wallet). */
+  recipientWalletProvider?: string
   submitBlockedReason?: string | null
   /** True while a submit is in flight — disables Confirm so a double-click can't create two txs. */
   isSubmitting?: boolean
@@ -28,81 +34,66 @@ export interface SendReviewStepProps {
   onConfirm: () => void
 }
 
-function truncateRecipient(recipient: string): string {
-  // 0zk shielded addresses are long alphanumeric strings; reuse truncateAddress's 6+4 shape so they
-  // visually match EVM addresses in the same UI surface.
-  if (recipient.startsWith('0zk') && recipient.length > 14) {
-    return `${recipient.slice(0, 7)}…${recipient.slice(-4)}`
-  }
-  return truncateAddress(recipient)
-}
-
 export function SendReviewStep({
   variant,
-  isPrivate,
-  destChainId,
   recipient,
+  armadaAddress,
   amount,
   fee,
   totalDeducted,
-  isXchain,
+  networkName,
+  recipientWalletProvider,
   submitBlockedReason,
   isSubmitting,
   onBack,
   onConfirm,
 }: SendReviewStepProps) {
-  const destChain = isPrivate ? null : getChainById(destChainId)
-  const modeLabel = isPrivate ? 'Private transfer' : 'External wallet'
-  const headline = variant === 'withdraw' ? 'Review your withdrawal' : 'Review send'
+  const title = variant === 'withdraw' ? 'Review your withdrawal' : 'Review transfer'
   const confirmLabel = variant === 'withdraw' ? 'Confirm withdrawal' : 'Confirm send'
 
   return (
     <div className={styles.root}>
-      <div className={styles.headline}>{headline}</div>
-      <div className={styles.amountBlock}>
-        <span className={styles.amount}>{formatUsdcAmount(amount)}</span>
-        <span className={styles.unit}>USDC</span>
+      <h1 className={styles.title}>{title}</h1>
+
+      <div className={styles.amountRow}>
+        <div className={styles.amountGroup}>
+          <span className={styles.tokenBadge} aria-hidden="true">
+            <TokenUSDC size={TOKEN_ICON_SIZE} variant="branded" className={styles.tokenBadgeIcon} />
+          </span>
+          <span className={[styles.amountValue, usdcAmount.font].join(' ')}>
+            {formatUsdcPlain(amount)}
+          </span>
+        </div>
       </div>
-      <dl className={styles.facts}>
-        <div>
-          <dt>Mode</dt>
-          <dd>
-            {modeLabel}
-            {isXchain ? <span className={styles.xchainTag}>cross-chain</span> : null}
-          </dd>
-        </div>
-        {destChain ? (
-          <div>
-            <dt>To chain</dt>
-            <dd>{destChain.name}</dd>
-          </div>
-        ) : null}
-        <div>
-          <dt>Recipient</dt>
-          <dd className={styles.recipient} title={recipient}>
-            {truncateRecipient(recipient)}
-          </dd>
-        </div>
-      </dl>
-      <FeeSummary
+
+      <TransferReviewSummary
+        recipient={recipient}
+        armadaAddress={armadaAddress}
+        amount={amount}
         fee={fee}
-        netAmount={totalDeducted}
-        netLabel="Total deducted from balance"
+        totalDeducted={totalDeducted}
+        variant={variant}
+        networkName={networkName}
+        recipientWalletProvider={recipientWalletProvider}
       />
+
       {submitBlockedReason ? (
         <div className={styles.syncNotice} role="status" aria-live="polite">
           {submitBlockedReason}
         </div>
       ) : null}
-      <FlowFooter
-        className={styles.footer}
-        primary={{
-          label: confirmLabel,
-          onClick: onConfirm,
-          disabled: Boolean(submitBlockedReason) || isSubmitting,
-        }}
-        secondary={{ label: 'Back', onClick: onBack }}
-      />
+
+      <div className={styles.buttonRow}>
+        <Button variant="secondary" size="lg" label="Back" showIcon={false} onClick={onBack} />
+        <Button
+          variant="primary"
+          size="lg"
+          label={confirmLabel}
+          showIcon={false}
+          onClick={onConfirm}
+          disabled={Boolean(submitBlockedReason) || isSubmitting}
+        />
+      </div>
     </div>
   )
 }

--- a/apps/armada-interface/src/components/payments/TransferReviewSummary/TransferReviewSummary.module.css
+++ b/apps/armada-interface/src/components/payments/TransferReviewSummary/TransferReviewSummary.module.css
@@ -1,0 +1,83 @@
+/* ABOUTME: TransferReviewSummary layout — borderless send/withdraw summary table (network / addresses / privacy / amount / fees) + total row. */
+/* ABOUTME: Mirrors DepositReviewSummary's structure; shared by SendReviewStep and SendCompleteStep. */
+
+/* Borderless summary table — send-review reference. */
+.summary {
+  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.summaryBody {
+  padding: var(--primitives-spacing-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-4);
+  background: var(--semantic-color-surface-main);
+}
+
+.summaryRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  /* Match the mockup's measured 21px row height. Our body-sm line-box is 13px × 1.4 = 18.2px, so
+     pin the row so the vertical rhythm matches. */
+  min-height: 21px;
+  gap: var(--primitives-spacing-3);
+}
+
+.summaryTotalRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--primitives-spacing-3);
+  padding: var(--primitives-spacing-5);
+  background: var(--semantic-color-surface-default);
+}
+
+.summaryLabel {
+  composes: bodySm from '../../../design/styles/typographyComposites.module.css';
+  color: var(--semantic-color-text-muted);
+  flex-shrink: 0;
+}
+
+.summaryValue {
+  composes: bodySmMedium from '../../../design/styles/typographyComposites.module.css';
+  color: var(--semantic-color-text-primary);
+  text-align: right;
+  min-width: 0;
+}
+
+.valueWithIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--primitives-spacing-2);
+  min-width: 0;
+}
+
+.valueWithIcon > span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.armadaIcon {
+  width: var(--primitives-spacing-4);
+  height: var(--primitives-spacing-4);
+  flex-shrink: 0;
+  display: block;
+}
+
+.summaryTotalLabel,
+.summaryTotalValue {
+  composes: bodySmSemibold from '../../../design/styles/typographyComposites.module.css';
+  color: var(--semantic-color-brand-deep);
+}
+
+.summaryTotalValue {
+  text-align: right;
+}

--- a/apps/armada-interface/src/components/payments/TransferReviewSummary/TransferReviewSummary.tsx
+++ b/apps/armada-interface/src/components/payments/TransferReviewSummary/TransferReviewSummary.tsx
@@ -1,0 +1,125 @@
+// ABOUTME: TransferReviewSummary — borderless send/withdraw summary table (network / private account / recipient / privacy / amount / fees) with a fee-on-top "Total" row.
+// ABOUTME: Shared by SendReviewStep and SendCompleteStep; an optional confirmedAt adds a leading "Date and time" row for confirmations.
+
+import { ArmadaLogo } from '@/design'
+import { WalletProviderIcon } from '@/components/ui/WalletProviderIcon'
+import { formatTransactionDateTime, formatUsdcAmount, truncateAddress } from '@/lib/format'
+import { isShieldedAddress } from '@/lib/address'
+import usdcAmount from '@/design/styles/usdcAmount.module.css'
+import type { SendFlowVariant } from '../SendRecipientStep'
+import styles from './TransferReviewSummary.module.css'
+
+const ROW_ICON_PX = 16
+
+export interface TransferReviewSummaryProps {
+  /** Destination address (0zk shielded or 0x public) — its format drives the privacy row + recipient icon. */
+  recipient: string
+  /** The user's own shielded (Armada) address — rendered (truncated) as the "From your private account" row when present. */
+  armadaAddress?: string
+  /** Gross amount sent/withdrawn (raw 6-decimal USDC). */
+  amount: bigint
+  /** Inclusive fee total — broadcaster + protocol + CCTP. Rendered as "—" when null (pre-quote-load). */
+  fee: bigint | null
+  /** USDC deducted from the user's shielded balance. Fee-on-top, so this is `amount + fee`. */
+  totalDeducted: bigint
+  variant: SendFlowVariant
+  /** Destination chain name — rendered on the "Network" row for public (0x) recipients only. */
+  networkName?: string
+  /**
+   * Wallet provider name (wagmi connector) to brand a public (0x) recipient's row glyph. Passed
+   * only when the recipient is the user's own connected wallet (e.g. withdraw-to-self) — for an
+   * arbitrary recipient it's omitted and a generic wallet glyph is shown instead. Matches the
+   * deposit flow's "From your wallet" treatment. Ignored for private (0zk) recipients.
+   */
+  recipientWalletProvider?: string
+  /** Completion timestamp (ms) — when present, adds a leading "Date and time" row for confirmations. */
+  confirmedAt?: number
+}
+
+export function TransferReviewSummary({
+  recipient,
+  armadaAddress,
+  amount,
+  fee,
+  totalDeducted,
+  variant,
+  networkName,
+  recipientWalletProvider,
+  confirmedAt,
+}: TransferReviewSummaryProps) {
+  // Private (0zk → 0zk) transfers stay inside the shielded pool; anything else exits to a public
+  // wallet. Drives the privacy row, the recipient-row icon, and whether the network row shows.
+  const isPrivate = isShieldedAddress(recipient)
+  const amountLabel = variant === 'withdraw' ? 'Withdrawal amount' : 'Send amount'
+  return (
+    <div className={styles.summary}>
+      <div className={styles.summaryBody}>
+        {confirmedAt !== undefined ? (
+          <div className={styles.summaryRow}>
+            <span className={styles.summaryLabel}>Date and time</span>
+            <span className={styles.summaryValue}>{formatTransactionDateTime(confirmedAt)}</span>
+          </div>
+        ) : null}
+        {/* Network only applies to a public unshield to a specific chain — a private transfer has
+            no destination-chain concept, so the row is omitted. */}
+        {!isPrivate && networkName ? (
+          <div className={styles.summaryRow}>
+            <span className={styles.summaryLabel}>Network</span>
+            <span className={styles.summaryValue}>{networkName}</span>
+          </div>
+        ) : null}
+        {armadaAddress ? (
+          <div className={styles.summaryRow}>
+            <span className={styles.summaryLabel}>From your private account</span>
+            <span className={styles.summaryValue}>
+              <span className={styles.valueWithIcon}>
+                <ArmadaLogo variant="mark" className={styles.armadaIcon} />
+                <span>{truncateAddress(armadaAddress)}</span>
+              </span>
+            </span>
+          </div>
+        ) : null}
+        <div className={styles.summaryRow}>
+          <span className={styles.summaryLabel}>To recipient</span>
+          <span className={styles.summaryValue}>
+            <span className={styles.valueWithIcon}>
+              {/* A private (0zk) recipient carries the Armada mark; a public wallet address carries
+                  a wallet-provider glyph (brand when it's the user's own wallet, else generic) —
+                  mirroring the deposit flow's "From your wallet" row. */}
+              {isPrivate ? (
+                <ArmadaLogo variant="mark" className={styles.armadaIcon} />
+              ) : (
+                <WalletProviderIcon provider={recipientWalletProvider} size={ROW_ICON_PX} />
+              )}
+              <span>{truncateAddress(recipient)}</span>
+            </span>
+          </span>
+        </div>
+        <div className={styles.summaryRow}>
+          <span className={styles.summaryLabel}>Privacy</span>
+          <span className={styles.summaryValue}>{isPrivate ? 'Private' : 'Public'}</span>
+        </div>
+        <div className={styles.summaryRow}>
+          <span className={styles.summaryLabel}>{amountLabel}</span>
+          <span className={[styles.summaryValue, usdcAmount.font].join(' ')}>
+            {formatUsdcAmount(amount)} USDC
+          </span>
+        </div>
+        <div className={styles.summaryRow}>
+          <span className={styles.summaryLabel}>Fees</span>
+          <span className={[styles.summaryValue, usdcAmount.font].join(' ')}>
+            {fee === null ? '—' : `${formatUsdcAmount(fee)} USDC`}
+          </span>
+        </div>
+      </div>
+      {/* Send/withdraw fees are fee-on-top: the shielded balance is charged `amount + fee`, so the
+          total is the full deduction (not a net "you'll receive" figure like the deposit flow). */}
+      <div className={styles.summaryTotalRow}>
+        <span className={styles.summaryTotalLabel}>Total</span>
+        <span className={[styles.summaryTotalValue, usdcAmount.font].join(' ')}>
+          {formatUsdcAmount(totalDeducted)} USDC
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/armada-interface/src/components/payments/TransferReviewSummary/index.ts
+++ b/apps/armada-interface/src/components/payments/TransferReviewSummary/index.ts
@@ -1,0 +1,5 @@
+// ABOUTME: Barrel export for TransferReviewSummary — the shared send/withdraw summary table.
+// ABOUTME: Consumed by SendReviewStep and SendCompleteStep.
+
+export { TransferReviewSummary } from './TransferReviewSummary'
+export type { TransferReviewSummaryProps } from './TransferReviewSummary'

--- a/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.module.css
+++ b/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.module.css
@@ -1,41 +1,121 @@
-/* ABOUTME: ChainSelect styling — surface-default chrome matching the AmountInput compact input look. */
-/* ABOUTME: Native <select> with a chevron via background-image; suitable for v1 until a designer ships a popover spec. */
+/* ABOUTME: ChainSelect styling — full-width neutral-50 pill trigger + popover listbox, ported from the mockup SendRecipientScreen. */
+/* ABOUTME: Trigger height/background match the recipient address field so the two pills line up. */
 
 .root {
+  position: relative;
+  width: 100%;
+}
+
+.trigger,
+.triggerStatic {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+  height: var(--primitives-spacing-16);
+  padding: 0 var(--primitives-spacing-5);
+  border: none;
+  border-radius: calc(var(--primitives-spacing-5) / 2);
+  background: var(--primitives-color-neutral-50);
+  text-align: left;
+  box-sizing: border-box;
 }
 
-.label {
-  color: var(--semantic-color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: var(--primitives-letterSpacing-wider);
-  font-size: calc(var(--primitives-fontSize-xs) * 1px);
-  margin-bottom: var(--primitives-spacing-2);
-}
-
-.select {
-  appearance: none;
-  -webkit-appearance: none;
-  background: var(--semantic-color-surface-default);
-  border: 1px solid var(--semantic-color-border-default);
-  border-radius: calc(var(--semantic-borderRadius-input) * 1px);
-  padding: 10px 36px 10px 12px;
-  color: var(--semantic-color-text-primary);
-  outline: none;
+.trigger {
   cursor: pointer;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23c491e5' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
-  background-repeat: no-repeat;
-  background-position: right 12px center;
-  background-size: 12px;
 }
 
-.select:focus {
-  border-color: var(--semantic-color-border-focus);
-  box-shadow: 0 0 0 2px rgba(196, 145, 229, 0.18);
+.trigger:focus-visible {
+  outline: calc(var(--primitives-borderWidth-default) * 1px) solid var(--semantic-color-border-focus);
+  outline-offset: calc(var(--primitives-spacing-1) * 0.5);
 }
 
-.select:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+.iconSlot {
+  width: var(--primitives-spacing-8);
+  height: var(--primitives-spacing-8);
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+}
+
+.iconSlot :global(svg) {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* Letter-avatar fallback for chains with no brand icon (e.g. local Anvil). */
+.iconSlotFallback {
+  border: var(--primitives-borderWidth-default) solid
+    color-mix(in srgb, var(--primitives-color-white-full) 40%, transparent);
+  background: var(--semantic-color-surface-raised);
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  font-weight: var(--primitives-fontWeight-medium);
+  color: var(--semantic-color-text-secondary);
+}
+
+.name {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  font-weight: var(--primitives-fontWeight-medium);
+  color: var(--semantic-color-text-primary);
+}
+
+.chevron {
+  width: var(--primitives-spacing-5);
+  height: var(--primitives-spacing-5);
+  color: var(--semantic-color-text-secondary);
+  flex-shrink: 0;
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + var(--primitives-spacing-2));
+  left: 0;
+  right: 0;
+  z-index: 20;
+  margin: 0;
+  padding: var(--primitives-spacing-1);
+  list-style: none;
+  background: var(--semantic-color-surface-raised);
+  border: calc(var(--primitives-borderWidth-default) * 1px) solid var(--semantic-color-border-default);
+  border-radius: calc(var(--semantic-borderRadius-card) * 1px);
+  box-shadow: 0 var(--primitives-spacing-3) var(--primitives-spacing-6)
+    color-mix(in srgb, var(--semantic-color-surface-bg) 55%, transparent);
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  gap: var(--primitives-spacing-2);
+  width: 100%;
+  padding: var(--primitives-spacing-2) var(--primitives-spacing-3);
+  border: none;
+  border-radius: calc(var(--primitives-borderRadius-sm) * 1px);
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+}
+
+.option:hover,
+.option[aria-selected='true'] {
+  background: var(--semantic-color-surface-hover);
+}
+
+.option:focus-visible {
+  outline: calc(var(--primitives-borderWidth-default) * 1px) solid var(--semantic-color-border-focus);
+  outline-offset: calc(var(--primitives-spacing-1) * -0.5);
+}
+
+.optionLabel {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-weight: var(--primitives-fontWeight-regular);
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  color: var(--semantic-color-text-secondary);
 }

--- a/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.test.tsx
+++ b/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.test.tsx
@@ -1,13 +1,17 @@
-// ABOUTME: Tests for ChainSelect — renders chain options, fires onChange with the parsed chainId, honors custom chains list.
+// ABOUTME: Tests for ChainSelect — styled popover trigger + listbox, fires onChange with the chainId, honors custom chains list.
 // ABOUTME: Default-chains path is exercised via the network.ts local fixture (Anvil hub + 2 clients).
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ChainSelect } from './ChainSelect'
 
+const MAINNET = { chainId: 1, domain: 0, name: 'Mainnet', rpcUrls: ['x'] as const }
+const OPTIMISM = { chainId: 10, domain: 2, name: 'Optimism', rpcUrls: ['y'] as const }
+
 describe('<ChainSelect>', () => {
-  it('renders all configured chains by default', () => {
+  it('renders all configured chains by default once opened', () => {
     render(<ChainSelect value={31337} onChange={() => {}} label="From chain" />)
+    fireEvent.click(screen.getByLabelText('From chain'))
     // Local mode: hub 31337 + clientA 31338 + clientB 31339
     expect(screen.getByRole('option', { name: /Anvil Hub/ })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: /Anvil Client A/ })).toBeInTheDocument()
@@ -15,23 +19,31 @@ describe('<ChainSelect>', () => {
   })
 
   it('honors the chains prop for a restricted list', () => {
-    const chains = [
-      { chainId: 1, domain: 0, name: 'Mainnet', rpcUrls: ['x'] as const },
-    ]
-    render(<ChainSelect value={1} onChange={() => {}} chains={chains} />)
+    render(<ChainSelect value={1} onChange={() => {}} chains={[MAINNET, OPTIMISM]} label="From chain" />)
+    fireEvent.click(screen.getByLabelText('From chain'))
     expect(screen.getByRole('option', { name: 'Mainnet' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Optimism' })).toBeInTheDocument()
     expect(screen.queryByRole('option', { name: /Anvil/ })).toBeNull()
   })
 
-  it('fires onChange with the numeric chainId', () => {
+  it('fires onChange with the numeric chainId when an option is picked', () => {
     const onChange = vi.fn()
     render(<ChainSelect value={31337} onChange={onChange} label="From chain" />)
-    fireEvent.change(screen.getByLabelText('From chain'), { target: { value: '31338' } })
+    fireEvent.click(screen.getByLabelText('From chain'))
+    fireEvent.click(screen.getByRole('option', { name: /Anvil Client A/ }))
     expect(onChange).toHaveBeenCalledWith(31338)
   })
 
-  it('respects disabled', () => {
+  it('collapses to a static, non-interactive trigger with a single chain', () => {
+    render(<ChainSelect value={1} onChange={() => {}} chains={[MAINNET]} label="From chain" />)
+    // Only one chain → nothing to pick → no trigger button, just the label shown statically.
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(screen.getByLabelText('From chain')).toHaveTextContent('Mainnet')
+  })
+
+  it('respects disabled — no interactive trigger', () => {
     render(<ChainSelect value={31337} onChange={() => {}} label="From chain" disabled />)
-    expect(screen.getByLabelText('From chain')).toBeDisabled()
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(screen.getByLabelText('From chain')).toBeInTheDocument()
   })
 })

--- a/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.tsx
+++ b/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.tsx
@@ -1,9 +1,13 @@
-// ABOUTME: ChainSelect — dropdown over the configured chains in network.ts (hub + clients by default).
-// ABOUTME: Renders a native <select> for v1; the styled-popover treatment can come later if real UX demands it.
+// ABOUTME: ChainSelect — full-width styled popover over the configured chains in network.ts (hub + clients by default).
+// ABOUTME: Trigger + listbox match the mockup's SendRecipientScreen network selector; icons via @web3icons, else a letter avatar.
 
-import { useId, useMemo } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { ChevronDownIcon } from '@heroicons/react/24/solid'
 import { getAllChainIdentities, type ChainIdentity } from '@/config/network'
+import { chainIconForChainId } from '@/components/ui/chainIcons'
 import styles from './ChainSelect.module.css'
+
+const ICON_SIZE = 32
 
 export interface ChainSelectProps {
   /** Selected chainId. */
@@ -11,37 +15,99 @@ export interface ChainSelectProps {
   onChange: (chainId: number) => void
   /** Subset of chains to offer; defaults to [hub, ...clients]. */
   chains?: ReadonlyArray<ChainIdentity>
+  /** Accessible name for the trigger (no visible label is rendered — matches the mockup). */
   label?: string
   disabled?: boolean
   className?: string
 }
 
+function ChainIcon({ chainId, name }: { chainId: number; name: string }) {
+  const Icon = chainIconForChainId(chainId)
+  if (Icon) {
+    // `background` variant carries the network's own dark circular backdrop (matches the mockup).
+    return (
+      <span className={styles.iconSlot} aria-hidden>
+        <Icon size={ICON_SIZE} variant="background" />
+      </span>
+    )
+  }
+  // Unmapped chain (e.g. local Anvil with no brand): letter avatar on a neutral slot.
+  return (
+    <span className={[styles.iconSlot, styles.iconSlotFallback].join(' ')} aria-hidden>
+      {name.charAt(0).toUpperCase()}
+    </span>
+  )
+}
+
 export function ChainSelect({ value, onChange, chains, label, disabled, className }: ChainSelectProps) {
-  const id = useId()
+  const listboxId = useId()
+  const rootRef = useRef<HTMLDivElement>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
+
   // useMemo so the default chain list is stable across renders without re-running getAllChainIdentities.
   const options = useMemo(() => chains ?? getAllChainIdentities(), [chains])
+  const selected = options.find(c => c.chainId === value) ?? options[0]
+  const selectable = !disabled && options.length > 1
+
+  useEffect(() => {
+    if (!menuOpen) return
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handlePointerDown)
+    return () => document.removeEventListener('mousedown', handlePointerDown)
+  }, [menuOpen])
+
+  function selectChain(nextId: number) {
+    onChange(nextId)
+    setMenuOpen(false)
+  }
+
   const cls = [styles.root, className].filter(Boolean).join(' ')
 
   return (
-    <div className={cls}>
-      {label ? (
-        <label htmlFor={id} className={styles.label}>
-          {label}
-        </label>
+    <div className={cls} ref={rootRef}>
+      {selectable ? (
+        <button
+          type="button"
+          className={styles.trigger}
+          aria-haspopup="listbox"
+          aria-expanded={menuOpen}
+          aria-controls={listboxId}
+          aria-label={label}
+          onClick={() => setMenuOpen(open => !open)}
+        >
+          <ChainIcon chainId={selected?.chainId ?? value} name={selected?.name ?? ''} />
+          <span className={styles.name}>{selected?.name}</span>
+          <ChevronDownIcon className={styles.chevron} aria-hidden />
+        </button>
+      ) : (
+        <div className={styles.triggerStatic} aria-label={label}>
+          <ChainIcon chainId={selected?.chainId ?? value} name={selected?.name ?? ''} />
+          <span className={styles.name}>{selected?.name}</span>
+        </div>
+      )}
+
+      {menuOpen && selectable ? (
+        <ul id={listboxId} className={styles.menu} role="listbox" aria-label="Network">
+          {options.map(option => (
+            <li key={option.chainId} role="presentation">
+              <button
+                type="button"
+                role="option"
+                aria-selected={option.chainId === value}
+                className={styles.option}
+                onClick={() => selectChain(option.chainId)}
+              >
+                <ChainIcon chainId={option.chainId} name={option.name} />
+                <span className={styles.optionLabel}>{option.name}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
       ) : null}
-      <select
-        id={id}
-        className={styles.select}
-        value={value}
-        onChange={e => onChange(Number(e.target.value))}
-        disabled={disabled}
-      >
-        {options.map(c => (
-          <option key={c.chainId} value={c.chainId}>
-            {c.name}
-          </option>
-        ))}
-      </select>
     </div>
   )
 }

--- a/apps/armada-interface/src/components/ui/chainIcons.tsx
+++ b/apps/armada-interface/src/components/ui/chainIcons.tsx
@@ -1,5 +1,5 @@
-// ABOUTME: Maps chain IDs from network config to @web3icons/react network icons (crowdfund DepositAmountCard parity).
-// ABOUTME: Unknown chains (e.g. local Anvil) return null — DepositAmountCard falls back to a letter avatar.
+// ABOUTME: Maps chain IDs from network config to @web3icons/react network icons.
+// ABOUTME: Unknown chains (e.g. local Anvil) return null — callers fall back to a letter avatar.
 
 import NetworkArbitrumSepolia from '@web3icons/react/icons/networks/NetworkArbitrumSepolia'
 import NetworkBaseSepolia from '@web3icons/react/icons/networks/NetworkBaseSepolia'


### PR DESCRIPTION
Stacked on the merged Send+Unshield convergence (#482). This is the visual pass — restyles the shared Send/Withdraw flow onto `FlowShell` + mockup visuals, step by step. No money-flow, kind-selection, or submit-meta changes.

## Recipient step
- Two-line serif "Where do you want to send your USDC?" prompt (both variants), centered to the step column.
- Neutral-50 address pill with **Paste** (empty) / **Clear** (filled); full value while focused, middle-truncated on blur.
- Footer (privacy badge + Continue) **reveals only once a valid address is entered** — no persistent buttons, matching the mockup.
- Chain selector rewritten as a full-width styled popover (was a native `<select>`): network icons via web3icons `background` variant (dark circular backdrop) + letter-avatar fallback; visible "Destination chain" label removed (now the trigger's accessible name).

## Amount step
- Chain row removed from the card (chosen on the recipient step; not in the mockup).
- Added **25% / 50% / 75% / Max** percent pills.
- Enlarged top padding to match the mockup's chain-less card.
- Available-balance text now fully matches the mockup (mono, base size, regular weight, secondary color).

## Review / Complete steps
- Wallet-provider glyph beside a public (0x) recipient, mirroring the deposit "From your wallet" row. Brand glyph (MetaMask/etc.) only when the recipient is the user's own connected wallet; generic wallet glyph otherwise (we don't know an arbitrary recipient's provider).

## Shared / refactor
- `DepositAmountCard` gains `showChain?` (default true) — deposit/yield unaffected.
- Chain→icon map relocated `components/deposit/depositChainIcons.tsx` → `components/ui/chainIcons.tsx` so the `ChainSelect` ui primitive can own it (single importer re-pointed).

Typecheck clean; full interface suite 1130 passed / 8 skipped.

Recent Addresses (in the mockup recipient step) is **deferred** — the app has no recents feature to back it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)