### PR TITLE
style(interface): processing step — hero tick-ring card + timeline disclosure from live state

### DIFF
--- a/apps/armada-interface/src/components/flow/ProgressStep/ProgressStep.test.tsx
+++ b/apps/armada-interface/src/components/flow/ProgressStep/ProgressStep.test.tsx
@@ -31,17 +31,11 @@ describe('<ProgressStep>', () => {
     expect(screen.getByText('Hang on a moment…')).toBeInTheDocument()
   })
 
-  it('delegates to TxLifecycleStepper when record is present', () => {
+  it('renders the processing layout (hero card + timeline) when a record is present', () => {
     render(<ProgressStep record={sampleRecord} />)
-    // TxLifecycleStepper renders one row per lifecycle stage; the first is "Preparing transaction"
-    // which is shield's build-proof copy. (The WalletConfirmList — S-M4 — also renders status
-    // labels including "Pending", so we assert the unique stepper copy rather than "Pending".)
+    // The hero card shows the per-kind title (rendered as two lines for shield); the timeline's
+    // active row shows the entry-stage label "Preparing transaction" (shield's build-proof copy).
+    expect(screen.getByText('being shielded')).toBeInTheDocument()
     expect(screen.getByText('Preparing transaction')).toBeInTheDocument()
-    expect(screen.getAllByText('Pending').length).toBeGreaterThanOrEqual(1)
-  })
-
-  it('renders the wallet-confirm checklist for shield kinds (S-M4)', () => {
-    render(<ProgressStep record={sampleRecord} />)
-    expect(screen.getByRole('list', { name: 'Wallet confirmations' })).toBeInTheDocument()
   })
 })

--- a/apps/armada-interface/src/components/flow/ProgressStep/ProgressStep.tsx
+++ b/apps/armada-interface/src/components/flow/ProgressStep/ProgressStep.tsx
@@ -1,28 +1,23 @@
-// ABOUTME: Shared progress step — renders the active tx's <TxLifecycleStepper> for any TxKind, with a Cancel CTA on in-flight records.
+// ABOUTME: Shared progress step — renders the processing layout (hero card + timeline) for any TxKind from the live record.
 // ABOUTME: When no record exists yet (user clicked Confirm but executor hasn't written the first transition), shows a preparing placeholder.
 
-import { useAtomValue } from 'jotai'
 import type { TxRecord } from '@/lib/tx/types'
-import { TxActions, TxLifecycleStepper } from '@/components/tx'
-import { WalletConfirmList } from '../WalletConfirmList/WalletConfirmList'
-import { shieldWalletSteps } from '@/lib/tx/shieldWalletSteps'
-import { preferencesAtom } from '@/state/preferences'
+import { TxProcessingLayout } from '@/components/tx/processing/TxProcessingLayout'
+import { buildProcessingView, type SendVariant } from '@/components/tx/processing/processingView'
 import styles from './ProgressStep.module.css'
 
 export interface ProgressStepProps {
   /** The in-flight tx record. Null when the executor hasn't created a record yet (e.g. user just clicked Confirm). */
   record: TxRecord | null
   /**
-   * Override the user's "Show technical details by default" preference. When undefined, falls back to
-   * preferencesAtom. Modals don't need to thread the preference; ProgressStep handles it once here.
+   * Send/Withdraw flow variant — disambiguates the shared `unshield-*` kinds so the hero title reads
+   * "Unshielding your USDC" (send) vs "Your withdraw is in progress" (withdraw). Only the SendModal
+   * passes it; other flows resolve their title from the kind alone.
    */
-  technicalDetailsDefaultOpen?: boolean
+  sendVariant?: SendVariant
 }
 
-export function ProgressStep({ record, technicalDetailsDefaultOpen }: ProgressStepProps) {
-  const prefs = useAtomValue(preferencesAtom)
-  const defaultOpen = technicalDetailsDefaultOpen ?? prefs.showTechnicalDetailsByDefault
-
+export function ProgressStep({ record, sendVariant }: ProgressStepProps) {
   if (!record) {
     return (
       <div className={styles.root}>
@@ -31,24 +26,17 @@ export function ProgressStep({ record, technicalDetailsDefaultOpen }: ProgressSt
       </div>
     )
   }
-  // S-M4: shield / shield-xchain surface a wallet-prompt checklist (approve + deposit, or a single
-  // "Authorize deposit" row on the gasless path) so the user can see which wallet prompts are
-  // pending vs done. Other kinds rely on the stepper's submit-relayer row alone.
-  const isShieldKind = record.kind === 'shield' || record.kind === 'shield-xchain'
+  const view = buildProcessingView(record, { sendVariant })
 
   return (
     <div className={styles.root}>
-      {isShieldKind ? (
-        <WalletConfirmList
-          steps={shieldWalletSteps(
-            record as TxRecord<'shield'> | TxRecord<'shield-xchain'>,
-            record.meta.amount,
-          )}
-        />
-      ) : null}
-      <TxLifecycleStepper record={record} technicalDetailsDefaultOpen={defaultOpen} />
-      {/* Cancel only — Retry on failure is handled by the modal's dedicated ErrorStep. */}
-      <TxActions record={record} variant="cancel" />
+      {/* Hero progress card + timeline stage disclosure (mockup), driven by the real lifecycle. */}
+      <TxProcessingLayout
+        cardCopy={view.cardCopy}
+        stages={view.stages}
+        activeStageIndex={view.activeStageIndex}
+        completed={view.completed}
+      />
     </div>
   )
 }

--- a/apps/armada-interface/src/components/payments/SendModal.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.test.tsx
@@ -190,7 +190,7 @@ describe('<SendModal>', () => {
       fireEvent.click(screen.getByRole('button', { name: /Confirm send/ }))
     })
     await waitFor(() => {
-      expect(screen.getByText('Pending')).toBeInTheDocument()
+      expect(screen.getByText('Preparing transaction')).toBeInTheDocument()
     })
   })
 
@@ -203,7 +203,7 @@ describe('<SendModal>', () => {
       fireEvent.click(screen.getByRole('button', { name: /Confirm send/ }))
     })
     await waitFor(() => {
-      expect(screen.getByText('Pending')).toBeInTheDocument()
+      expect(screen.getByText('Preparing transaction')).toBeInTheDocument()
     })
   })
 
@@ -216,7 +216,7 @@ describe('<SendModal>', () => {
       fireEvent.click(screen.getByRole('button', { name: /Confirm send/ }))
     })
     await waitFor(() => {
-      expect(screen.getByText('Pending')).toBeInTheDocument()
+      expect(screen.getByText('Preparing transaction')).toBeInTheDocument()
     })
   })
 
