### PR TITLE
style(interface): re-polish wallet panel — labeled action tiles, USDC caption, pill fade handoff

### DIFF
--- a/apps/armada-interface/src/components/WalletMenu/WalletMenu.module.css
+++ b/apps/armada-interface/src/components/WalletMenu/WalletMenu.module.css
@@ -14,7 +14,19 @@
   color: var(--semantic-color-text-primary);
   cursor: pointer;
   white-space: nowrap;
-  transition: background 0.15s ease;
+  transition: background 0.15s ease, opacity 180ms ease;
+}
+
+/* Faded out while the panel opens (and until it finishes sliding out on close). */
+.pillHidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pill {
+    transition: background 0.15s ease;
+  }
 }
 
 .pillIcon {
@@ -39,51 +51,40 @@
   white-space: nowrap;
 }
 
-/* Panel content column inside the SidePanel body — top padding + toolbar→body gap match the mockup. */
+/* Panel content column inside the SidePanel body. The close floats top-right (mockup has no title bar). */
 .panel {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: var(--primitives-spacing-5);
   width: 100%;
   min-width: 0;
   padding-top: calc(var(--primitives-spacing-5) + var(--mobile-safe-area-top, 0px));
 }
 
-/* Content column below the close toolbar. */
+/* Content column — extra top padding clears the absolutely-positioned close button. */
 .body {
   display: flex;
   flex-direction: column;
   align-items: center;
   width: 100%;
   min-width: 0;
+  padding-top: var(--primitives-spacing-10);
 }
 
-/* Close toolbar — X at the panel's top-right (mockup has no title bar). */
-.toolbar {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  width: 100%;
-}
-
+/* Close — frosted IconButton pinned to the panel's top-right corner (mockup: 32px tile, 20px glyph). */
 .close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--mobile-touch-target-min, var(--primitives-spacing-11));
-  height: var(--mobile-touch-target-min, var(--primitives-spacing-11));
-  padding: 0;
-  border: none;
-  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
-  background: transparent;
-  color: var(--semantic-color-text-muted);
-  cursor: pointer;
-  flex-shrink: 0;
+  position: absolute;
+  top: var(--primitives-spacing-5);
+  right: 0;
+  z-index: 1;
+  width: var(--primitives-spacing-8);
+  height: var(--primitives-spacing-8);
 }
 
-.close:hover {
-  color: var(--semantic-color-text-primary);
+.close > span {
+  width: var(--primitives-spacing-5);
+  height: var(--primitives-spacing-5);
 }
 
 /* Identity hero — provider glyph + address + network tag, centered. */
@@ -135,30 +136,65 @@
   white-space: nowrap;
 }
 
-/* Action row — hide / copy / explorer / disconnect. */
+/* Action row — labeled hide / copy / explorer / disconnect (shared BalanceActionButton). */
 .actionRow {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  gap: var(--primitives-spacing-3);
+  gap: var(--primitives-spacing-5);
   margin-top: var(--primitives-spacing-10);
 }
 
-.actionIcon {
-  width: var(--primitives-spacing-5);
-  height: var(--primitives-spacing-5);
-  display: block;
+/* Wallet-panel tint for the BalanceActionButton glyph tile — smaller (48px) purple-50 chip. */
+.labeledAction > span:first-child {
+  width: var(--primitives-spacing-12);
+  height: var(--primitives-spacing-12);
+  background: var(--primitives-color-purple-50);
 }
 
-/* USDC balance row — inset card. */
+.labeledAction > span:first-child :global(svg) {
+  width: var(--primitives-spacing-5);
+  height: var(--primitives-spacing-5);
+}
+
+.labeledAction:active:not(:disabled) > span:first-child {
+  background: var(--primitives-color-purple-100);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .labeledAction:hover:not(:disabled) > span:first-child {
+    background: var(--primitives-color-purple-100);
+  }
+}
+
+/* USDC balance block — a muted caption above the inset row. */
+.usdcBlock {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--primitives-spacing-2);
+  width: 100%;
+  margin-top: var(--semantic-spacing-section-gap);
+}
+
+.usdcLabel {
+  margin: 0;
+  padding-left: var(--primitives-spacing-1);
+  font-family: var(--semantic-typography-ui-label-md-font-family);
+  font-size: var(--semantic-typography-ui-label-md-font-size);
+  font-weight: var(--semantic-typography-ui-label-md-font-weight);
+  letter-spacing: var(--semantic-typography-ui-label-md-letter-spacing);
+  color: var(--semantic-color-text-muted);
+}
+
+/* USDC balance row — inset purple pill. */
 .usdcRow {
   display: flex;
   align-items: center;
   gap: var(--primitives-spacing-3);
   width: 100%;
-  margin-top: var(--primitives-spacing-10);
   padding: var(--primitives-spacing-3);
-  border-radius: calc(var(--primitives-spacing-5) / 2);
+  border-radius: calc(var(--primitives-borderRadius-xl) * 1px);
   background: var(--primitives-color-purple-50);
   box-sizing: border-box;
 }
