### PR TITLE
style(interface): flow motion pass — modal exit, step transitions, amount-roll, tooltip fade

### DIFF
--- a/apps/armada-interface/src/components/dashboard/ActivityReceipt/ActivityReceipt.tsx
+++ b/apps/armada-interface/src/components/dashboard/ActivityReceipt/ActivityReceipt.tsx
@@ -1,9 +1,10 @@
 // ABOUTME: Activity receipt — reopens a past tx's confirm-step view (same FlowShell chrome + frost card + review summary).
 // ABOUTME: Reconstructs the summary props from the record's meta/artifacts (no stored snapshot — chunk 6b decision a); step-bar hidden, CTAs are View-on-explorer + Done.
 
-import { useEffect, useRef, useState, type ReactNode } from 'react'
-import { Button, modalStepBodyEnter, modalActionRowEnter, MODAL_EXIT_TOTAL_MS } from '@/design'
+import { type ReactNode } from 'react'
+import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { FlowShell } from '@/components/flow/FlowShell'
+import { useFlowExit } from '@/components/flow/useFlowExit'
 import { DepositReviewSummary } from '@/components/deposit/DepositReviewSummary'
 import { TransferReviewSummary } from '@/components/payments/TransferReviewSummary'
 import { EarnReviewSummary } from '@/components/yield/EarnReviewSummary'
@@ -156,23 +157,7 @@ export function ActivityReceipt({ record, ownWalletAddress, open, onClose }: Act
   const view = record ? buildReceiptView(record, ownWalletAddress) : null
 
   // Play the slide-down exit before the parent unmounts us (mockup parity with the flow modals).
-  const [exiting, setExiting] = useState(false)
-  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  useEffect(() => {
-    return () => {
-      if (exitTimerRef.current) clearTimeout(exitTimerRef.current)
-    }
-  }, [])
-
-  function requestClose() {
-    if (exiting) return
-    setExiting(true)
-    exitTimerRef.current = setTimeout(() => {
-      exitTimerRef.current = null
-      setExiting(false)
-      onClose()
-    }, MODAL_EXIT_TOTAL_MS)
-  }
+  const { exiting, requestClose } = useFlowExit(onClose)
 
   return (
     <FlowShell

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
@@ -336,6 +336,27 @@
   outline: none;
 }
 
+/* Odometer overlay shown while a preset/Max roll plays — sits over the (hidden) static value,
+   right-aligned to match the amount. RollingBalanceValue owns the digit-spin motion. */
+.amountRollLayer {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  font-family: var(--primitives-fontFamily-mono), ui-monospace, monospace;
+  font-size: calc(var(--primitives-fontSize-4xl) * 1px);
+  font-weight: var(--primitives-fontWeight-regular);
+  line-height: calc(var(--primitives-fontSize-4xl) * 1px);
+  color: var(--semantic-color-text-primary);
+  pointer-events: none;
+}
+
+/* Hide the static value + caret during the roll so only the odometer shows. */
+.amountValueHidden {
+  visibility: hidden;
+}
+
 .visuallyHidden {
   position: absolute;
   width: 1px;

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.test.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.test.tsx
@@ -1,11 +1,33 @@
 // ABOUTME: Tests for DepositAmountCard's balance row — specifically the pendingBalance suffix that
 // ABOUTME: surfaces not-yet-spendable ("pending") notes alongside the available balance.
 
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { formatUsdcPlain } from '@/lib/format'
 import { DepositAmountCard } from './DepositAmountCard'
 
 const CHAINS = [{ chainId: 31337, label: 'Hub' }]
+
+/** Temporarily report non-reduced motion (setup defaults to reduced) for the duration of `fn`. */
+function withMotionEnabled(fn: () => void) {
+  const original = window.matchMedia
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList) as typeof window.matchMedia
+  try {
+    fn()
+  } finally {
+    window.matchMedia = original
+  }
+}
 
 function renderCard(props: Partial<Parameters<typeof DepositAmountCard>[0]> = {}) {
   return render(
@@ -31,5 +53,81 @@ describe('DepositAmountCard — pendingBalance', () => {
     renderCard()
     expect(screen.getByText('12.00')).toBeInTheDocument()
     expect(screen.queryByText(/pending/)).not.toBeInTheDocument()
+  })
+})
+
+describe('DepositAmountCard — presets + amount roll', () => {
+  it('commits a fraction of maxInput when a percentage pill is clicked', () => {
+    const onAmountChange = vi.fn()
+    // 12 USDC cap → 25% is 3 USDC (integer bigint math, no float rounding).
+    renderCard({ maxInput: 12_000000n, onAmountChange })
+    fireEvent.click(screen.getByRole('button', { name: '25%' }))
+    expect(onAmountChange).toHaveBeenCalledWith(formatUsdcPlain(3_000000n))
+  })
+
+  it('delegates Max to the caller-supplied onMax (fee-on-top cap) over the maxInput fraction', () => {
+    const onMax = vi.fn()
+    const onAmountChange = vi.fn()
+    renderCard({ maxInput: 12_000000n, onMax, onAmountChange })
+    fireEvent.click(screen.getByRole('button', { name: 'Max' }))
+    expect(onMax).toHaveBeenCalledTimes(1)
+    // onMax owns the amount update; the card does not also commit its own fraction.
+    expect(onAmountChange).not.toHaveBeenCalled()
+  })
+
+  it('freezes the input into a roll while a preset lands (motion enabled)', () => {
+    withMotionEnabled(() => {
+      const onAmountChange = vi.fn()
+      const { rerender } = render(
+        <DepositAmountCard
+          chains={CHAINS}
+          chainId={31337}
+          amount="1"
+          onAmountChange={onAmountChange}
+          maxInput={12_000000n}
+          amountAriaLabel="Deposit amount"
+        />,
+      )
+      fireEvent.click(screen.getByRole('button', { name: '50%' }))
+      // The parent commits the new amount → the roll effect starts on the prop change.
+      rerender(
+        <DepositAmountCard
+          chains={CHAINS}
+          chainId={31337}
+          amount="6"
+          onAmountChange={onAmountChange}
+          maxInput={12_000000n}
+          amountAriaLabel="Deposit amount"
+        />,
+      )
+      // While the odometer plays, the underlying input is held read-only.
+      expect(screen.getByLabelText('Deposit amount')).toHaveAttribute('readonly')
+    })
+  })
+
+  it('does not roll under reduced motion — the amount updates without freezing the input', () => {
+    const onAmountChange = vi.fn()
+    const { rerender } = render(
+      <DepositAmountCard
+        chains={CHAINS}
+        chainId={31337}
+        amount="1"
+        onAmountChange={onAmountChange}
+        maxInput={12_000000n}
+        amountAriaLabel="Deposit amount"
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: '50%' }))
+    rerender(
+      <DepositAmountCard
+        chains={CHAINS}
+        chainId={31337}
+        amount="6"
+        onAmountChange={onAmountChange}
+        maxInput={12_000000n}
+        amountAriaLabel="Deposit amount"
+      />,
+    )
+    expect(screen.getByLabelText('Deposit amount')).not.toHaveAttribute('readonly')
   })
 })

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
@@ -6,11 +6,27 @@ import { ChevronDownIcon, WalletIcon } from '@heroicons/react/24/solid'
 import { hasActiveAmount, sanitizeAmountInput } from '@/utils/amountInput'
 import { chainIconForChainId } from '@/components/ui/chainIcons'
 import { FeeBreakdownTooltip, type FlowFeeBreakdown } from '@/components/ui/FeeBreakdownTooltip'