@@ -253,7 +253,7 @@ describe('<SendModal>', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
       })
       await waitFor(() => {
-        expect(screen.getByText('Pending')).toBeInTheDocument()
+        expect(screen.getByText('Preparing transaction')).toBeInTheDocument()
       })
     })
 

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -420,7 +420,7 @@ export function SendModal() {
           onConfirm={handleSubmit}
         />
       )}
-      {step === 'progress' && <ProgressStep record={record} />}
+      {step === 'progress' && <ProgressStep record={record} sendVariant={variant} />}
       {step === 'complete' && (
         <SendCompleteStep
           variant={variant}

--- a/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
@@ -160,7 +160,7 @@ describe('<ShieldModal>', () => {
     // executionState is 'pending' which maps to the "Pending" chip. submit() awaits IDB
     // persistence so waitFor() handles the brief gap before the record reaches the atom.
     await waitFor(() => {
-      expect(screen.getAllByText('Pending').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getByText('Preparing transaction')).toBeInTheDocument()
     })
   })
 
@@ -176,7 +176,7 @@ describe('<ShieldModal>', () => {
       fireEvent.click(confirm)
     })
     await waitFor(() => {
-      expect(screen.getAllByText('Pending').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getByText('Preparing transaction')).toBeInTheDocument()
     })
     expect(store.get(txListAtom).length).toBe(1)
   })
@@ -204,7 +204,7 @@ describe('<ShieldModal>', () => {
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^Confirm$/ }))
     })
