### PR TITLE
style(interface): restyle earn/yield flow onto FlowShell + mockup visuals

### DIFF
--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
@@ -4,7 +4,7 @@
 .card {
   display: flex;
   flex-direction: column;
-  gap: var(--primitives-spacing-8);
+  gap: var(--primitives-spacing-10);
   width: 100%;
   padding: var(--primitives-spacing-5);
   background: var(--semantic-color-surface-main);
@@ -254,7 +254,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: var(--primitives-spacing-3);
+  gap: var(--primitives-spacing-2);
   width: 100%;
   min-height: calc(var(--primitives-fontSize-4xl) * 1.2 * 1px);
   cursor: text;

--- a/apps/armada-interface/src/components/yield/EarnCompleteStep.module.css
+++ b/apps/armada-interface/src/components/yield/EarnCompleteStep.module.css
@@ -1,53 +1,73 @@
-/* ABOUTME: EarnCompleteStep layout — matches Shield/Unshield/Send CompleteStep proportions. */
+/* ABOUTME: EarnCompleteStep layout — centered serif title, coin+amount block, shared summary table, two-button CTA row. */
+/* ABOUTME: Mirrors SendCompleteStep so success states feel consistent across the app. */
 
 .root {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: var(--primitives-spacing-3);
-  text-align: center;
-}
-
-.icon {
-  width: 72px;
-  height: 72px;
-  border-radius: 50%;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(52, 211, 153, 0.12);
-  color: var(--semantic-color-status-success);
-  margin-bottom: var(--primitives-spacing-2);
+  align-items: stretch;
+  gap: var(--primitives-spacing-8);
 }
 
 .title {
-  font-family: "Charis SIL", serif;
-  font-size: calc(var(--primitives-fontSize-2xl) * 1px);
-  line-height: var(--primitives-lineHeight-tight);
-  font-weight: var(--primitives-fontWeight-regular);
+  composes: displayLg from '../../design/styles/displayLgTitle.module.css';
+  margin: 0;
+  width: 100%;
   color: var(--semantic-color-text-primary);
-  margin: 0;
+  text-align: center;
 }
 
-.body {
-  color: var(--semantic-color-text-muted);
-  max-width: 46ch;
-  margin: 0;
+.amountRow {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
 }
 
-.explorerLink {
+.amountGroup {
   display: inline-flex;
   align-items: center;
-  gap: var(--primitives-spacing-1);
-  color: var(--semantic-color-text-accent);
-  text-decoration: none;
+  gap: var(--primitives-spacing-2);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
 }
 
-.explorerLink:hover {
-  text-decoration: underline;
+.tokenBadge {
+  width: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.footer {
-  align-self: stretch;
-  margin: var(--primitives-spacing-6) calc(var(--primitives-spacing-6) * -1) calc(var(--primitives-spacing-6) * -1);
+.tokenBadgeIcon {
+  flex-shrink: 0;
+  display: block;
+}
+
+.tokenBadgeIcon :global(svg) {
+  display: block;
+}
+
+.amountValue {
+  display: block;
+  font-weight: var(--primitives-fontWeight-medium);
+  font-size: var(--primitives-spacing-10);
+  line-height: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  color: var(--semantic-color-text-primary);
+}
+
+/* Two-button CTA row — equal-width View on explorer / Go to dashboard, no divider above. */
+.buttonRow {
+  display: flex;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+}
+
+.buttonRow > * {
+  flex: 1;
+  max-width: 211px;
 }

--- a/apps/armada-interface/src/components/yield/EarnCompleteStep.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnCompleteStep.test.tsx
@@ -1,85 +1,95 @@
-// ABOUTME: Tests for EarnCompleteStep — title + body copy adapts to add vs withdraw, second line + explorer link render conditionally.
+// ABOUTME: Tests for EarnCompleteStep — title + summary rows adapt to add vs withdraw; explorer/dashboard CTAs.
+// ABOUTME: The summary total row echoes the modal's per-tab netLabel/netAmount (not a blind amount + fee).
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { EarnCompleteStep } from './EarnCompleteStep'
+import type { YieldRate } from '@/hooks/useYieldRate'
+
+const RATE: YieldRate = { rate: 1_000_000_000_000_000_000n, apyBps: 420n, fetchedAt: 0 }
+const CONFIRMED_AT = 1_700_000_000_000
 
 describe('<EarnCompleteStep>', () => {
-  it("add tab: 'Earning' headline + matching body copy", () => {
+  it("add tab: 'Deposit to vault complete' title + Add-to-vault summary", () => {
     render(
       <EarnCompleteStep
         tab="add"
-        recipientReceives={100_000_000n}
-        totalDeducted={100_000_000n}
-        onDone={() => {}}
+        amount={100_000_000n}
+        rate={RATE}
+        fee={1_000_000n}
+        netAmount={101_000_000n}
+        netLabel="Total deducted from balance"
+        confirmedAt={CONFIRMED_AT}
+        explorerUrl="https://example.test/tx/0xabc"
+        onViewExplorer={() => {}}
+        onGoToDashboard={() => {}}
       />,
     )
-    expect(screen.getByRole('heading', { name: 'Earning' })).toBeInTheDocument()
-    expect(screen.getByText(/earning yield on 100\.00 USDC/)).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Deposit to vault complete' })).toBeInTheDocument()
+    expect(screen.getByText('Add to vault')).toBeInTheDocument()
+    expect(screen.getByText('Your deposit')).toBeInTheDocument()
+    expect(screen.getByText('Total deducted from balance')).toBeInTheDocument()
   })
 
-  it("withdraw tab: 'Withdrawn from vault' headline + matching body", () => {
+  it("withdraw tab: 'Withdrawal from vault complete' title + Withdraw summary", () => {
     render(
       <EarnCompleteStep
         tab="withdraw"
-        recipientReceives={50_000_000n}
-        totalDeducted={50_000_000n}
-        onDone={() => {}}
+        amount={50_000_000n}
+        rate={RATE}
+        fee={500_000n}
+        netAmount={50_000_000n}
+        netLabel="You'll receive into private balance"
+        confirmedAt={CONFIRMED_AT}
+        onViewExplorer={() => {}}
+        onGoToDashboard={() => {}}
       />,
     )
-    expect(screen.getByRole('heading', { name: 'Withdrawn from vault' })).toBeInTheDocument()
-    expect(screen.getByText(/Returned 50\.00 USDC/)).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Withdrawal from vault complete' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Withdraw from vault')).toBeInTheDocument()
+    expect(screen.getByText('Your withdrawal')).toBeInTheDocument()
+    expect(screen.getByText("You'll receive into private balance")).toBeInTheDocument()
   })
 
-  it("shows the 'Total deducted' second line when totalDeducted > recipientReceives", () => {
+  it('disables View on explorer when no explorerUrl is provided', () => {
     render(
       <EarnCompleteStep
         tab="add"
-        recipientReceives={100_000_000n}
-        totalDeducted={101_000_000n}
-        onDone={() => {}}
+        amount={1_000_000n}
+        rate={RATE}
+        fee={0n}
+        netAmount={1_000_000n}
+        netLabel="Total deducted from balance"
+        confirmedAt={CONFIRMED_AT}
+        onViewExplorer={() => {}}
+        onGoToDashboard={() => {}}
       />,
     )
-    expect(screen.getByText(/Total deducted from your private balance: 101\.00 USDC/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'View on explorer' })).toBeDisabled()
   })
 
-  it('hides the second line when totalDeducted equals recipientReceives', () => {
+  it('fires onViewExplorer + onGoToDashboard on the CTAs', () => {
+    const onViewExplorer = vi.fn()
+    const onGoToDashboard = vi.fn()
     render(
       <EarnCompleteStep
         tab="add"
-        recipientReceives={100_000_000n}
-        totalDeducted={100_000_000n}
-        onDone={() => {}}
-      />,
-    )
-    expect(screen.queryByText(/Total deducted from your private balance/)).not.toBeInTheDocument()
-  })
-
-  it('renders the explorer link when explorerUrl is provided', () => {
-    render(
-      <EarnCompleteStep
-        tab="add"
-        recipientReceives={1_000_000n}
-        totalDeducted={1_010_000n}
+        amount={1_000_000n}
+        rate={RATE}
+        fee={0n}
+        netAmount={1_000_000n}
+        netLabel="Total deducted from balance"
+        confirmedAt={CONFIRMED_AT}
         explorerUrl="https://example.test/tx/0xabc"
-        onDone={() => {}}
+        onViewExplorer={onViewExplorer}
+        onGoToDashboard={onGoToDashboard}
       />,
     )
-    const link = screen.getByRole('link', { name: /View transaction/ })
-    expect(link).toHaveAttribute('href', 'https://example.test/tx/0xabc')
-  })
-
-  it('fires onDone on the CTA', () => {
-    const onDone = vi.fn()
-    render(
-      <EarnCompleteStep
-        tab="add"
-        recipientReceives={1_000_000n}
-        totalDeducted={1_000_000n}
-        onDone={onDone}
-      />,
-    )
-    fireEvent.click(screen.getByRole('button', { name: /Done/ }))
-    expect(onDone).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: 'View on explorer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Go to dashboard' }))
+    expect(onViewExplorer).toHaveBeenCalledTimes(1)
+    expect(onGoToDashboard).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/armada-interface/src/components/yield/EarnCompleteStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnCompleteStep.tsx
@@ -1,59 +1,93 @@
-// ABOUTME: Earn complete step — success copy adapts to add (moved into vault) vs withdraw (returned to private balance).
-// ABOUTME: Mirrors the other CompleteStep shapes — recipient-receives + total-deducted + explorer link.
+// ABOUTME: Earn complete step — serif "Deposit to vault complete"/"Withdrawal from vault complete" title, coin + amount, EarnReviewSummary (with date/time), explorer/dashboard CTAs.
+// ABOUTME: Mirrors SendCompleteStep — no divider between the summary card and the button row.
 
-import { CheckCircle2, ExternalLink } from 'lucide-react'
-import { FlowFooter } from '@/components/flow/FlowFooter'
-import { formatUsdcAmount } from '@/lib/format'
+import TokenUSDC from '@web3icons/react/icons/tokens/TokenUSDC'
+import { Button } from '@/design'
+import { EarnReviewSummary } from './EarnReviewSummary'
+import { formatUsdcPlain } from '@/lib/format'
+import usdcAmount from '@/design/styles/usdcAmount.module.css'
+import type { YieldRate } from '@/hooks/useYieldRate'
 import type { EarnTab } from './EarnInputStep'
 import styles from './EarnCompleteStep.module.css'
 
+const TOKEN_BADGE_PX = 40
+/** @web3icons branded assets use an 18px circle in a 24px viewBox — scale up to fill the badge. */
+const TOKEN_ICON_SIZE = Math.round((TOKEN_BADGE_PX * 24) / 18)
+
 export interface EarnCompleteStepProps {
   tab: EarnTab
-  /** Add: USDC now earning yield. Withdraw: USDC returned to private balance. Equals `amount`. */
-  recipientReceives: bigint
-  /** Total USDC deducted from the user's shielded balance — `amount + fee` for both kinds. */
-  totalDeducted: bigint
-  /** Explorer URL for the hub-chain tx. Undefined for local Anvil; hidden when unset. */
+  /** Requested USDC (raw 6-decimal) — shown full-precision in the coin block. */
+  amount: bigint
+  rate: YieldRate | null
+  /** Inclusive fee total — broadcaster + protocol. Rendered as "—" when null. */
+  fee: bigint | null
+  /** Per-tab summary total: Add → private-balance debit (`amount + fee`); Withdraw → net gain (`amount`). */
+  netAmount: bigint
+  netLabel: string
+  /** Completion timestamp (ms) — drives the summary's "Date and time" row. */
+  confirmedAt: number
+  /** Hub-chain explorer URL for the tx; absent disables the "View on explorer" button. */
   explorerUrl?: string
-  onDone: () => void
+  onViewExplorer: () => void
+  onGoToDashboard: () => void
 }
 
 export function EarnCompleteStep({
   tab,
-  recipientReceives,
-  totalDeducted,
+  amount,
+  rate,
+  fee,
+  netAmount,
+  netLabel,
+  confirmedAt,
   explorerUrl,
-  onDone,
+  onViewExplorer,
+  onGoToDashboard,
 }: EarnCompleteStepProps) {
+  const title = tab === 'add' ? 'Deposit to vault complete' : 'Withdrawal from vault complete'
+
   return (
     <div className={styles.root}>
-      <div className={styles.icon} aria-hidden="true">
-        <CheckCircle2 size={40} />
+      <h1 className={styles.title}>{title}</h1>
+
+      <div className={styles.amountRow}>
+        <div className={styles.amountGroup}>
+          <span className={styles.tokenBadge} aria-hidden="true">
+            <TokenUSDC size={TOKEN_ICON_SIZE} variant="branded" className={styles.tokenBadgeIcon} />
+          </span>
+          <span className={[styles.amountValue, usdcAmount.font].join(' ')}>
+            {formatUsdcPlain(amount)}
+          </span>
+        </div>
       </div>
-      <h3 className={styles.title}>
-        {tab === 'add' ? 'Earning' : 'Withdrawn from vault'}
-      </h3>
-      <p className={styles.body}>
-        {tab === 'add'
-          ? <>You're now earning yield on {formatUsdcAmount(recipientReceives)} USDC.</>
-          : <>Returned {formatUsdcAmount(recipientReceives)} USDC to your private balance.</>}
-      </p>
-      {totalDeducted !== recipientReceives ? (
-        <p className={styles.body}>
-          Total deducted from your private balance: {formatUsdcAmount(totalDeducted)} USDC.
-        </p>
-      ) : null}
-      {explorerUrl ? (
-        <p className={styles.body}>
-          <a href={explorerUrl} target="_blank" rel="noreferrer noopener" className={styles.explorerLink}>
-            View transaction <ExternalLink size={14} aria-hidden="true" />
-          </a>
-        </p>
-      ) : null}
-      <FlowFooter
-        className={styles.footer}
-        primary={{ label: 'Done', onClick: onDone }}
+
+      <EarnReviewSummary
+        tab={tab}
+        amount={amount}
+        rate={rate}
+        fee={fee}
+        netAmount={netAmount}
+        netLabel={netLabel}
+        confirmedAt={confirmedAt}
       />
+
+      <div className={styles.buttonRow}>
+        <Button
+          variant="secondary"
+          size="lg"
+          label="View on explorer"
+          showIcon={false}
+          onClick={onViewExplorer}
+          disabled={!explorerUrl}
+        />
+        <Button
+          variant="primary"
+          size="lg"
+          label="Go to dashboard"
+          showIcon={false}
+          onClick={onGoToDashboard}
+        />
+      </div>
     </div>
   )
 }

--- a/apps/armada-interface/src/components/yield/EarnInputStep.module.css
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.module.css
@@ -1,12 +1,68 @@
-/* ABOUTME: EarnInputStep layout — tabs + amount + APY block + fee summary + footer. */
-/* ABOUTME: APY block is its own panel: label, big value, and a caveat line in muted text. */
+/* ABOUTME: EarnInputStep layout — Add/Withdraw pill tabs, serif prompt, amount card, APY hint panel. */
+/* ABOUTME: Tabs + APY block ported from the mockup EarnAmountScreen; APY panel is a surface-main card. */
 
 .root {
   display: flex;
   flex-direction: column;
-  gap: var(--primitives-spacing-5);
+  gap: var(--primitives-spacing-8);
+  width: 100%;
 }
 
+/* Segmented Add/Withdraw pill toggle. */
+.tabs {
+  display: flex;
+  width: 100%;
+  padding: var(--primitives-spacing-1);
+  gap: var(--primitives-spacing-1);
+  border-radius: calc(var(--semantic-borderRadius-item) * 1px);
+  background: color-mix(in srgb, var(--semantic-color-text-primary) 6%, transparent);
+  box-sizing: border-box;
+}
+
+.tab {
+  flex: 1;
+  min-height: var(--primitives-spacing-8);
+  padding: 0 var(--primitives-spacing-3);
+  border: none;
+  border-radius: calc(var(--semantic-borderRadius-item) * 1px - 2px);
+  background: transparent;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  font-weight: var(--primitives-fontWeight-medium);
+  color: var(--semantic-color-text-secondary);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, transform 0.1s ease;
+}
+
+.tab:hover {
+  color: var(--semantic-color-text-primary);
+}
+
+.tab:active {
+  transform: translateY(1px);
+}
+
+.tabActive {
+  background: var(--primitives-color-neutral-50);
+  color: var(--semantic-color-text-primary);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--semantic-color-text-primary) 8%, transparent);
+}
+
+.tab:focus-visible {
+  outline: calc(var(--primitives-borderWidth-default) * 1px) solid var(--semantic-color-border-focus);
+  outline-offset: calc(var(--primitives-spacing-1) * 0.5);
+}
+
+/* Serif display prompt (matches the flow mockup). */
+.title {
+  composes: displayLg from '../../design/styles/displayLgTitle.module.css';
+  margin: 0;
+  width: 100%;
+  color: var(--semantic-color-text-primary);
+  text-align: center;
+}
+
+/* Pre-flight gate (e.g. Withdraw fee shortfall). */
 .blockedReason {
   font-family: var(--primitives-fontFamily-ui), sans-serif;
   font-size: calc(var(--primitives-fontSize-sm) * 1px);
@@ -17,37 +73,34 @@
   padding: var(--primitives-spacing-3) var(--primitives-spacing-4);
 }
 
+/* APY hint — surface-main panel (Add tab only). */
 .apyBlock {
   display: flex;
   flex-direction: column;
   gap: var(--primitives-spacing-1);
-  background: var(--semantic-color-surface-default);
-  border: 1px solid var(--semantic-color-border-default);
-  border-radius: calc(var(--semantic-borderRadius-card) * 1px);
+  width: 100%;
   padding: var(--primitives-spacing-4) var(--primitives-spacing-5);
+  border-radius: calc(var(--semantic-borderRadius-card) * 1px);
+  background: var(--semantic-color-surface-main);
+  box-sizing: border-box;
 }
 
 .apyLabel {
-  color: var(--semantic-color-text-muted);
+  composes: labelXs from '../../design/styles/typographyComposites.module.css';
   text-transform: uppercase;
-  letter-spacing: var(--primitives-letterSpacing-wider);
-  font-size: calc(var(--primitives-fontSize-xs) * 1px);
+  color: var(--semantic-color-text-muted);
 }
 
 .apyValue {
-  color: var(--semantic-color-text-primary);
-  font-family: var(--primitives-fontFamily-ui), sans-serif;
-  font-size: calc(var(--primitives-fontSize-2xl) * 1px);
+  composes: headingLg from '../../design/styles/typographyComposites.module.css';
   line-height: var(--primitives-lineHeight-tight);
+  color: var(--semantic-color-text-primary);
   font-variant-numeric: tabular-nums;
 }
 
 .apyCaveat {
+  composes: bodySm from '../../design/styles/typographyComposites.module.css';
+  margin: var(--primitives-spacing-1) 0 0;
+  line-height: var(--primitives-lineHeight-normal);
   color: var(--semantic-color-text-muted);
-  margin-top: var(--primitives-spacing-1);
-}
-
-.footer {
-  align-self: stretch;
-  margin: var(--primitives-spacing-4) calc(var(--primitives-spacing-6) * -1) calc(var(--primitives-spacing-6) * -1);
 }

--- a/apps/armada-interface/src/components/yield/EarnInputStep.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.test.tsx
@@ -56,6 +56,29 @@ describe('<EarnInputStep>', () => {
     expect(screen.getByRole('tab', { name: 'Withdraw' })).toBeInTheDocument()
   })
 
+  it('hides the chain row (the vault has no chain selection)', () => {
+    setup()
+    expect(screen.queryByText(/Anvil Hub/)).toBeNull()
+    expect(screen.queryByRole('listbox')).toBeNull()
+  })
+
+  it('renders the 25% / 50% / 75% / Max percent pills', () => {
+    setup()
+    for (const label of ['25%', '50%', '75%', 'Max']) {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument()
+    }
+  })
+
+  it('shows the APY hint on the Add tab', () => {
+    setup({ tab: 'add', rate: { rate: 1_000_000n, apyBps: 450n, fetchedAt: 0 } })
+    expect(screen.getByText('Estimated APY')).toBeInTheDocument()
+  })
+
+  it('hides the APY hint entirely on the Withdraw tab', () => {
+    setup({ tab: 'withdraw', rate: { rate: 1_000_000n, apyBps: 450n, fetchedAt: 0 } })
+    expect(screen.queryByText('Estimated APY')).toBeNull()
+  })
+
   it('uses the vault-deposit aria-label when tab=add', () => {
     setup({ tab: 'add' })
     expect(screen.getByLabelText('Vault deposit amount')).toBeInTheDocument()

--- a/apps/armada-interface/src/components/yield/EarnInputStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.tsx
@@ -1,10 +1,11 @@
-// ABOUTME: Earn amount step — tab switcher, DepositAmountCard, APY hint (full-viewport earn flow).
+// ABOUTME: Earn amount step — Add/Withdraw pill tabs, serif prompt, chain-less DepositAmountCard + percent pills, and an APY hint on the Add tab.
+// ABOUTME: The vault has no chain selection; the APY panel is shown only for deposits (matches the mockup).
 
 import { useMemo } from 'react'
 import { Button } from '@/design'
 import { DepositAmountCard } from '@/components/deposit/DepositAmountCard/DepositAmountCard'
 import { depositOverlayShellStyles } from '@/components/deposit/DepositOverlayShell/DepositOverlayShell'
-import { GasBalanceNotice, Tabs } from '@/components/ui'
+import { GasBalanceNotice } from '@/components/ui'
 import type { DisplayFees } from '@/lib/fees/displayFees'
 import type { FlowFeeBreakdown } from '@/components/ui/FeeBreakdownTooltip'
 import { useGasBalanceWarning } from '@/hooks/useGasBalanceWarning'
@@ -13,7 +14,6 @@ import { formatUsdcPlain, parseUsdcInput, usdcInputErrorMessage } from '@/lib/fo
 import { rateToApy } from '@/lib/yield'
 import type { YieldRate } from '@/hooks/useYieldRate'
 import { hasActiveAmount } from '@/utils/amountInput'
-import shieldStyles from '@/components/shield/ShieldInputStep.module.css'
 import styles from './EarnInputStep.module.css'
 
 export type EarnTab = 'add' | 'withdraw'
@@ -121,12 +121,29 @@ export function EarnInputStepContent({
       : 'How much USDC do you want to withdraw from the vault?'
 
   return (
-    <div className={shieldStyles.contentZone}>
-      <Tabs items={TABS} selected={tab} onSelect={onTabChange} ariaLabel="Earn mode" />
-      <p className={shieldStyles.question}>{question}</p>
+    <div className={styles.root}>
+      <div className={styles.tabs} role="tablist" aria-label="Earn mode">
+        {TABS.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            role="tab"
+            aria-selected={tab === item.id}
+            className={[styles.tab, tab === item.id && styles.tabActive].filter(Boolean).join(' ')}
+            onClick={() => onTabChange(item.id)}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      <h1 className={styles.title}>{question}</h1>
+
       <DepositAmountCard
         chains={chains}
         chainId={hub.chainId}
+        // The vault has no chain selection — the mockup's earn amount card has no chain row.
+        showChain={false}
         amount={amountStr}
         onAmountChange={onAmountChange}
         balance={formatUsdcPlain(max)}
@@ -134,28 +151,36 @@ export function EarnInputStepContent({
         displayFees={displayFees}
         flowBreakdown={flowBreakdown}
         feeLoading={feeLoading}
+        // maxInput drives the 25% / 50% / 75% / Max percent pills; onMax keeps the exact fee-aware cap.
+        maxInput={maxInput}
         onMax={() => onAmountChange(formatUsdcPlain(maxInput))}
         error={amountError}
         amountAriaLabel={tab === 'add' ? 'Vault deposit amount' : 'Vault withdrawal amount'}
       />
+
       {showGasNotice ? (
         <GasBalanceNotice
           nativeSymbol={gasWarning.nativeSymbol}
           formattedBalance={gasWarning.formattedBalance}
         />
       ) : null}
+
       {continueBlockedReason ? (
         <div className={styles.blockedReason} role="alert">
           {continueBlockedReason}
         </div>
       ) : null}
-      <div className={styles.apyBlock}>
-        <div className={styles.apyLabel}>Estimated APY</div>
-        <div className={styles.apyValue}>{formatApy(rate)}</div>
-        <div className={styles.apyCaveat}>
-          Based on the vault's recent rate; the actual yield earned will vary.
+
+      {/* APY hint is a deposit concern — shown on the Add tab only (matches the mockup). */}
+      {tab === 'add' ? (
+        <div className={styles.apyBlock}>
+          <span className={styles.apyLabel}>Estimated APY</span>
+          <span className={styles.apyValue}>{formatApy(rate)}</span>
+          <p className={styles.apyCaveat}>
+            Based on the vault&apos;s recent rate; the actual yield earned will vary.
+          </p>
         </div>
-      </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/armada-interface/src/components/yield/EarnModal.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.test.tsx
@@ -109,7 +109,7 @@ describe('<EarnModal>', () => {
     renderModal({ open: 'yield-deposit', shielded: 10_000_000n })
     fireEvent.change(screen.getByLabelText('Vault deposit amount'), { target: { value: '3' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
-    expect(screen.getByText('Review deposit')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Review your deposit' })).toBeInTheDocument()
   })
 
   it('Confirm submits the tx and advances to the progress step', async () => {

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -20,14 +20,12 @@ import { canRetryTx } from '@/lib/tx/executor'
 import { sharesToUsdc } from '@/lib/yield'
 import { assertSpendableForFeeOnTop } from '@/lib/tx/spendable'
 import {
-  overlayIndicatorStep,
-  overlayIndicatorStatus,
   ProgressStep,
   ErrorStep,
   type FlowStep,
   type FlowVisibleStep,
 } from '@/components/flow'
-import { DepositOverlayShell } from '@/components/deposit/DepositOverlayShell/DepositOverlayShell'
+import { FlowShell } from '@/components/flow/FlowShell'
 import { EarnInputStepContent, EarnInputStepFooter, type EarnTab } from './EarnInputStep'
 import { useDisplayFees } from '@/hooks/useDisplayFees'
 import { EarnReviewStep } from './EarnReviewStep'
@@ -273,14 +271,25 @@ export function EarnModal() {
 
   if (!isOpen) return null
 
+  // FlowShell renders a 3-segment Steps indicator (Amount / Review / Confirm). progress / complete /
+  // error all map to the final Confirm segment; the ErrorStep itself owns the retry button + copy.
+  const currentStep =
+    step === 'input' ? 1
+    : step === 'review' ? 2
+    : 3
+  const status: 'default' | 'confirmed' | 'error' =
+    step === 'complete' ? 'confirmed'
+    : step === 'error' ? 'error'
+    : 'default'
+
   return (
-    <DepositOverlayShell
-      open
+    <FlowShell
+      open={isOpen}
       onClose={close}
-      dismissible={true}
       flowLabel="Earn"
-      currentStep={overlayIndicatorStep(step)}
-      status={overlayIndicatorStatus(step)}
+      steps={['Amount', 'Review', 'Confirm']}
+      currentStep={currentStep}
+      status={status}
     >
       <RelayerStatusBanner isOpen={isOpen} />
       {step === 'input' && (
@@ -335,15 +344,21 @@ export function EarnModal() {
       {step === 'complete' && (
         <EarnCompleteStep
           tab={tab}
-          // Add: vault gained `recipientReceives` (= amount) of USDC; user spent amount + fee.
-          // Withdraw: vault returned `amount` USDC into the user's private balance; the
-          // broadcaster fee was paid as a separate proof leg out of the user's existing private
-          // USDC. The success copy reads "Returned amount USDC" because that's literally what
-          // came back from the vault — the fee debit is accounted for separately.
-          recipientReceives={recipientReceives}
-          totalDeducted={totalDeducted}
+          amount={amount}
+          rate={yieldRate}
+          // Inclusive Fee total — broadcaster + protocol. No CCTP on yield kinds.
+          fee={fee + displayFees.protocolFee}
+          // Per-tab net figure: Add debits `amount + fee`; Withdraw returns `amount` in full (the
+          // broadcaster fee was paid as a separate proof leg out of existing private USDC).
+          netAmount={displayNetAmount}
+          netLabel={displayNetLabel}
+          confirmedAt={record?.updatedAt ?? Date.now()}
           explorerUrl={txExplorerUrl(record?.walletContext.sourceChainId, displayTxHash(record))}
-          onDone={close}
+          onViewExplorer={() => {
+            const url = txExplorerUrl(record?.walletContext.sourceChainId, displayTxHash(record))
+            if (url) window.open(url, '_blank', 'noopener,noreferrer')
+          }}
+          onGoToDashboard={close}
         />
       )}
       {step === 'error' && (
@@ -385,6 +400,6 @@ export function EarnModal() {
           }
         />
       )}
-    </DepositOverlayShell>
+    </FlowShell>
   )
 }

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.module.css
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.module.css
@@ -1,65 +1,78 @@
-/* ABOUTME: EarnReviewStep styling — matches Shield/Unshield/Send review proportions. */
-/* ABOUTME: APY value displayed in the facts grid alongside Mode. */
+/* ABOUTME: EarnReviewStep layout — serif title, coin+amount block, sync/slippage notices, two-button CTA row. */
+/* ABOUTME: The vault summary table itself lives in the shared EarnReviewSummary component. */
 
 .root {
   display: flex;
   flex-direction: column;
-  gap: var(--primitives-spacing-4);
+  gap: var(--primitives-spacing-8);
 }
 
-.headline {
-  color: var(--semantic-color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: var(--primitives-letterSpacing-wider);
-  font-size: calc(var(--primitives-fontSize-xs) * 1px);
+.title {
+  composes: displayLg from '../../design/styles/displayLgTitle.module.css';
+  margin: 0;
+  width: 100%;
+  color: var(--semantic-color-text-primary);
   text-align: center;
 }
 
-.amountBlock {
+.amountRow {
   display: flex;
-  align-items: baseline;
   justify-content: center;
-  gap: var(--primitives-spacing-3);
+  align-items: center;
+  width: 100%;
 }
 
-.amount {
-  color: var(--semantic-color-text-primary);
-  font-family: "Charis SIL", serif;
-  font-size: calc(var(--primitives-fontSize-5xl) * 1px);
-  line-height: var(--primitives-lineHeight-tight);
-  font-weight: var(--primitives-fontWeight-regular);
-  font-variant-numeric: tabular-nums;
+.amountGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--primitives-spacing-2);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
 }
 
-.unit {
-  color: var(--semantic-color-text-muted);
-  font-size: calc(var(--primitives-fontSize-lg) * 1px);
-}
-
-.facts {
+.tokenBadge {
+  width: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  overflow: hidden;
   display: flex;
-  flex-direction: column;
-  gap: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.tokenBadgeIcon {
+  flex-shrink: 0;
+  display: block;
+}
+
+.tokenBadgeIcon :global(svg) {
+  display: block;
+}
+
+.amountValue {
+  display: block;
+  font-weight: var(--primitives-fontWeight-medium);
+  font-size: var(--primitives-spacing-10);
+  line-height: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  color: var(--semantic-color-text-primary);
+}
+
+/* Withdraw-only reminder that the vault rate drifts each block. Matches the mockup: centered,
+   sans, sm (11px), regular weight, muted. */
+.slippageNotice {
   margin: 0;
-}
-
-.facts > div {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: var(--primitives-spacing-3);
-  padding: var(--primitives-spacing-2) 0;
-  border-bottom: 1px solid var(--semantic-color-border-default);
-}
-
-.facts dt {
+  width: 100%;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  font-weight: var(--primitives-fontWeight-regular);
+  line-height: var(--primitives-lineHeight-normal);
   color: var(--semantic-color-text-muted);
+  text-align: center;
 }
 
-.facts dd {
-  color: var(--semantic-color-text-primary);
-}
-
+/* Non-blocking notice while the initial shielded-balance sync is still completing. */
 .syncNotice {
   background: rgba(196, 145, 229, 0.08);
   border: 1px solid var(--semantic-color-border-lavender);
@@ -68,13 +81,14 @@
   color: var(--semantic-color-text-secondary);
 }
 
-.slippageNotice {
-  color: var(--semantic-color-text-muted);
-  font-size: calc(var(--primitives-fontSize-sm) * 1px);
-  padding: 0 var(--primitives-spacing-1);
+/* Two-button CTA row — equal-width Back / Confirm, no divider above. */
+.buttonRow {
+  display: flex;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
 }
 
-.footer {
-  align-self: stretch;
-  margin: var(--primitives-spacing-4) calc(var(--primitives-spacing-6) * -1) calc(var(--primitives-spacing-6) * -1);
+.buttonRow > * {
+  flex: 1;
+  max-width: 211px;
 }

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.test.tsx
@@ -23,9 +23,9 @@ function setupAdd() {
 }
 
 describe('<EarnReviewStep>', () => {
-  it("tab=add: headline 'Review deposit' and mode 'Add to vault'", () => {
+  it("tab=add: title 'Review your deposit' and mode 'Add to vault'", () => {
     setupAdd()
-    expect(screen.getByText('Review deposit')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Review your deposit' })).toBeInTheDocument()
     expect(screen.getByText('Add to vault')).toBeInTheDocument()
   })
 
@@ -42,7 +42,7 @@ describe('<EarnReviewStep>', () => {
         onConfirm={() => {}}
       />,
     )
-    expect(screen.getByText('Review withdrawal')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Review your withdrawal' })).toBeInTheDocument()
     expect(screen.getByText('Withdraw from vault')).toBeInTheDocument()
   })
 

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
@@ -1,23 +1,29 @@
-// ABOUTME: Earn review step — echoes the requested amount, the resolved mode (Add Funds / Withdraw), the APY used for the quote, and the fee summary.
-// ABOUTME: Same hero-numeral + facts layout as the other review steps for visual consistency.
+// ABOUTME: Earn review step — serif title, USDC coin + amount block, shared EarnReviewSummary table, Confirm/Back CTAs.
+// ABOUTME: Delegates the summary rows (mode, APY, amount, fees, total) to EarnReviewSummary; keeps the sync-gate + slippage notices.
 
-import { FlowFooter } from '@/components/flow/FlowFooter'
-import { FeeSummary } from '@/components/ui'
-import { formatUsdcAmount } from '@/lib/format'
-import { rateToApy } from '@/lib/yield'
+import TokenUSDC from '@web3icons/react/icons/tokens/TokenUSDC'
+import { Button } from '@/design'
+import { EarnReviewSummary } from './EarnReviewSummary'
+import { formatUsdcPlain } from '@/lib/format'
+import usdcAmount from '@/design/styles/usdcAmount.module.css'
 import type { YieldRate } from '@/hooks/useYieldRate'
 import type { EarnTab } from './EarnInputStep'
 import styles from './EarnReviewStep.module.css'
+
+const TOKEN_BADGE_PX = 40
+/** @web3icons branded assets use an 18px circle in a 24px viewBox — scale up to fill the badge. */
+const TOKEN_ICON_SIZE = Math.round((TOKEN_BADGE_PX * 24) / 18)
 
 export interface EarnReviewStepProps {
   tab: EarnTab
   amount: bigint
   rate: YieldRate | null
+  /** Inclusive fee total — broadcaster + protocol. No CCTP on yield kinds. */
   fee: bigint | null
   /**
-   * Bottom-line USDC number for the FeeSummary, computed by the modal per tab. For Add this is
-   * the private-balance debit (`amount + fee`); for Withdraw it's the net private-balance gain
-   * (`amount - fee`), matching the actual yield-withdraw balance flow.
+   * Bottom-line USDC number for the summary total row, computed by the modal per tab. For Add this
+   * is the private-balance debit (`amount + fee`); for Withdraw it's the net private-balance gain
+   * (`amount`), matching the actual yield-withdraw balance flow.
    */
   netAmount: bigint
   /** Label paired with `netAmount` — also per-tab from the modal. */
@@ -27,13 +33,6 @@ export interface EarnReviewStepProps {
   isSubmitting?: boolean
   onBack: () => void
   onConfirm: () => void
-}
-
-function formatApy(rate: YieldRate | null): string {
-  if (!rate) return 'syncing…'
-  const apy = rateToApy(rate.apyBps)
-  if (apy === 0) return 'unavailable'
-  return `~${apy.toFixed(2)}%`
 }
 
 export function EarnReviewStep({
@@ -48,51 +47,56 @@ export function EarnReviewStep({
   onBack,
   onConfirm,
 }: EarnReviewStepProps) {
-  const modeLabel = tab === 'add' ? 'Add to vault' : 'Withdraw from vault'
+  const title = tab === 'add' ? 'Review your deposit' : 'Review your withdrawal'
+  const confirmLabel = tab === 'add' ? 'Confirm deposit' : 'Confirm withdrawal'
 
   return (
     <div className={styles.root}>
-      <div className={styles.headline}>Review {tab === 'add' ? 'deposit' : 'withdrawal'}</div>
-      <div className={styles.amountBlock}>
-        <span className={styles.amount}>{formatUsdcAmount(amount)}</span>
-        <span className={styles.unit}>USDC</span>
+      <h1 className={styles.title}>{title}</h1>
+
+      <div className={styles.amountRow}>
+        <div className={styles.amountGroup}>
+          <span className={styles.tokenBadge} aria-hidden="true">
+            <TokenUSDC size={TOKEN_ICON_SIZE} variant="branded" className={styles.tokenBadgeIcon} />
+          </span>
+          <span className={[styles.amountValue, usdcAmount.font].join(' ')}>
+            {formatUsdcPlain(amount)}
+          </span>
+        </div>
       </div>
-      <dl className={styles.facts}>
-        <div>
-          <dt>Mode</dt>
-          <dd>{modeLabel}</dd>
-        </div>
-        <div>
-          <dt>Estimated APY</dt>
-          <dd>{formatApy(rate)}</dd>
-        </div>
-      </dl>
-      <FeeSummary
+
+      <EarnReviewSummary
+        tab={tab}
+        amount={amount}
+        rate={rate}
         fee={fee}
         netAmount={netAmount}
         netLabel={netLabel}
-        feeLabel="Relayer fee"
       />
+
       {tab === 'withdraw' ? (
-        <div className={styles.slippageNotice}>
-          The vault rate moves with each new block. Your final USDC may differ slightly from
-          this quote.
-        </div>
+        <p className={styles.slippageNotice}>
+          The vault rate moves with each new block. Your final USDC may differ slightly from this quote.
+        </p>
       ) : null}
+
       {submitBlockedReason ? (
         <div className={styles.syncNotice} role="status" aria-live="polite">
           {submitBlockedReason}
         </div>
       ) : null}
-      <FlowFooter
-        className={styles.footer}
-        primary={{
-          label: tab === 'add' ? 'Confirm deposit' : 'Confirm withdrawal',
-          onClick: onConfirm,
-          disabled: Boolean(submitBlockedReason) || isSubmitting,
-        }}
-        secondary={{ label: 'Back', onClick: onBack }}
-      />
+
+      <div className={styles.buttonRow}>
+        <Button variant="secondary" size="lg" label="Back" showIcon={false} onClick={onBack} />
+        <Button
+          variant="primary"
+          size="lg"
+          label={confirmLabel}
+          showIcon={false}
+          onClick={onConfirm}
+          disabled={Boolean(submitBlockedReason) || isSubmitting}
+        />
+      </div>
     </div>
   )
 }

--- a/apps/armada-interface/src/components/yield/EarnReviewSummary/EarnReviewSummary.module.css
+++ b/apps/armada-interface/src/components/yield/EarnReviewSummary/EarnReviewSummary.module.css
@@ -1,0 +1,60 @@
+/* ABOUTME: EarnReviewSummary layout — borderless vault summary table (mode / APY / amount / fees) + total row. */
+/* ABOUTME: Mirrors TransferReviewSummary's structure; shared by EarnReviewStep and EarnCompleteStep. */
+
+.summary {
+  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.summaryBody {
+  padding: var(--primitives-spacing-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-4);
+  background: var(--semantic-color-surface-main);
+}
+
+.summaryRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  /* Match the mockup's measured 21px row height (body-sm line-box is 13px × 1.4 = 18.2px). */
+  min-height: 21px;
+  gap: var(--primitives-spacing-3);
+}
+
+.summaryTotalRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--primitives-spacing-3);
+  padding: var(--primitives-spacing-5);
+  background: var(--semantic-color-surface-default);
+}
+
+.summaryLabel {
+  composes: bodySm from '../../../design/styles/typographyComposites.module.css';
+  color: var(--semantic-color-text-muted);
+  flex-shrink: 0;
+}
+
+.summaryValue {
+  composes: bodySmMedium from '../../../design/styles/typographyComposites.module.css';
+  color: var(--semantic-color-text-primary);
+  text-align: right;
+  min-width: 0;
+}
+
+.summaryTotalLabel,
+.summaryTotalValue {
+  composes: bodySmSemibold from '../../../design/styles/typographyComposites.module.css';
+  color: var(--semantic-color-brand-deep);
+}
+
+.summaryTotalValue {
+  text-align: right;
+}

--- a/apps/armada-interface/src/components/yield/EarnReviewSummary/EarnReviewSummary.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewSummary/EarnReviewSummary.test.tsx
@@ -1,0 +1,88 @@
+// ABOUTME: Tests for EarnReviewSummary — per-tab mode/amount labels, APY row, fee "—" placeholder, and the per-tab net total row.
+// ABOUTME: The total row echoes the caller's netLabel/netAmount (deposit debit vs withdraw net gain), never a blind amount + fee.
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EarnReviewSummary } from './EarnReviewSummary'
+import type { YieldRate } from '@/hooks/useYieldRate'
+
+const RATE: YieldRate = { rate: 1_000_000_000_000_000_000n, apyBps: 450n, fetchedAt: 0 }
+
+describe('<EarnReviewSummary>', () => {
+  it('add tab: Mode "Add to vault", "Your deposit", and the deposit-debit total', () => {
+    render(
+      <EarnReviewSummary
+        tab="add"
+        amount={100_000_000n}
+        rate={RATE}
+        fee={1_000_000n}
+        netAmount={101_000_000n}
+        netLabel="Total deducted from balance"
+      />,
+    )
+    expect(screen.getByText('Add to vault')).toBeInTheDocument()
+    expect(screen.getByText('Your deposit')).toBeInTheDocument()
+    expect(screen.getByText('~4.50%')).toBeInTheDocument()
+    expect(screen.getByText('Total deducted from balance')).toBeInTheDocument()
+    expect(screen.getByText('101.00 USDC')).toBeInTheDocument()
+  })
+
+  it('withdraw tab: Mode "Withdraw from vault", "Your withdrawal", and the net-gain total', () => {
+    render(
+      <EarnReviewSummary
+        tab="withdraw"
+        amount={50_000_000n}
+        rate={RATE}
+        fee={500_000n}
+        netAmount={50_000_000n}
+        netLabel="You'll receive into private balance"
+      />,
+    )
+    expect(screen.getByText('Withdraw from vault')).toBeInTheDocument()
+    expect(screen.getByText('Your withdrawal')).toBeInTheDocument()
+    expect(screen.getByText("You'll receive into private balance")).toBeInTheDocument()
+  })
+
+  it('renders "—" for the fee before a quote loads (fee=null)', () => {
+    render(
+      <EarnReviewSummary
+        tab="add"
+        amount={100_000_000n}
+        rate={RATE}
+        fee={null}
+        netAmount={100_000_000n}
+        netLabel="Total deducted from balance"
+      />,
+    )
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('shows the syncing APY copy when rate is null', () => {
+    render(
+      <EarnReviewSummary
+        tab="add"
+        amount={100_000_000n}
+        rate={null}
+        fee={0n}
+        netAmount={100_000_000n}
+        netLabel="Total deducted from balance"
+      />,
+    )
+    expect(screen.getByText('syncing…')).toBeInTheDocument()
+  })
+
+  it('adds a "Date and time" row when confirmedAt is set', () => {
+    render(
+      <EarnReviewSummary
+        tab="add"
+        amount={100_000_000n}
+        rate={RATE}
+        fee={0n}
+        netAmount={100_000_000n}
+        netLabel="Total deducted from balance"
+        confirmedAt={1_700_000_000_000}
+      />,
+    )
+    expect(screen.getByText('Date and time')).toBeInTheDocument()
+  })
+})

--- a/apps/armada-interface/src/components/yield/EarnReviewSummary/EarnReviewSummary.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewSummary/EarnReviewSummary.tsx
@@ -1,0 +1,89 @@
+// ABOUTME: EarnReviewSummary — borderless vault summary table (mode / APY / amount / fees) with a per-tab total row.
+// ABOUTME: Shared by EarnReviewStep and EarnCompleteStep; an optional confirmedAt adds a leading "Date and time" row.
+
+import { formatTransactionDateTime, formatUsdcAmount } from '@/lib/format'
+import { rateToApy } from '@/lib/yield'
+import type { YieldRate } from '@/hooks/useYieldRate'
+import usdcAmount from '@/design/styles/usdcAmount.module.css'
+import type { EarnTab } from '../EarnInputStep'
+import styles from './EarnReviewSummary.module.css'
+
+export interface EarnReviewSummaryProps {
+  tab: EarnTab
+  /** Requested USDC (raw 6-decimal) — the deposit or withdrawal amount. */
+  amount: bigint
+  /** Vault rate snapshot — drives the "Estimated APY" row. */
+  rate: YieldRate | null
+  /** Inclusive fee total — broadcaster + protocol. Rendered as "—" when null (pre-quote-load). */
+  fee: bigint | null
+  /**
+   * Bottom-line USDC number, computed per-tab by the modal. For Add this is the private-balance
+   * debit (`amount + fee`); for Withdraw it's the net private-balance gain (`amount`, with the fee
+   * paid as a separate proof leg). NOT a blind `amount + fee` — the two tabs' balance flows differ.
+   */
+  netAmount: bigint
+  /** Label paired with `netAmount` — also per-tab from the modal. */
+  netLabel: string
+  /** Completion timestamp (ms) — when present, adds a leading "Date and time" row for confirmations. */
+  confirmedAt?: number
+}
+
+function formatApy(rate: YieldRate | null): string {
+  if (!rate) return 'syncing…'
+  const apy = rateToApy(rate.apyBps)
+  if (apy === 0) return 'unavailable'
+  return `~${apy.toFixed(2)}%`
+}
+
+export function EarnReviewSummary({
+  tab,
+  amount,
+  rate,
+  fee,
+  netAmount,
+  netLabel,
+  confirmedAt,
+}: EarnReviewSummaryProps) {
+  const modeLabel = tab === 'add' ? 'Add to vault' : 'Withdraw from vault'
+  const amountLabel = tab === 'add' ? 'Your deposit' : 'Your withdrawal'
+  return (
+    <div className={styles.summary}>
+      <div className={styles.summaryBody}>
+        {confirmedAt !== undefined ? (
+          <div className={styles.summaryRow}>
+            <span className={styles.summaryLabel}>Date and time</span>
+            <span className={styles.summaryValue}>{formatTransactionDateTime(confirmedAt)}</span>
+          </div>
+        ) : null}
+        <div className={styles.summaryRow}>
+          <span className={styles.summaryLabel}>Mode</span>
+          <span className={styles.summaryValue}>{modeLabel}</span>
+        </div>
+        <div className={styles.summaryRow}>
+          <span className={styles.summaryLabel}>Estimated APY</span>
+          <span className={styles.summaryValue}>{formatApy(rate)}</span>
+        </div>
+        <div className={styles.summaryRow}>
+          <span className={styles.summaryLabel}>{amountLabel}</span>
+          <span className={[styles.summaryValue, usdcAmount.font].join(' ')}>
+            {formatUsdcAmount(amount)} USDC
+          </span>
+        </div>
+        <div className={styles.summaryRow}>
+          <span className={styles.summaryLabel}>Fees</span>
+          <span className={[styles.summaryValue, usdcAmount.font].join(' ')}>
+            {fee === null ? '—' : `${formatUsdcAmount(fee)} USDC`}
+          </span>
+        </div>
+      </div>
+      {/* Total row is the modal's per-tab net figure — deposit debits `amount + fee`; withdraw
+          returns `amount` in full (fee paid on a separate leg). Not a generic `amount + fee`. */}
+      <div className={styles.summaryTotalRow}>
+        <span className={styles.summaryTotalLabel}>{netLabel}</span>
+        <span className={[styles.summaryTotalValue, usdcAmount.font].join(' ')}>
+          {formatUsdcAmount(netAmount)} USDC
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/armada-interface/src/components/yield/EarnReviewSummary/index.ts
+++ b/apps/armada-interface/src/components/yield/EarnReviewSummary/index.ts
@@ -1,0 +1,4 @@
+// ABOUTME: Barrel for EarnReviewSummary — the shared vault summary table.
+// ABOUTME: Re-exports the component + its props type.
+
+export { EarnReviewSummary, type EarnReviewSummaryProps } from './EarnReviewSummary'


### PR DESCRIPTION
Restyles the Earn/Yield modal (Add funds / Withdraw) onto `FlowShell` + mockup visuals, mirroring the deposit and transfer passes. Money-flow logic, kind selection, fee math, and slippage handling are unchanged — this is a visual pass.

## Shell
- `DepositOverlayShell` → `FlowShell` with a 3-segment `Amount / Review / Confirm` indicator; `status='confirmed'` on completion.

## Amount step
- Add/Withdraw pill tabs restyled to the mockup segmented control (was the shared `Tabs` primitive).
- Serif prompt ("How much USDC do you want to add to / withdraw from the vault?").
- Chain-less amount card (`showChain={false}`) + **25% / 50% / 75% / Max** percent pills.
- APY hint panel restyled to the mockup surface-main card; shown on the **Add tab only** (per mockup).

## Review / Complete steps
- New shared `EarnReviewSummary` table (mirrors `TransferReviewSummary`): **Mode / Estimated APY / amount / Fees / Total**.
- Review: serif title, USDC coin + amount block, summary, withdraw slippage notice, Back/Confirm.
- Complete: mockup confirmed screen — title, coin + amount, summary with a date/time row, explorer + dashboard CTAs.

## Semantics preserved (not blindly matched to the mockup)
- The mockup's generic `Total = amount + fee` misstates **withdraw**, whose fee is a *separate proof leg* (vault returns `amount` in full; fee debits existing private USDC). The summary total keeps our per-tab `netAmount`/`netLabel` (Add → "Total deducted" = amount+fee; Withdraw → "You'll receive into private balance" = amount).
- Real `useYieldRate` (with syncing / unavailable states) is kept over the mockup's demo constant.

## Shared component tweaks (affect deposit + send too)
- `DepositAmountCard`: amount-row gaps aligned to the mockup — token↔amount `spacing-3`→`spacing-2`, card gap `spacing-8`→`spacing-10`. All three amount steps were already mutually consistent; this brings them to the mockup. Side-effect: the deposit chain↔amount gap widens to 40px (uniform card gap).

## Deferred (consistent with prior PRs)
- Processing/in-flight styling (`ProgressStep`) — shared across flows, its own pass.
- Mobile keypad chrome + `EarnChooserSheet` bottom-sheet (desktop uses the tabs).

Typecheck clean; full interface suite 1137 passed / 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)