+import { RollingBalanceValue } from '@/components/dashboard/RollingBalanceValue'
+import {
+  BALANCE_ROLL_DURATION_MS,
+  BALANCE_ROLL_DIGIT_STAGGER_MS,
+} from '@/components/dashboard/BalanceCard/balanceRevealMotion'
 import { formatUsdcAmount, formatUsdcPlain } from '@/lib/format'
 import type { DisplayFees } from '@/lib/fees/displayFees'
 import styles from './DepositAmountCard.module.css'
 
 const ICON_SIZE = 32
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+/** Roll animation lifetime for a target value — long enough for the odometer + digit stagger to settle. */
+function amountRollMs(formatted: string): number {
+  const digitCount = formatted.replace(/\D/g, '').length
+  return BALANCE_ROLL_DURATION_MS + Math.max(0, digitCount - 1) * BALANCE_ROLL_DIGIT_STAGGER_MS + 80
+}
 
 export interface DepositChainOption {
   chainId: number
@@ -116,20 +132,87 @@ export function DepositAmountCard({
     setMenuOpen(false)
   }
 
+  // Odometer roll for preset/Max taps (mockup): the amount digit-spins from the old value to the new
+  // one. A preset handler records where we're rolling *from*; the effect below detects the resulting
+  // `amount` change and starts the roll. Typing clears the marker so keystrokes never roll.
+  const [amountRoll, setAmountRoll] = useState<{
+    fromValue: string
+    toValue: string
+    trigger: number
+  } | null>(null)
+  const rollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const rollCounterRef = useRef(0)
+  const pendingRollFromRef = useRef<string | null>(null)
+
+  function clearAmountRoll() {
+    if (rollTimerRef.current) {
+      clearTimeout(rollTimerRef.current)
+      rollTimerRef.current = null
+    }
+    setAmountRoll(null)
+  }
+
+  useEffect(
+    () => () => {
+      if (rollTimerRef.current) clearTimeout(rollTimerRef.current)
+    },
+    [],
+  )
+
+  // Start the roll once the preset-driven `amount` change lands. Typed changes leave the marker null.
+  useEffect(() => {
+    const fromValue = pendingRollFromRef.current
+    if (fromValue === null) return
+    pendingRollFromRef.current = null
+    const toValue = hasActiveAmount(amount) ? amount : '0'
+    if (prefersReducedMotion() || fromValue === toValue) {
+      clearAmountRoll()
+      return
+    }
+    rollCounterRef.current += 1
+    const trigger = rollCounterRef.current
+    setAmountRoll({ fromValue, toValue, trigger })
+    if (rollTimerRef.current) clearTimeout(rollTimerRef.current)
+    rollTimerRef.current = setTimeout(() => {
+      rollTimerRef.current = null
+      setAmountRoll(null)
+    }, amountRollMs(toValue))
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- roll is keyed off the amount change only.
+  }, [amount])
+
   function handleAmountInput(raw: string) {
+    clearAmountRoll()
+    pendingRollFromRef.current = null
     const next = sanitizeAmountInput(raw)
     onAmountChange(hasActiveAmount(next) ? next : '')
   }
 
+  /** Mark the current display as the roll origin, then apply the preset amount (the effect rolls it). */
+  function applyPreset(nextAmount: string) {
+    pendingRollFromRef.current = hasActiveAmount(amount) ? amount : '0'
+    onAmountChange(nextAmount)
+  }
+
   // Percentage pills set the amount to a fraction of the raw input cap. Integer bigint math keeps
-  // full 6-decimal precision (no float rounding); Max reuses the caller's `onMax` when supplied so
-  // fee-on-top paths keep their exact cap, else it falls back to the full `maxInput`.
+  // full 6-decimal precision (no float rounding).
   function applyPercent(percent: bigint) {
     if (maxInput === undefined) return
-    onAmountChange(formatUsdcPlain((maxInput * percent) / 100n))
+    applyPreset(formatUsdcPlain((maxInput * percent) / 100n))
+  }
+
+  // Max reuses the caller's `onMax` when supplied so fee-on-top paths keep their exact cap, else it
+  // falls back to the full `maxInput`. Either way the roll origin is marked so the value spins.
+  function handleMax() {
+    if (onMax) {
+      pendingRollFromRef.current = hasActiveAmount(amount) ? amount : '0'
+      onMax()
+    } else {
+      applyPercent(100n)
+    }
   }
 
   const showActiveAmount = hasActiveAmount(amount)
+  const isAmountRolling = amountRoll !== null
 
   // Total displayed fee (protocol + broadcaster + CCTP). Rendered as the under-amount caption
   // ("+ $X.XX FEE") once an amount is entered and the fee is non-zero — matching the mockup, which
@@ -199,7 +282,11 @@ export function DepositAmountCard({
               .join(' ')}
           >
             <span
-              className={[styles.amountDisplay, showActiveAmount && styles.amountDisplayActive]
+              className={[
+                styles.amountDisplay,
+                showActiveAmount && styles.amountDisplayActive,
+                isAmountRolling && styles.amountValueHidden,
+              ]
                 .filter(Boolean)
                 .join(' ')}
               aria-hidden="true"
@@ -210,12 +297,27 @@ export function DepositAmountCard({
               id={amountInputId}
               type="text"
               inputMode="decimal"
-              className={styles.amountInput}
+              className={[styles.amountInput, isAmountRolling && styles.amountValueHidden]
+                .filter(Boolean)
+                .join(' ')}
               value={amount}
               onChange={(e) => handleAmountInput(e.target.value)}
               aria-label={amountAriaLabel}
               aria-invalid={Boolean(error)}
+              readOnly={isAmountRolling}
             />
+            {isAmountRolling && amountRoll ? (
+              <span className={styles.amountRollLayer} aria-hidden>
+                <RollingBalanceValue
+                  key={amountRoll.trigger}
+                  value={amountRoll.toValue}
+                  fromValue={amountRoll.fromValue}
+                  mode="fromValue"
+                  rollTrigger={amountRoll.trigger}
+                  rollStartMs={0}
+                />
+              </span>
+            ) : null}
           </span>
         </label>
 
@@ -265,16 +367,12 @@ export function DepositAmountCard({
               <button type="button" className={styles.pctPill} onClick={() => applyPercent(75n)}>
                 75%
               </button>
-              <button
-                type="button"
-                className={styles.pctPill}
-                onClick={onMax ?? (() => applyPercent(100n))}
-              >
+              <button type="button" className={styles.pctPill} onClick={handleMax}>
                 Max
               </button>
             </div>
           ) : onMax ? (
-            <button type="button" className={styles.maxBtn} onClick={onMax}>
+            <button type="button" className={styles.maxBtn} onClick={handleMax}>
               Max
             </button>
           ) : null}

--- a/apps/armada-interface/src/components/flow/CLAUDE.md
+++ b/apps/armada-interface/src/components/flow/CLAUDE.md
@@ -12,6 +12,11 @@ ActionFlowShell + its supporting primitives. This is the shared chrome that wrap
 | `ActionFlowShell` | Combines Modal + FlowHeader + body. Controlled by parent (`step` prop). Auto-locks dismissal during `progress`. |
 | `ProgressStep` | Shared progress UI for any TxKind. **Stub** until `<TxLifecycleStepper>` lands in `components/tx/`. |
 | `ErrorStep` | Icon + headline + message + Try Again (disabled when `onRetry` omitted) + optional View Details. |
+| `useFlowExit` | Close hook — plays `FlowShell`'s slide-down before running the real `onClose` (holds `exiting` for `MODAL_EXIT_TOTAL_MS`; closes synchronously under reduced motion). Each modal wires `const { exiting, requestClose: close } = useFlowExit(() => setOpenModal(null))` and passes `exiting` to `FlowShell`; the atom stays set until the animation ends so the step content stays frozen. |
+
+## FlowShell motion
+
+`FlowShell` threads two motion props: `exiting` (drives the overlay/shell slide-down — set via `useFlowExit`) and `stepKey` (when it changes, the vendored `ModalStepSwitch` plays a short content exit then remounts the next step so its enter animations replay). Pass the modal's `step` string as `stepKey`; omit it for static shells (e.g. the activity receipt).
 
 ## Conventions
 

--- a/apps/armada-interface/src/components/flow/FlowShell/FlowShell.tsx
+++ b/apps/armada-interface/src/components/flow/FlowShell/FlowShell.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Replaces DepositOverlayShell for the redesigned flows; renders the logo + Steps progress + close + backdrop/focus-trap.
 
 import type { ReactNode } from 'react'
-import { FlowModalOverlay, ModalShell } from '@/design'
+import { FlowModalOverlay, ModalShell, ModalStepSwitch } from '@/design'
 import styles from './FlowShell.module.css'
 
 /** Default 3-step deposit/action progress labels (Amount → Review → Confirm). */
@@ -20,6 +20,11 @@ export interface FlowShellProps {
   hideSteps?: boolean
   /** Play the close (slide-down) animation. The caller keeps `open` true until the exit completes. */
   exiting?: boolean
+  /**
+   * Current step identifier. When it changes, ModalStepSwitch plays a short content exit then
+   * remounts the new step so its enter animations replay. Omit for static shells (e.g. the receipt).
+   */
+  stepKey?: string
   children: ReactNode
 }
 
@@ -32,6 +37,7 @@ export function FlowShell({
   status = 'default',
   hideSteps = false,
   exiting = false,
+  stepKey,
   children,
 }: FlowShellProps) {
   if (!open && !exiting) return null
@@ -47,7 +53,15 @@ export function FlowShell({
         flowLabel={flowLabel}
         onClose={onClose}
       >
-        <div className={styles.stepColumn}>{children}</div>
+        <div className={styles.stepColumn}>
+          {stepKey !== undefined ? (
+            <ModalStepSwitch stepKey={stepKey} skipExit={exiting}>
+              {children}
+            </ModalStepSwitch>
+          ) : (
+            children
+          )}
+        </div>
       </ModalShell>
     </FlowModalOverlay>
   )

--- a/apps/armada-interface/src/components/flow/FlowShell/FlowShell.tsx
+++ b/apps/armada-interface/src/components/flow/FlowShell/FlowShell.tsx
@@ -53,15 +53,17 @@ export function FlowShell({
         flowLabel={flowLabel}
         onClose={onClose}
       >
-        <div className={styles.stepColumn}>
-          {stepKey !== undefined ? (
-            <ModalStepSwitch stepKey={stepKey} skipExit={exiting}>
-              {children}
-            </ModalStepSwitch>
-          ) : (
-            children
-          )}
-        </div>
+        {/* The .stepColumn (436px column + inter-element gap) lives INSIDE ModalStepSwitch so it
+            plays the role of the mockup's `modalStepShell`: ModalStepSwitch's own `.stepShell`
+            wrapper only centers + animates, so the column layout must wrap the content, not the
+            switch — otherwise the gap + width never reach the card/buttons. */}
+        {stepKey !== undefined ? (
+          <ModalStepSwitch stepKey={stepKey} skipExit={exiting}>
+            <div className={styles.stepColumn}>{children}</div>
+          </ModalStepSwitch>
+        ) : (
+          <div className={styles.stepColumn}>{children}</div>
+        )}
       </ModalShell>
     </FlowModalOverlay>
   )

--- a/apps/armada-interface/src/components/flow/useFlowExit.test.ts
+++ b/apps/armada-interface/src/components/flow/useFlowExit.test.ts
@@ -1,0 +1,78 @@
+// ABOUTME: Tests for useFlowExit — the flow-modal close that plays the slide-down before running onClose.
+// ABOUTME: Covers the reduced-motion synchronous path, the motion-enabled deferred path, and re-entry guarding.
+
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useFlowExit } from './useFlowExit'
+
+/** Run `fn` with non-reduced motion reported (test setup defaults to reduced). */
+function withMotionEnabled(fn: () => void) {
+  const original = window.matchMedia
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList) as typeof window.matchMedia
+  try {
+    fn()
+  } finally {
+    window.matchMedia = original
+  }
+}
+
+describe('useFlowExit', () => {
+  it('closes synchronously under reduced motion (nothing to animate)', () => {
+    const onClose = vi.fn()
+    const { result } = renderHook(() => useFlowExit(onClose))
+    act(() => result.current.requestClose())
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(result.current.exiting).toBe(false)
+  })
+
+  it('plays the exit, then closes after the animation window (motion enabled)', () => {
+    vi.useFakeTimers()
+    try {
+      withMotionEnabled(() => {
+        const onClose = vi.fn()
+        const { result } = renderHook(() => useFlowExit(onClose))
+        act(() => result.current.requestClose())
+        // Mid-animation: exiting is flagged, the real close hasn't run yet.
+        expect(result.current.exiting).toBe(true)
+        expect(onClose).not.toHaveBeenCalled()
+        act(() => {
+          vi.runAllTimers()
+        })
+        expect(onClose).toHaveBeenCalledTimes(1)
+        expect(result.current.exiting).toBe(false)
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores re-entrant close requests while the exit is already running', () => {
+    vi.useFakeTimers()
+    try {
+      withMotionEnabled(() => {
+        const onClose = vi.fn()
+        const { result } = renderHook(() => useFlowExit(onClose))
+        act(() => {
+          result.current.requestClose()
+          result.current.requestClose()
+        })
+        act(() => {
+          vi.runAllTimers()
+        })
+        expect(onClose).toHaveBeenCalledTimes(1)
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/apps/armada-interface/src/components/flow/useFlowExit.ts
+++ b/apps/armada-interface/src/components/flow/useFlowExit.ts
@@ -1,0 +1,53 @@
+// ABOUTME: useFlowExit — plays the modal slide-down (close) animation before running the real close.
+// ABOUTME: Holds `exiting` true for MODAL_EXIT_TOTAL_MS so FlowShell can animate out, then invokes onClose.
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { MODAL_EXIT_TOTAL_MS } from '@/design'
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+export interface FlowExit {
+  /** True while the close animation plays. Pass to FlowShell so it keeps rendering + slides out. */
+  exiting: boolean
+  /** Begin the close animation, then invoke `onClose` once it completes (immediate under reduced motion). */
+  requestClose: () => void
+}
+
+/**
+ * Wraps a flow modal's close so the shell plays its exit animation first. The caller keeps the flow
+ * mounted (open) until `onClose` fires — FlowShell renders while `exiting` so the slide-down shows.
+ * Under reduced motion the delay is skipped and `onClose` runs synchronously.
+ */
+export function useFlowExit(onClose: () => void): FlowExit {
+  const [exiting, setExiting] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    },
+    [],
+  )
+
+  const requestClose = useCallback(() => {
+    // Guard re-entry: a second close request while the animation is already running is a no-op.
+    if (timerRef.current) return
+    if (prefersReducedMotion()) {
+      onCloseRef.current()
+      return
+    }
+    setExiting(true)
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      setExiting(false)
+      onCloseRef.current()
+    }, MODAL_EXIT_TOTAL_MS)
+  }, [])
+
+  return { exiting, requestClose }
+}

--- a/apps/armada-interface/src/components/payments/SendCompleteStep.module.css
+++ b/apps/armada-interface/src/components/payments/SendCompleteStep.module.css
@@ -16,6 +16,15 @@
   );
 }
 
+/* Body group above the button row — keeps the column gap so the modalStepBodyEnter animation
+   layer doesn't collapse the internal spacing. */
+.body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--primitives-spacing-8);
+}
+
 .titleBlock {
   display: flex;
   flex-direction: column;

--- a/apps/armada-interface/src/components/payments/SendCompleteStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendCompleteStep.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Send/Withdraw complete step — frost card with left-aligned "USDC send/unshield confirmed" title + big mono amount, shared TransferReviewSummary (with date/time), and explorer/dashboard CTAs.
 // ABOUTME: Mirrors ShieldCompleteStep — no divider between the summary card and the button row.
 
-import { Button } from '@/design'
+import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { TransferReviewSummary } from './TransferReviewSummary'
 import { formatUsdcPlain } from '@/lib/format'
 import type { SendFlowVariant } from './SendRecipientStep'
@@ -48,25 +48,27 @@ export function SendCompleteStep({
 
   return (
     <div className={styles.root}>
-      <div className={styles.titleBlock}>
-        <h1 className={styles.title}>{title}</h1>
-        <div className={styles.amountRow}>
-          <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
+      <div className={`${styles.body} ${modalStepBodyEnter}`}>
+        <div className={styles.titleBlock}>
+          <h1 className={styles.title}>{title}</h1>
+          <div className={styles.amountRow}>
+            <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
+          </div>
         </div>
+
+        <TransferReviewSummary
+          recipient={recipient}
+          armadaAddress={armadaAddress}
+          fee={fee}
+          totalDeducted={totalDeducted}
+          variant={variant}
+          networkName={networkName}
+          recipientWalletProvider={recipientWalletProvider}
+          confirmedAt={confirmedAt}
+        />
       </div>
 
-      <TransferReviewSummary
-        recipient={recipient}
-        armadaAddress={armadaAddress}
-        fee={fee}
-        totalDeducted={totalDeducted}
-        variant={variant}
-        networkName={networkName}
-        recipientWalletProvider={recipientWalletProvider}
-        confirmedAt={confirmedAt}
-      />
-
-      <div className={styles.buttonRow}>
+      <div className={`${styles.buttonRow} ${modalActionRowEnter}`}>
         <Button
           variant="secondary"
           size="lg"

--- a/apps/armada-interface/src/components/payments/SendInputStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendInputStep.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Recipient + chain live on the preceding recipient step, so this step gates only on the amount.
 
 import { useMemo } from 'react'
-import { Button } from '@/design'
+import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { DepositAmountCard } from '@/components/deposit/DepositAmountCard/DepositAmountCard'
 import { depositOverlayShellStyles } from '@/components/deposit/DepositOverlayShell/DepositOverlayShell'
 import { GasBalanceNotice } from '@/components/ui'
@@ -88,7 +88,7 @@ export function SendInputStepContent({
     ?? (tooMuch ? 'Amount exceeds your private balance after fees.' : undefined)
 
   return (
-    <div className={styles.sendContent}>
+    <div className={`${styles.sendContent} ${modalStepBodyEnter}`}>
       <div className={styles.amountGroup}>
         <DepositAmountCard
           chains={allChains}
@@ -136,7 +136,7 @@ export function SendInputStepFooter({
   const canReview = hasActiveAmount(amountStr) && !tooMuch && !parseError
 
   return (
-    <div className={depositOverlayShellStyles.buttonRow}>
+    <div className={`${depositOverlayShellStyles.buttonRow} ${modalActionRowEnter}`}>
       <Button
         variant="secondary"
         size="lg"

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -35,6 +35,7 @@ import {
   type FlowVisibleStep,
 } from '@/components/flow'
 import { FlowShell } from '@/components/flow/FlowShell'
+import { useFlowExit } from '@/components/flow/useFlowExit'
 import { SendRecipientStep, type SendFlowVariant } from './SendRecipientStep'
 import { SendInputStepContent, SendInputStepFooter } from './SendInputStep'
 import { useDisplayFees } from '@/hooks/useDisplayFees'
@@ -217,9 +218,9 @@ export function SendModal() {
     }
   }, [record?.executionState])
 
-  function close() {
-    setOpenModal(null)
-  }
+  // Route the close through useFlowExit so FlowShell plays its slide-down before unmounting. The
+  // atom stays set (isOpen true) until the animation completes, which keeps the step content frozen.
+  const { exiting, requestClose: close } = useFlowExit(() => setOpenModal(null))
 
   async function handleSubmit() {
     if (submittingRef.current) return
@@ -356,6 +357,8 @@ export function SendModal() {
     <FlowShell
       open={isOpen}
       onClose={close}
+      exiting={exiting}
+      stepKey={step}
       flowLabel={flowLabel}
       steps={['Recipient', 'Amount', 'Review', 'Confirm']}
       currentStep={currentStep}

--- a/apps/armada-interface/src/components/payments/SendRecipientStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendRecipientStep.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useState } from 'react'
 import { XMarkIcon, GlobeAltIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline'
-import { ArmadaLogo, Button } from '@/design'
+import { ArmadaLogo, Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import iconButtonStyles from '@/design/components/IconButton/IconButton.module.css'
 import { ChainSelect } from '@/components/ui'
 import { isShieldedAddress, validateEvmAddress } from '@/lib/address'
@@ -106,7 +106,7 @@ export function SendRecipientStep({
 
   return (
     <div className={styles.root}>
-      <div className={styles.card}>
+      <div className={`${styles.card} ${modalStepBodyEnter}`}>
         <h1 className={`armada-text-ui-body-lg ${styles.cardTitle}`}>{title}</h1>
 
         <div className={styles.addressBlock}>
@@ -220,7 +220,7 @@ export function SendRecipientStep({
       </div>
 
       {/* Always-visible action row — Continue stays disabled + labeled "Enter address" until valid. */}
-      <div className={styles.buttonRow}>
+      <div className={`${styles.buttonRow} ${modalActionRowEnter}`}>
         <Button variant="secondary" size="lg" label="Cancel" showIcon={false} onClick={onCancel} />
         <Button
           variant="primary"

--- a/apps/armada-interface/src/components/payments/SendReviewStep.module.css
+++ b/apps/armada-interface/src/components/payments/SendReviewStep.module.css
@@ -15,6 +15,15 @@
   );
 }
 
+/* Body group above the button row — keeps the column gap so the modalStepBodyEnter animation
+   layer doesn't collapse the internal spacing. */
+.body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--primitives-spacing-8);
+}
+
 .titleBlock {
   display: flex;
   flex-direction: column;

--- a/apps/armada-interface/src/components/payments/SendReviewStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendReviewStep.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Send/Withdraw review step — frost card with left-aligned UI title + big mono amount, shared TransferReviewSummary table, Confirm/Back CTAs.
 // ABOUTME: Delegates the summary rows (date, private account, recipient, fees, total + privacy notice) to TransferReviewSummary; keeps the sync-gate notice + submit disabling.
 
-import { Button } from '@/design'
+import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { TransferReviewSummary } from './TransferReviewSummary'
 import { formatUsdcPlain } from '@/lib/format'
 import type { SendFlowVariant } from './SendRecipientStep'
@@ -47,30 +47,32 @@ export function SendReviewStep({
 
   return (
     <div className={styles.root}>
-      <div className={styles.titleBlock}>
-        <h1 className={styles.title}>{title}</h1>
-        <div className={styles.amountRow}>
-          <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
+      <div className={`${styles.body} ${modalStepBodyEnter}`}>
+        <div className={styles.titleBlock}>
+          <h1 className={styles.title}>{title}</h1>
+          <div className={styles.amountRow}>
+            <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
+          </div>
         </div>
+
+        <TransferReviewSummary
+          recipient={recipient}
+          armadaAddress={armadaAddress}
+          fee={fee}
+          totalDeducted={totalDeducted}
+          variant={variant}
+          networkName={networkName}
+          recipientWalletProvider={recipientWalletProvider}
+        />
+
+        {submitBlockedReason ? (
+          <div className={styles.syncNotice} role="status" aria-live="polite">
+            {submitBlockedReason}
+          </div>
+        ) : null}
       </div>
 
-      <TransferReviewSummary
-        recipient={recipient}
-        armadaAddress={armadaAddress}
-        fee={fee}
-        totalDeducted={totalDeducted}
-        variant={variant}
-        networkName={networkName}
-        recipientWalletProvider={recipientWalletProvider}
-      />
-
-      {submitBlockedReason ? (
-        <div className={styles.syncNotice} role="status" aria-live="polite">
-          {submitBlockedReason}
-        </div>
-      ) : null}
-
-      <div className={styles.buttonRow}>
+      <div className={`${styles.buttonRow} ${modalActionRowEnter}`}>
         <Button
           variant="secondary"
           size="lg"

--- a/apps/armada-interface/src/components/settings/SettingsModal.module.css
+++ b/apps/armada-interface/src/components/settings/SettingsModal.module.css
@@ -12,6 +12,47 @@
   align-items: stretch;
   padding: var(--primitives-spacing-5);
   box-sizing: border-box;
+  /* Rise + fade in on open (the FlowModalOverlay backdrop fades independently). */
+  animation: settingsShellEnter 360ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* Sink + fade out on close — completes well inside the backdrop's fade-out window
+   (backdrop starts at 440ms), so the panel leaves before the blur clears. */
+.shellExiting {
+  animation: settingsShellExit 260ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes settingsShellEnter {
+  from {
+    opacity: 0;
+    transform: translateY(var(--primitives-spacing-3));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes settingsShellExit {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(var(--primitives-spacing-3));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shell,
+  .shellExiting {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
 }
 
 /* Header — logo left, centered title, circular close right (mirrors ModalShell). */

--- a/apps/armada-interface/src/components/settings/SettingsModal.tsx
+++ b/apps/armada-interface/src/components/settings/SettingsModal.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState, type ChangeEvent } from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { ArmadaLogo, Button, FlowModalOverlay } from '@/design'
+import { useFlowExit } from '@/components/flow/useFlowExit'
 import { Card } from '@/components/ui'
 import {
   ClearHistoryDialog,
@@ -43,9 +44,9 @@ export function SettingsModal() {
   const walletUnlocked = state?.status === 'unlocked'
   const isScanning = recovery.state === 'scanning'
 
-  function close() {
-    setOpenModal(null)
-  }
+  // Route the close through useFlowExit so the overlay fades + the panel sinks before unmounting.
+  // The atom stays set (isOpen true) until the animation completes; reduced motion closes instantly.
+  const { exiting, requestClose: close } = useFlowExit(() => setOpenModal(null))
 
   function handleRescan() {
     // Re-scan: drop the per-wallet checkpoint so useHistoryRecovery walks from the hub deploy
@@ -58,8 +59,8 @@ export function SettingsModal() {
   if (!isOpen) return null
 
   return (
-    <FlowModalOverlay label="Settings" onClose={close}>
-      <div className={styles.shell}>
+    <FlowModalOverlay label="Settings" exiting={exiting} onClose={close}>
+      <div className={[styles.shell, exiting && styles.shellExiting].filter(Boolean).join(' ')}>
         <header className={styles.header}>
           <div className={styles.logoSlot}>
             <ArmadaLogo variant="mark" markTone="white" className={styles.logo} />

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.module.css
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.module.css
@@ -16,6 +16,15 @@
   );
 }
 
+/* Body group — everything above the button row. Carries the column gap so wrapping it in the
+   modalStepBodyEnter animation layer doesn't collapse the internal spacing. */
+.body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--primitives-spacing-8);
+}
+
 .titleBlock {
   display: flex;
   flex-direction: column;

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Shield complete step — frost card with left-aligned "USDC deposit confirmed" title + big mono deposited-amount, shared DepositReviewSummary (with date/time), and explorer/dashboard CTAs.
 // ABOUTME: Mirrors the deposit-confirmed reference — no divider between the summary card and the button row.
 
-import { Button } from '@/design'
+import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { DepositReviewSummary } from '@/components/deposit/DepositReviewSummary'
 import { formatUsdcPlain } from '@/lib/format'
 import styles from './ShieldCompleteStep.module.css'
@@ -39,25 +39,27 @@ export function ShieldCompleteStep({
 }: ShieldCompleteStepProps) {
   return (
     <div className={styles.root}>
-      <div className={styles.titleBlock}>
-        <h1 className={styles.title}>USDC deposit confirmed</h1>
-        <div className={styles.amountRow}>
-          <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
+      <div className={`${styles.body} ${modalStepBodyEnter}`}>
+        <div className={styles.titleBlock}>
+          <h1 className={styles.title}>USDC deposit confirmed</h1>
+          <div className={styles.amountRow}>
+            <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
+          </div>
         </div>
+
+        <DepositReviewSummary
+          fromChainId={fromChainId}
+          amount={amount}
+          fee={fee}
+          netAmount={netAmount}
+          walletAddress={walletAddress}
+          walletProvider={walletProvider}
+          shieldedAddress={shieldedAddress}
+          confirmedAt={confirmedAt}
+        />
       </div>
 
-      <DepositReviewSummary
-        fromChainId={fromChainId}
-        amount={amount}
-        fee={fee}
-        netAmount={netAmount}
-        walletAddress={walletAddress}
-        walletProvider={walletProvider}
-        shieldedAddress={shieldedAddress}
-        confirmedAt={confirmedAt}
-      />
-
-      <div className={styles.buttonRow}>
+      <div className={`${styles.buttonRow} ${modalActionRowEnter}`}>
         <Button
           variant="secondary"
           size="lg"

--- a/apps/armada-interface/src/components/shield/ShieldInputStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldInputStep.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: gaslessMode hides the GasBalanceNotice on the relayer-mediated permit path; the wallet-submit fallback shows it when the wallet's native balance is low.
 
 import { useMemo } from 'react'
-import { Button } from '@/design'
+import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { DepositAmountCard } from '@/components/deposit/DepositAmountCard/DepositAmountCard'
 import { depositOverlayShellStyles } from '@/components/deposit/DepositOverlayShell/DepositOverlayShell'
 import { GasBalanceNotice } from '@/components/ui'
@@ -89,7 +89,7 @@ export function ShieldInputStepContent({
   const balanceDisplay = formatUsdcPlain(max)
 
   return (
-    <div className={styles.contentZone}>
+    <div className={`${styles.contentZone} ${modalStepBodyEnter}`}>
       <DepositAmountCard
         chains={chains}
         chainId={fromChainId}
@@ -134,7 +134,7 @@ export function ShieldInputStepFooter({
   const canReview = hasActiveAmount(amountStr) && !tooMuch && !tooSmall && !parseError
 
   return (
-    <div className={depositOverlayShellStyles.buttonRow}>
+    <div className={`${depositOverlayShellStyles.buttonRow} ${modalActionRowEnter}`}>
       <Button
         variant="secondary"
         size="lg"

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -28,6 +28,7 @@ import {
   type FlowVisibleStep,
 } from '@/components/flow'
 import { FlowShell } from '@/components/flow/FlowShell'
+import { useFlowExit } from '@/components/flow/useFlowExit'
 import { RelayerStatusBanner } from '@/components/RelayerStatusBanner'
 import { ShieldInputStepContent, ShieldInputStepFooter } from './ShieldInputStep'
 import { ShieldReviewStep } from './ShieldReviewStep'
@@ -223,9 +224,9 @@ export function ShieldModal() {
     }
   }, [record?.executionState])
 
-  function close() {
-    setOpenModal(null)
-  }
+  // Route the close through useFlowExit so FlowShell plays its slide-down before unmounting. The
+  // atom stays set (isOpen true) until the animation completes, which keeps the step content frozen.
+  const { exiting, requestClose: close } = useFlowExit(() => setOpenModal(null))
 
   async function handleSubmit() {
     if (submittingRef.current) return
@@ -343,6 +344,8 @@ export function ShieldModal() {
     <FlowShell
       open={isOpen}
       onClose={close}
+      exiting={exiting}
+      stepKey={step}
       flowLabel="Shield"
       currentStep={indicatorStep}
       status={indicatorStatus}

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.module.css
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.module.css
@@ -15,6 +15,14 @@
   );
 }
 
+/* Body group — everything above the button row. Carries the column gap so wrapping it in the
+   modalStepBodyEnter animation layer doesn't collapse the internal spacing. */
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-8);
+}
+
 .titleBlock {
   display: flex;
   flex-direction: column;

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Delegates the summary rows (network, wallet/Armada addresses, fees, total) to DepositReviewSummary; duplicate caution preserved.
 
 import { AlertTriangle } from 'lucide-react'
-import { Button } from '@/design'
+import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { DepositReviewSummary } from '@/components/deposit/DepositReviewSummary'
 import { formatUsdcPlain } from '@/lib/format'
 import styles from './ShieldReviewStep.module.css'
@@ -41,34 +41,36 @@ export function ShieldReviewStep({
 }: ShieldReviewStepProps) {
   return (
     <div className={styles.root}>
-      <div className={styles.titleBlock}>
-        <h1 className={styles.title}>Review your USDC deposit</h1>
-        <div className={styles.amountRow}>
-          <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
+      <div className={`${styles.body} ${modalStepBodyEnter}`}>
+        <div className={styles.titleBlock}>
+          <h1 className={styles.title}>Review your USDC deposit</h1>
+          <div className={styles.amountRow}>
+            <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
+          </div>
         </div>
+
+        <DepositReviewSummary
+          fromChainId={fromChainId}
+          amount={amount}
+          fee={fee}
+          netAmount={netAmount}
+          walletAddress={walletAddress}
+          walletProvider={walletProvider}
+          shieldedAddress={shieldedAddress}
+        />
+
+        {duplicateWarning ? (
+          <div className={styles.caution} role="alert">
+            <AlertTriangle size={16} className={styles.cautionIcon} aria-hidden="true" />
+            <span>
+              A deposit of this amount may still be processing on chain. Submitting again could
+              deposit twice — check Recent Activity first.
+            </span>
+          </div>
+        ) : null}
       </div>
 
-      <DepositReviewSummary
-        fromChainId={fromChainId}
-        amount={amount}
-        fee={fee}
-        netAmount={netAmount}
-        walletAddress={walletAddress}
-        walletProvider={walletProvider}
-        shieldedAddress={shieldedAddress}
-      />
-
-      {duplicateWarning ? (
-        <div className={styles.caution} role="alert">
-          <AlertTriangle size={16} className={styles.cautionIcon} aria-hidden="true" />
-          <span>
-            A deposit of this amount may still be processing on chain. Submitting again could deposit
-            twice — check Recent Activity first.
-          </span>
-        </div>
-      ) : null}
-
-      <div className={styles.buttonRow}>
+      <div className={`${styles.buttonRow} ${modalActionRowEnter}`}>
         <Button
           variant="secondary"
           size="lg"

--- a/apps/armada-interface/src/components/yield/EarnCompleteStep.module.css
+++ b/apps/armada-interface/src/components/yield/EarnCompleteStep.module.css
@@ -16,6 +16,15 @@
   );
 }
 
+/* Body group above the button row — keeps the column gap so the modalStepBodyEnter animation
+   layer doesn't collapse the internal spacing. */
+.body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--primitives-spacing-8);
+}
+
 .titleBlock {
   display: flex;
   flex-direction: column;

--- a/apps/armada-interface/src/components/yield/EarnCompleteStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnCompleteStep.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Earn complete step — frost card with left-aligned UI title + big mono amount, shared EarnReviewSummary (with date/time), explorer/dashboard CTAs.
 // ABOUTME: Mirrors SendCompleteStep — no divider between the summary and the button row.
 
-import { Button } from '@/design'
+import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { EarnReviewSummary } from './EarnReviewSummary'
 import { formatUsdcPlain } from '@/lib/format'
 import type { YieldRate } from '@/hooks/useYieldRate'
@@ -42,24 +42,26 @@ export function EarnCompleteStep({
 
   return (
     <div className={styles.root}>
-      <div className={styles.titleBlock}>
-        <h1 className={styles.title}>{title}</h1>
-        <div className={styles.amountRow}>
-          <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
+      <div className={`${styles.body} ${modalStepBodyEnter}`}>
+        <div className={styles.titleBlock}>
+          <h1 className={styles.title}>{title}</h1>
+          <div className={styles.amountRow}>
+            <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
+          </div>
         </div>
+
+        <EarnReviewSummary
+          tab={tab}
+          amount={amount}
+          rate={rate}
+          fee={fee}
+          netAmount={netAmount}
+          netLabel={netLabel}
+          confirmedAt={confirmedAt}
+        />
       </div>
 
-      <EarnReviewSummary
-        tab={tab}
-        amount={amount}
-        rate={rate}
-        fee={fee}
-        netAmount={netAmount}
-        netLabel={netLabel}
-        confirmedAt={confirmedAt}
-      />
-
-      <div className={styles.buttonRow}>
+      <div className={`${styles.buttonRow} ${modalActionRowEnter}`}>
         <Button
           variant="secondary"
           size="lg"

--- a/apps/armada-interface/src/components/yield/EarnInputStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.tsx
@@ -3,7 +3,7 @@
 
 import { useMemo } from 'react'
 import { ChartBarIcon } from '@heroicons/react/24/solid'
-import { Button } from '@/design'
+import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { DepositAmountCard } from '@/components/deposit/DepositAmountCard/DepositAmountCard'
 import { depositOverlayShellStyles } from '@/components/deposit/DepositOverlayShell/DepositOverlayShell'
 import { DepositTooltip } from '@/components/dashboard/DepositTooltip'
@@ -133,7 +133,7 @@ export function EarnInputStepContent({
     tab === 'add' ? 'Deposit USDC to the vault' : 'Withdraw USDC from the vault'
 
   return (
-    <div className={styles.root}>
+    <div className={`${styles.root} ${modalStepBodyEnter}`}>
       {/* APY intro banner — shown on both tabs (mockup). The live vault rate fills the headline. */}
       <DepositTooltip
         stretch
@@ -208,7 +208,7 @@ export function EarnInputStepFooter({
     hasActiveAmount(amountStr) && !tooMuch && !parseError && !continueBlockedReason
 
   return (
-    <div className={depositOverlayShellStyles.buttonRow}>
+    <div className={`${depositOverlayShellStyles.buttonRow} ${modalActionRowEnter}`}>
       <Button
         variant="secondary"
         size="lg"

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -26,6 +26,7 @@ import {
   type FlowVisibleStep,
 } from '@/components/flow'
 import { FlowShell } from '@/components/flow/FlowShell'
+import { useFlowExit } from '@/components/flow/useFlowExit'
 import { EarnInputStepContent, EarnInputStepFooter, type EarnTab } from './EarnInputStep'
 import { useDisplayFees } from '@/hooks/useDisplayFees'
 import { EarnReviewStep } from './EarnReviewStep'
@@ -200,9 +201,9 @@ export function EarnModal() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [record?.executionState])
 
-  function close() {
-    setOpenModal(null)
-  }
+  // Route the close through useFlowExit so FlowShell plays its slide-down before unmounting. The
+  // atom stays set (isOpen true) until the animation completes, which keeps the step content frozen.
+  const { exiting, requestClose: close } = useFlowExit(() => setOpenModal(null))
 
   async function handleSubmit() {
     if (submittingRef.current) return
@@ -295,6 +296,8 @@ export function EarnModal() {
     <FlowShell
       open={isOpen}
       onClose={close}
+      exiting={exiting}
+      stepKey={step}
       flowLabel="Earn"
       steps={['Amount', 'Review', 'Confirm']}
       currentStep={currentStep}

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.module.css
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.module.css
@@ -15,6 +15,15 @@
   );
 }
 
+/* Body group above the button row — keeps the column gap so the modalStepBodyEnter animation
+   layer doesn't collapse the internal spacing. */
+.body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--primitives-spacing-8);
+}
+
 .titleBlock {
   display: flex;
   flex-direction: column;

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Earn review step — frost card with left-aligned UI title + big mono amount, shared EarnReviewSummary table, Confirm/Back CTAs.
 // ABOUTME: Delegates the summary rows (mode, APY, amount, fees, total) to EarnReviewSummary; keeps the sync-gate + slippage notices.
 
-import { Button } from '@/design'
+import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { EarnReviewSummary } from './EarnReviewSummary'
 import { formatUsdcPlain } from '@/lib/format'
 import type { YieldRate } from '@/hooks/useYieldRate'
@@ -46,35 +46,38 @@ export function EarnReviewStep({
 
   return (
     <div className={styles.root}>
-      <div className={styles.titleBlock}>
-        <h1 className={styles.title}>{title}</h1>
-        <div className={styles.amountRow}>
-          <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
+      <div className={`${styles.body} ${modalStepBodyEnter}`}>
+        <div className={styles.titleBlock}>
+          <h1 className={styles.title}>{title}</h1>
+          <div className={styles.amountRow}>
+            <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
+          </div>
         </div>
+
+        <EarnReviewSummary
+          tab={tab}
+          amount={amount}
+          rate={rate}
+          fee={fee}
+          netAmount={netAmount}
+          netLabel={netLabel}
+        />
+
+        {tab === 'withdraw' ? (
+          <p className={styles.slippageNotice}>
+            The vault rate moves with each new block. Your final USDC may differ slightly from this
+            quote.
+          </p>
+        ) : null}
+
+        {submitBlockedReason ? (
+          <div className={styles.syncNotice} role="status" aria-live="polite">
+            {submitBlockedReason}
+          </div>
+        ) : null}
       </div>
 
-      <EarnReviewSummary
-        tab={tab}
-        amount={amount}
-        rate={rate}
-        fee={fee}
-        netAmount={netAmount}
-        netLabel={netLabel}
-      />
-
-      {tab === 'withdraw' ? (
-        <p className={styles.slippageNotice}>
-          The vault rate moves with each new block. Your final USDC may differ slightly from this quote.
-        </p>
-      ) : null}
-
-      {submitBlockedReason ? (
-        <div className={styles.syncNotice} role="status" aria-live="polite">
-          {submitBlockedReason}
-        </div>
-      ) : null}
-
-      <div className={styles.buttonRow}>
+      <div className={`${styles.buttonRow} ${modalActionRowEnter}`}>
         <Button
           variant="secondary"
           size="lg"

--- a/apps/armada-interface/src/pages/Dashboard.module.css
+++ b/apps/armada-interface/src/pages/Dashboard.module.css
@@ -23,6 +23,36 @@
 /* BalanceCard and RecentActivityList self-fill to 100%; the DepositTooltip keeps its natural
    width (360px) and stays centered — matching the mockup's narrower callout under the card. */
 
+/* Tooltip/earn-banner slot: fades up shortly after the balance card's action row finishes entering,
+   so the callout arrives after the numbers settle rather than all at once. Delay comes from the
+   caller via --dashboard-tooltip-enter-delay (mockup DASHBOARD_TOOLTIP_ENTER_DELAY_MS). */
+.tooltipEnter {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  animation: dashboardTooltipFade 360ms ease-out var(--dashboard-tooltip-enter-delay, 1330ms) both;
+}
+
+@keyframes dashboardTooltipFade {
+  from {
+    opacity: 0;
+    transform: translateY(var(--primitives-spacing-3));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltipEnter {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
 @media (max-width: 767px) {
   .page {
     padding-bottom: var(--primitives-spacing-5);

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -1,11 +1,12 @@
 // ABOUTME: Dashboard page — centered Private-USDC BalanceCard + deposit tooltip + recent activity.
 // ABOUTME: Presentation from the armada-app mockup; wired to real shielded balance, yield, and tx history.
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { ChartBarIcon } from '@heroicons/react/24/outline'
 import { BalanceCard } from '@/components/dashboard/BalanceCard'
 import { DepositTooltip } from '@/components/dashboard/DepositTooltip'
+import { DASHBOARD_TOOLTIP_ENTER_DELAY_MS } from '@/components/dashboard/BalanceCard/balanceRevealMotion'
 import { DashboardScrollTopFade } from '@/components/dashboard/DashboardScrollTopFade'
 import { RecentActivityList, ActivityAllPanel } from '@/components/dashboard/RecentActivityList'
 import { ActivityReceipt } from '@/components/dashboard/ActivityReceipt'
@@ -94,6 +95,11 @@ export function Dashboard() {
   const showEarnBanner =
     !showDepositTooltip && balanceNumber > 0 && vaultNumber <= 0 && vaultApy !== undefined && vaultApy > 0
 
+  // Tooltip/earn-banner enter delay — fades up after the balance card's action row settles.
+  const tooltipEnterStyle = {
+    '--dashboard-tooltip-enter-delay': `${DASHBOARD_TOOLTIP_ENTER_DELAY_MS}ms`,
+  } as CSSProperties
+
   // Gate the dashboard behind the initial shielded-balance sync. The navbar (AppLayout) stays visible.
   if (isInitialSyncGated(shielded, sync.status)) {
     return <SyncGate />
@@ -121,21 +127,25 @@ export function Dashboard() {
         />
 
         {showDepositTooltip ? (
-          <DepositTooltip stretch onDeposit={() => openActionModal('shield')} />
+          <div className={styles.tooltipEnter} style={tooltipEnterStyle}>
+            <DepositTooltip stretch onDeposit={() => openActionModal('shield')} />
+          </div>
         ) : null}
 
         {showEarnBanner ? (
-          <DepositTooltip
-            stretch
-            BadgeIcon={ChartBarIcon}
-            badgeBackground="white"
-            iconTileTone="purple"
-            headline={`Earn ~${(vaultApy ?? 0).toFixed(1)}% APY`}
-            body="Deposit into the vault and start earning now."
-            infoTooltip="The APY is an estimate from recent vault performance."
-            ariaLabel={`Estimated yearly yield ~${(vaultApy ?? 0).toFixed(1)}%`}
-            onDeposit={() => openActionModal('yield-deposit')}
-          />
+          <div className={styles.tooltipEnter} style={tooltipEnterStyle}>
+            <DepositTooltip
+              stretch
+              BadgeIcon={ChartBarIcon}
+              badgeBackground="white"
+              iconTileTone="purple"
+              headline={`Earn ~${(vaultApy ?? 0).toFixed(1)}% APY`}
+              body="Deposit into the vault and start earning now."
+              infoTooltip="The APY is an estimate from recent vault performance."
+              ariaLabel={`Estimated yearly yield ~${(vaultApy ?? 0).toFixed(1)}%`}
+              onDeposit={() => openActionModal('yield-deposit')}
+            />
+          </div>
         ) : null}
 
         {showActivity ? (

--- a/apps/armada-interface/src/test-setup.ts
+++ b/apps/armada-interface/src/test-setup.ts
@@ -9,7 +9,10 @@ import 'fake-indexeddb/auto'
 if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
   window.matchMedia = (query: string) =>
     ({
-      matches: false,
+      // Report reduced motion under test so motion helpers (useFlowExit exit delay, odometer rolls,
+      // step-switch exits) resolve synchronously instead of scheduling real timers — deterministic
+      // renders, no waiting on animation windows. Other queries stay non-matching.
+      matches: query.includes('prefers-reduced-motion'),
       media: query,
       onchange: null,
       addEventListener: () => {},


### PR DESCRIPTION
Animation follow-up from the 6b audit — wires the four vendored-but-unused motion machineries so the live flows match the mockup. (The 5th audit item, inline fee-reveal, is intentionally skipped — the confirm-step tooltip move stands.)

## 1. Live-modal exit slide-down
The Shield / Send / Earn modals unmounted instantly on close. New `useFlowExit(onClose)` hook plays `FlowShell`'s slide-down first: it holds `exiting` true for `MODAL_EXIT_TOTAL_MS`, keeps the atom set so the step content stays frozen, then runs the real close. Each modal now does `const { exiting, requestClose: close } = useFlowExit(() => setOpenModal(null))` and passes `exiting` to `FlowShell`. Reduced motion → closes synchronously. `ActivityReceipt` was carrying a hand-rolled copy of this timer — refactored onto the hook.

## 2. Step-to-step transitions
`FlowShell` gained a `stepKey` prop; when it changes, the vendored `ModalStepSwitch` plays a short content exit then remounts the next step so its enter animations replay. Each modal passes its `step` string.

## 3. Preset / Max amount roll
`DepositAmountCard` now odometer-rolls the amount from the old value to the new when a %-pill or Max is tapped (shared by deposit/send/withdraw/earn). A preset marks the roll origin; an effect starts the roll on the resulting `amount` change (typing clears it), so the caller-driven `onMax` fee-on-top path rolls too. Reuses the dashboard `RollingBalanceValue`. Reduced motion → no roll, value just updates.

## 4. Deposit-tooltip fade
The first-run deposit callout + earn banner now fade up (`dashboardTooltipFade`) after the balance card's action row settles, using the mockup's `DASHBOARD_TOOLTIP_ENTER_DELAY_MS`.

## Tests
- New `useFlowExit.test.ts` (reduced-motion sync close, motion deferred close, re-entry guard) and DepositAmountCard preset/roll tests.
- Test setup now reports `prefers-reduced-motion: reduce` so motion helpers resolve synchronously in jsdom — deterministic, no waiting on animation windows (this is what fixed the ~20 modal-close assertions that would otherwise race the new exit timer).
- Typecheck clean; full interface suite 1157 passing (8 pre-existing OnboardingFlow skips).

All motion is reduced-motion-guarded.