-    await waitFor(() => expect(screen.getAllByText('Pending').length).toBeGreaterThanOrEqual(1))
+    await waitFor(() => expect(screen.getByText('Preparing transaction')).toBeInTheDocument())
 
     // The Close affordance is present during progress now (was hidden pre-S-M2).
     await act(async () => {

--- a/apps/armada-interface/src/components/tx/TxLifecycleStepper.tsx
+++ b/apps/armada-interface/src/components/tx/TxLifecycleStepper.tsx
@@ -17,6 +17,12 @@ export interface TxLifecycleStepperProps {
   record: TxRecord
   /** Whether the technical-details disclosure starts open. Wired to user preference at the page level. */
   technicalDetailsDefaultOpen?: boolean
+  /**
+   * Render only the ETA + technical-details disclosure, hiding the status chip and stage list.
+   * The processing step uses this to keep the debug/ETA affordances beneath the new progress card
+   * without duplicating the (now timeline-rendered) stage list.
+   */
+  detailsOnly?: boolean
   className?: string
 }
 
@@ -58,6 +64,7 @@ function explorerLinkFor(chainId: number, txHash: `0x${string}`): string | null 
 export function TxLifecycleStepper({
   record,
   technicalDetailsDefaultOpen = false,
+  detailsOnly = false,
   className,
 }: TxLifecycleStepperProps) {
   const lifecycle = lifecycleFor(record.kind)
@@ -70,7 +77,9 @@ export function TxLifecycleStepper({
   return (
     <div className={cls}>
       <header className={styles.header}>
-        <TxStatusChip state={record.executionState} error={record.artifacts.error ?? null} />
+        {detailsOnly ? null : (
+          <TxStatusChip state={record.executionState} error={record.artifacts.error ?? null} />
+        )}
         {eta.label ? (
           <span className={[styles.eta, eta.overdue ? styles.etaOverdue : ''].filter(Boolean).join(' ')}>
             {eta.label}
@@ -78,6 +87,7 @@ export function TxLifecycleStepper({
         ) : null}
       </header>
 
+      {detailsOnly ? null : (
       <ol className={styles.stages}>
         {lifecycle.stages.map(stage => {
           const kind = rowKindFor(
@@ -135,6 +145,7 @@ export function TxLifecycleStepper({
           )
         })}
       </ol>
+      )}
 
       <TechnicalDetailsDisclosure defaultOpen={technicalDetailsDefaultOpen}>
         <dl className={styles.facts}>

--- a/apps/armada-interface/src/components/tx/processing/TransactionProgressDisclosure/TransactionProgressDisclosure.module.css
+++ b/apps/armada-interface/src/components/tx/processing/TransactionProgressDisclosure/TransactionProgressDisclosure.module.css
@@ -1,0 +1,175 @@
+/* ABOUTME: Styles for the timeline transaction-progress disclosure — slide/measure + bar travel. */
+/* ABOUTME: Ported from the armada-app design mockup (timeline variant only). */
+.root {
+  position: relative;
+  width: 100%;
+  /* EXCEPTION — solid white card on the modal processing surface. */
+  background: var(--semantic-color-surface-default);
+  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
+  padding: var(--primitives-spacing-4) var(--primitives-spacing-5);
+  padding-right: var(--primitives-spacing-8);
+}
+
+.toggleButton {
+  position: absolute;
+  top: var(--primitives-spacing-4);
+  right: var(--primitives-spacing-5);
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--primitives-spacing-6);
+  height: var(--primitives-spacing-6);
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--primitives-color-purple-100);
+  cursor: pointer;
+  transition: background-color 150ms ease;
+}
+
+.toggleButton:hover {
+  background: var(--primitives-color-purple-200);
+}
+
+.chevron {
+  color: var(--semantic-color-text-secondary);
+  transition: transform 280ms cubic-bezier(0.22, 1, 0.36, 1);
+  flex-shrink: 0;
+}
+
+.toggleButton[aria-expanded='true'] .chevron {
+  transform: rotate(180deg);
+}
+
+.viewport {
+  overflow: hidden;
+  transition: height 280ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: height;
+}
+
+.track {
+  transition: transform 280ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: transform;
+}
+
+.stepList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-4);
+}
+
+.stepItem {
+  margin: 0;
+}
+
+.stepRow {
+  display: flex;
+  align-items: stretch;
+  gap: var(--primitives-spacing-4);
+  min-width: 0;
+}
+
+.barTrack {
+  --bar-inset: var(--primitives-spacing-1);
+  --bar-indicator-size: 14px;
+  position: relative;
+  width: 4px;
+  align-self: stretch;
+  min-height: 3.25rem;
+  flex-shrink: 0;
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  overflow: hidden;
+}
+
+.barTrack_pending {
+  background: color-mix(in srgb, var(--semantic-color-brand-lavender) 18%, transparent);
+}
+
+.barTrack_currentActive {
+  background: color-mix(in srgb, var(--semantic-color-brand-lavender) 28%, transparent);
+}
+
+.barTrack_done,
+.barTrack_completedFinal {
+  background: var(--semantic-color-brand-lavender);
+}
+
+.barIndicator {
+  position: absolute;
+  left: 0;
+  width: 4px;
+  height: var(--bar-indicator-size);
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  background: var(--semantic-color-brand-lavender);
+  animation: barTravel 1.8s ease-in-out infinite;
+}
+
+@keyframes barTravel {
+  0%,
+  100% {
+    top: var(--bar-inset);
+  }
+
+  50% {
+    top: calc(100% - var(--bar-indicator-size) - var(--bar-inset));
+  }
+}
+
+.stepCopy {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-1);
+  min-width: 0;
+}
+
+.counter {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-weight: var(--primitives-fontWeight-medium);
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  color: var(--semantic-color-text-muted);
+}
+
+.stepTitle {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-weight: var(--primitives-fontWeight-regular);
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  color: var(--semantic-color-text-primary);
+}
+
+.currentActive .stepTitle,
+.completedFinal .stepTitle {
+  color: var(--semantic-color-brand-lavender);
+  font-weight: var(--primitives-fontWeight-semibold);
+}
+
+.pending .stepTitle,
+.done .stepTitle {
+  color: var(--semantic-color-text-primary);
+  font-weight: var(--primitives-fontWeight-regular);
+}
+
+.stepSubtitle {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-weight: var(--primitives-fontWeight-regular);
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  color: var(--semantic-color-text-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chevron,
+  .toggleButton,
+  .viewport,
+  .track {
+    transition: none;
+  }
+
+  .barIndicator {
+    animation: none;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+}

--- a/apps/armada-interface/src/components/tx/processing/TransactionProgressDisclosure/TransactionProgressDisclosure.tsx
+++ b/apps/armada-interface/src/components/tx/processing/TransactionProgressDisclosure/TransactionProgressDisclosure.tsx
@@ -1,0 +1,184 @@
+// ABOUTME: Collapsible transaction-progress disclosure — animated lavender timeline variant.
+// ABOUTME: Ported from the armada-app design mockup (timeline variant only).
+import { ChevronDown } from 'lucide-react'
+import { useId, useLayoutEffect, useRef, useState } from 'react'
+import type { RowKind, TxProgressStage } from '../processingCopy'
+import { rowKindFor, stageLabelFor } from '../processingCopy'
+import styles from './TransactionProgressDisclosure.module.css'
+
+export interface TransactionProgressVariantProps {
+  stages: ReadonlyArray<TxProgressStage>
+  activeStageIndex?: number
+  completed?: boolean
+  className?: string
+}
+
+export type TransactionProgressVariant = 'timeline'
+
+export interface TransactionProgressDisclosureProps extends TransactionProgressVariantProps {
+  variant?: TransactionProgressVariant
+}
+
+interface TimelineStepProps {
+  kind: RowKind
+  counter: string
+  label: string
+  subtitle: string
+}
+
+interface SlideMetrics {
+  rowHeight: number
+  rowStride: number
+  totalHeight: number
+}
+
+const DEFAULT_ROW_HEIGHT = 52
+const DEFAULT_ROW_STRIDE = 68
+const DEFAULT_TOTAL_HEIGHT = 220
+
+function ProgressBar({ kind }: { kind: RowKind }) {
+  return (
+    <div
+      className={[styles.barTrack, styles[`barTrack_${kind}`]].filter(Boolean).join(' ')}
+      aria-hidden
+    >
+      {kind === 'currentActive' ? <span className={styles.barIndicator} /> : null}
+    </div>
+  )
+}
+
+function TimelineStep({ kind, counter, label, subtitle }: TimelineStepProps) {
+  return (
+    <div className={[styles.stepRow, styles[kind]].filter(Boolean).join(' ')}>
+      <ProgressBar kind={kind} />
+
+      <div className={styles.stepCopy}>
+        <span className={styles.counter}>{counter}</span>
+        <span className={styles.stepTitle}>{label}</span>
+        <span className={styles.stepSubtitle}>{subtitle}</span>
+      </div>
+    </div>
+  )
+}
+
+function measureSlideMetrics(
+  list: HTMLOListElement,
+  rows: Array<HTMLLIElement | null>,
+): SlideMetrics {
+  const firstRow = rows[0]
+  if (!firstRow) {
+    return {
+      rowHeight: DEFAULT_ROW_HEIGHT,
+      rowStride: DEFAULT_ROW_STRIDE,
+      totalHeight: DEFAULT_TOTAL_HEIGHT,
+    }
+  }
+
+  const gap = Number.parseFloat(getComputedStyle(list).rowGap || getComputedStyle(list).gap) || 0
+  const rowHeight = firstRow.getBoundingClientRect().height
+  const rowStride = rowHeight + gap
+
+  return {
+    rowHeight,
+    rowStride,
+    totalHeight: list.scrollHeight,
+  }
+}
+
+function TimelineVariant({
+  stages,
+  activeStageIndex = 0,
+  completed = false,
+  className,
+}: TransactionProgressVariantProps) {
+  const panelId = useId()
+  const [isOpen, setIsOpen] = useState(false)
+  const [metrics, setMetrics] = useState<SlideMetrics>({
+    rowHeight: DEFAULT_ROW_HEIGHT,
+    rowStride: DEFAULT_ROW_STRIDE,
+    totalHeight: DEFAULT_TOTAL_HEIGHT,
+  })
+
+  const listRef = useRef<HTMLOListElement>(null)
+  const rowRefs = useRef<Array<HTMLLIElement | null>>([])
+
+  useLayoutEffect(() => {
+    const list = listRef.current
+    if (!list) return
+
+    const updateMetrics = () => {
+      setMetrics(measureSlideMetrics(list, rowRefs.current))
+    }
+
+    updateMetrics()
+
+    const observer = new ResizeObserver(updateMetrics)
+    observer.observe(list)
+    rowRefs.current.forEach((row) => {
+      if (row) observer.observe(row)
+    })
+
+    return () => observer.disconnect()
+  }, [stages, activeStageIndex, completed, isOpen])
+
+  const collapsedOffset = activeStageIndex * metrics.rowStride
+  const viewportHeight = isOpen ? metrics.totalHeight : metrics.rowHeight
+  const trackOffset = isOpen ? 0 : collapsedOffset
+
+  const cls = [styles.root, className].filter(Boolean).join(' ')
+
+  return (
+    <div className={cls}>
+      <button
+        type="button"
+        className={styles.toggleButton}
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        <ChevronDown className={styles.chevron} size={14} aria-hidden />
+      </button>
+
+      <div
+        id={panelId}
+        className={styles.viewport}
+        style={{ height: viewportHeight }}
+        aria-label="Transaction progress"
+      >
+        <div className={styles.track} style={{ transform: `translateY(-${trackOffset}px)` }}>
+          <ol ref={listRef} className={styles.stepList}>
+            {stages.map((stage, index) => {
+              const kind = rowKindFor(index, activeStageIndex, completed)
+              return (
+                <li
+                  key={stage.id}
+                  ref={(element) => {
+                    rowRefs.current[index] = element
+                  }}
+                  className={styles.stepItem}
+                  aria-current={
+                    kind === 'currentActive' || kind === 'completedFinal' ? 'step' : undefined
+                  }
+                >
+                  <TimelineStep
+                    kind={kind}
+                    counter={`${index + 1} of ${stages.length}`}
+                    label={stageLabelFor(stage, index, stages, completed)}
+                    subtitle={stage.subtitle}
+                  />
+                </li>
+              )
+            })}
+          </ol>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function TransactionProgressDisclosure({
+  variant: _variant = 'timeline',
+  ...props
+}: TransactionProgressDisclosureProps) {
+  return <TimelineVariant {...props} />
+}

--- a/apps/armada-interface/src/components/tx/processing/TransactionProgressDisclosure/index.ts
+++ b/apps/armada-interface/src/components/tx/processing/TransactionProgressDisclosure/index.ts
@@ -1,0 +1,8 @@
+// ABOUTME: Barrel for the timeline transaction-progress disclosure.
+// ABOUTME: Ported from the armada-app design mockup.
+export { TransactionProgressDisclosure } from './TransactionProgressDisclosure'
+export type {
+  TransactionProgressDisclosureProps,
+  TransactionProgressVariant,
+  TransactionProgressVariantProps,
+} from './TransactionProgressDisclosure'

--- a/apps/armada-interface/src/components/tx/processing/TxProcessingLayout/TxProcessingLayout.module.css
+++ b/apps/armada-interface/src/components/tx/processing/TxProcessingLayout/TxProcessingLayout.module.css
@@ -1,0 +1,50 @@
+/* ABOUTME: Layout styles composing the hero card + timeline disclosure (default + immersive). */
+/* ABOUTME: Ported from the armada-app design mockup. */
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-5);
+  width: 100%;
+}
+
+.rootImmersive {
+  flex: 1;
+  min-height: 0;
+  gap: 0;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-4);
+  width: 100%;
+}
+
+.bodyImmersive {
+  flex: 1;
+  min-height: 0;
+  gap: var(--primitives-spacing-5);
+}
+
+.heroImmersive {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+/* Keep in sync with TxProgressCard max-width */
+.belowCardStack {
+  width: 100%;
+  max-width: 420px;
+  margin-inline: auto;
+}
+
+.belowCardStackImmersive {
+  max-width: none;
+  margin-inline: 0;
+  flex-shrink: 0;
+  width: 100%;
+}

--- a/apps/armada-interface/src/components/tx/processing/TxProcessingLayout/TxProcessingLayout.tsx
+++ b/apps/armada-interface/src/components/tx/processing/TxProcessingLayout/TxProcessingLayout.tsx
@@ -1,0 +1,73 @@
+// ABOUTME: Composes the in-progress hero card + timeline disclosure into a processing layout.
+// ABOUTME: Ported from the armada-app design mockup.
+import { modalStepBodyEnter } from '@/design'
+import a11y from '@/design/styles/formA11y.module.css'
+import {
+  TransactionProgressDisclosure,
+  type TransactionProgressVariant,
+} from '../TransactionProgressDisclosure'
+import { TxProgressCard, type TxProgressCardVariant } from '../TxProgressCard'
+import { resolveStageLabel, type TxProgressCardCopy, type TxProgressStage } from '../processingCopy'
+import styles from './TxProcessingLayout.module.css'
+
+export type TxProcessingLayoutVariant = 'default' | 'immersive'
+
+export interface TxProcessingLayoutProps {
+  cardCopy: TxProgressCardCopy
+  stages: ReadonlyArray<TxProgressStage>
+  activeStageIndex?: number
+  completed?: boolean
+  progressVariant?: TransactionProgressVariant
+  /** Mobile keypad: full-bleed gradient shell, details docked at bottom. */
+  layout?: TxProcessingLayoutVariant
+  className?: string
+}
+
+export function TxProcessingLayout({
+  cardCopy,
+  stages,
+  activeStageIndex = 0,
+  completed = false,
+  progressVariant = 'timeline',
+  layout = 'default',
+  className,
+}: TxProcessingLayoutProps) {
+  const immersive = layout === 'immersive'
+  const cardVariant: TxProgressCardVariant = immersive ? 'immersive' : 'card'
+  const cls = [styles.root, immersive && styles.rootImmersive, className].filter(Boolean).join(' ')
+  const bodyClassName = immersive
+    ? [styles.body, styles.bodyImmersive].filter(Boolean).join(' ')
+    : [modalStepBodyEnter, styles.body].filter(Boolean).join(' ')
+  const activeStage = stages[activeStageIndex]
+  const statusAnnouncement = activeStage
+    ? completed && activeStageIndex === stages.length - 1
+      ? resolveStageLabel(activeStage, activeStageIndex, stages.length, true)
+      : `${resolveStageLabel(activeStage, activeStageIndex, stages.length, completed)}. ${activeStage.subtitle}`
+    : ''
+
+  const progressCard = <TxProgressCard copy={cardCopy} variant={cardVariant} />
+
+  return (
+    <div className={cls}>
+      <p className={a11y.srOnly} aria-live="polite" aria-atomic="true">
+        {statusAnnouncement}
+      </p>
+      <div className={bodyClassName}>
+        {immersive ? <div className={styles.heroImmersive}>{progressCard}</div> : progressCard}
+
+        <div
+          className={[styles.belowCardStack, immersive && styles.belowCardStackImmersive]
+            .filter(Boolean)
+            .join(' ')}
+        >
+          <TransactionProgressDisclosure
+            variant={progressVariant}
+            stages={stages}
+            activeStageIndex={activeStageIndex}
+            completed={completed}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/armada-interface/src/components/tx/processing/TxProcessingLayout/index.ts
+++ b/apps/armada-interface/src/components/tx/processing/TxProcessingLayout/index.ts
@@ -1,0 +1,4 @@
+// ABOUTME: Barrel for the TxProcessingLayout in-progress composition.
+// ABOUTME: Ported from the armada-app design mockup.
+export { TxProcessingLayout } from './TxProcessingLayout'
+export type { TxProcessingLayoutProps, TxProcessingLayoutVariant } from './TxProcessingLayout'

--- a/apps/armada-interface/src/components/tx/processing/TxProgressCard/TxProgressCard.module.css
+++ b/apps/armada-interface/src/components/tx/processing/TxProgressCard/TxProgressCard.module.css
@@ -1,0 +1,164 @@
+/* ABOUTME: Styles for the in-progress hero card — brand-gradient surface + tick-ring sweep. */
+/* ABOUTME: Ported from the armada-app design mockup. */
+.card {
+  position: relative;
+  width: 100%;
+  height: auto;
+  max-width: 420px;
+  margin-inline: auto;
+  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
+  display: flex;
+  overflow: hidden;
+
+  /* EXCEPTION — brand gem as surface for the in-progress emotional beat. */
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--semantic-color-brand-lavender) 80%, transparent) 0%,
+    color-mix(in srgb, var(--semantic-color-brand-gradient-rose) 80%, transparent) 48%,
+    color-mix(in srgb, var(--semantic-color-brand-amber) 80%, transparent) 100%
+  );
+}
+
+/* Shell owns the gradient; hero stretches this block above the details card. */
+.cardImmersive {
+  aspect-ratio: unset;
+  max-width: none;
+  width: 100%;
+  height: auto;
+  min-height: 0;
+  flex: 1;
+  margin-inline: 0;
+  border-radius: 0;
+  background: transparent;
+  overflow: visible;
+  display: flex;
+  flex-direction: column;
+}
+
+.tickRing {
+  position: relative;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  align-self: center;
+  width: var(--primitives-spacing-20);
+  height: var(--primitives-spacing-20);
+}
+
+.token {
+  position: relative;
+  z-index: 1;
+}
+
+.cardImmersive .tickRing {
+  width: var(--primitives-spacing-20);
+  height: var(--primitives-spacing-20);
+}
+
+.tick {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 1.5px;
+  height: var(--primitives-spacing-2);
+  border-radius: calc(var(--primitives-borderRadius-sm) * 0.5px);
+  /* EXCEPTION — ticks stay white on the fixed light gradient surface. */
+  background: var(--semantic-component-tag-label);
+  transform-origin: 50% calc(var(--primitives-spacing-20) / 2);
+  transform: translate(-50%, calc(var(--primitives-spacing-20) / -2)) rotate(calc(var(--i) * 6deg));
+  opacity: 0.4;
+  animation: tickSweep 2.1s linear infinite;
+  animation-delay: calc(var(--i) * 0.035s);
+}
+
+@keyframes tickSweep {
+  0% {
+    opacity: 1;
+    width: 3px;
+  }
+
+  12% {
+    opacity: 0.7;
+    width: 2.25px;
+  }
+
+  30% {
+    opacity: 0.45;
+    width: 1.5px;
+  }
+
+  100% {
+    opacity: 0.4;
+    width: 1.5px;
+  }
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--primitives-spacing-5);
+  width: 100%;
+  padding: var(--primitives-spacing-20) var(--primitives-spacing-8);
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.cardImmersive .content {
+  height: 100%;
+  min-height: 0;
+  flex: 1;
+  padding: var(--primitives-spacing-20) var(--primitives-spacing-8);
+}
+
+.titleBlock {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+}
+
+.cardImmersive .titleBlock {
+  flex: 0 0 auto;
+}
+
+.title {
+  composes: displayXl from '../../../../design/styles/displayXlTitle.module.css';
+  margin: 0;
+  /* EXCEPTION — headline stays white on the fixed light gradient surface. */
+  color: var(--semantic-component-tag-label);
+}
+
+.titleLine {
+  display: block;
+  white-space: nowrap;
+}
+
+.subtitle {
+  composes: labelSmRegular from '../../../../design/styles/typographyComposites.module.css';
+  margin: 0;
+  width: 100%;
+  line-height: var(--primitives-lineHeight-normal);
+  /* EXCEPTION — dark subtitle on the fixed light gradient surface. */
+  color: rgb(14 13 15 / 65%);
+}
+
+.subtitleLine {
+  display: block;
+}
+
+.cardImmersive .subtitle {
+  width: auto;
+  max-width: 100%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tick {
+    animation: none;
+    opacity: 0.55;
+    width: 1.5px;
+  }
+}

--- a/apps/armada-interface/src/components/tx/processing/TxProgressCard/TxProgressCard.tsx
+++ b/apps/armada-interface/src/components/tx/processing/TxProgressCard/TxProgressCard.tsx
@@ -1,0 +1,97 @@
+// ABOUTME: In-progress hero card — rotating 60-tick ring around a USDC badge + title/subtitle.
+// ABOUTME: Ported from the armada-app design mockup.
+import { useMemo, type CSSProperties } from 'react'
+import { TokenBadge } from '@/components/dashboard/TokenBadge'
+import type { TxProgressCardCopy } from '../processingCopy'
+import styles from './TxProgressCard.module.css'
+
+const TICK_COUNT = 60
+/** Matches `--primitives-spacing-10` (40px) inside the 80px tick ring. */
+const USDC_BADGE_PX = 40
+
+export type TxProgressCardVariant = 'card' | 'immersive'
+
+export interface TxProgressCardProps {
+  copy: TxProgressCardCopy
+  /** `immersive` = no inset card chrome; used when the shell owns the gradient. */
+  variant?: TxProgressCardVariant
+  className?: string
+}
+
+function ProgressTitle({ copy }: { copy: TxProgressCardCopy }) {
+  if (copy.titleLines && copy.titleLines.length > 0) {
+    return (
+      <p className={styles.title}>
+        {copy.titleLines.map((line, index) => (
+          <span key={`${index}-${line}`} className={styles.titleLine}>
+            {line}
+          </span>
+        ))}
+      </p>
+    )
+  }
+
+  if (!copy.titleBreakAfter) {
+    return <p className={styles.title}>{copy.title}</p>
+  }
+
+  const breakIndex = copy.title.indexOf(copy.titleBreakAfter)
+  if (breakIndex === -1) {
+    return <p className={styles.title}>{copy.title}</p>
+  }
+
+  const splitAt = breakIndex + copy.titleBreakAfter.length
+  const firstLine = copy.title.slice(0, splitAt).trimEnd()
+  const secondLine = copy.title.slice(splitAt).trim()
+
+  return (
+    <p className={styles.title}>
+      <span className={styles.titleLine}>{firstLine}</span>
+      <span className={styles.titleLine}>{secondLine}</span>
+    </p>
+  )
+}
+
+function ProgressSubtitle({ copy }: { copy: TxProgressCardCopy }) {
+  const lines = copy.subtitleLines
+
+  if (lines && lines.length > 0) {
+    return (
+      <p className={styles.subtitle}>
+        {lines.map((line) => (
+          <span key={line} className={styles.subtitleLine}>
+            {line}
+          </span>
+        ))}
+      </p>
+    )
+  }
+
+  return <p className={styles.subtitle}>{copy.subtitle}</p>
+}
+
+export function TxProgressCard({ copy, variant = 'card', className }: TxProgressCardProps) {
+  const ticks = useMemo(() => Array.from({ length: TICK_COUNT }, (_, index) => index), [])
+  const immersive = variant === 'immersive'
+
+  const cls = [styles.card, immersive && styles.cardImmersive, className].filter(Boolean).join(' ')
+
+  return (
+    <section className={cls} aria-label={copy.title}>
+      <div className={styles.content}>
+        <div className={styles.tickRing} aria-hidden>
+          {ticks.map((index) => (
+            <span key={index} className={styles.tick} style={{ '--i': index } as CSSProperties} />
+          ))}
+          <TokenBadge size={USDC_BADGE_PX} className={styles.token} />
+        </div>
+
+        <div className={styles.titleBlock}>
+          <ProgressTitle copy={copy} />
+        </div>
+
+        <ProgressSubtitle copy={copy} />
+      </div>
+    </section>
+  )
+}

--- a/apps/armada-interface/src/components/tx/processing/TxProgressCard/index.ts
+++ b/apps/armada-interface/src/components/tx/processing/TxProgressCard/index.ts
@@ -1,0 +1,4 @@
+// ABOUTME: Barrel for the TxProgressCard in-progress hero card.
+// ABOUTME: Ported from the armada-app design mockup.
+export { TxProgressCard } from './TxProgressCard'
+export type { TxProgressCardProps, TxProgressCardVariant } from './TxProgressCard'

--- a/apps/armada-interface/src/components/tx/processing/processingCopy.ts
+++ b/apps/armada-interface/src/components/tx/processing/processingCopy.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Presentational copy types + label/row-kind helpers for the tx processing UI.
+// ABOUTME: Ported from the armada-app design mockup (txProcessingCopy + transactionProgressUtils).
+
+export interface TxProgressStage {
+  id: string
+  label: string
+  subtitle: string
+  /** Shown on the final step once the whole flow has completed. */
+  completedLabel?: string
+}
+
+export interface TxProgressCardCopy {
+  /** Sentence case in copy; used for accessible name. */
+  tag: string
+  title: string
+  titleBreakAfter?: string
+  /** Explicit line breaks (takes precedence over `titleBreakAfter`). */
+  titleLines?: readonly string[]
+  subtitle: string
+  subtitleLines?: readonly string[]
+}
+
+export function resolveStageLabel(
+  stage: TxProgressStage,
+  index: number,
+  stageCount: number,
+  completed: boolean,
+): string {
+  if (completed && index === stageCount - 1 && stage.completedLabel) {
+    return stage.completedLabel
+  }
+
+  return stage.label
+}
+
+export type RowKind = 'done' | 'currentActive' | 'pending' | 'completedFinal'
+
+export function rowKindFor(index: number, activeIndex: number, completed = false): RowKind {
+  if (completed) {
+    if (index < activeIndex) return 'done'
+    if (index === activeIndex) return 'completedFinal'
+    return 'pending'
+  }
+
+  if (index < activeIndex) return 'done'
+  if (index === activeIndex) return 'currentActive'
+  return 'pending'
+}
+
+export function stageLabelFor(
+  stage: TxProgressStage,
+  index: number,
+  stages: ReadonlyArray<TxProgressStage>,
+  completed: boolean,
+): string {
+  return resolveStageLabel(stage, index, stages.length, completed)
+}

--- a/apps/armada-interface/src/components/tx/processing/processingView.test.ts
+++ b/apps/armada-interface/src/components/tx/processing/processingView.test.ts
@@ -1,0 +1,80 @@
+// ABOUTME: Tests for buildProcessingView — maps a live TxRecord to the processing view model.
+// ABOUTME: Covers stage mapping from the real lifecycle, active-index tracking, completion, and xchain granularity.
+
+import { describe, it, expect } from 'vitest'
+import { buildProcessingView } from './processingView'
+import type { TxKind, TxRecord, TxExecutionState } from '@/lib/tx/types'
+
+// buildProcessingView only reads kind/stage/executionState/artifacts; a partial cast is sufficient.
+function rec(
+  kind: TxKind,
+  stage: string,
+  executionState: TxExecutionState,
+  artifacts: Record<string, unknown> = {},
+): TxRecord {
+  return { kind, stage, executionState, artifacts } as unknown as TxRecord
+}
+
+describe('buildProcessingView', () => {
+  it('maps a shield record to its real lifecycle stages + active index', () => {
+    const view = buildProcessingView(rec('shield', 'submit-relayer', 'active'))
+    expect(view.stages.map((s) => s.id)).toEqual([
+      'build-proof',
+      'submit-relayer',
+      'hub-confirmed',
+    ])
+    expect(view.activeStageIndex).toBe(1)
+    expect(view.completed).toBe(false)
+    expect(view.cardCopy.title).toBe('Your USDC is being shielded')
+  })
+
+  it('picks the send-flow title from the variant for the shared unshield-* kinds', () => {
+    const send = buildProcessingView(rec('unshield-local', 'build-proof', 'active'), {
+      sendVariant: 'send',
+    })
+    expect(send.cardCopy.title).toBe('Unshielding your USDC')
+
+    const withdraw = buildProcessingView(rec('unshield-local', 'build-proof', 'active'), {
+      sendVariant: 'withdraw',
+    })
+    expect(withdraw.cardCopy.title).toBe('Your withdraw is in progress')
+    expect(withdraw.cardCopy.titleLines).toEqual(['Your withdraw', 'is in progress'])
+  })
+
+  it('snaps to the final stage and exposes the completedLabel when completed', () => {
+    const view = buildProcessingView(rec('shield', 'hub-confirmed', 'completed'))
+    expect(view.completed).toBe(true)
+    expect(view.activeStageIndex).toBe(view.stages.length - 1)
+    expect(view.stages.find((s) => s.id === 'hub-confirmed')?.completedLabel).toBe('Deposited')
+  })
+
+  it('renders the real (granular) xchain stages, not a fixed 3', () => {
+    const view = buildProcessingView(rec('unshield-xchain', 'iris-attestation-pending', 'active'))
+    expect(view.stages.length).toBeGreaterThan(3)
+    expect(view.stages.some((s) => s.id === 'iris-attestation-pending')).toBe(true)
+    expect(view.activeStageIndex).toBe(
+      view.stages.findIndex((s) => s.id === 'iris-attestation-pending'),
+    )
+  })
+
+  it('falls back to index 0 for an unknown stage', () => {
+    const view = buildProcessingView(rec('transfer-shielded', 'not-a-stage', 'pending'))
+    expect(view.activeStageIndex).toBe(0)
+  })
+
+  it('shows the safe-to-close reassurance only once the tx has broadcast', () => {
+    // Pre-broadcast: generic "Preparing…" subtitle, no "you can close" promise.
+    const pre = buildProcessingView(rec('shield', 'build-proof', 'active'))
+    expect(pre.cardCopy.subtitleLines).toBeUndefined()
+    expect(pre.cardCopy.subtitle).toBe('Preparing your transaction…')
+
+    // Broadcast (sourceTxHash present): the reassurance appears.
+    const post = buildProcessingView(
+      rec('shield', 'hub-confirmed', 'active', { sourceTxHash: '0xabc' }),
+    )
+    expect(post.cardCopy.subtitleLines).toEqual([
+      'You can now close this window.',
+      "We'll keep processing in the background.",
+    ])
+  })
+})

--- a/apps/armada-interface/src/components/tx/processing/processingView.ts
+++ b/apps/armada-interface/src/components/tx/processing/processingView.ts
@@ -1,0 +1,174 @@
+// ABOUTME: Adapter from a live TxRecord to the processing UI's view model (hero card copy + timeline stages).
+// ABOUTME: Drives TxProcessingLayout from our REAL lifecycle stages (lifecycleFor + record state), styled like the mockup.
+
+import { lifecycleFor } from '@/lib/tx/lifecycles'
+import type { TxKind, TxRecord } from '@/lib/tx/types'
+import type { TxProgressCardCopy, TxProgressStage } from './processingCopy'
+
+interface StageCopyEntry {
+  label: string
+  subtitle: string
+  /** Shown on the final stage once the flow completes (else `label` is used). */
+  completedLabel?: string
+}
+
+/**
+ * Per-(kind, stage) processing copy. Labels are active-tense ("Depositing") with a `completedLabel`
+ * for the final row ("Deposited"); subtitles echo the mockup's supporting line. Stage ids MUST match
+ * `lifecycleFor(kind).stages` — every id a kind can reach needs an entry here.
+ */
+const STAGE_COPY: Record<TxKind, Record<string, StageCopyEntry>> = {
+  shield: {
+    'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
+    'submit-relayer': { label: 'Submitting transaction', subtitle: 'Confirm in your wallet' },
+    'hub-confirmed': { label: 'Depositing', subtitle: 'Confirming on chain', completedLabel: 'Deposited' },
+  },
+  'shield-xchain': {
+    'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
+    'submit-relayer': { label: 'Submitting on source chain', subtitle: 'Confirm in your wallet' },
+    'client-burn-confirmed': { label: 'Bridging', subtitle: 'Confirmed on source chain' },
+    'iris-attestation-pending': { label: 'Bridging', subtitle: 'Waiting for cross-chain confirmation' },
+    'iris-attestation-ready': { label: 'Bridging', subtitle: 'Cross-chain confirmation ready' },
+    'hub-mint-pending': { label: 'Depositing', subtitle: 'Delivering to your private balance' },
+    'hub-mint-confirmed': { label: 'Depositing', subtitle: 'Confirming on chain', completedLabel: 'Deposited' },
+  },
+  'unshield-local': {
+    'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
+    'submit-relayer': { label: 'Submitting privately', subtitle: 'Relaying to the hub' },
+    'hub-confirmed': { label: 'Withdrawing', subtitle: 'Sending USDC to your wallet', completedLabel: 'Withdrawn' },
+  },
+  'unshield-xchain': {
+    'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
+    'submit-relayer': { label: 'Submitting privately', subtitle: 'Relaying to the hub' },
+    'hub-burn-confirmed': { label: 'Bridging', subtitle: 'Confirmed on hub' },
+    'iris-attestation-pending': { label: 'Bridging', subtitle: 'Waiting for cross-chain confirmation' },
+    'iris-attestation-ready': { label: 'Bridging', subtitle: 'Cross-chain confirmation ready' },
+    'client-mint-pending': { label: 'Delivering', subtitle: 'Delivering on the destination chain' },
+    'client-mint-confirmed': { label: 'Delivering', subtitle: 'Confirming on chain', completedLabel: 'Funds delivered' },
+  },
+  'transfer-shielded': {
+    'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
+    'submit-relayer': { label: 'Submitting privately', subtitle: 'Delivering to the recipient' },
+    'hub-confirmed': { label: 'Sending', subtitle: 'Confirming on chain', completedLabel: 'Sent' },
+  },
+  'transfer-shielded-received': {
+    observed: { label: 'Received', subtitle: 'Payment received', completedLabel: 'Received' },
+  },
+  'yield-deposit': {
+    'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
+    'submit-relayer': { label: 'Submitting privately', subtitle: 'Relaying to the vault' },
+    'hub-confirmed': { label: 'Adding to vault', subtitle: 'Confirming on chain', completedLabel: 'Earning' },
+  },
+  'yield-withdraw': {
+    'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
+    'submit-relayer': { label: 'Submitting privately', subtitle: 'Relaying to the vault' },
+    'hub-confirmed': { label: 'Withdrawing', subtitle: 'Confirming on chain', completedLabel: 'Returned to balance' },
+  },
+}
+
+/**
+ * Reassurance subtitle — shown ONLY once the tx has broadcast on chain (`sourceTxHash` present).
+ * Before broadcast, closing the browser tab would abort the tx (useTxResume fails pre-broadcast
+ * interruptions), so we don't promise background processing until it's genuinely safe to leave.
+ */
+const CLOSE_SUBTITLE_LINES = [
+  'You can now close this window.',
+  "We'll keep processing in the background.",
+] as const
+
+/** Generic pre-broadcast subtitle (shown for every kind until the tx is on chain). */
+const PREPARING_SUBTITLE = 'Preparing your transaction…'
+
+/** Which Send/Withdraw flow the user is in — needed to disambiguate the shared `unshield-*` kinds. */
+export type SendVariant = 'send' | 'withdraw'
+
+type CardBase = Pick<TxProgressCardCopy, 'tag' | 'title' | 'titleLines' | 'titleBreakAfter'>
+
+/**
+ * Hero card tag + title per flow. The Send/Withdraw flow shares the `unshield-*` kinds across two
+ * user intents — an external send vs a withdraw-to-wallet — so those need `sendVariant` to pick the
+ * right framing (mirrors the mockup's `sendProcessingCopyMode`). Every other kind resolves from the
+ * kind alone. (`tag` isn't rendered today — the card shows title + subtitle — but is kept for
+ * accessible-name fidelity with the mockup.)
+ */
+function resolveCardBase(record: TxRecord, sendVariant?: SendVariant): CardBase {
+  switch (record.kind) {
+    case 'shield':
+    case 'shield-xchain':
+      return {
+        tag: 'Deposit in progress',
+        title: 'Your USDC is being shielded',
+        titleLines: ['Your USDC is', 'being shielded'],
+      }
+    case 'transfer-shielded':
+      return {
+        tag: 'Private send in progress',
+        title: 'Sending your USDC privately',
+        titleBreakAfter: 'your',
+      }
+    case 'transfer-shielded-received':
+      return { tag: 'Received', title: 'Payment received' }
+    case 'unshield-local':
+    case 'unshield-xchain':
+      return sendVariant === 'withdraw'
+        ? {
+            tag: 'Withdrawal in progress',
+            title: 'Your withdraw is in progress',
+            titleLines: ['Your withdraw', 'is in progress'],
+          }
+        : { tag: 'Send in progress', title: 'Unshielding your USDC' }
+    case 'yield-deposit':
+      return {
+        tag: 'Deposit to vault in progress',
+        title: 'Depositing USDC into the vault',
+        titleBreakAfter: 'USDC',
+      }
+    case 'yield-withdraw':
+      return { tag: 'Withdrawal from vault in progress', title: 'Your withdrawal is in progress' }
+  }
+}
+
+export interface ProcessingView {
+  cardCopy: TxProgressCardCopy
+  stages: TxProgressStage[]
+  activeStageIndex: number
+  completed: boolean
+}
+
+/**
+ * Build the processing view model from a live record. Stages come from the record's real lifecycle
+ * (not a fixed 3-step demo); `activeStageIndex` tracks `record.stage`, snapping to the final stage
+ * once the flow completes.
+ */
+export function buildProcessingView(
+  record: TxRecord,
+  opts?: { sendVariant?: SendVariant },
+): ProcessingView {
+  const stageIds = lifecycleFor(record.kind).stages as ReadonlyArray<string>
+  const copyMap = STAGE_COPY[record.kind]
+  const stages: TxProgressStage[] = stageIds.map((id) => {
+    const entry = copyMap[id]
+    return {
+      id,
+      label: entry?.label ?? id,
+      subtitle: entry?.subtitle ?? '',
+      completedLabel: entry?.completedLabel,
+    }
+  })
+
+  const completed = record.executionState === 'completed'
+  const currentIndex = stageIds.indexOf(record.stage as string)
+  const activeStageIndex = completed
+    ? Math.max(0, stages.length - 1)
+    : Math.max(0, currentIndex)
+
+  // Only promise "safe to close" once the tx has broadcast on chain — before that, leaving the tab
+  // would abort it (nothing was submitted yet). Pre-broadcast keeps the neutral per-kind subtitle.
+  const broadcast = Boolean(record.artifacts.sourceTxHash)
+  const base = resolveCardBase(record, opts?.sendVariant)
+  const cardCopy: TxProgressCardCopy = broadcast
+    ? { ...base, subtitle: CLOSE_SUBTITLE_LINES.join(' '), subtitleLines: CLOSE_SUBTITLE_LINES }
+    : { ...base, subtitle: PREPARING_SUBTITLE }
+
+  return { cardCopy, stages, activeStageIndex, completed }
+}

--- a/apps/armada-interface/src/components/yield/EarnModal.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.test.tsx
@@ -120,7 +120,7 @@ describe('<EarnModal>', () => {
       fireEvent.click(screen.getByRole('button', { name: /Confirm deposit/ }))
     })
     await waitFor(() => {
-      expect(screen.getByText('Pending')).toBeInTheDocument()
+      expect(screen.getByText('Preparing transaction')).toBeInTheDocument()
     })
   })
 

--- a/apps/armada-interface/src/design/styles/displayXlTitle.module.css
+++ b/apps/armada-interface/src/design/styles/displayXlTitle.module.css
@@ -1,0 +1,11 @@
+/* ABOUTME: display-xl composite — Charis SIL 44px emotional headlines via composes. */
+/* ABOUTME: Ported verbatim from the armada-app design mockup. */
+
+/* display-xl composite — Charis SIL 44px emotional headlines */
+.displayXl {
+  font-family: var(--semantic-typography-display-xl-font-family), serif;
+  font-weight: var(--semantic-typography-display-xl-font-weight);
+  font-size: var(--semantic-typography-display-xl-font-size);
+  line-height: var(--semantic-typography-display-xl-line-height);
+  letter-spacing: var(--semantic-typography-display-xl-letter-spacing);
+}


### PR DESCRIPTION
Processing-step re-polish (chunk 6a of the new-flows work). Replaces the plain vertical stepper with the mockup's processing UI, driven by our real tx lifecycle. Desktop; immersive/mobile-keypad layout deferred.

## What's new
- Ported three presentational components into `components/tx/processing/`: **`TxProgressCard`** (rotating 60-tick ring around a USDC badge + title/subtitle, opacity-sweep animation, reduced-motion-respecting), the **timeline** `TransactionProgressDisclosure` (collapsed to the active stage, expandable), and **`TxProcessingLayout`** composing the two + an sr-only aria-live status. New `displayXlTitle` type composite.
- **`processingView.ts` adapter** maps the live `record.{stage, stagesCompleted, executionState}` + `lifecycleFor(kind)` → the layout's `stages[] / activeStageIndex / completed`, using our **real** stages (xchain shows its CCTP steps), styled like the mockup.

## Copy accuracy
- **Titles match the mockup per flow**, including the shared `unshield-*` split: `SendModal` threads `variant` → the hero reads "Unshielding your USDC" (send) vs "Your withdraw is in progress" (withdraw). Deposit / private-send / earn resolve from kind. Two-line titles use `titleLines`/`titleBreakAfter`.
- **Subtitle gated on broadcast** (`sourceTxHash`): before broadcast, generic "Preparing your transaction…" (no "safe to close" promise, since leaving pre-submit would abort the tx); after broadcast, "You can now close this window. / We'll keep processing in the background." — honest for both modal-close and tab-close (`useTxResume` re-attaches broadcast txs).

## Subtractions (per review)
- Removed from the processing step: the shield **wallet-confirm checklist** (`WalletConfirmList` — kept for a future dedicated screen), the **technical-details** disclosure, the **Stop-tracking** cancel, and the **status chip** (timeline conveys status). ETA also dropped (it was bundled with technical details). All underlying components are retained (History still uses the full `TxLifecycleStepper`; added a `detailsOnly` mode to it).

Typecheck clean; full interface suite 1147 passing (8 pre-existing OnboardingFlow skips). No temporary dev scaffolding ships.