@@ -244,10 +280,33 @@
   white-space: nowrap;
 }
 
-/* Deposit CTA. */
+/* Deposit CTA. The brand gradient (amber → rose → lavender) overrides SendButton's default
+   gradient to match the mockup; scoped under .body so it wins over SendButton's hover/active. */
 .depositButton {
   width: 100%;
-  margin-top: var(--primitives-spacing-4);
+  margin-top: var(--primitives-spacing-5);
+}
+
+.body .depositButton,
+.body .depositButton:hover:not(:disabled),
+.body .depositButton:active:not(:disabled) {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--semantic-color-brand-amber) 80%, transparent) 0%,
+    color-mix(in srgb, var(--semantic-color-brand-gradient-rose) 80%, transparent) 50%,
+    color-mix(in srgb, var(--semantic-color-brand-lavender) 80%, transparent) 100%
+  );
+  color: var(--semantic-color-text-primary);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .body .depositButton:hover:not(:disabled) {
+    filter: brightness(1.04);
+  }
+}
+
+.body .depositButton:active:not(:disabled) {
+  filter: brightness(0.96);
 }
 
 .depositIcon {

--- a/apps/armada-interface/src/components/WalletMenu/WalletMenu.test.tsx
+++ b/apps/armada-interface/src/components/WalletMenu/WalletMenu.test.tsx
@@ -26,8 +26,10 @@ function setup(extra?: Partial<WalletMenuProps>) {
   return props
 }
 
-function openPanel() {
+// Opening fades the pill out, then reveals the panel on a short timer — await the dialog.
+async function openPanel() {
   fireEvent.click(screen.getByRole('button', { name: new RegExp(DISPLAY) }))
+  await screen.findByRole('dialog', { name: 'Wallet' })
 }
 
 describe('<WalletMenu>', () => {
@@ -36,10 +38,10 @@ describe('<WalletMenu>', () => {
     expect(screen.getByRole('button', { name: new RegExp(DISPLAY) })).toBeInTheDocument()
   })
 
-  it('opens the side panel on pill click', () => {
+  it('opens the side panel on pill click', async () => {
     setup()
     expect(screen.queryByRole('dialog', { name: 'Wallet' })).toBeNull()
-    openPanel()
+    await openPanel()
     expect(screen.getByRole('dialog', { name: 'Wallet' })).toBeInTheDocument()
   })
 
@@ -47,43 +49,43 @@ describe('<WalletMenu>', () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
     setup()
-    openPanel()
-    fireEvent.click(screen.getByRole('button', { name: 'Copy wallet address' }))
+    await openPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
     expect(writeText).toHaveBeenCalledWith(FULL)
     // Await the post-copy state flip so the async setState settles inside act (pristine output).
-    expect(await screen.findByRole('button', { name: 'Address copied' })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: 'Copied' })).toBeInTheDocument()
   })
 
-  it('fires onDisconnect', () => {
+  it('fires onDisconnect', async () => {
     const props = setup()
-    openPanel()
-    fireEvent.click(screen.getByRole('button', { name: 'Disconnect wallet' }))
+    await openPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }))
     expect(props.onDisconnect).toHaveBeenCalledTimes(1)
   })
 
-  it('fires onDeposit', () => {
+  it('fires onDeposit', async () => {
     const props = setup()
-    openPanel()
-    fireEvent.click(screen.getByRole('button', { name: 'DEPOSIT' }))
+    await openPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Shield your USDC' }))
     expect(props.onDeposit).toHaveBeenCalledTimes(1)
   })
 
-  it('requests a balance-visibility change (controlled, shared app-wide)', () => {
+  it('requests a balance-visibility change (controlled, shared app-wide)', async () => {
     const props = setup()
-    openPanel()
-    fireEvent.click(screen.getByRole('button', { name: 'Hide balance' }))
+    await openPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Hide' }))
     expect(props.onBalanceHiddenChange).toHaveBeenCalledWith(true)
   })
 
-  it('reflects the hidden state from props', () => {
+  it('reflects the hidden state from props', async () => {
     setup({ balanceHidden: true })
-    openPanel()
-    expect(screen.getByRole('button', { name: 'Show balance' })).toBeInTheDocument()
+    await openPanel()
+    expect(screen.getByRole('button', { name: 'Show' })).toBeInTheDocument()
   })
 
-  it('disables the explorer action when no URL is available', () => {
+  it('disables the explorer action when no URL is available', async () => {
     setup({ explorerUrl: undefined })
-    openPanel()
-    expect(screen.getByRole('button', { name: 'View wallet on explorer' })).toBeDisabled()
+    await openPanel()
+    expect(screen.getByRole('button', { name: 'Explorer' })).toBeDisabled()
   })
 })

--- a/apps/armada-interface/src/components/WalletMenu/WalletMenu.tsx
+++ b/apps/armada-interface/src/components/WalletMenu/WalletMenu.tsx
@@ -1,21 +1,22 @@
-// ABOUTME: Connected-wallet control — a pill trigger (provider icon + address) that opens a right-edge SidePanel with the EVM wallet identity, actions (hide/copy/explorer/disconnect, each tooltipped), USDC balance, and a Deposit CTA.
-// ABOUTME: Replaces the old dropdown WalletPillMenu; matches the mockup's side-panel design. Balance-hide is shared app-wide via balanceHiddenAtom (owned by the parent).
+// ABOUTME: Connected-wallet control — a pill trigger (provider icon + address) that opens a right-edge SidePanel with the EVM wallet identity, labeled actions (hide/copy/explorer/disconnect), USDC balance, and a Shield CTA.
+// ABOUTME: Matches the mockup's polished wallet panel; the pill fades out as the panel opens and back in as it closes. Balance-hide is shared app-wide via balanceHiddenAtom (owned by the parent).
 
 import { useEffect, useRef, useState } from 'react'
 import {
-  ArrowRightOnRectangleIcon,
   ArrowTopRightOnSquareIcon,
   CheckIcon,
   ClipboardDocumentIcon,
   EyeIcon,
   EyeSlashIcon,
   PlusIcon,
+  PowerIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import TokenUSDC from '@web3icons/react/icons/tokens/TokenUSDC'
-import { IconButton, SidePanel, Tooltip } from '@/design'
+import { IconButton, SidePanel, SIDE_PANEL_EXIT_MS } from '@/design'
 import { WalletProviderIcon } from '@/components/ui/WalletProviderIcon'
 import { chainIconForChainId } from '@/components/ui/chainIcons'
+import { BalanceActionButton } from '@/components/dashboard/BalanceActionButton'
 import { SendButton } from '@/components/dashboard/SendButton'
 import { BalanceScrambleValue } from '@/components/dashboard/BalanceScrambleValue'
 import { formatUsdcAmount } from '@/components/dashboard/dashboardFormat'
@@ -25,6 +26,14 @@ const HERO_ICON_PX = 56
 const USDC_GLYPH_PX = 40
 const USDC_GLYPH_SIZE = Math.round((USDC_GLYPH_PX * 24) / 18)
 const USDC_OVERLAY_ICON_PX = 16
+
+/** Pill fade duration — the pill fades out before the panel opens (and back in after it closes). */
+const PILL_FADE_MS = 180
+
+function fadeDelayMs(): number {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return PILL_FADE_MS
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : PILL_FADE_MS
+}
 
 export interface WalletMenuProps {
   /** Truncated EVM address — shown on the pill + panel hero. */
@@ -39,7 +48,7 @@ export interface WalletMenuProps {
   usdcBalance: number
   /** Connected chain name — shown as the network tag + USDC row subtitle. */
   networkLabel: string
-  /** Address explorer URL; the "View on explorer" action is disabled when absent (e.g. local Anvil). */
+  /** Address explorer URL; the "Explorer" action is disabled when absent (e.g. local Anvil). */
   explorerUrl?: string
   /** Shared app-wide balance visibility (from balanceHiddenAtom). */
   balanceHidden: boolean
@@ -64,15 +73,59 @@ export function WalletMenu({
   onDeposit,
   triggerClassName,
 }: WalletMenuProps) {
-  const [open, setOpen] = useState(false)
+  const [panelOpen, setPanelOpen] = useState(false)
+  const [pillHidden, setPillHidden] = useState(false)
   const [copied, setCopied] = useState(false)
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  function clearOpenCloseTimers() {
+    if (openTimerRef.current) clearTimeout(openTimerRef.current)
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
+    openTimerRef.current = null
+    closeTimerRef.current = null
+  }
 
   useEffect(() => {
     return () => {
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+      clearOpenCloseTimers()
     }
   }, [])
+
+  // While the pill is faded out but the panel hasn't opened yet, Escape restores the pill.
+  useEffect(() => {
+    if (!pillHidden || panelOpen) return
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== 'Escape') return
+      clearOpenCloseTimers()
+      setPillHidden(false)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [pillHidden, panelOpen])
+
+  function openMenu() {
+    if (pillHidden || panelOpen) return
+    clearOpenCloseTimers()
+    setPillHidden(true)
+    openTimerRef.current = setTimeout(() => {
+      setPanelOpen(true)
+      openTimerRef.current = null
+    }, fadeDelayMs())
+  }
+
+  function closeMenu() {
+    clearOpenCloseTimers()
+    setPanelOpen(false)
+    // Wait for the panel's slide-out before fading the pill back in, so they hand off cleanly.
+    const restoreDelay = fadeDelayMs() === 0 ? 0 : SIDE_PANEL_EXIT_MS
+    closeTimerRef.current = setTimeout(() => {
+      setPillHidden(false)
+      closeTimerRef.current = null
+    }, restoreDelay)
+  }
 
   async function handleCopy() {
     try {
@@ -86,7 +139,7 @@ export function WalletMenu({
   }
 
   function handleDeposit() {
-    setOpen(false)
+    closeMenu()
     onDeposit()
   }
 
@@ -97,10 +150,13 @@ export function WalletMenu({
     <>
       <button
         type="button"
-        className={[styles.pill, triggerClassName].filter(Boolean).join(' ')}
+        className={[styles.pill, pillHidden && styles.pillHidden, triggerClassName]
+          .filter(Boolean)
+          .join(' ')}
         aria-haspopup="dialog"
-        aria-expanded={open}
-        onClick={() => setOpen(true)}
+        aria-expanded={panelOpen || pillHidden}
+        tabIndex={pillHidden ? -1 : undefined}
+        onClick={openMenu}
       >
         <span className={styles.pillIcon} aria-hidden>
           <WalletProviderIcon provider={walletProvider} size={24} />
@@ -109,100 +165,102 @@ export function WalletMenu({
       </button>
 
       {/* No SidePanel title — the mockup panel has no header bar; the close X floats top-right. */}
-      <SidePanel open={open} onClose={() => setOpen(false)} ariaLabel="Wallet">
+      <SidePanel open={panelOpen} onClose={closeMenu} ariaLabel="Wallet">
         <div className={styles.panel}>
-          <div className={styles.toolbar}>
-            <button type="button" className={styles.close} aria-label="Close" onClick={() => setOpen(false)}>
-              <XMarkIcon width={20} height={20} strokeWidth={2} aria-hidden />
-            </button>
-          </div>
+          <IconButton
+            variant="frosted"
+            size="sm"
+            className={styles.close}
+            aria-label="Close"
+            icon={<XMarkIcon strokeWidth={2} aria-hidden />}
+            onClick={closeMenu}
+          />
 
           <div className={styles.body}>
-          <div className={styles.identity}>
-            <span className={styles.heroIcon} aria-hidden>
-              <WalletProviderIcon provider={walletProvider} size={HERO_ICON_PX} />
-            </span>
-            <p className={styles.address}>{displayAddress}</p>
-            <span className={styles.networkTag}>{networkLabel}</span>
-          </div>
+            <div className={styles.identity}>
+              <span className={styles.heroIcon} aria-hidden>
+                <WalletProviderIcon provider={walletProvider} size={HERO_ICON_PX} />
+              </span>
+              <p className={styles.address}>{displayAddress}</p>
+              <span className={styles.networkTag}>{networkLabel}</span>
+            </div>
 
-          <div className={styles.actionRow}>
-            <Tooltip variant="action" content={balanceHidden ? 'Show balance' : 'Hide balance'}>
-              <IconButton
-                variant="secondary"
+            <div className={styles.actionRow}>
+              <BalanceActionButton
+                variant="subtle"
+                className={styles.labeledAction}
+                label={balanceHidden ? 'Show' : 'Hide'}
                 icon={
                   balanceHidden ? (
-                    <EyeSlashIcon className={styles.actionIcon} strokeWidth={1.5} aria-hidden />
+                    <EyeSlashIcon strokeWidth={1.5} aria-hidden />
                   ) : (
-                    <EyeIcon className={styles.actionIcon} strokeWidth={1.5} aria-hidden />
+                    <EyeIcon strokeWidth={1.5} aria-hidden />
                   )
                 }
-                aria-label={balanceHidden ? 'Show balance' : 'Hide balance'}
                 onClick={() => onBalanceHiddenChange(!balanceHidden)}
               />
-            </Tooltip>
-            <Tooltip variant="action" content={copied ? 'Copied' : 'Copy address'}>
-              <IconButton
-                variant="secondary"
+              <BalanceActionButton
+                variant="subtle"
+                className={styles.labeledAction}
+                label={copied ? 'Copied' : 'Copy'}
                 icon={
                   copied ? (
-                    <CheckIcon className={styles.actionIcon} strokeWidth={1.5} aria-hidden />
+                    <CheckIcon strokeWidth={1.5} aria-hidden />
                   ) : (
-                    <ClipboardDocumentIcon className={styles.actionIcon} strokeWidth={1.5} aria-hidden />
+                    <ClipboardDocumentIcon strokeWidth={1.5} aria-hidden />
                   )
                 }
-                aria-label={copied ? 'Address copied' : 'Copy wallet address'}
                 onClick={() => void handleCopy()}
               />
-            </Tooltip>
-            <Tooltip variant="action" content="View on explorer">
-              <IconButton
-                variant="secondary"
-                icon={<ArrowTopRightOnSquareIcon className={styles.actionIcon} strokeWidth={1.5} aria-hidden />}
-                aria-label="View wallet on explorer"
+              <BalanceActionButton
+                variant="subtle"
+                className={styles.labeledAction}
+                label="Explorer"
+                icon={<ArrowTopRightOnSquareIcon strokeWidth={1.5} aria-hidden />}
                 disabled={!explorerUrl}
                 onClick={() => {
                   if (explorerUrl) window.open(explorerUrl, '_blank', 'noopener,noreferrer')
                 }}
               />
-            </Tooltip>
-            <Tooltip variant="action" content="Disconnect">
-              <IconButton
-                variant="secondary"
-                icon={<ArrowRightOnRectangleIcon className={styles.actionIcon} strokeWidth={1.5} aria-hidden />}
-                aria-label="Disconnect wallet"
+              <BalanceActionButton
+                variant="subtle"
+                className={styles.labeledAction}
+                label="Disconnect"
+                icon={<PowerIcon strokeWidth={1.5} aria-hidden />}
                 onClick={onDisconnect}
               />
-            </Tooltip>
-          </div>
-
-          <div className={styles.usdcRow}>
-            <span className={styles.usdcIcon} aria-hidden>
-              <span className={styles.usdcGlyph}>
-                <TokenUSDC size={USDC_GLYPH_SIZE} variant="branded" />
-              </span>
-              {OverlayIcon ? (
-                <span className={styles.usdcOverlay}>
-                  <OverlayIcon size={USDC_OVERLAY_ICON_PX} variant="branded" />
-                </span>
-              ) : null}
-            </span>
-            <div className={styles.tokenIdentity}>
-              <p className={styles.tokenName}>USDC</p>
-              <p className={styles.tokenNetwork}>{networkLabel}</p>
             </div>
-            <p className={styles.tokenBalance}>
-              <BalanceScrambleValue value={balanceLabel} revealed={!balanceHidden} />
-            </p>
-          </div>
 
-          <SendButton
-            variant="gradient"
-            label="DEPOSIT"
-            icon={<PlusIcon className={styles.depositIcon} strokeWidth={1.5} aria-hidden />}
-            className={styles.depositButton}
-            onClick={handleDeposit}
-          />
+            <div className={styles.usdcBlock}>
+              <p className={styles.usdcLabel}>Your USDC wallet balance</p>
+              <div className={styles.usdcRow}>
+                <span className={styles.usdcIcon} aria-hidden>
+                  <span className={styles.usdcGlyph}>
+                    <TokenUSDC size={USDC_GLYPH_SIZE} variant="branded" />
+                  </span>
+                  {OverlayIcon ? (
+                    <span className={styles.usdcOverlay}>
+                      <OverlayIcon size={USDC_OVERLAY_ICON_PX} variant="branded" />
+                    </span>
+                  ) : null}
+                </span>
+                <div className={styles.tokenIdentity}>
+                  <p className={styles.tokenName}>USDC</p>
+                  <p className={styles.tokenNetwork}>{networkLabel}</p>
+                </div>
+                <p className={styles.tokenBalance}>
+                  <BalanceScrambleValue value={balanceLabel} revealed={!balanceHidden} />
+                </p>
+              </div>
+            </div>
+
+            <SendButton
+              variant="gradient"
+              label="Shield your USDC"
+              icon={<PlusIcon className={styles.depositIcon} strokeWidth={1.5} aria-hidden />}
+              className={styles.depositButton}
+              onClick={handleDeposit}
+            />
           </div>
         </div>
       </SidePanel>


### PR DESCRIPTION
Wallet panel re-polish (chunk 5 of the designer polish update, mockup `8dc3e28`). Applies the polish delta to our single-wallet `WalletMenu` side panel. Desktop.

## Panel content
- **Action row → labeled `BalanceActionButton`s** (reusing the dashboard primitive): **Show/Hide · Copy · Explorer · Disconnect**, each a purple-50 glyph tile (48px, hover/active purple-100) with a visible label. Replaces the four icon-only tooltipped `IconButton`s. Disconnect icon → `PowerIcon`; Explorer still disables without an explorer URL.
- **"Your USDC wallet balance" caption** added above the USDC pill; pill radius bumped to `xl`.
- **CTA relabeled** "DEPOSIT" → **"Shield your USDC"**, and its fill matched to the mockup's 3-stop brand gradient (135° amber → rose → lavender) with hover-brighten / press-darken feedback.
- **Close → frosted `IconButton`** pinned top-right, sized to the mockup (32px tile, 20px glyph).

## Motion
- The trigger pill fades out (~180ms) as the panel opens and fades back in timed to the panel's slide-out (`SIDE_PANEL_EXIT_MS`) on close — a clean handoff. Escape restores the pill if pressed mid-fade. Guarded for reduced-motion + jsdom (missing `matchMedia`).

## Scope
- Skipped the mockup's multi-wallet management (wallet list / switch / connect-more) — our app is a single wagmi/RainbowKit EVM wallet. Kept the `.networkTag` span rather than porting the `Tag` component.

Tests updated for the new action-button names + the now-async panel open (8 pass). Typecheck clean; full interface suite 1142 passing (8 pre-existing OnboardingFlow skips).
