### PR TITLE
style(interface): polish deposit flow (frost-card review/confirmed + Shield chrome)

### DIFF
--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
@@ -84,6 +84,7 @@
   flex-shrink: 0;
 }
 
+/* Frosted fill — mirrors IconButton's `.frostedFill` (translucent neutral-50 over the card blur). */
 .pctPill {
   display: inline-flex;
   align-items: center;
@@ -92,7 +93,7 @@
   padding: 0 var(--primitives-spacing-2);
   border: none;
   border-radius: calc(var(--primitives-borderRadius-full) * 1px);
-  background: var(--semantic-color-surface-raised);
+  background: color-mix(in srgb, var(--primitives-color-neutral-50) 60%, transparent);
   font-family: var(--primitives-fontFamily-ui), sans-serif;
   font-weight: var(--primitives-fontWeight-medium);
   font-size: calc(var(--primitives-fontSize-sm) * 1px);
@@ -101,8 +102,10 @@
   transition: background 0.15s ease, transform 0.1s ease;
 }
 
-.pctPill:hover {
-  background: var(--semantic-color-surface-hover);
+@media (hover: hover) and (pointer: fine) {
+  .pctPill:hover:not(:disabled) {
+    background: var(--primitives-color-neutral-50);
+  }
 }
 
 .pctPill:active {

--- a/apps/armada-interface/src/components/deposit/DepositReviewSummary/DepositReviewSummary.module.css
+++ b/apps/armada-interface/src/components/deposit/DepositReviewSummary/DepositReviewSummary.module.css
@@ -1,51 +1,51 @@
-/* ABOUTME: DepositReviewSummary layout — borderless summary table (network / addresses / deposit amount / fees) + total row. */
+/* ABOUTME: DepositReviewSummary layout — subtle bordered summary table (network / addresses / fees) + total row. */
 /* ABOUTME: Mirrors the deposit-review reference; shared by ShieldReviewStep and ShieldCompleteStep. */
 
-/* Borderless summary table — deposit-review reference. */
+/* Subtle bordered summary table — deposit-review reference. */
 .summary {
-  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
-  overflow: hidden;
   display: flex;
   flex-direction: column;
   width: 100%;
   box-sizing: border-box;
+  gap: var(--primitives-spacing-2);
+  padding-inline: var(--primitives-spacing-2);
+  border: calc(var(--primitives-borderWidth-default) * 1px) solid
+    color-mix(in srgb, var(--primitives-color-neutral-50) 7%, transparent);
+  border-radius: calc(var(--semantic-borderRadius-item) * 1px);
+  background: transparent;
 }
 
 .summaryBody {
-  padding: var(--primitives-spacing-5);
   display: flex;
   flex-direction: column;
-  gap: var(--primitives-spacing-4);
-  background: var(--semantic-color-surface-main);
+  gap: var(--primitives-spacing-2);
+  padding: 0;
+  background: transparent;
 }
 
-.summaryRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  /* Match the mockup's measured 21px row height. Our body-sm line-box is 13px × 1.4 = 18.2px, so
-     pin the row so the vertical rhythm matches. */
-  min-height: 21px;
-  gap: var(--primitives-spacing-3);
-}
-
+.summaryRow,
 .summaryTotalRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  min-height: var(--primitives-spacing-5);
   gap: var(--primitives-spacing-3);
-  padding: var(--primitives-spacing-5);
-  background: var(--semantic-color-surface-default);
+  padding: 0;
+  background: transparent;
+}
+
+.summaryLabel,
+.summaryValue {
+  composes: bodySm from '../../../design/styles/typographyComposites.module.css';
+  line-height: var(--primitives-spacing-5);
 }
 
 .summaryLabel {
-  composes: bodySm from '../../../design/styles/typographyComposites.module.css';
-  color: var(--semantic-color-text-muted);
+  color: color-mix(in srgb, var(--semantic-color-text-primary) 80%, transparent);
   flex-shrink: 0;
 }
 
 .summaryValue {
-  composes: bodySmMedium from '../../../design/styles/typographyComposites.module.css';
   color: var(--semantic-color-text-primary);
   text-align: right;
   min-width: 0;
@@ -75,9 +75,14 @@
 .summaryTotalLabel,
 .summaryTotalValue {
   composes: bodySmSemibold from '../../../design/styles/typographyComposites.module.css';
-  color: var(--semantic-color-brand-deep);
+  line-height: var(--primitives-spacing-5);
+}
+
+.summaryTotalLabel {
+  color: color-mix(in srgb, var(--semantic-color-text-primary) 80%, transparent);
 }
 
 .summaryTotalValue {
+  color: var(--semantic-color-text-primary);
   text-align: right;
 }

--- a/apps/armada-interface/src/components/deposit/DepositReviewSummary/DepositReviewSummary.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositReviewSummary/DepositReviewSummary.tsx
@@ -1,9 +1,14 @@
-// ABOUTME: DepositReviewSummary — borderless deposit summary table (network / wallet / shielded account / amount / fees) with a "You'll receive" total.
+// ABOUTME: DepositReviewSummary — subtle bordered deposit summary table (network / wallet / Armada account / fees) with a "You'll receive" total.
 // ABOUTME: Shared by ShieldReviewStep and ShieldCompleteStep; an optional confirmedAt adds a leading "Date and time" row for confirmations.
 
 import { ArmadaLogo } from '@/design'
 import { WalletProviderIcon } from '@/components/ui/WalletProviderIcon'
-import { formatTransactionDateTime, formatUsdcAmount, truncateAddress } from '@/lib/format'
+import {
+  formatTransactionDateTime,
+  formatUsdcAmount,
+  truncateAddress,
+  truncateArmadaAddress,
+} from '@/lib/format'
 import { getChainById } from '@/config/network'
 import usdcAmount from '@/design/styles/usdcAmount.module.css'
 import styles from './DepositReviewSummary.module.css'
@@ -27,7 +32,6 @@ export interface DepositReviewSummaryProps {
 
 export function DepositReviewSummary({
   fromChainId,
-  amount,
   fee,
   netAmount,
   walletAddress,
@@ -65,21 +69,15 @@ export function DepositReviewSummary({
         ) : null}
         {shieldedAddress ? (
           <div className={styles.summaryRow}>
-            <span className={styles.summaryLabel}>To your private account</span>
+            <span className={styles.summaryLabel}>To Armada</span>
             <span className={styles.summaryValue}>
               <span className={styles.valueWithIcon}>
-                <ArmadaLogo variant="mark" className={styles.armadaIcon} />
-                <span>{truncateAddress(shieldedAddress)}</span>
+                <ArmadaLogo variant="mark" markTone="deep" className={styles.armadaIcon} />
+                <span>{truncateArmadaAddress(shieldedAddress)}</span>
               </span>
             </span>
           </div>
         ) : null}
-        <div className={styles.summaryRow}>
-          <span className={styles.summaryLabel}>Deposit amount</span>
-          <span className={[styles.summaryValue, usdcAmount.font].join(' ')}>
-            {formatUsdcAmount(amount)} USDC
-          </span>
-        </div>
         <div className={styles.summaryRow}>
           <span className={styles.summaryLabel}>Fees</span>
           <span className={[styles.summaryValue, usdcAmount.font].join(' ')}>

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.module.css
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.module.css
@@ -1,4 +1,4 @@
-/* ABOUTME: ShieldCompleteStep layout — centered serif title, coin+amount block, shared summary table, two-button CTA row. */
+/* ABOUTME: ShieldCompleteStep layout — frost-gradient card, left-aligned UI title + big mono amount, shared summary table, two-button CTA row. */
 /* ABOUTME: Mirrors the deposit-confirmed reference so success states feel consistent across the app. */
 
 .root {
@@ -6,68 +6,93 @@
   flex-direction: column;
   align-items: stretch;
   gap: var(--primitives-spacing-8);
+  padding: var(--primitives-spacing-8);
+  box-sizing: border-box;
+  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--primitives-color-neutral-50) 40%, transparent) 0%,
+    color-mix(in srgb, var(--primitives-color-neutral-50) 20%, transparent) 100%
+  );
+}
+
+.titleBlock {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--primitives-spacing-3);
+  padding-inline: var(--primitives-spacing-2);
 }
 
 .title {
-  composes: displayLg from '../../design/styles/displayLgTitle.module.css';
   margin: 0;
   width: 100%;
+  text-align: left;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-weight: var(--primitives-fontWeight-medium);
+  font-size: calc(var(--primitives-fontSize-md) * 1px);
+  line-height: var(--primitives-spacing-6);
+  letter-spacing: var(--primitives-letterSpacing-normal);
   color: var(--semantic-color-text-primary);
-  text-align: center;
 }
 
 .amountRow {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   width: 100%;
-}
-
-.amountGroup {
-  display: inline-flex;
-  align-items: center;
   gap: var(--primitives-spacing-2);
-  height: var(--primitives-spacing-10);
-  flex-shrink: 0;
-}
-
-.tokenBadge {
-  width: var(--primitives-spacing-10);
-  height: var(--primitives-spacing-10);
-  flex-shrink: 0;
-  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
-  overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.tokenBadgeIcon {
-  flex-shrink: 0;
-  display: block;
-}
-
-.tokenBadgeIcon :global(svg) {
-  display: block;
 }
 
 .amountValue {
   display: block;
-  font-weight: var(--primitives-fontWeight-medium);
-  font-size: var(--primitives-spacing-10);
-  line-height: var(--primitives-spacing-10);
-  height: var(--primitives-spacing-10);
+  font-family: var(--primitives-fontFamily-mono), ui-monospace, monospace;
+  font-weight: var(--primitives-fontWeight-regular);
+  font-size: calc(var(--primitives-fontSize-4xl) * 1px);
+  line-height: calc(var(--primitives-fontSize-4xl) * 1px);
   color: var(--semantic-color-text-primary);
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
 }
 
 /* Two-button CTA row — deposit-confirmed mockup: equal-width View on explorer / Go to dashboard, no divider above. */
 .buttonRow {
   display: flex;
-  gap: var(--primitives-spacing-3);
+  align-items: center;
+  justify-content: center;
+  gap: var(--primitives-spacing-5);
   width: 100%;
 }
 
 .buttonRow > * {
   flex: 1;
-  max-width: 211px;
+  min-width: 0;
+}
+
+.cancelButton,
+.confirmButton {
+  height: var(--primitives-spacing-12);
+  padding-left: var(--primitives-spacing-8);
+  padding-right: var(--primitives-spacing-6);
+  font-size: calc(var(--primitives-fontSize-md) * 1px);
+  line-height: calc(var(--primitives-spacing-5) + var(--primitives-spacing-1) * 0.5);
+}
+
+.cancelButton {
+  background: color-mix(in srgb, var(--primitives-color-neutral-50) 40%, transparent);
+  border: calc(var(--primitives-borderWidth-default) * 1px) solid
+    color-mix(in srgb, var(--primitives-color-neutral-50) 14%, transparent);
+  color: var(--semantic-color-text-primary);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .cancelButton:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--primitives-color-neutral-50) 55%, transparent);
+  }
+}
+
+@media (max-width: 767px) {
+  .root {
+    padding: var(--primitives-spacing-5);
+  }
 }

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.test.tsx
@@ -25,7 +25,7 @@ function setup(overrides?: { explorerUrl?: string }) {
 describe('<ShieldCompleteStep>', () => {
   it('renders the headline, the amount in the coin+amount block, and the chain name', () => {
     setup()
-    expect(screen.getByRole('heading', { name: 'Deposit confirmed' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'USDC deposit confirmed' })).toBeInTheDocument()
     // Gross amount renders full-precision in the coin block; net amount ("250.50 USDC") is the
     // summary Total row, a distinct node — so the exact-text query still resolves the block.
     expect(screen.getByText('250.5')).toBeInTheDocument()

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.tsx
@@ -1,16 +1,10 @@
-// ABOUTME: Shield complete step — serif "Deposit confirmed" title, USDC coin + deposited-amount block, shared DepositReviewSummary (with date/time), and explorer/dashboard CTAs.
+// ABOUTME: Shield complete step — frost card with left-aligned "USDC deposit confirmed" title + big mono deposited-amount, shared DepositReviewSummary (with date/time), and explorer/dashboard CTAs.
 // ABOUTME: Mirrors the deposit-confirmed reference — no divider between the summary card and the button row.
 
-import TokenUSDC from '@web3icons/react/icons/tokens/TokenUSDC'
 import { Button } from '@/design'
 import { DepositReviewSummary } from '@/components/deposit/DepositReviewSummary'
 import { formatUsdcPlain } from '@/lib/format'
-import usdcAmount from '@/design/styles/usdcAmount.module.css'
 import styles from './ShieldCompleteStep.module.css'
-
-const TOKEN_BADGE_PX = 40
-/** @web3icons branded assets use an 18px circle in a 24px viewBox — scale up to fill the badge. */
-const TOKEN_ICON_SIZE = Math.round((TOKEN_BADGE_PX * 24) / 18)
 
 export interface ShieldCompleteStepProps {
   fromChainId: number
@@ -45,16 +39,10 @@ export function ShieldCompleteStep({
 }: ShieldCompleteStepProps) {
   return (
     <div className={styles.root}>
-      <h1 className={styles.title}>Deposit confirmed</h1>
-
-      <div className={styles.amountRow}>
-        <div className={styles.amountGroup}>
-          <span className={styles.tokenBadge} aria-hidden="true">
-            <TokenUSDC size={TOKEN_ICON_SIZE} variant="branded" className={styles.tokenBadgeIcon} />
-          </span>
-          <span className={[styles.amountValue, usdcAmount.font].join(' ')}>
-            {formatUsdcPlain(amount)}
-          </span>
+      <div className={styles.titleBlock}>
+        <h1 className={styles.title}>USDC deposit confirmed</h1>
+        <div className={styles.amountRow}>
+          <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
         </div>
       </div>
 
@@ -75,6 +63,7 @@ export function ShieldCompleteStep({
           size="lg"
           label="View on explorer"
           showIcon={false}
+          className={styles.cancelButton}
           onClick={onViewExplorer}
           disabled={!explorerUrl}
         />
@@ -83,6 +72,7 @@ export function ShieldCompleteStep({
           size="lg"
           label="Go to dashboard"
           showIcon={false}
+          className={styles.confirmButton}
           onClick={onGoToDashboard}
         />
       </div>

--- a/apps/armada-interface/src/components/shield/ShieldInputStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldInputStep.tsx
@@ -90,7 +90,7 @@ export function ShieldInputStepContent({
 
   return (
     <div className={styles.contentZone}>
-      <h1 className={styles.title}>How much do you want to deposit?</h1>
+      <h1 className={styles.title}>Shield your USDC</h1>
       <DepositAmountCard
         chains={chains}
         chainId={fromChainId}

--- a/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
@@ -121,7 +121,7 @@ describe('<ShieldModal>', () => {
 
   it('renders the input step when open', () => {
     renderModal({ open: true, max: 10_000_000n })
-    expect(screen.getByRole('dialog', { name: 'Deposit' })).toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: 'Shield' })).toBeInTheDocument()
     expect(screen.getByLabelText('Deposit amount')).toBeInTheDocument()
   })
 
@@ -129,9 +129,9 @@ describe('<ShieldModal>', () => {
     renderModal({ open: true, max: 10_000_000n })
     fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
-    expect(screen.getByRole('heading', { name: 'Review your deposit' })).toBeInTheDocument()
-    // Amount renders full-precision ("5") in the coin+amount block and 2dp in the summary rows
-    // ("5.00 USDC"); match the summary rows.
+    expect(screen.getByRole('heading', { name: 'Review your USDC deposit' })).toBeInTheDocument()
+    // Amount renders full-precision ("5") in the big amount block and 2dp in the summary total
+    // ("5.00 USDC"); match the summary total.
     expect(screen.getAllByText(/5\.00/).length).toBeGreaterThanOrEqual(1)
   })
 
@@ -154,7 +154,7 @@ describe('<ShieldModal>', () => {
     fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Confirm deposit/ }))
+      fireEvent.click(screen.getByRole('button', { name: /^Confirm$/ }))
     })
     // ProgressStep renders the TxLifecycleStepper which surfaces the StatusChip; the initial
     // executionState is 'pending' which maps to the "Pending" chip. submit() awaits IDB
@@ -168,7 +168,7 @@ describe('<ShieldModal>', () => {
     const store = renderModal({ open: true, max: 10_000_000n })
     fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
-    const confirm = screen.getByRole('button', { name: /Confirm deposit/ })
+    const confirm = screen.getByRole('button', { name: /^Confirm$/ })
     // Fire twice before React can flush the disabled state — the synchronous submittingRef guard
     // must make the second click a no-op. Without it, a fast double-click = two real deposits.
     await act(async () => {
@@ -202,7 +202,7 @@ describe('<ShieldModal>', () => {
     fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /Confirm deposit/ }))
+      fireEvent.click(screen.getByRole('button', { name: /^Confirm$/ }))
     })
     await waitFor(() => expect(screen.getAllByText('Pending').length).toBeGreaterThanOrEqual(1))
 

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -343,7 +343,7 @@ export function ShieldModal() {
     <FlowShell
       open={isOpen}
       onClose={close}
-      flowLabel="Deposit"
+      flowLabel="Shield"
       currentStep={indicatorStep}
       status={indicatorStatus}
     >

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.module.css
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.module.css
@@ -1,62 +1,57 @@
-/* ABOUTME: ShieldReviewStep layout — serif title, coin+amount block, non-blocking duplicate caution, two-button CTA row. */
+/* ABOUTME: ShieldReviewStep layout — frost-gradient card, left-aligned UI title + big mono amount, non-blocking duplicate caution, two-button CTA row. */
 /* ABOUTME: The deposit summary table itself lives in the shared DepositReviewSummary component. */
 
 .root {
   display: flex;
   flex-direction: column;
   gap: var(--primitives-spacing-8);
+  padding: var(--primitives-spacing-8);
+  box-sizing: border-box;
+  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--primitives-color-neutral-50) 40%, transparent) 0%,
+    color-mix(in srgb, var(--primitives-color-neutral-50) 20%, transparent) 100%
+  );
+}
+
+.titleBlock {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--primitives-spacing-3);
+  padding-inline: var(--primitives-spacing-2);
 }
 
 .title {
-  composes: displayLg from '../../design/styles/displayLgTitle.module.css';
   margin: 0;
   width: 100%;
+  text-align: left;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-weight: var(--primitives-fontWeight-medium);
+  font-size: calc(var(--primitives-fontSize-md) * 1px);
+  line-height: var(--primitives-spacing-6);
+  letter-spacing: var(--primitives-letterSpacing-normal);
   color: var(--semantic-color-text-primary);
-  text-align: center;
 }
 
 .amountRow {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   width: 100%;
-}
-
-.amountGroup {
-  display: inline-flex;
-  align-items: center;
   gap: var(--primitives-spacing-2);
-  height: var(--primitives-spacing-10);
-  flex-shrink: 0;
-}
-
-.tokenBadge {
-  width: var(--primitives-spacing-10);
-  height: var(--primitives-spacing-10);
-  flex-shrink: 0;
-  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
-  overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.tokenBadgeIcon {
-  flex-shrink: 0;
-  display: block;
-}
-
-.tokenBadgeIcon :global(svg) {
-  display: block;
 }
 
 .amountValue {
   display: block;
-  font-weight: var(--primitives-fontWeight-medium);
-  font-size: var(--primitives-spacing-10);
-  line-height: var(--primitives-spacing-10);
-  height: var(--primitives-spacing-10);
+  font-family: var(--primitives-fontFamily-mono), ui-monospace, monospace;
+  font-weight: var(--primitives-fontWeight-regular);
+  font-size: calc(var(--primitives-fontSize-4xl) * 1px);
+  line-height: calc(var(--primitives-fontSize-4xl) * 1px);
   color: var(--semantic-color-text-primary);
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
 }
 
 /* S-L7: non-blocking caution when an unresolved same-amount deposit may still be on-chain. */
@@ -79,11 +74,41 @@
 /* Two-button CTA row — deposit-review mockup: equal-width Back / Confirm, no divider above. */
 .buttonRow {
   display: flex;
-  gap: var(--primitives-spacing-3);
+  align-items: center;
+  justify-content: center;
+  gap: var(--primitives-spacing-5);
   width: 100%;
 }
 
 .buttonRow > * {
   flex: 1;
-  max-width: 211px;
+  min-width: 0;
+}
+
+.cancelButton,
+.confirmButton {
+  height: var(--primitives-spacing-12);
+  padding-left: var(--primitives-spacing-8);
+  padding-right: var(--primitives-spacing-6);
+  font-size: calc(var(--primitives-fontSize-md) * 1px);
+  line-height: calc(var(--primitives-spacing-5) + var(--primitives-spacing-1) * 0.5);
+}
+
+.cancelButton {
+  background: color-mix(in srgb, var(--primitives-color-neutral-50) 40%, transparent);
+  border: calc(var(--primitives-borderWidth-default) * 1px) solid
+    color-mix(in srgb, var(--primitives-color-neutral-50) 14%, transparent);
+  color: var(--semantic-color-text-primary);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .cancelButton:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--primitives-color-neutral-50) 55%, transparent);
+  }
+}
+
+@media (max-width: 767px) {
+  .root {
+    padding: var(--primitives-spacing-5);
+  }
 }

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.test.tsx
@@ -23,15 +23,15 @@ function setup() {
 describe('<ShieldReviewStep>', () => {
   it('renders the amount and chain name', () => {
     setup()
-    // Amount renders full-precision in the coin+amount block ("100.5") and 2dp in the summary
-    // "Deposit amount" row ("100.50 USDC"); a regex resolves either. Chain name is the Network row.
+    // Amount renders full-precision in the big amount block ("100.5") and 2dp in the summary
+    // "You'll receive" total row ("100.50 USDC"); a regex resolves either. Chain name is the Network row.
     expect(screen.getAllByText(/100\.5/).length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText(/Anvil Hub/)).toBeInTheDocument()
   })
 
   it('fires onConfirm on the primary CTA', () => {
     const { onConfirm } = setup()
-    fireEvent.click(screen.getByRole('button', { name: /Confirm deposit/ }))
+    fireEvent.click(screen.getByRole('button', { name: /^Confirm$/ }))
     expect(onConfirm).toHaveBeenCalledTimes(1)
   })
 

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.tsx
@@ -1,17 +1,11 @@
-// ABOUTME: Shield review step — serif title, USDC coin + full-precision amount block, shared DepositReviewSummary table, Confirm/Back CTAs.
-// ABOUTME: Delegates the summary rows (network, wallet/shielded addresses, deposit amount, fees, total) to DepositReviewSummary; duplicate caution preserved.
+// ABOUTME: Shield review step — frost card with left-aligned UI title + big mono amount, shared DepositReviewSummary table, Confirm/Back CTAs.
+// ABOUTME: Delegates the summary rows (network, wallet/Armada addresses, fees, total) to DepositReviewSummary; duplicate caution preserved.
 
 import { AlertTriangle } from 'lucide-react'
-import TokenUSDC from '@web3icons/react/icons/tokens/TokenUSDC'
 import { Button } from '@/design'
 import { DepositReviewSummary } from '@/components/deposit/DepositReviewSummary'
 import { formatUsdcPlain } from '@/lib/format'
-import usdcAmount from '@/design/styles/usdcAmount.module.css'
 import styles from './ShieldReviewStep.module.css'
-
-const TOKEN_BADGE_PX = 40
-/** @web3icons branded assets use an 18px circle in a 24px viewBox — scale up to fill the badge. */
-const TOKEN_ICON_SIZE = Math.round((TOKEN_BADGE_PX * 24) / 18)
 
 export interface ShieldReviewStepProps {
   fromChainId: number
@@ -47,16 +41,10 @@ export function ShieldReviewStep({
 }: ShieldReviewStepProps) {
   return (
     <div className={styles.root}>
-      <h1 className={styles.title}>Review your deposit</h1>
-
-      <div className={styles.amountRow}>
-        <div className={styles.amountGroup}>
-          <span className={styles.tokenBadge} aria-hidden="true">
-            <TokenUSDC size={TOKEN_ICON_SIZE} variant="branded" className={styles.tokenBadgeIcon} />
-          </span>
-          <span className={[styles.amountValue, usdcAmount.font].join(' ')}>
-            {formatUsdcPlain(amount)}
-          </span>
+      <div className={styles.titleBlock}>
+        <h1 className={styles.title}>Review your USDC deposit</h1>
+        <div className={styles.amountRow}>
+          <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
         </div>
       </div>
 
@@ -81,12 +69,20 @@ export function ShieldReviewStep({
       ) : null}
 
       <div className={styles.buttonRow}>
-        <Button variant="secondary" size="lg" label="Back" showIcon={false} onClick={onBack} />
+        <Button
+          variant="secondary"
+          size="lg"
+          label="Back"
+          showIcon={false}
+          className={styles.cancelButton}
+          onClick={onBack}
+        />
         <Button
           variant="primary"
           size="lg"
-          label="Confirm deposit"
+          label="Confirm"
           showIcon={false}
+          className={styles.confirmButton}
           onClick={onConfirm}
           disabled={isSubmitting}
         />

--- a/apps/armada-interface/src/lib/format.ts
+++ b/apps/armada-interface/src/lib/format.ts
@@ -133,6 +133,12 @@ export function truncateAddressEnds(address: string, head = 6, tail = 6): string
   return `${address.slice(0, head)}...${address.slice(-tail)}`
 }
 
+/** Shielded / Armada zk address — slightly longer tail for readability. */
+export function truncateArmadaAddress(address: string): string {
+  if (address.length <= 15) return address
+  return `${address.slice(0, 6)}...${address.slice(-6)}`
+}
+
 /**
  * Compact relative-time formatter — "just now" / "12s ago" / "5m ago" / "3h ago" / "Yesterday" / "Mar 14".
  *


### PR DESCRIPTION
Chunk 4a of the designer polish (mockup diff `cec8936..8dc3e28`) — the deposit (shield) flow. First of the per-flow re-polish PRs. Depends on the merged foundation (#487) + primitives (#488) + dashboard (#489). No money-flow logic changes.

## Review & Confirmed screens
- Content now sits in a **frost-gradient card** (`neutral-50` 40%→20%).
- Title is **left-aligned, small UI** (was big centered serif); amount is **left-aligned, larger (4xl), no coin badge**.
- Buttons restyled (frost "cancel" + "confirm"); copy: "Confirm deposit" → **"Confirm"**, "Deposit confirmed" → **"USDC deposit confirmed"**, review title **"Review your USDC deposit"**.

## Summary
- `DepositReviewSummary` → subtle-bordered container, tighter rows; the redundant **"Deposit amount" row dropped** (amount shows big above); "To your private account" → **"To Armada"** with the deep-tone logo + `truncateArmadaAddress`.

## Amount step + chrome
- `DepositAmountCard` percent pills use the **frosted fill** (shared, so send/earn get it too).
- Amount-step title → **"Shield your USDC"**.
- `ShieldModal` flow chrome relabeled **Deposit → Shield** (matches the dashboard's Shield button); body "deposit" copy untouched.

## Deferred / skipped
- The mockup's **joint shield/unshield input** on the amount step (`layout="shield"` + direction toggle) — deferred; doesn't fit our converged model (unshield lives in Send).
- **`ModalStepSwitch`** step-transition — deferred to a shared FlowShell change (touches all flows at once).
- Mobile keypad / entry-modes; the mockup's unused `.privacyNotice`; demo constants.
- Optional preset-tap roll animation (not added).

Minor: `truncateArmadaAddress` added to `lib/format.ts`. Two **pre-existing** `act()` warnings in the shield "warns at review" tests (not introduced here).

Typecheck clean; full interface suite 1140 passed / 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)