### PR TITLE
style(interface): polish foundation — frost scale + radius/spacing tokens

### DIFF
--- a/.claude/PLAN_INTERFACE_POLISH.md
+++ b/.claude/PLAN_INTERFACE_POLISH.md
@@ -1,0 +1,60 @@
+# Interface — Designer Polish Update (apply plan)
+
+## Source
+Designer polish pulled into the mockup clone `.context/armada-app`.
+Diff range: **`cec8936..8dc3e28`** (2 commits on 2026-08-18):
+- `000e1b8` Polish dashboard, modal, and pay-via-link UI to one motion and layout system.
+- `8dc3e28` Roll dashboard balances after the tx modal closes.
+
+`cec8936` is the clone baseline all our prior redesign PRs (#478–#486) were built against, so this range is exactly "what's new since we started."
+
+127 files changed. Re-diff any file with:
+`git -C .context/armada-app diff cec8936 8dc3e28 -- <path>`
+
+## Foundation (do FIRST — ripples everywhere)
+- **`styles/tokens.css`**: new `--primitives-borderRadius-2xl` (16), `-3xl` (20); `--semantic-borderRadius-modal` now → `3xl`; new `--semantic-spacing-page-block` (spacing-24 + 1).
+- **`styles/theme-overrides.css`**: new **frost scale** — `--semantic-color-frost` / `-frost-raised` / `-frost-hover` / `-frost-pressed` (white/neutral-50 over the gradient at 20/40/55/70%). `surface-main` now = `frost-raised`. Replaces one-off `color-mix(neutral-50 …%)` usages.
+- Action: port both into `src/design/styles`, then sweep our merged components that used one-off color-mix / surface-main to adopt frost tokens where the mockup now does (e.g. header controls, gear hover).
+
+## New components we don't have yet
+- **`SegmentedControl`** — factored-out tab control (Earn Add/Withdraw currently inline in our EarnInputStep; likely adopt this).
+- **`BalanceActionButton`** — dashboard balance action buttons (replaces IconButton usage on the card).
+- **`TxProgressCard` + `TxProcessingLayout`** + `constants/txProcessingCopy.ts` / `txProcessingTiming.ts` — the in-flight/processing display we DEFERRED. Designer has now polished it.
+- **`NumericKeypad`** — mobile keypad (we deferred mobile).
+- **`DashboardScrollTopFade`**, hooks **`useFineHover`**, **`useHidePeek`**.
+- **History**: `RecentActivityList/ActivityAllPanel` + `ActivityKindFilters` + `ActivityTxHashSearch` — the "View all" history surface (we haven't built History to the mockup yet).
+
+## Changed components we HAVE ported (re-polish)
+Shared primitives: `ModalShell` (+`ModalStepSwitch`, `modalExitMotion`), `FlowModalOverlay`, `SidePanel`, `IconButton`, `Tooltip`, `Button`, `SendButton`, `ArmadaLogo`, `BottomSheet`.
+Dashboard: `BalanceCard`, `RecentActivityList`, `VaultPositionBar`, `DepositTooltip`, `ArmadaAppDashboard` (layout/motion), `DashboardCardStack`, `DashboardOverlays`.
+Summaries: `DepositReviewSummary`, `EarnReviewSummary`, `SendReviewSummary`, `TransactionDateTimeRow`.
+Amount: `AmountInputScreen`.
+
+## Per-flow re-polish (flows already merged)
+- **Dashboard** (#480): BalanceCard, RecentActivityList, VaultPositionBar, DepositTooltip, layout/motion, scroll-top fade, balances roll after modal close (`8dc3e28`).
+- **Deposit** (#481): DepositAmountScreen, DepositReviewScreen(+css), DepositConfirmedScreen(+css), DepositModalFlow.
+- **Send/Withdraw** (#482/#483): SendRecipientScreen(+css, big), SendReviewScreen(+css), SendConfirmedScreen(+css), Send/WithdrawModalFlow, sendFlowConstants.
+- **Earn** (#484): EarnAmountScreen (css deleted → moved to SegmentedControl/AmountInputScreen), EarnReviewScreen, EarnConfirmedScreen, EarnModalFlow (big −157), EarnChooserSheet, earnFlowConstants.
+- **Wallet panel** (#486): WalletMenuPanel(Ethereum/Shell), WalletPillMenu, WalletItem.
+
+## New flows / areas not yet touched
+- **History** (ActivityAllPanel + filters + hash search).
+- **Processing / in-flight** (TxProgressCard / TxProcessingLayout) — previously deferred; now designer-polished.
+- **Receive / Request / Pay-via-link** (RequestModalFlow, RequestLink/Details/Receive screens, PayViaLinkLanding, ReceivePayment* + their ReviewSummaries) — net-new flows.
+- **NumericKeypad** / mobile — still deferrable.
+
+## Proposed sequencing (PR-sized)
+1. **Foundation**: tokens + frost scale + sweep merged components to frost. (small, unblocks the rest)
+2. **Shared primitives**: ModalShell/FlowModalOverlay/SidePanel/IconButton/Tooltip/Button/SendButton/ArmadaLogo/BottomSheet + new SegmentedControl + BalanceActionButton.
+3. **Dashboard re-polish** (incl. balances-roll-after-close, scroll fade).
+4. **Deposit + Send/Withdraw + Earn re-polish** (per flow; Earn adopts SegmentedControl).
+5. **Wallet panel re-polish**.
+6. **History** (new).
+7. **Processing/in-flight** (new; was deferred).
+8. **Receive/Request/Pay-via-link** (new).
+9. Mobile keypad (optional/deferred).
+
+## Open decisions
+- Adopt `SegmentedControl` to replace our inline Earn tabs? (recommend yes)
+- Tackle the deferred Processing display now that it's polished, or keep after the merged-flow re-polish? (recommend after re-polish, as its own PR)
+- Batch vs per-flow PRs — foundation must be its own first PR; the rest can be per-flow.

--- a/apps/armada-interface/src/design/styles/theme-overrides.css
+++ b/apps/armada-interface/src/design/styles/theme-overrides.css
@@ -5,15 +5,27 @@
   EXCEPTION — marketing gem gradient (logo + footer Figma stops).
   Overrides synced brand-lavender / brand-amber so animations match the footer.
 */
+:root,
 [data-theme='light'],
 [data-theme='dark'] {
   --semantic-color-brand-lavender: #ca8aea;
   --semantic-color-brand-amber: #f8d197;
   --semantic-color-brand-gradient-rose: #f39db0;
+
+  /*
+    Frost scale — white (neutral-50) mixed over the dashboard gradient.
+    Use these instead of one-off color-mix percentages.
+    quiet 20% → raised 40% → hover 55% → pressed 70%.
+    Solid --semantic-color-surface-hover stays for opaque chrome (panels, menus).
+  */
+  --semantic-color-frost: color-mix(in srgb, var(--primitives-color-neutral-50) 20%, transparent);
+  --semantic-color-frost-raised: color-mix(in srgb, var(--primitives-color-neutral-50) 40%, transparent);
+  --semantic-color-frost-hover: color-mix(in srgb, var(--primitives-color-neutral-50) 55%, transparent);
+  --semantic-color-frost-pressed: color-mix(in srgb, var(--primitives-color-neutral-50) 70%, transparent);
 }
 
 [data-theme='light'] {
-  --semantic-color-surface-main: color-mix(in srgb, var(--primitives-color-neutral-50) 40%, transparent);
+  --semantic-color-surface-main: var(--semantic-color-frost-raised);
   --semantic-component-button-secondary-bg: var(--semantic-color-surface-main);
 }
 

--- a/apps/armada-interface/src/design/styles/tokens.css
+++ b/apps/armada-interface/src/design/styles/tokens.css
@@ -100,6 +100,8 @@
   --primitives-borderRadius-md: 6;
   --primitives-borderRadius-lg: 8;
   --primitives-borderRadius-xl: 12;
+  --primitives-borderRadius-2xl: 16;
+  --primitives-borderRadius-3xl: 20;
   --primitives-borderRadius-full: 999;
   --primitives-borderWidth-default: 1;
 
@@ -137,11 +139,12 @@
   --semantic-spacing-card-padding: var(--primitives-spacing-6);
   --semantic-spacing-section-gap: var(--primitives-spacing-10);
   --semantic-spacing-component-gap: var(--primitives-spacing-3);
+  --semantic-spacing-page-block: calc(var(--primitives-spacing-24) + var(--primitives-spacing-1));
   --semantic-spacing-site-title-to-body: calc(var(--semantic-typography-title-font-size) * 0.5);
   --semantic-spacing-site-body-to-cta: calc(var(--semantic-typography-body-font-size) * 1.6);
   --semantic-borderRadius-card: var(--primitives-borderRadius-lg);
   --semantic-borderRadius-item: 8;
-  --semantic-borderRadius-modal: 20;
+  --semantic-borderRadius-modal: var(--primitives-borderRadius-3xl);
   --semantic-borderRadius-button: var(--primitives-borderRadius-full);
   --semantic-borderRadius-input: var(--primitives-borderRadius-md);
   --semantic-borderRadius-badge: var(--primitives-borderRadius-sm);
@@ -364,6 +367,8 @@
   --primitives-borderRadius-md: 6;
   --primitives-borderRadius-lg: 8;
   --primitives-borderRadius-xl: 12;
+  --primitives-borderRadius-2xl: 16;
+  --primitives-borderRadius-3xl: 20;
   --primitives-borderRadius-full: 999;
   --primitives-borderWidth-default: 1;
   /* Semantic */
@@ -400,11 +405,12 @@
   --semantic-spacing-card-padding: var(--primitives-spacing-6);
   --semantic-spacing-section-gap: var(--primitives-spacing-10);
   --semantic-spacing-component-gap: var(--primitives-spacing-3);
+  --semantic-spacing-page-block: calc(var(--primitives-spacing-24) + var(--primitives-spacing-1));
   --semantic-spacing-site-title-to-body: calc(var(--semantic-typography-title-font-size) * 0.5);
   --semantic-spacing-site-body-to-cta: calc(var(--semantic-typography-body-font-size) * 1.6);
   --semantic-borderRadius-card: var(--primitives-borderRadius-lg);
   --semantic-borderRadius-item: 8;
-  --semantic-borderRadius-modal: 20;
+  --semantic-borderRadius-modal: var(--primitives-borderRadius-3xl);
   --semantic-borderRadius-button: var(--primitives-borderRadius-full);
   --semantic-borderRadius-input: var(--primitives-borderRadius-md);
   --semantic-borderRadius-badge: var(--primitives-borderRadius-sm);


### PR DESCRIPTION
First PR of the designer's polish update (mockup diff `cec8936..8dc3e28`). Foundational token vocabulary only — **zero visual change** (all additions are new tokens or value-identical remaps). Unblocks the per-flow polish PRs that follow.

## tokens.css
- New `--primitives-borderRadius-2xl` (16) + `-3xl` (20).
- `--semantic-borderRadius-modal` now → `borderRadius-3xl` (still 20 — value-identical).
- New `--semantic-spacing-page-block` (`spacing-24 + 1`).

## theme-overrides.css
- New **frost scale** — `--semantic-color-frost` / `-frost-raised` / `-frost-hover` / `-frost-pressed` (neutral-50 over the gradient at 20 / 40 / 55 / 70%). Replaces the one-off `color-mix` percentages the mockup polish now standardizes on.
- `surface-main` (light) remapped to `frost-raised` — value-identical to the previous inline 40% mix.

## Plan doc
- `.claude/PLAN_INTERFACE_POLISH.md` — full inventory + sequencing for the rest of the polish work (shared primitives → per-flow re-polish → new flows: History, Processing, Receive/Request).

Per-flow PRs will adopt the frost tokens as they port each polished component's CSS.

Typecheck clean; full interface suite 1142 passed / 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)