### PR TITLE
feat(interface): pay-via-link — request flow + payer landing + Send prefill (6c)

### DIFF
--- a/apps/armada-interface/CLAUDE.md
+++ b/apps/armada-interface/CLAUDE.md
@@ -21,7 +21,8 @@ Architectural decisions and rationale: `../../.claude/PLAN_ARMADA_INTERFACE.md`.
 | Server state | `@tanstack/react-query` | All HTTP, all RPC reads, all polling that fits the request/response shape |
 | Styling | Vendored design system in `src/design` (CSS Modules + tokens, imported as `@/design`) + Tailwind v4 (layout glue) | Severed from the shared `@armada/ui` so the app is self-contained. No typography Tailwind classes in app code — body baseline (15px Geist 1.5) drives everything |
 | Persistence | IndexedDB (`lib/cache.ts`) | Stores tx history, fee quotes, ENS, shielded balance snapshots |
-| Routing | `react-router-dom` 7 | Three pages today (Dashboard, History, Settings) plus a parked AddressBook |
+| Routing | `react-router-dom` 7 | Routed pages: Dashboard (`/`), Debug (`/debug`), parked AddressBook, and the standalone `PayViaLinkLanding` (`/pay-via-link`, outside the App shell). Settings is a modal, not a page; `/history` was retired |
+| QR | `qrcode.react` | Renders the pay-via-link QR (`components/payViaLink/PaymentLinkQrCode`) |
 
 ## Folder map
 
@@ -38,7 +39,7 @@ src/
 ├── state/                   Jotai atoms (tx, wallet, fees, visibility, ui)
 ├── hooks/                   per-concern hooks (useWallet, useShieldedWallet, useBalances, useYieldRate, useFees, useTx, useTxHistory, useTabVisible)
 ├── components/              AppLayout, WalletConnector, plus subfolders for each feature (dashboard/, shield/, yield/, payments/, tx/, settings/) — payments/ is the shared Send/Withdraw flow
-└── pages/                   Dashboard, History, Settings, AddressBook
+└── pages/                   Dashboard, Debug, AddressBook, PayViaLinkLanding (Settings is a modal)
 ```
 
 ## Conventions (enforced)

--- a/apps/armada-interface/package.json
+++ b/apps/armada-interface/package.json
@@ -28,6 +28,7 @@
     "jotai": "^2.15.1",
     "level-js": "^6.1.0",
     "lucide-react": "^0.552.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.6.1",
@@ -39,13 +40,13 @@
     "wagmi": "^2.19.5"
   },
   "devDependencies": {
+    "@sentry/vite-plugin": "^5.3.0",
     "@tailwindcss/vite": "^4.1.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^22.15.0",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
-    "@sentry/vite-plugin": "^5.3.0",
     "@vitejs/plugin-react": "^5.0.4",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.0.1",

--- a/apps/armada-interface/src/App.tsx
+++ b/apps/armada-interface/src/App.tsx
@@ -12,6 +12,7 @@ import { ReceiveDialog } from '@/components/receive'
 import { EarnModal } from '@/components/yield'
 import { SettingsModal } from '@/components/settings'
 import { useAutoLock } from '@/hooks/useAutoLock'
+import { usePayViaLinkIntent } from '@/hooks/usePayViaLinkIntent'
 import { useHistoryRecovery } from '@/hooks/useHistoryRecovery'
 import { useIncomingTransferDetector } from '@/hooks/useIncomingTransferDetector'
 import { useNowTicker } from '@/hooks/useNowTicker'
@@ -58,6 +59,7 @@ export function App() {
   useHistoryRecovery() // chain-recover synthetic rows on unlock + re-scan epoch (Phase 9.3)
   useIncomingTransferDetector() // re-scan on balance events so received transfers surface live (Phase 9.4)
   useAutoLock()  // idle-timer-driven lock for the shielded wallet
+  usePayViaLinkIntent() // pick up a pending pay-via-link hand-off + open the prefilled Send on unlock
   // Mirror wagmi's connection state into evmAddressAtom for atom-consumers (OnboardingFlow's
   // SignEnrollment step, SendModal's withdraw-variant recipient pre-fill, useShieldedWallet.enroll). Mounted
   // before the onboarding/unlock guard so the atom is correct even before the user reaches /app.

--- a/apps/armada-interface/src/App.tsx
+++ b/apps/armada-interface/src/App.tsx
@@ -23,6 +23,7 @@ import { useShieldedSyncPoll } from '@/hooks/useShieldedSyncPoll'
 import { useNullifierCrossCheck } from '@/hooks/useNullifierCrossCheck'
 import { useTabVisible } from '@/hooks/useTabVisible'
 import { useTxHistory } from '@/hooks/useTxHistory'
+import { useRequestLinks } from '@/hooks/useRequestLinks'
 import { useTxResume } from '@/hooks/useTxResume'
 import { useUsdcBalances } from '@/hooks/useUsdcBalances'
 import { useWallet } from '@/hooks/useWallet'
@@ -56,6 +57,7 @@ export function App() {
   useTabVisible()
   useNowTicker() // refresh "3m ago" labels on a 60s cadence
   useTxHistory() // hydrate tx history from IDB on cold load
+  useRequestLinks() // hydrate created payment-request links (encrypted, per-wallet) for Recent Activity
   useTxResume() // on unlock (leader only), resume watchers for broadcast txs / fail pre-broadcast interruptions (P0-2)
   useHistoryRecovery() // chain-recover synthetic rows on unlock + re-scan epoch (Phase 9.3)
   useIncomingTransferDetector() // re-scan on balance events so received transfers surface live (Phase 9.4)

--- a/apps/armada-interface/src/App.tsx
+++ b/apps/armada-interface/src/App.tsx
@@ -9,6 +9,7 @@ import { OnboardingFlowV2, UnlockFlow } from '@/components/onboarding'
 import { ShieldModal } from '@/components/shield'
 import { SendModal } from '@/components/payments'
 import { ReceiveDialog } from '@/components/receive'
+import { RequestModal } from '@/components/request'
 import { EarnModal } from '@/components/yield'
 import { SettingsModal } from '@/components/settings'
 import { useAutoLock } from '@/hooks/useAutoLock'
@@ -227,6 +228,7 @@ export function App() {
       <SendModal />
       <EarnModal />
       <ReceiveDialog />
+      <RequestModal />
       <SettingsModal />
     </>
   )

--- a/apps/armada-interface/src/components/CLAUDE.md
+++ b/apps/armada-interface/src/components/CLAUDE.md
@@ -22,8 +22,11 @@ UI components. **Dumb when possible.** State comes from hooks + atoms; effects b
 | `tx/` | TxLifecycleStepper, TxRow, TxStatusChip, stageCopy helpers — see `tx/CLAUDE.md` |
 | `dashboard/` | BalanceCard + numerals + RecentActivityList + DepositTooltip (centered card stack) — see `dashboard/CLAUDE.md` |
 | `shield/` | ShieldModal + steps — see `shield/CLAUDE.md` |
-| `payments/` | SendModal — the shared Send/Withdraw flow (variant-driven, address-picks-kind) — see `payments/CLAUDE.md` |
+| `payments/` | SendModal — the shared Send/Withdraw flow (variant-driven, address-picks-kind). Also seeds recipient/amount from a pay-via-link `paymentIntentAtom` on open — see `payments/CLAUDE.md` |
 | `yield/` | EarnModal + steps (Add / Withdraw tabs) — see `yield/CLAUDE.md` |
+| `receive/` | ReceiveDialog — plain 0zk address + copy (opened via `openModalAtom='receive'`; also from the Request flow's "Copy your address instead") |
+| `request/` | RequestModal — the "Request USDC via link" flow (compose amount/expiry/note → generated link screen). Revoke is disabled ("coming soon"); the Link-revoked variant is built but unreachable until backend-backed revocation lands |
+| `payViaLink/` | `PaymentLinkQrCode` — QR of a pay-via-link URL (`qrcode.react`). Shared by the payer landing (`pages/PayViaLinkLanding`) |
 | `onboarding/` | OnboardingFlow (5-step first-run), UnlockFlow, OnboardingShell — see `onboarding/CLAUDE.md` |
 | `settings/` | RecoverySecretExportDialog, ResetWalletDialog — see `settings/CLAUDE.md` |
 

--- a/apps/armada-interface/src/components/CLAUDE.md
+++ b/apps/armada-interface/src/components/CLAUDE.md
@@ -24,7 +24,7 @@ UI components. **Dumb when possible.** State comes from hooks + atoms; effects b
 | `shield/` | ShieldModal + steps — see `shield/CLAUDE.md` |
 | `payments/` | SendModal — the shared Send/Withdraw flow (variant-driven, address-picks-kind). Also seeds recipient/amount from a pay-via-link `paymentIntentAtom` on open — see `payments/CLAUDE.md` |
 | `yield/` | EarnModal + steps (Add / Withdraw tabs) — see `yield/CLAUDE.md` |
-| `receive/` | ReceiveDialog — plain 0zk address + copy (opened via `openModalAtom='receive'`; also from the Request flow's "Copy your address instead") |
+| `receive/` | ReceiveDialog — plain 0zk address + copy (`openModalAtom='receive'`). Dormant: no entry point today (the Request flow is the dashboard's only receive affordance) |
 | `request/` | RequestModal — the "Request USDC via link" flow (compose amount/expiry/note → generated link screen). Revoke is disabled ("coming soon"); the Link-revoked variant is built but unreachable until backend-backed revocation lands |
 | `payViaLink/` | `PaymentLinkQrCode` — QR of a pay-via-link URL (`qrcode.react`). Shared by the payer landing (`pages/PayViaLinkLanding`) |
 | `onboarding/` | OnboardingFlow (5-step first-run), UnlockFlow, OnboardingShell — see `onboarding/CLAUDE.md` |

--- a/apps/armada-interface/src/components/dashboard/CLAUDE.md
+++ b/apps/armada-interface/src/components/dashboard/CLAUDE.md
@@ -35,5 +35,5 @@ Shared primitives `IconButton`, `Tooltip`, `BottomSheet` live in `@/design`; the
 ## Known follow-ups
 
 - `useDashboardBackground` is a stub returning `'gradient'`; the solid/gradient toggle UI is not ported.
-- The `Request` action opens the request-via-link flow (`components/request/RequestModal`); its "Copy your address instead" secondary hands off to the plain `ReceiveDialog`.
+- The `Request` action opens the request-via-link flow (`components/request/RequestModal`).
 - `VaultPositionBar` "earned" figure shows a literal `???` placeholder — real accrued yield needs vault cost-basis tracking (`sharesToUsdc(shares) − principal`), which isn't wired. Pass a real `earnedAmount` once that exists. Deliberately not a realistic-looking estimate, so the stub can't be mistaken for real data.

--- a/apps/armada-interface/src/components/dashboard/CLAUDE.md
+++ b/apps/armada-interface/src/components/dashboard/CLAUDE.md
@@ -35,5 +35,5 @@ Shared primitives `IconButton`, `Tooltip`, `BottomSheet` live in `@/design`; the
 ## Known follow-ups
 
 - `useDashboardBackground` is a stub returning `'gradient'`; the solid/gradient toggle UI is not ported.
-- `↓` maps to Receive as a placeholder; a dedicated payment-request flow is planned.
+- The `Request` action opens the request-via-link flow (`components/request/RequestModal`); its "Copy your address instead" secondary hands off to the plain `ReceiveDialog`.
 - `VaultPositionBar` "earned" figure shows a literal `???` placeholder — real accrued yield needs vault cost-basis tracking (`sharesToUsdc(shares) − principal`), which isn't wired. Pass a real `earnedAmount` once that exists. Deliberately not a realistic-looking estimate, so the stub can't be mistaken for real data.

--- a/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityKindFilters/ActivityKindFilters.tsx
+++ b/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityKindFilters/ActivityKindFilters.tsx
@@ -1,15 +1,23 @@
-// ABOUTME: Segmented kind-filter chips for the activity panel — All / Deposit / Withdraw / Sent / Received.
-// ABOUTME: Ported from the armada-app mockup; earn items appear only under "All" (no dedicated chip).
+// ABOUTME: Segmented kind-filter chips for the activity panel — All / Deposit / Withdraw / Sent / Requests / Received / Earn.
+// ABOUTME: Ported from the armada-app mockup; the chip id equals the activity kind so the predicate is a direct match.
 
 import styles from './ActivityKindFilters.module.css'
 
-export type ActivityKindFilter = 'all' | 'deposit' | 'withdraw' | 'send' | 'receive' | 'earn'
+export type ActivityKindFilter =
+  | 'all'
+  | 'deposit'
+  | 'withdraw'
+  | 'send'
+  | 'requestLink'
+  | 'receive'
+  | 'earn'
 
 const FILTERS: Array<{ id: ActivityKindFilter; label: string }> = [
   { id: 'all', label: 'All' },
   { id: 'deposit', label: 'Deposit' },
   { id: 'withdraw', label: 'Withdraw' },
   { id: 'send', label: 'Sent' },
+  { id: 'requestLink', label: 'Requests' },
   { id: 'receive', label: 'Received' },
   { id: 'earn', label: 'Earn' },
 ]

--- a/apps/armada-interface/src/components/dashboard/RecentActivityList/RecentActivityList.tsx
+++ b/apps/armada-interface/src/components/dashboard/RecentActivityList/RecentActivityList.tsx
@@ -17,10 +17,12 @@ import {
   ArrowRightIcon,
   ChartBarIcon,
   ClockIcon,
+  LinkIcon,
   PlusIcon,
 } from '@heroicons/react/24/outline'
 import { BalanceScrambleValue } from '@/components/dashboard/BalanceScrambleValue'
 import { formatUsdcAmount, formatTimeAgo } from '@/components/dashboard/dashboardFormat'
+import { formatPaymentLinkExpiry } from '@/lib/payViaLink'
 import type { DashboardActivityItem, DashboardActivityKind } from '@/components/dashboard/txActivityAdapter'
 import usdcAmount from '@/design/styles/usdcAmount.module.css'
 import { hidePeekEventHandlers } from '@/hooks/useHidePeek'
@@ -36,10 +38,13 @@ const ACTIVITY_ICONS: Record<DashboardActivityKind, ComponentType<SVGProps<SVGSV
   earn: ChartBarIcon,
   withdraw: ArrowLeftIcon,
   receive: ArrowDownIcon,
+  requestLink: LinkIcon,
 }
 
 function formatActivityAmount(item: DashboardActivityItem): string {
   const absolute = formatUsdcAmount(Math.abs(item.amount))
+  // A created link moves no funds — show the requested amount with no +/- sign.
+  if (item.kind === 'requestLink') return absolute
   if (item.amount > 0) return `+${absolute}`
   if (item.amount < 0) return `-${absolute}`
   return absolute
@@ -47,12 +52,15 @@ function formatActivityAmount(item: DashboardActivityItem): string {
 
 function formatActivitySubtitle(item: DashboardActivityItem): string {
   const timeAgo = formatTimeAgo(item.occurredAt)
+  if (item.kind === 'requestLink' && item.expiresAt !== undefined) {
+    return `${timeAgo} • ${formatPaymentLinkExpiry(item.expiresAt)}`
+  }
   return item.pending ? `Pending • ${timeAgo}` : timeAgo
 }
 
 function activityAmountTone(item: DashboardActivityItem, balanceRevealed: boolean): string {
-  // Pending rows and hidden balances read neutral — no green/red inflow/outflow tint.
-  if (!balanceRevealed || item.pending) return ''
+  // Pending rows, request-link rows, and hidden balances read neutral — no green/red tint.
+  if (!balanceRevealed || item.pending || item.kind === 'requestLink') return ''
   if (item.amount > 0) return styles.amountPositive ?? ''
   if (item.amount < 0) return styles.amountNegative ?? ''
   return ''

--- a/apps/armada-interface/src/components/dashboard/txActivityAdapter.test.ts
+++ b/apps/armada-interface/src/components/dashboard/txActivityAdapter.test.ts
@@ -2,7 +2,25 @@
 
 import { describe, it, expect } from 'vitest'
 import type { TxRecord, TxKind, TxExecutionState } from '@/lib/tx/types'
-import { txRecordToActivityItem, txListToActivityItems } from './txActivityAdapter'
+import type { RequestLinkRecord } from '@/lib/shielded/requestLinks'
+import {
+  buildActivityItems,
+  requestLinkToActivityItem,
+  txRecordToActivityItem,
+  txListToActivityItems,
+} from './txActivityAdapter'
+
+function makeLink(opts: Partial<RequestLinkRecord> = {}): RequestLinkRecord {
+  return {
+    requestId: opts.requestId ?? 'req_abc',
+    paymentLink: opts.paymentLink ?? 'https://app/pay-via-link?to=0zk&amount=25',
+    amount: opts.amount ?? '25',
+    note: opts.note,
+    expiresAt: opts.expiresAt ?? 2_000,
+    createdAt: opts.createdAt ?? 1_500,
+    shieldedWalletId: opts.shieldedWalletId ?? 'w1',
+  }
+}
 
 function makeRecord(
   kind: TxKind,
@@ -106,5 +124,35 @@ describe('txListToActivityItems', () => {
     const pending = items.find((i) => i.id === 'pending')
     expect(pending?.pending).toBe(true)
     expect(items).toHaveLength(2)
+  })
+})
+
+describe('requestLinkToActivityItem', () => {
+  it('maps a created link to a neutral "Payment link created" row', () => {
+    const item = requestLinkToActivityItem(makeLink({ amount: '25', createdAt: 1_500, expiresAt: 2_000 }))
+    expect(item.kind).toBe('requestLink')
+    expect(item.label).toBe('Payment link created')
+    expect(item.amount).toBe(25) // positive/neutral — no sign applied here
+    expect(item.pending).toBe(false)
+    expect(item.requestId).toBe('req_abc')
+    expect(item.expiresAt).toBe(2_000)
+    expect(item.occurredAt).toBe(1_500)
+  })
+})
+
+describe('buildActivityItems', () => {
+  it('merges tx + request-link rows newest-first', () => {
+    const tx = makeRecord('shield', { id: 'tx-old', amount: 1_000_000n, createdAt: 1_000, updatedAt: 1_000 })
+    const link = makeLink({ requestId: 'req_new', createdAt: 3_000 })
+    const items = buildActivityItems([tx], [link])
+    expect(items.map((i) => i.id)).toEqual(['req_new', 'tx-old']) // link is newer → first
+    expect(items[0]?.kind).toBe('requestLink')
+  })
+
+  it('caps the merged list at max', () => {
+    const links = Array.from({ length: 5 }, (_, i) =>
+      makeLink({ requestId: `req_${i}`, createdAt: 1_000 + i }),
+    )
+    expect(buildActivityItems([], links, null, 3)).toHaveLength(3)
   })
 })

--- a/apps/armada-interface/src/components/dashboard/txActivityAdapter.ts
+++ b/apps/armada-interface/src/components/dashboard/txActivityAdapter.ts
@@ -4,20 +4,25 @@
 import type { TxRecord, TxKind } from '@/lib/tx/types'
 import { historySortTime, isTerminalState } from '@/lib/tx/types'
 import { recordTitle } from '@/components/tx/stageCopy'
+import type { RequestLinkRecord } from '@/lib/shielded/requestLinks'
 
 /** Icon/semantic kind for an activity row — a coarser grouping than TxKind. */
-export type DashboardActivityKind = 'send' | 'deposit' | 'earn' | 'withdraw' | 'receive'
+export type DashboardActivityKind = 'send' | 'deposit' | 'earn' | 'withdraw' | 'receive' | 'requestLink'
 
 export interface DashboardActivityItem {
   id: string
   kind: DashboardActivityKind
   label: string
-  /** Signed USDC amount as a plain number: positive = inflow, negative = outflow. */
+  /** Signed USDC amount as a plain number: positive = inflow, negative = outflow. `requestLink`
+   *  rows render this neutrally (no sign/tone) — a created link moves no funds. */
   amount: number
   occurredAt: number
   txHash?: string
   /** True while the underlying tx is non-terminal (still in flight). */
   pending: boolean
+  /** `requestLink` only — the request id (re-opens the Share step) + expiry (row subtitle). */
+  requestId?: string
+  expiresAt?: number
 }
 
 /** Per-TxKind direction: the activity icon-kind and the sign of the amount (inflow vs outflow). */
@@ -95,4 +100,33 @@ export function txListToActivityItems(
     .sort((a, b) => historySortTime(b) - historySortTime(a))
     .slice(0, max)
     .map((record) => txRecordToActivityItem(record, ownWallet))
+}
+
+/** A created payment-request link as an activity row. Neutral amount; clicking re-opens the link. */
+export function requestLinkToActivityItem(link: RequestLinkRecord): DashboardActivityItem {
+  const amount = Number(link.amount)
+  return {
+    id: link.requestId,
+    kind: 'requestLink',
+    label: 'Payment link created',
+    amount: Number.isFinite(amount) ? amount : 0,
+    occurredAt: link.createdAt,
+    pending: false,
+    requestId: link.requestId,
+    expiresAt: link.expiresAt,
+  }
+}
+
+/** Merge tx-derived + request-link activity rows into one newest-first list, capped. */
+export function buildActivityItems(
+  list: readonly TxRecord[],
+  links: readonly RequestLinkRecord[],
+  ownWallet?: string | null,
+  max = 8,
+): DashboardActivityItem[] {
+  const items = [
+    ...list.map((record) => txRecordToActivityItem(record, ownWallet)),
+    ...links.map(requestLinkToActivityItem),
+  ]
+  return items.sort((a, b) => b.occurredAt - a.occurredAt).slice(0, max)
 }

--- a/apps/armada-interface/src/components/payViaLink/PaymentLinkQrCode/PaymentLinkQrCode.module.css
+++ b/apps/armada-interface/src/components/payViaLink/PaymentLinkQrCode/PaymentLinkQrCode.module.css
@@ -1,0 +1,19 @@
+/* ABOUTME: PaymentLinkQrCode styles — centered QR on a rounded surface; QR sized off spacing tokens. */
+
+.root {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: var(--primitives-spacing-4);
+  border-radius: calc(var(--semantic-borderRadius-item) * 1px);
+  background: var(--semantic-color-surface-main);
+  color: var(--semantic-color-text-primary);
+  box-sizing: border-box;
+}
+
+.qr {
+  display: block;
+  width: calc(var(--primitives-spacing-24) + var(--primitives-spacing-6));
+  height: calc(var(--primitives-spacing-24) + var(--primitives-spacing-6));
+}

--- a/apps/armada-interface/src/components/payViaLink/PaymentLinkQrCode/PaymentLinkQrCode.tsx
+++ b/apps/armada-interface/src/components/payViaLink/PaymentLinkQrCode/PaymentLinkQrCode.tsx
@@ -1,0 +1,34 @@
+// ABOUTME: PaymentLinkQrCode — renders a scannable QR of a pay-via-link URL (qrcode.react QRCodeSVG).
+// ABOUTME: Transparent background + currentColor foreground so it inherits the surrounding frost surface.
+
+import { QRCodeSVG } from 'qrcode.react'
+import styles from './PaymentLinkQrCode.module.css'
+
+export interface PaymentLinkQrCodeProps {
+  value: string
+  label?: string
+  className?: string
+}
+
+export function PaymentLinkQrCode({
+  value,
+  label = 'Payment link QR code',
+  className,
+}: PaymentLinkQrCodeProps) {
+  return (
+    <div
+      className={[styles.root, className].filter(Boolean).join(' ')}
+      role="img"
+      aria-label={label}
+    >
+      <QRCodeSVG
+        value={value}
+        size={200}
+        level="M"
+        className={styles.qr}
+        bgColor="transparent"
+        fgColor="currentColor"
+      />
+    </div>
+  )
+}

--- a/apps/armada-interface/src/components/payViaLink/PaymentLinkQrCode/index.ts
+++ b/apps/armada-interface/src/components/payViaLink/PaymentLinkQrCode/index.ts
@@ -1,0 +1,2 @@
+// ABOUTME: Barrel for the PaymentLinkQrCode component and its props type.
+export { PaymentLinkQrCode, type PaymentLinkQrCodeProps } from './PaymentLinkQrCode'

--- a/apps/armada-interface/src/components/payments/SendModal.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.test.tsx
@@ -4,7 +4,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { Provider, createStore } from 'jotai'
 import { SendModal } from './SendModal'
-import { openModalAtom } from '@/state/ui'
+import { openModalAtom, paymentIntentAtom } from '@/state/ui'
 import {
   activeShieldedWalletIdAtom,
   evmAddressAtom,
@@ -84,9 +84,11 @@ function renderModal(opts?: {
   open?: 'payment' | 'withdraw' | false
   shielded?: bigint
   evm?: string
+  intent?: { recipient: string; amount?: string }
 }) {
   const store = createStore()
   if (opts?.open) store.set(openModalAtom, opts.open)
+  if (opts?.intent) store.set(paymentIntentAtom, opts.intent)
   if (opts?.shielded !== undefined) {
     store.set(shieldedUsdcAtom, opts.shielded)
     store.set(shieldedUsdcSpendableAtom, opts.shielded) // no pending in tests → spendable == total
@@ -130,6 +132,19 @@ describe('<SendModal>', () => {
     renderModal({ open: 'payment', shielded: 10_000_000n })
     expect(screen.getByRole('dialog', { name: 'Send' })).toBeInTheDocument()
     expect(screen.getByLabelText('Recipient address')).toBeInTheDocument()
+  })
+
+  it('seeds the recipient from a pay-via-link intent and consumes it', () => {
+    const store = renderModal({
+      open: 'payment',
+      shielded: 10_000_000n,
+      intent: { recipient: VALID_0ZK, amount: '25' },
+    })
+    // Prefilled recipient is recognised as a valid 0zk (privacy badge) and held on the input title.
+    expect(screen.getByLabelText('Recipient address')).toHaveAttribute('title', VALID_0ZK)
+    expect(screen.getByText('Private address')).toBeInTheDocument()
+    // The intent is consumed on open so it can't re-fire.
+    expect(store.get(paymentIntentAtom)).toBeNull()
   })
 
   it('Continue enables only once the recipient is a valid address', () => {

--- a/apps/armada-interface/src/components/payments/SendModal.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.test.tsx
@@ -134,17 +134,29 @@ describe('<SendModal>', () => {
     expect(screen.getByLabelText('Recipient address')).toBeInTheDocument()
   })
 
-  it('seeds the recipient from a pay-via-link intent and consumes it', () => {
+  it('opens directly on Review from a pay-via-link intent and consumes it', () => {
     const store = renderModal({
       open: 'payment',
       shielded: 10_000_000n,
       intent: { recipient: VALID_0ZK, amount: '25' },
     })
-    // Prefilled recipient is recognised as a valid 0zk (privacy badge) and held on the input title.
-    expect(screen.getByLabelText('Recipient address')).toHaveAttribute('title', VALID_0ZK)
-    expect(screen.getByText('Private address')).toBeInTheDocument()
+    // Recipient + amount are both known, so the flow jumps past the recipient/amount steps.
+    expect(screen.getByRole('heading', { name: 'Review your USDC transfer' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Confirm send' })).toBeInTheDocument()
+    expect(screen.queryByLabelText('Recipient address')).toBeNull()
     // The intent is consumed on open so it can't re-fire.
     expect(store.get(paymentIntentAtom)).toBeNull()
+  })
+
+  it('lands on the amount step for an amount-less pay-via-link intent', () => {
+    renderModal({
+      open: 'payment',
+      shielded: 10_000_000n,
+      intent: { recipient: VALID_0ZK },
+    })
+    // No amount to review yet — the amount step is shown (recipient already seeded).
+    expect(screen.queryByLabelText('Recipient address')).toBeNull()
+    expect(screen.getByLabelText('Send amount')).toBeInTheDocument()
   })
 
   it('Continue enables only once the recipient is a valid address', () => {

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -4,7 +4,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { useAccount } from 'wagmi'
 import { useAtom, useAtomValue } from 'jotai'
-import { openModalAtom } from '@/state/ui'
+import { openModalAtom, paymentIntentAtom } from '@/state/ui'
+import { clearPendingPayViaLink } from '@/lib/payViaLink'
 import { preferencesAtom } from '@/state/preferences'
 import {
   evmAddressAtom,
@@ -57,6 +58,7 @@ function computeKind(recipient: string, destChainId: number, hubChainId: number)
 
 export function SendModal() {
   const [openModal, setOpenModal] = useAtom(openModalAtom)
+  const [paymentIntent, setPaymentIntent] = useAtom(paymentIntentAtom)
   const isOpen = openModal === 'payment' || openModal === 'withdraw'
   const variant: SendFlowVariant = openModal === 'withdraw' ? 'withdraw' : 'send'
   // A6 — frozen into the record's meta at submit-time so a mid-flight toggle doesn't strand the handler.
@@ -204,6 +206,18 @@ export function SendModal() {
   useEffect(() => {
     if (!isOpen) return
     if (variant === 'withdraw') setRecipient(connectedEvm ?? '')
+  }, [isOpen])
+
+  // Pay-via-link hand-off: when opened from a payment-request link, seed the recipient (+ amount)
+  // from the intent, then consume it (clear the atom + the pending sessionStorage carrier). Fires
+  // once per open, same as the withdraw prefill above.
+  useEffect(() => {
+    if (!isOpen || !paymentIntent) return
+    setRecipient(paymentIntent.recipient)
+    if (paymentIntent.amount) setAmountStr(paymentIntent.amount)
+    setPaymentIntent(null)
+    clearPendingPayViaLink()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen])
 
   // Watch the submitted record for terminal transitions. Dep is `record?.executionState` rather

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -83,6 +83,25 @@ export function SendModal() {
   const [errorAtStep, setErrorAtStep] = useState<FlowVisibleStep | undefined>(undefined)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [submittedKind, setSubmittedKind] = useState<SubmittedKind | null>(null)
+
+  // Seed the flow synchronously when it opens from a pay-via-link intent, so the modal starts on
+  // Review (recipient + amount are both known) rather than flashing the Recipient step. This runs
+  // during render (React's "adjust state on an incoming change" pattern) so FlowShell's stepKey is
+  // already 'review' on the first paint — no ModalStepSwitch transition. The atom + pending carrier
+  // are consumed in an effect below. Amount-less links land on the amount step instead.
+  const [wasOpen, setWasOpen] = useState(false)
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen)
+    if (isOpen && paymentIntent) {
+      setRecipient(paymentIntent.recipient)
+      if (paymentIntent.amount) {
+        setAmountStr(paymentIntent.amount)
+        setStep('review')
+      } else {
+        setStep('input')
+      }
+    }
+  }
   // Double-submit guard (P0-7): ref = synchronous gate (state is async), state = button disable.
   const submittingRef = useRef(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -208,17 +227,15 @@ export function SendModal() {
     if (variant === 'withdraw') setRecipient(connectedEvm ?? '')
   }, [isOpen])
 
-  // Pay-via-link hand-off: when opened from a payment-request link, seed the recipient (+ amount)
-  // from the intent, then consume it (clear the atom + the pending sessionStorage carrier). Fires
-  // once per open, same as the withdraw prefill above.
+  // Consume the pay-via-link intent once the modal has opened + seeded (the render-time block
+  // above applies recipient/amount/step). Clearing the atom + pending carrier here (post-commit)
+  // keeps the cross-component write out of render.
   useEffect(() => {
-    if (!isOpen || !paymentIntent) return
-    setRecipient(paymentIntent.recipient)
-    if (paymentIntent.amount) setAmountStr(paymentIntent.amount)
-    setPaymentIntent(null)
-    clearPendingPayViaLink()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen])
+    if (isOpen && paymentIntent) {
+      setPaymentIntent(null)
+      clearPendingPayViaLink()
+    }
+  }, [isOpen, paymentIntent, setPaymentIntent])
 
   // Watch the submitted record for terminal transitions. Dep is `record?.executionState` rather
   // than `record` so artifact patches during xchain polling don't re-fire this needlessly — the

--- a/apps/armada-interface/src/components/request/CLAUDE.md
+++ b/apps/armada-interface/src/components/request/CLAUDE.md
@@ -1,0 +1,21 @@
+# components/request/
+
+The "Request USDC via link" flow — compose a payment request and share a link that drops the payer into a prefilled Send. Opened via `setOpenModal('request')` (the dashboard **Request** action).
+
+## Contents
+
+| Component | Purpose |
+|---|---|
+| `RequestModal` | Orchestrator on `FlowShell` (steps `Receive → Share link`). Owns amount/expiry/note state; builds the link on Create via `lib/payViaLink.buildPayViaLinkUrl` from the active wallet's 0zk address. |
+| `RequestReceiveScreen` | Compose step — amount + `Link expires` SegmentedControl + optional note. "Create link" advances to the link screen. "Copy your address instead" hands off to `ReceiveDialog` (the amount-less path). |
+| `RequestLinkScreen` | Link step — the generated URL (middle-truncated) + Copy, plus the wired-ready **Link revoked** variant. |
+
+## What's real vs. deferred
+
+- **Real:** amount / expiry / note / request id / the shareable `/pay-via-link` URL (with our origin + the real 0zk address). The payer path (landing → Send prefill) is in `pages/PayViaLinkLanding` + `hooks/usePayViaLinkIntent`.
+- **Disabled placeholder — Revoke.** A session-local flag can't stop a payer who already has the link; true revocation needs shared backend state. The Revoke trigger is disabled + marked "coming soon". The `revoked` variant screen is built and rendered when `RequestLinkScreen`'s `revoked` prop is true — nothing sets it yet.
+- **Dropped:** per-request "paid" tracking + the mockup's 60s mock auto-settle + fake tx hash. Received payments surface through the normal activity/receipt path (chunk 6b), not a request-specific signal — matching a payment back to a request would need memo-on-send tagging (not wired).
+
+## Deviation from the mockup
+
+The mockup's desktop compose has no plain copy-address affordance (it lives only in the mobile chooser sheet). To preserve the amount-less "share my address" path on desktop without the mobile chrome, `RequestReceiveScreen` adds a subtle **"Copy your address instead"** link that opens `ReceiveDialog`.

--- a/apps/armada-interface/src/components/request/CLAUDE.md
+++ b/apps/armada-interface/src/components/request/CLAUDE.md
@@ -7,7 +7,7 @@ The "Request USDC via link" flow — compose a payment request and share a link 
 | Component | Purpose |
 |---|---|
 | `RequestModal` | Orchestrator on `FlowShell` (steps `Receive → Share link`). Owns amount/expiry/note state; builds the link on Create via `lib/payViaLink.buildPayViaLinkUrl` from the active wallet's 0zk address. |
-| `RequestReceiveScreen` | Compose step — amount + `Link expires` SegmentedControl + optional note. "Create link" advances to the link screen. "Copy your address instead" hands off to `ReceiveDialog` (the amount-less path). |
+| `RequestReceiveScreen` | Compose step — amount + `Link expires` SegmentedControl + optional note. "Create link" advances to the link screen. |
 | `RequestLinkScreen` | Link step — the generated URL (middle-truncated) + Copy, plus the wired-ready **Link revoked** variant. |
 
 ## What's real vs. deferred
@@ -16,6 +16,6 @@ The "Request USDC via link" flow — compose a payment request and share a link 
 - **Disabled placeholder — Revoke.** A session-local flag can't stop a payer who already has the link; true revocation needs shared backend state. The Revoke trigger is disabled + marked "coming soon". The `revoked` variant screen is built and rendered when `RequestLinkScreen`'s `revoked` prop is true — nothing sets it yet.
 - **Dropped:** per-request "paid" tracking + the mockup's 60s mock auto-settle + fake tx hash. Received payments surface through the normal activity/receipt path (chunk 6b), not a request-specific signal — matching a payment back to a request would need memo-on-send tagging (not wired).
 
-## Deviation from the mockup
+## Note
 
-The mockup's desktop compose has no plain copy-address affordance (it lives only in the mobile chooser sheet). To preserve the amount-less "share my address" path on desktop without the mobile chrome, `RequestReceiveScreen` adds a subtle **"Copy your address instead"** link that opens `ReceiveDialog`.
+`ReceiveDialog` (plain 0zk address + copy, `openModalAtom='receive'`) currently has **no entry point** — the Request flow is the only receive affordance on the dashboard. The component + `'receive'` modal kind are retained but dormant until a raw-address path is (re)introduced.

--- a/apps/armada-interface/src/components/request/CLAUDE.md
+++ b/apps/armada-interface/src/components/request/CLAUDE.md
@@ -16,6 +16,10 @@ The "Request USDC via link" flow — compose a payment request and share a link 
 - **Disabled placeholder — Revoke.** A session-local flag can't stop a payer who already has the link; true revocation needs shared backend state. The Revoke trigger is disabled + marked "coming soon". The `revoked` variant screen is built and rendered when `RequestLinkScreen`'s `revoked` prop is true — nothing sets it yet.
 - **Dropped:** per-request "paid" tracking + the mockup's 60s mock auto-settle + fake tx hash. Received payments surface through the normal activity/receipt path (chunk 6b), not a request-specific signal — matching a payment back to a request would need memo-on-send tagging (not wired).
 
+## Recent Activity integration
+
+Creating a link persists a `RequestLinkRecord` (encrypted, per-wallet — `lib/shielded/requestLinks.ts`, hydrated via `useRequestLinks` into `requestLinksAtom`). The dashboard merges these into the activity list (`buildActivityItems`) as neutral **"Payment link created"** rows (`LinkIcon`, no +/- amount, expiry in the subtitle, a "Requests" filter chip). Clicking a row sets `requestShareIntentAtom` + opens this modal, which re-opens **directly on the Share step** seeded from the stored link. Created links are local-only (not chain-recoverable); "Clear local history" wipes them.
+
 ## Note
 
 `ReceiveDialog` (plain 0zk address + copy, `openModalAtom='receive'`) currently has **no entry point** — the Request flow is the only receive affordance on the dashboard. The component + `'receive'` modal kind are retained but dormant until a raw-address path is (re)introduced.

--- a/apps/armada-interface/src/components/request/RequestLinkScreen.module.css
+++ b/apps/armada-interface/src/components/request/RequestLinkScreen.module.css
@@ -1,0 +1,362 @@
+/* ABOUTME: RequestLinkScreen styles — ported from the armada-app mockup src/pages/RequestLinkScreen.module.css. */
+.column {
+  width: 100%;
+  max-width: calc(
+    var(--primitives-spacing-20) * 5 + var(--primitives-spacing-8) + var(--primitives-spacing-1) *
+      0.5
+  );
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--primitives-spacing-10);
+  padding: var(--primitives-spacing-10);
+  box-sizing: border-box;
+  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--primitives-color-neutral-50) 40%, transparent) 0%,
+    color-mix(in srgb, var(--primitives-color-neutral-50) 20%, transparent) 100%
+  );
+  backdrop-filter: blur(calc(var(--primitives-spacing-24) * 3 + var(--primitives-spacing-3)));
+  -webkit-backdrop-filter: blur(calc(var(--primitives-spacing-24) * 3 + var(--primitives-spacing-3)));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .column {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+@keyframes shareCascadeEnter {
+  from {
+    opacity: 0;
+    transform: translateY(var(--primitives-spacing-10));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes shareCtaEnter {
+  0% {
+    opacity: 0;
+    transform: translateY(0);
+  }
+
+  48% {
+    opacity: 1;
+    transform: translateY(calc(var(--primitives-spacing-3) * -1));
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.enter {
+  opacity: 0;
+  animation: shareCascadeEnter 360ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.enterTitle {
+  animation-delay: var(--modal-step-enter-delay, 360ms);
+}
+
+.enterAmount {
+  animation-delay: calc(var(--modal-step-enter-delay, 360ms) + 70ms);
+}
+
+.enterShareRow {
+  animation-delay: calc(var(--modal-step-enter-delay, 360ms) + 140ms);
+}
+
+.enterLinkBox {
+  animation-delay: calc(var(--modal-step-enter-delay, 360ms) + 210ms);
+}
+
+.enterCopy {
+  animation-name: shareCtaEnter;
+  animation-duration: 520ms;
+  animation-timing-function: cubic-bezier(0.34, 1.15, 0.64, 1);
+  animation-delay: calc(var(--modal-step-enter-delay, 360ms) + 280ms);
+}
+
+.enterRevoke {
+  animation-delay: calc(var(--modal-step-enter-delay, 360ms) + 350ms);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .enter {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+}
+
+.title {
+  margin: 0;
+  width: 100%;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  font-weight: var(--primitives-fontWeight-semibold);
+  line-height: var(--primitives-spacing-5);
+  letter-spacing: var(--primitives-letterSpacing-normal);
+  color: var(--semantic-color-text-primary);
+  text-align: left;
+}
+
+.amountValue {
+  --amount-size: calc(var(--primitives-fontSize-4xl) + var(--primitives-spacing-3) / 1px);
+  display: block;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  font-family: var(--primitives-fontFamily-mono), ui-monospace, monospace;
+  font-weight: var(--primitives-fontWeight-regular);
+  font-size: calc(var(--amount-size) * 1px);
+  line-height: 1;
+  color: var(--semantic-color-brand-ink);
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.linkSection {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--primitives-spacing-5);
+  width: 100%;
+}
+
+.linkHeading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+}
+
+.linkHeadingLabel {
+  margin: 0;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  font-weight: var(--primitives-fontWeight-semibold);
+  line-height: var(--primitives-lineHeight-normal);
+  color: var(--semantic-color-text-primary);
+}
+
+.expiryPill {
+  flex-shrink: 0;
+  margin: 0;
+  padding: 0 var(--primitives-spacing-3);
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  background: color-mix(in srgb, var(--primitives-color-neutral-50) 40%, transparent);
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: var(--semantic-component-button-primary-sm-font-size);
+  font-weight: var(--primitives-fontWeight-medium);
+  line-height: var(--primitives-lineHeight-normal);
+  letter-spacing: var(--primitives-letterSpacing-wide);
+  color: var(--semantic-color-text-primary);
+}
+
+.linkBox {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  height: calc(var(--primitives-spacing-12) + var(--primitives-spacing-2));
+  padding: 0 var(--primitives-spacing-3);
+  box-sizing: border-box;
+  border-radius: calc(
+    (var(--primitives-borderRadius-lg) + var(--primitives-borderRadius-xl)) / 2 * 1px
+  );
+  background: color-mix(in srgb, var(--primitives-color-neutral-50) 60%, transparent);
+}
+
+.linkValue {
+  position: relative;
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-start;
+  width: 100%;
+  min-width: 0;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  font-weight: var(--primitives-fontWeight-regular);
+  line-height: var(--primitives-lineHeight-normal);
+  color: var(--semantic-color-brand-ink);
+  text-align: left;
+}
+
+.linkRuler {
+  position: absolute;
+  visibility: hidden;
+  height: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.linkStart,
+.linkEnd {
+  flex: 0 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.linkEllipsis {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.copyButton {
+  width: 100%;
+}
+
+.copyStatus {
+  position: absolute;
+  width: var(--primitives-spacing-1);
+  height: var(--primitives-spacing-1);
+  padding: 0;
+  margin: calc(var(--primitives-spacing-1) * -1);
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.revokeLink {
+  margin: 0;
+  padding: var(--primitives-spacing-2) var(--primitives-spacing-3);
+  min-height: var(--primitives-spacing-11);
+  border: none;
+  background: transparent;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: var(--semantic-component-button-primary-sm-font-size);
+  font-weight: var(--primitives-fontWeight-medium);
+  line-height: var(--primitives-lineHeight-normal);
+  letter-spacing: var(--primitives-letterSpacing-wide);
+  color: var(--semantic-color-text-primary);
+  text-decoration: underline;
+  text-underline-offset: var(--primitives-spacing-1);
+  cursor: pointer;
+}
+
+.revokeLink:focus-visible {
+  outline: calc(var(--primitives-borderWidth-default) * 2px) solid var(--semantic-color-border-focus);
+  outline-offset: var(--primitives-spacing-1);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .revokeLink:hover {
+    color: var(--semantic-color-brand-ink);
+  }
+}
+
+.lede {
+  margin: 0;
+  width: 100%;
+  font-family: var(--semantic-typography-ui-body-sm-font-family);
+  font-size: var(--semantic-typography-ui-body-sm-font-size);
+  font-weight: var(--semantic-typography-ui-body-sm-font-weight);
+  line-height: var(--semantic-typography-ui-body-sm-line-height);
+  letter-spacing: var(--semantic-typography-ui-body-sm-letter-spacing);
+  color: var(--semantic-color-text-muted);
+  text-align: left;
+}
+
+.linkCardActionButton {
+  width: 100%;
+}
+
+.revokeButtonDestructive {
+  border: calc(var(--primitives-borderWidth-default) * 1px) solid var(--semantic-color-status-error);
+  color: var(--semantic-color-status-error);
+  background: color-mix(in srgb, var(--semantic-color-status-error) 8%, transparent);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .revokeButtonDestructive:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--semantic-color-status-error) 14%, transparent);
+  }
+
+  .doneButton:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--primitives-color-neutral-50) 55%, transparent);
+  }
+}
+
+.revokeConfirm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+  padding: var(--primitives-spacing-4);
+  border-radius: calc(var(--semantic-borderRadius-item) * 1px);
+  background: color-mix(in srgb, var(--primitives-color-neutral-50) 20%, transparent);
+  box-sizing: border-box;
+}
+
+.revokeCopy {
+  margin: 0;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  line-height: var(--primitives-lineHeight-normal);
+  color: var(--semantic-color-text-muted);
+  text-align: left;
+}
+
+.revokeActions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-2);
+  width: 100%;
+}
+
+.buttonRow {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+}
+
+.doneButton {
+  width: 100%;
+  height: var(--primitives-spacing-12);
+  background: color-mix(in srgb, var(--primitives-color-neutral-50) 40%, transparent);
+  border: calc(var(--primitives-borderWidth-default) * 1px) solid
+    color-mix(in srgb, var(--primitives-color-neutral-50) 14%, transparent);
+  color: var(--semantic-color-text-primary);
+}
+/* Revoke row — disabled trigger + honest "coming soon" marker (real revoke needs backend state). */
+.revokeRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--primitives-spacing-2);
+}
+.revokeSoon {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: var(--semantic-typography-ui-body-sm-font-size);
+  font-weight: var(--primitives-fontWeight-medium);
+  color: var(--semantic-color-text-muted);
+}
+.revokeLink:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/apps/armada-interface/src/components/request/RequestLinkScreen.tsx
+++ b/apps/armada-interface/src/components/request/RequestLinkScreen.tsx
@@ -1,0 +1,187 @@
+// ABOUTME: RequestLinkScreen — shows the generated pay-via-link with Copy + a (disabled) Revoke, plus a wired-ready "Link revoked" variant.
+// ABOUTME: Revoke needs shared backend state to actually work, so its trigger is disabled ("coming soon") until that lands.
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
+import { formatUsdcAmount, parseUsdcInput } from '@/lib/format'
+import { formatPaymentLinkExpiry } from '@/lib/payViaLink'
+import styles from './RequestLinkScreen.module.css'
+
+const COPY_FEEDBACK_MS = 2000
+
+function formatExpireInLabel(expiresAt: number): string {
+  const relative = formatPaymentLinkExpiry(expiresAt)
+  if (relative === 'Expired') return 'Expired'
+  return relative.replace(/^Expires /, 'Expire ')
+}
+
+/** Middle-truncates a long URL (head…tail) to fit its container, remeasuring on resize. */
+function LinkDisplay({ url }: { url: string }) {
+  const containerRef = useRef<HTMLParagraphElement>(null)
+  const rulerRef = useRef<HTMLSpanElement>(null)
+  const [parts, setParts] = useState<{ head: string; tail: string; truncated: boolean }>({
+    head: url,
+    tail: '',
+    truncated: false,
+  })
+
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    const ruler = rulerRef.current
+    if (!container || !ruler) return
+
+    const ellipsis = '…'
+    const measure = (value: string) => {
+      ruler.textContent = value
+      return ruler.getBoundingClientRect().width
+    }
+
+    const fit = () => {
+      const available = container.clientWidth
+      if (!available || measure(url) <= available) {
+        setParts({ head: url, tail: '', truncated: false })
+        return
+      }
+      let headLen = 1
+      let tailLen = 1
+      while (headLen + tailLen < url.length) {
+        const width = measure(url.slice(0, headLen)) + measure(ellipsis) + measure(url.slice(url.length - tailLen))
+        if (width > available) break
+        headLen += 1
+        tailLen += 1
+      }
+      headLen = Math.max(1, headLen - 1)
+      tailLen = Math.max(1, tailLen - 1)
+      setParts({ head: url.slice(0, headLen), tail: url.slice(url.length - tailLen), truncated: true })
+    }
+
+    fit()
+    const observer = new ResizeObserver(fit)
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [url])
+
+  return (
+    <p ref={containerRef} className={styles.linkValue} title={url}>
+      <span ref={rulerRef} className={styles.linkRuler} aria-hidden />
+      {parts.truncated ? (
+        <>
+          <span className={styles.linkStart}>{parts.head}</span>
+          <span className={styles.linkEllipsis} aria-hidden>
+            …
+          </span>
+          <span className={styles.linkEnd}>{parts.tail}</span>
+        </>
+      ) : (
+        url
+      )}
+    </p>
+  )
+}
+
+export interface RequestLinkScreenProps {
+  paymentLink: string
+  amount?: string
+  expiresAt: number
+  /** Rendered as the "Link revoked" terminal screen. Never true today (revoke is disabled). */
+  revoked: boolean
+  onDone: () => void
+}
+
+export function RequestLinkScreen({
+  paymentLink,
+  amount,
+  expiresAt,
+  revoked,
+  onDone,
+}: RequestLinkScreenProps) {
+  const [linkCopied, setLinkCopied] = useState(false)
+  const linkCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const amountLabel = amount ? formatUsdcAmount(parseUsdcInput(amount).value) : null
+  const expiryLabel = formatExpireInLabel(expiresAt)
+
+  async function handleCopyLink() {
+    try {
+      await navigator.clipboard.writeText(paymentLink)
+      setLinkCopied(true)
+      if (linkCopyTimerRef.current) clearTimeout(linkCopyTimerRef.current)
+      linkCopyTimerRef.current = setTimeout(() => setLinkCopied(false), COPY_FEEDBACK_MS)
+    } catch {
+      // clipboard unavailable
+    }
+  }
+
+  useEffect(
+    () => () => {
+      if (linkCopyTimerRef.current) clearTimeout(linkCopyTimerRef.current)
+    },
+    [],
+  )
+
+  // Wired-ready terminal screen — reachable once real (backend-backed) revocation lands.
+  if (revoked) {
+    return (
+      <div className={styles.column}>
+        <div className={`${styles.header} ${modalStepBodyEnter}`}>
+          <h1 className={styles.title}>Link revoked</h1>
+          <p className={styles.lede}>This payment link no longer works. Create a new one anytime.</p>
+        </div>
+        <div className={`${styles.buttonRow} ${modalActionRowEnter}`}>
+          <Button
+            variant="secondary"
+            size="lg"
+            label="Done"
+            showIcon={false}
+            className={styles.doneButton}
+            onClick={onDone}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.column}>
+      <header className={styles.header}>
+        <h1 className={`${styles.title} ${styles.enter} ${styles.enterTitle}`}>
+          USDC payment request
+        </h1>
+        {amountLabel ? (
+          <span className={`${styles.amountValue} ${styles.enter} ${styles.enterAmount}`}>
+            {amountLabel}
+          </span>
+        ) : null}
+      </header>
+
+      <div className={styles.linkSection}>
+        <div className={`${styles.linkHeading} ${styles.enter} ${styles.enterShareRow}`}>
+          <p className={styles.linkHeadingLabel}>Share this link</p>
+          <p className={styles.expiryPill}>{expiryLabel}</p>
+        </div>
+        <div className={`${styles.linkBox} ${styles.enter} ${styles.enterLinkBox}`}>
+          <LinkDisplay url={paymentLink} />
+        </div>
+        <Button
+          variant="primary"
+          size="md"
+          label={linkCopied ? 'Copied' : 'Copy'}
+          showIcon={false}
+          className={`${styles.copyButton} ${styles.enter} ${styles.enterCopy}`}
+          onClick={() => void handleCopyLink()}
+        />
+        <span className={styles.copyStatus} role="status" aria-live="polite">
+          {linkCopied ? 'Link copied to clipboard' : ''}
+        </span>
+      </div>
+
+      {/* Revoke is disabled until backend-backed revocation exists — a session-local flag can't stop
+          a payer who already has the link, so we don't ship a fake that implies it can. */}
+      <div className={`${styles.revokeRow} ${styles.enter} ${styles.enterRevoke}`}>
+        <button type="button" className={styles.revokeLink} disabled aria-disabled="true">
+          Revoke link
+        </button>
+        <span className={styles.revokeSoon}>Coming soon</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/armada-interface/src/components/request/RequestModal.test.tsx
+++ b/apps/armada-interface/src/components/request/RequestModal.test.tsx
@@ -1,0 +1,73 @@
+// ABOUTME: Tests for the Request-via-link flow — compose → generated link screen, with disabled revoke + copy-address hand-off.
+// ABOUTME: Seeds an unlocked shielded wallet so the link builder has a real 0zk recipient.
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Provider, createStore } from 'jotai'
+import { RequestModal } from './RequestModal'
+import { openModalAtom } from '@/state/ui'
+import { activeShieldedWalletIdAtom, shieldedWalletsAtom } from '@/state/wallet'
+
+const VALID_0ZK = '0zk' + 'a'.repeat(40)
+
+function renderRequest() {
+  const store = createStore()
+  store.set(shieldedWalletsAtom, {
+    w1: { id: 'w1', status: 'unlocked', shieldedAddress: VALID_0ZK },
+  })
+  store.set(activeShieldedWalletIdAtom, 'w1')
+  store.set(openModalAtom, 'request')
+  render(
+    <Provider store={store}>
+      <RequestModal />
+    </Provider>,
+  )
+  return store
+}
+
+describe('<RequestModal>', () => {
+  it('renders nothing when the request modal is not open', () => {
+    const store = createStore()
+    render(
+      <Provider store={store}>
+        <RequestModal />
+      </Provider>,
+    )
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('opens on the compose step with the create-link CTA gated on an amount', () => {
+    renderRequest()
+    expect(screen.getByRole('heading', { name: 'Request USDC via link' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Input amount' })).toBeDisabled()
+  })
+
+  it('generates a real pay-via-link on Create and shows the link screen', () => {
+    renderRequest()
+    fireEvent.change(screen.getByLabelText('Requested amount in USDC'), { target: { value: '25' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create link' }))
+
+    expect(screen.getByRole('heading', { name: 'USDC payment request' })).toBeInTheDocument()
+    expect(screen.getByText('Share this link')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument()
+    // The generated link is a real /pay-via-link URL carrying the recipient + amount.
+    const linkEl = screen.getByTitle(/\/pay-via-link\?/)
+    expect(linkEl.getAttribute('title')).toContain(`to=${VALID_0ZK}`)
+    expect(linkEl.getAttribute('title')).toContain('amount=25')
+  })
+
+  it('disables Revoke with a "coming soon" marker (real revoke needs backend state)', () => {
+    renderRequest()
+    fireEvent.change(screen.getByLabelText('Requested amount in USDC'), { target: { value: '25' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create link' }))
+
+    expect(screen.getByRole('button', { name: 'Revoke link' })).toBeDisabled()
+    expect(screen.getByText('Coming soon')).toBeInTheDocument()
+  })
+
+  it('hands off the amount-less path to the copy-address dialog', () => {
+    const store = renderRequest()
+    fireEvent.click(screen.getByRole('button', { name: 'Copy your address instead' }))
+    expect(store.get(openModalAtom)).toBe('receive')
+  })
+})

--- a/apps/armada-interface/src/components/request/RequestModal.test.tsx
+++ b/apps/armada-interface/src/components/request/RequestModal.test.tsx
@@ -2,20 +2,23 @@
 // ABOUTME: Seeds an unlocked shielded wallet so the link builder has a real 0zk recipient.
 
 import { describe, it, expect } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { Provider, createStore } from 'jotai'
 import { RequestModal } from './RequestModal'
 import { openModalAtom } from '@/state/ui'
 import { activeShieldedWalletIdAtom, shieldedWalletsAtom } from '@/state/wallet'
+import { requestLinksAtom, requestShareIntentAtom } from '@/state/requestLinks'
+import type { RequestLinkRecord } from '@/lib/shielded/requestLinks'
 
 const VALID_0ZK = '0zk' + 'a'.repeat(40)
 
-function renderRequest() {
+function renderRequest(opts?: { shareIntent?: RequestLinkRecord }) {
   const store = createStore()
   store.set(shieldedWalletsAtom, {
     w1: { id: 'w1', status: 'unlocked', shieldedAddress: VALID_0ZK },
   })
   store.set(activeShieldedWalletIdAtom, 'w1')
+  if (opts?.shareIntent) store.set(requestShareIntentAtom, opts.shareIntent)
   store.set(openModalAtom, 'request')
   render(
     <Provider store={store}>
@@ -65,4 +68,34 @@ describe('<RequestModal>', () => {
     expect(screen.getByText('Coming soon')).toBeInTheDocument()
   })
 
+  it('records the created link into requestLinksAtom (for Recent Activity)', async () => {
+    const store = renderRequest()
+    fireEvent.change(screen.getByLabelText('Requested amount in USDC'), { target: { value: '25' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create link' }))
+
+    await waitFor(() => expect(store.get(requestLinksAtom)).toHaveLength(1))
+    const [link] = store.get(requestLinksAtom)
+    expect(link).toMatchObject({ amount: '25', shieldedWalletId: 'w1' })
+    expect(link?.paymentLink).toContain('/pay-via-link?')
+    expect(link?.requestId).toMatch(/^req_/)
+  })
+
+  it('re-opens directly on the Share step from a share intent, then consumes it', () => {
+    const record: RequestLinkRecord = {
+      requestId: 'req_reopen',
+      paymentLink: 'https://app/pay-via-link?to=0zk&id=req_reopen&amount=40',
+      amount: '40',
+      expiresAt: Date.now() + 86_400_000,
+      createdAt: Date.now(),
+      shieldedWalletId: 'w1',
+    }
+    const store = renderRequest({ shareIntent: record })
+
+    // Opens on Share-link (not compose) with the stored link.
+    expect(screen.getByRole('heading', { name: 'USDC payment request' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Request USDC via link' })).toBeNull()
+    expect(screen.getByTitle(record.paymentLink)).toBeInTheDocument()
+    // Intent consumed so it can't re-fire.
+    expect(store.get(requestShareIntentAtom)).toBeNull()
+  })
 })

--- a/apps/armada-interface/src/components/request/RequestModal.test.tsx
+++ b/apps/armada-interface/src/components/request/RequestModal.test.tsx
@@ -65,9 +65,4 @@ describe('<RequestModal>', () => {
     expect(screen.getByText('Coming soon')).toBeInTheDocument()
   })
 
-  it('hands off the amount-less path to the copy-address dialog', () => {
-    const store = renderRequest()
-    fireEvent.click(screen.getByRole('button', { name: 'Copy your address instead' }))
-    expect(store.get(openModalAtom)).toBe('receive')
-  })
 })

--- a/apps/armada-interface/src/components/request/RequestModal.tsx
+++ b/apps/armada-interface/src/components/request/RequestModal.tsx
@@ -90,7 +90,6 @@ export function RequestModal() {
           onExpiryChange={setExpiryId}
           onCancel={close}
           onCreateLink={handleCreateLink}
-          onCopyAddress={() => setOpenModal('receive')}
         />
       ) : (
         <RequestLinkScreen

--- a/apps/armada-interface/src/components/request/RequestModal.tsx
+++ b/apps/armada-interface/src/components/request/RequestModal.tsx
@@ -4,7 +4,9 @@
 import { useEffect, useState } from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { openModalAtom } from '@/state/ui'
-import { shieldedWalletAtom } from '@/state/wallet'
+import { shieldedWalletAtom, activeShieldedWalletIdAtom } from '@/state/wallet'
+import { requestShareIntentAtom } from '@/state/requestLinks'
+import { useAddRequestLink } from '@/hooks/useRequestLinks'
 import { FlowShell } from '@/components/flow/FlowShell'
 import { useFlowExit } from '@/components/flow/useFlowExit'
 import {
@@ -24,6 +26,9 @@ type RequestStep = 'receive' | 'link'
 export function RequestModal() {
   const [openModal, setOpenModal] = useAtom(openModalAtom)
   const shieldedWallet = useAtomValue(shieldedWalletAtom)
+  const activeWalletId = useAtomValue(activeShieldedWalletIdAtom)
+  const [shareIntent, setShareIntent] = useAtom(requestShareIntentAtom)
+  const addRequestLink = useAddRequestLink()
   const isOpen = openModal === 'request'
 
   const [step, setStep] = useState<RequestStep>('receive')
@@ -36,7 +41,22 @@ export function RequestModal() {
   // RequestLinkScreen's revoked variant is built + ready for when real revocation lands.
   const [linkRevoked] = useState(false)
 
-  // Reset on close so re-opening starts fresh at the compose step.
+  // Re-open at the Share step from a "Payment link created" activity row: seed the stored link
+  // synchronously on the open transition so FlowShell's stepKey is 'link' on the first paint (no
+  // compose-step flash). The intent is consumed in an effect below. See SendModal for the pattern.
+  const [wasOpen, setWasOpen] = useState(false)
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen)
+    if (isOpen && shareIntent) {
+      setAmount(shareIntent.amount)
+      setNote(shareIntent.note ?? '')
+      setPaymentLink(shareIntent.paymentLink)
+      setExpiresAt(shareIntent.expiresAt)
+      setStep('link')
+    }
+  }
+
+  // Reset on close so re-opening (without a share intent) starts fresh at the compose step.
   useEffect(() => {
     if (isOpen) return
     setStep('receive')
@@ -47,16 +67,22 @@ export function RequestModal() {
     setExpiresAt(0)
   }, [isOpen])
 
+  // Consume the share intent once opened (post-commit; the render-time block above already seeded).
+  useEffect(() => {
+    if (isOpen && shareIntent) setShareIntent(null)
+  }, [isOpen, shareIntent, setShareIntent])
+
   const { exiting, requestClose: close } = useFlowExit(() => setOpenModal(null))
 
   function handleCreateLink() {
     const recipientAddress = shieldedWallet.shieldedAddress
-    if (!recipientAddress) return
+    if (!recipientAddress || !activeWalletId) return
+    const requestId = createPaymentRequestId()
     const nextExpiresAt = Date.now() + requestLinkExpiryMs(expiryId)
     const trimmedNote = note.trim()
     const link = buildPayViaLinkUrl({
       recipientAddress,
-      requestId: createPaymentRequestId(),
+      requestId,
       expiresAt: nextExpiresAt,
       amount,
       note: trimmedNote || undefined,
@@ -64,6 +90,17 @@ export function RequestModal() {
     setPaymentLink(link)
     setExpiresAt(nextExpiresAt)
     setStep('link')
+    // Persist for Recent Activity (encrypted, per-wallet). Fire-and-forget — a storage failure
+    // shouldn't block showing the link the user just created.
+    void addRequestLink({
+      requestId,
+      paymentLink: link,
+      amount,
+      note: trimmedNote || undefined,
+      expiresAt: nextExpiresAt,
+      createdAt: Date.now(),
+      shieldedWalletId: activeWalletId,
+    })
   }
 
   if (!isOpen && !exiting) return null

--- a/apps/armada-interface/src/components/request/RequestModal.tsx
+++ b/apps/armada-interface/src/components/request/RequestModal.tsx
@@ -1,0 +1,106 @@
+// ABOUTME: RequestModal — the "Request USDC via link" flow: compose (amount/expiry/note) → generated link screen.
+// ABOUTME: Opened via openModalAtom='request'. Builds a real pay-via-link from the user's 0zk address; copy-address hands off to ReceiveDialog.
+
+import { useEffect, useState } from 'react'
+import { useAtom, useAtomValue } from 'jotai'
+import { openModalAtom } from '@/state/ui'
+import { shieldedWalletAtom } from '@/state/wallet'
+import { FlowShell } from '@/components/flow/FlowShell'
+import { useFlowExit } from '@/components/flow/useFlowExit'
+import {
+  DEFAULT_REQUEST_LINK_EXPIRY_ID,
+  buildPayViaLinkUrl,
+  createPaymentRequestId,
+  requestLinkExpiryMs,
+  type RequestLinkExpiryId,
+} from '@/lib/payViaLink'
+import { RequestReceiveScreen } from './RequestReceiveScreen'
+import { RequestLinkScreen } from './RequestLinkScreen'
+
+const REQUEST_STEPS = ['Receive', 'Share link']
+
+type RequestStep = 'receive' | 'link'
+
+export function RequestModal() {
+  const [openModal, setOpenModal] = useAtom(openModalAtom)
+  const shieldedWallet = useAtomValue(shieldedWalletAtom)
+  const isOpen = openModal === 'request'
+
+  const [step, setStep] = useState<RequestStep>('receive')
+  const [amount, setAmount] = useState('')
+  const [note, setNote] = useState('')
+  const [expiryId, setExpiryId] = useState<RequestLinkExpiryId>(DEFAULT_REQUEST_LINK_EXPIRY_ID)
+  const [paymentLink, setPaymentLink] = useState('')
+  const [expiresAt, setExpiresAt] = useState(0)
+  // Revoke isn't wired yet (needs backend state), so the link is never revoked in-app. The
+  // RequestLinkScreen's revoked variant is built + ready for when real revocation lands.
+  const [linkRevoked] = useState(false)
+
+  // Reset on close so re-opening starts fresh at the compose step.
+  useEffect(() => {
+    if (isOpen) return
+    setStep('receive')
+    setAmount('')
+    setNote('')
+    setExpiryId(DEFAULT_REQUEST_LINK_EXPIRY_ID)
+    setPaymentLink('')
+    setExpiresAt(0)
+  }, [isOpen])
+
+  const { exiting, requestClose: close } = useFlowExit(() => setOpenModal(null))
+
+  function handleCreateLink() {
+    const recipientAddress = shieldedWallet.shieldedAddress
+    if (!recipientAddress) return
+    const nextExpiresAt = Date.now() + requestLinkExpiryMs(expiryId)
+    const trimmedNote = note.trim()
+    const link = buildPayViaLinkUrl({
+      recipientAddress,
+      requestId: createPaymentRequestId(),
+      expiresAt: nextExpiresAt,
+      amount,
+      note: trimmedNote || undefined,
+    })
+    setPaymentLink(link)
+    setExpiresAt(nextExpiresAt)
+    setStep('link')
+  }
+
+  if (!isOpen && !exiting) return null
+
+  const currentStep = step === 'link' ? 2 : 1
+
+  return (
+    <FlowShell
+      open={isOpen}
+      exiting={exiting}
+      onClose={close}
+      flowLabel="Request"
+      steps={REQUEST_STEPS}
+      currentStep={currentStep}
+      stepKey={step}
+    >
+      {step === 'receive' ? (
+        <RequestReceiveScreen
+          amount={amount}
+          note={note}
+          expiryId={expiryId}
+          onAmountChange={setAmount}
+          onNoteChange={setNote}
+          onExpiryChange={setExpiryId}
+          onCancel={close}
+          onCreateLink={handleCreateLink}
+          onCopyAddress={() => setOpenModal('receive')}
+        />
+      ) : (
+        <RequestLinkScreen
+          paymentLink={paymentLink}
+          amount={amount || undefined}
+          expiresAt={expiresAt}
+          revoked={linkRevoked}
+          onDone={close}
+        />
+      )}
+    </FlowShell>
+  )
+}

--- a/apps/armada-interface/src/components/request/RequestReceiveScreen.module.css
+++ b/apps/armada-interface/src/components/request/RequestReceiveScreen.module.css
@@ -1,0 +1,194 @@
+/* ABOUTME: RequestReceiveScreen styles — ported from the armada-app mockup src/pages/RequestReceiveScreen.module.css. */
+.column {
+  width: 100%;
+  max-width: 434px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--primitives-spacing-8);
+}
+
+.title,
+.cardTitle {
+  margin: 0;
+  width: 100%;
+  padding-left: var(--primitives-spacing-1);
+  color: var(--semantic-color-text-primary);
+  text-align: left;
+  box-sizing: border-box;
+  font-weight: var(--primitives-fontWeight-medium);
+}
+
+.linkCard {
+  width: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-5);
+  padding: var(--primitives-spacing-8);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--primitives-color-neutral-50) 40%, transparent) 0%,
+    color-mix(in srgb, var(--primitives-color-neutral-50) 20%, transparent) 100%
+  );
+  backdrop-filter: blur(calc(var(--primitives-spacing-24) * 3 + var(--primitives-spacing-3)));
+  -webkit-backdrop-filter: blur(calc(var(--primitives-spacing-24) * 3 + var(--primitives-spacing-3)));
+  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .linkCard {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+@media (max-width: 767px) {
+  .linkCard {
+    padding: var(--primitives-spacing-5);
+  }
+}
+
+.noteFieldBlock {
+  margin-top: 0;
+}
+
+.expiryFieldBlock {
+  margin-top: 0;
+}
+
+.buttonRow {
+  display: flex;
+  gap: var(--primitives-spacing-5);
+  width: 100%;
+  flex-shrink: 0;
+}
+
+.buttonRow > * {
+  flex: 1;
+}
+
+.fieldBlock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-2);
+  width: 100%;
+}
+
+.fieldLabel {
+  margin: 0;
+  font-family: var(--semantic-typography-ui-label-xs-font-family);
+  font-size: var(--semantic-typography-ui-label-xs-font-size);
+  font-weight: var(--semantic-typography-ui-label-xs-font-weight);
+  line-height: var(--primitives-lineHeight-tight);
+  letter-spacing: var(--semantic-typography-ui-label-xs-letter-spacing);
+  text-transform: uppercase;
+  color: var(--semantic-color-text-muted);
+}
+
+.fieldOptional {
+  text-transform: none;
+  font-weight: var(--primitives-fontWeight-regular);
+}
+
+.noteInput {
+  width: 100%;
+  min-height: var(--primitives-spacing-16);
+  padding: var(--primitives-spacing-4) var(--primitives-spacing-5);
+  border: none;
+  border-radius: calc(var(--primitives-borderRadius-xl) * 1px);
+  background: color-mix(in srgb, var(--primitives-color-neutral-50) 40%, transparent);
+  box-sizing: border-box;
+  resize: vertical;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  font-weight: var(--primitives-fontWeight-regular);
+  line-height: var(--primitives-lineHeight-normal);
+  color: var(--semantic-color-text-primary);
+}
+
+.noteInput:focus {
+  outline: calc(var(--primitives-borderWidth-default) * 1px) solid var(--semantic-color-border-focus);
+  outline-offset: calc(var(--primitives-spacing-1) * 1px);
+}
+
+.noteInput::placeholder {
+  color: var(--semantic-color-text-muted);
+}
+
+.noteMeta {
+  margin: 0;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-xs) * 1px);
+  line-height: var(--primitives-lineHeight-tight);
+  color: var(--semantic-color-text-muted);
+  text-align: right;
+}
+
+.amountRow {
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-end;
+  width: 100%;
+}
+
+.amountGroup {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: var(--primitives-spacing-2);
+  height: auto;
+  min-height: calc(var(--primitives-fontSize-4xl) * 1px);
+  flex-shrink: 0;
+}
+
+.amountField {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  height: auto;
+  min-height: calc(var(--primitives-fontSize-4xl) * 1px);
+}
+
+.amountInput {
+  width: auto;
+  min-width: 1ch;
+  max-width: 100%;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-family: var(--primitives-fontFamily-mono), ui-monospace, monospace;
+  font-weight: var(--primitives-fontWeight-regular);
+  font-size: calc(var(--primitives-fontSize-4xl) * 1px);
+  line-height: calc(var(--primitives-fontSize-4xl) * 1px);
+  height: auto;
+  min-height: calc(var(--primitives-fontSize-4xl) * 1px);
+  letter-spacing: 0;
+  color: var(--semantic-color-text-primary);
+  text-align: left;
+  outline: none;
+  field-sizing: content;
+}
+
+.amountInput::placeholder {
+  font-family: var(--primitives-fontFamily-mono), ui-monospace, monospace;
+  font-weight: var(--primitives-fontWeight-regular);
+  font-size: calc(var(--primitives-fontSize-4xl) * 1px);
+  color: color-mix(in srgb, var(--semantic-color-text-primary) 30%, transparent);
+}
+/* Amount-less secondary path — subtle text button under the create-link CTA. */
+.copyAddressLink {
+  align-self: center;
+  margin: 0;
+  padding: var(--primitives-spacing-2);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: var(--semantic-typography-ui-body-sm-font-size);
+  font-weight: var(--primitives-fontWeight-medium);
+  color: var(--semantic-color-text-secondary);
+}
+.copyAddressLink:hover {
+  color: var(--semantic-color-text-primary);
+}

--- a/apps/armada-interface/src/components/request/RequestReceiveScreen.module.css
+++ b/apps/armada-interface/src/components/request/RequestReceiveScreen.module.css
@@ -176,19 +176,3 @@
   font-size: calc(var(--primitives-fontSize-4xl) * 1px);
   color: color-mix(in srgb, var(--semantic-color-text-primary) 30%, transparent);
 }
-/* Amount-less secondary path — subtle text button under the create-link CTA. */
-.copyAddressLink {
-  align-self: center;
-  margin: 0;
-  padding: var(--primitives-spacing-2);
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-family: var(--primitives-fontFamily-ui), sans-serif;
-  font-size: var(--semantic-typography-ui-body-sm-font-size);
-  font-weight: var(--primitives-fontWeight-medium);
-  color: var(--semantic-color-text-secondary);
-}
-.copyAddressLink:hover {
-  color: var(--semantic-color-text-primary);
-}

--- a/apps/armada-interface/src/components/request/RequestReceiveScreen.tsx
+++ b/apps/armada-interface/src/components/request/RequestReceiveScreen.tsx
@@ -21,8 +21,6 @@ export interface RequestReceiveScreenProps {
   onExpiryChange: (expiryId: RequestLinkExpiryId) => void
   onCancel: () => void
   onCreateLink: () => void
-  /** Amount-less path — hand off to the plain address-copy dialog. */
-  onCopyAddress: () => void
 }
 
 export function RequestReceiveScreen({
@@ -34,7 +32,6 @@ export function RequestReceiveScreen({
   onExpiryChange,
   onCancel,
   onCreateLink,
-  onCopyAddress,
 }: RequestReceiveScreenProps) {
   const amountInputId = useId()
   const noteInputId = useId()
@@ -114,11 +111,6 @@ export function RequestReceiveScreen({
           onClick={onCreateLink}
         />
       </div>
-
-      {/* Amount-less path: no link, just share the raw 0zk address (the existing Receive dialog). */}
-      <button type="button" className={styles.copyAddressLink} onClick={onCopyAddress}>
-        Copy your address instead
-      </button>
     </div>
   )
 }

--- a/apps/armada-interface/src/components/request/RequestReceiveScreen.tsx
+++ b/apps/armada-interface/src/components/request/RequestReceiveScreen.tsx
@@ -1,0 +1,124 @@
+// ABOUTME: RequestReceiveScreen — compose a payment request (amount + expiry + note) that becomes a shareable link.
+// ABOUTME: The first step of the Request flow; "Create link" advances to RequestLinkScreen. Amount-less requests copy the raw address instead.
+
+import { useId } from 'react'
+import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
+import { SegmentedControl } from '@/components/ui'
+import { hasActiveAmount, sanitizeAmountInput } from '@/utils/amountInput'
+import {
+  REQUEST_LINK_EXPIRY_OPTIONS,
+  REQUEST_NOTE_MAX_LENGTH,
+  type RequestLinkExpiryId,
+} from '@/lib/payViaLink'
+import styles from './RequestReceiveScreen.module.css'
+
+export interface RequestReceiveScreenProps {
+  amount: string
+  note: string
+  expiryId: RequestLinkExpiryId
+  onAmountChange: (amount: string) => void
+  onNoteChange: (note: string) => void
+  onExpiryChange: (expiryId: RequestLinkExpiryId) => void
+  onCancel: () => void
+  onCreateLink: () => void
+  /** Amount-less path — hand off to the plain address-copy dialog. */
+  onCopyAddress: () => void
+}
+
+export function RequestReceiveScreen({
+  amount,
+  note,
+  expiryId,
+  onAmountChange,
+  onNoteChange,
+  onExpiryChange,
+  onCancel,
+  onCreateLink,
+  onCopyAddress,
+}: RequestReceiveScreenProps) {
+  const amountInputId = useId()
+  const noteInputId = useId()
+
+  const canCreateLink = hasActiveAmount(amount)
+  const ctaLabel = canCreateLink ? 'Create link' : 'Input amount'
+
+  function handleAmountChange(raw: string) {
+    const next = sanitizeAmountInput(raw)
+    onAmountChange(hasActiveAmount(next) ? next : '')
+  }
+
+  return (
+    <div className={styles.column}>
+      <div className={modalStepBodyEnter}>
+        <div className={styles.linkCard}>
+          <h1 className={`armada-text-ui-body-lg ${styles.cardTitle}`}>Request USDC via link</h1>
+
+          <div className={styles.amountRow}>
+            <div className={styles.amountGroup}>
+              <div className={styles.amountField}>
+                <input
+                  id={amountInputId}
+                  className={styles.amountInput}
+                  type="text"
+                  inputMode="decimal"
+                  autoComplete="off"
+                  placeholder="0"
+                  value={amount}
+                  onChange={(event) => handleAmountChange(event.target.value)}
+                  aria-label="Requested amount in USDC"
+                  size={Math.max(1, amount.length || 1)}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className={[styles.fieldBlock, styles.expiryFieldBlock].join(' ')}>
+            <p className={styles.fieldLabel}>Link expires</p>
+            <SegmentedControl<RequestLinkExpiryId>
+              size="md"
+              aria-label="Link expiry"
+              value={expiryId}
+              onChange={onExpiryChange}
+              options={REQUEST_LINK_EXPIRY_OPTIONS}
+            />
+          </div>
+
+          <div className={[styles.fieldBlock, styles.noteFieldBlock].join(' ')}>
+            <label className={styles.fieldLabel} htmlFor={noteInputId}>
+              Note <span className={styles.fieldOptional}>(optional)</span>
+            </label>
+            <textarea
+              id={noteInputId}
+              className={styles.noteInput}
+              value={note}
+              maxLength={REQUEST_NOTE_MAX_LENGTH}
+              placeholder="For invoice #123"
+              rows={2}
+              onChange={(event) => onNoteChange(event.target.value)}
+            />
+            <p className={styles.noteMeta}>
+              {note.length}/{REQUEST_NOTE_MAX_LENGTH}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className={`${styles.buttonRow} ${modalActionRowEnter}`}>
+        <Button variant="secondary" size="lg" label="Cancel" showIcon={false} onClick={onCancel} />
+        <Button
+          variant="primary"
+          size="lg"
+          label={ctaLabel}
+          showIcon={false}
+          disabled={!canCreateLink}
+          onClick={onCreateLink}
+        />
+      </div>
+
+      {/* Amount-less path: no link, just share the raw 0zk address (the existing Receive dialog). */}
+      <button type="button" className={styles.copyAddressLink} onClick={onCopyAddress}>
+        Copy your address instead
+      </button>
+    </div>
+  )
+}

--- a/apps/armada-interface/src/components/request/index.ts
+++ b/apps/armada-interface/src/components/request/index.ts
@@ -1,0 +1,2 @@
+// ABOUTME: Barrel for the Request-via-link flow (compose → link) modal.
+export { RequestModal } from './RequestModal'

--- a/apps/armada-interface/src/components/settings/ClearHistoryDialog.tsx
+++ b/apps/armada-interface/src/components/settings/ClearHistoryDialog.tsx
@@ -8,6 +8,7 @@ import { Modal } from '@/components/ui'
 import { FlowFooter } from '@/components/flow/FlowFooter'
 import { activeShieldedWalletIdAtom } from '@/state/wallet'
 import { txListAtom } from '@/state/tx'
+import { requestLinksAtom } from '@/state/requestLinks'
 import { historyRecoveryEpochAtom } from '@/state/history'
 import { cacheClear } from '@/lib/cache'
 import { clearHistoryCheckpoint } from '@/lib/shielded/history-checkpoint'
@@ -22,6 +23,7 @@ export interface ClearHistoryDialogProps {
 export function ClearHistoryDialog({ open, onClose }: ClearHistoryDialogProps) {
   const walletId = useAtomValue(activeShieldedWalletIdAtom)
   const setTxList = useSetAtom(txListAtom)
+  const setRequestLinks = useSetAtom(requestLinksAtom)
   const setEpoch = useSetAtom(historyRecoveryEpochAtom)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -41,11 +43,16 @@ export function ClearHistoryDialog({ open, onClose }: ClearHistoryDialogProps) {
       //    surprising — and they're equally re-recoverable from chain on next unlock. Cleaner
       //    to flush the whole store and let each wallet rebuild on its own scan.
       await cacheClear('txHistory')
+      // 1b. Also wipe created payment-request links. Unlike tx history these are NOT chain-
+      //     recoverable (local-only artifacts), so clearing is permanent — the shared links
+      //     themselves keep working; only the local activity records go.
+      await cacheClear('requestLinks')
       // 2. Drop the checkpoint so the next scan walks from the hub deploy block.
       if (walletId) clearHistoryCheckpoint(walletId)
-      // 3. Reset the in-memory atom so the UI immediately shows an empty activity feed.
+      // 3. Reset the in-memory atoms so the UI immediately shows an empty activity feed.
       //    Without this the rows would linger until the next walletId-change re-hydration.
       setTxList([])
+      setRequestLinks([])
       // 4. Bump the epoch so useHistoryRecovery's effect re-fires and starts the rescan.
       setEpoch((prev) => prev + 1)
       onClose()

--- a/apps/armada-interface/src/hooks/CLAUDE.md
+++ b/apps/armada-interface/src/hooks/CLAUDE.md
@@ -20,6 +20,7 @@ One concern per hook. Hooks own the React lifecycle (effects, subscriptions, tim
 | `useTx({ kind })` | Per-tx submit/track/retry/cancel. Multi-instance — each call owns a ulid. | Working — all kinds run end-to-end via registered handlers; submit/retry/cancel wired |
 | `useTxHistory()` | Hydrates `txListAtom` from IDB on `activeShieldedWalletIdAtom` change (V2 Phase 6); clears the atom on lock. Only hydrates records belonging to the active walletId. | Working |
 | `useTxResume()` | On unlock (leader tab only), calls `executor.resumeForWallet(walletId)` — re-attaches watchers to already-broadcast txs (has `sourceTxHash`) and fails pre-broadcast interruptions as `INTERRUPTED`. Idempotent per (walletId, session). Mount once at App root. | Working |
+| `useRequestLinks()` / `useAddRequestLink()` | Hydrator (mount at App root) loads the active wallet's created payment-request links from the encrypted `requestLinks` store into `requestLinksAtom` on unlock; `useAddRequestLink` persists a new link + prepends it. Drives the "Payment link created" activity rows. | Working |
 
 ## Conventions
 

--- a/apps/armada-interface/src/hooks/usePayViaLinkIntent.ts
+++ b/apps/armada-interface/src/hooks/usePayViaLinkIntent.ts
@@ -1,0 +1,36 @@
+// ABOUTME: usePayViaLinkIntent — hydrates a pending pay-via-link hand-off and opens the prefilled Send.
+// ABOUTME: Reads the sessionStorage pending link (set by the landing page); SendModal seeds + clears it.
+
+import { useEffect } from 'react'
+import { useAtom } from 'jotai'
+import { openModalAtom, paymentIntentAtom } from '@/state/ui'
+import { readPendingPayViaLink } from '@/lib/payViaLink'
+import { useShieldedWallet } from '@/hooks/useShieldedWallet'
+
+/**
+ * Mounted once at App level. When the payer lands from a `/pay-via-link` link and hits "Continue to
+ * pay", the landing writes a pending hand-off + navigates to the dashboard; this hydrates that into
+ * `paymentIntentAtom` and — once the wallet is unlocked and nothing else is open — opens the Send
+ * flow, which seeds the recipient/amount from the intent and clears it.
+ */
+export function usePayViaLinkIntent(): void {
+  const [intent, setIntent] = useAtom(paymentIntentAtom)
+  const [openModal, setOpenModal] = useAtom(openModalAtom)
+  const { state } = useShieldedWallet()
+  const unlocked = state?.status === 'unlocked'
+
+  // Hydrate the intent from the pending sessionStorage hand-off on mount (survives a full reload).
+  useEffect(() => {
+    if (intent) return
+    const pending = readPendingPayViaLink()
+    if (pending) setIntent({ recipient: pending.recipient, amount: pending.amount })
+    // Mount-only: the landing client-navigates here, so App mounts fresh with the pending set.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Drop the payer into the prefilled Send once the wallet is ready and nothing else is open.
+  useEffect(() => {
+    if (!intent || !unlocked || openModal !== null) return
+    setOpenModal('payment')
+  }, [intent, unlocked, openModal, setOpenModal])
+}

--- a/apps/armada-interface/src/hooks/useRequestLinks.ts
+++ b/apps/armada-interface/src/hooks/useRequestLinks.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Hydrates requestLinksAtom from the encrypted per-wallet store on unlock, and exposes an append callback.
+// ABOUTME: Mirrors useTxHistory's scoping — reset the atom on wallet change, hydrate only when unlocked.
+
+import { useCallback, useEffect } from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { activeShieldedWalletAtom } from '@/state/wallet'
+import { requestLinksAtom } from '@/state/requestLinks'
+import { loadRequestLinks, saveRequestLink, type RequestLinkRecord } from '@/lib/shielded/requestLinks'
+import { trackError } from '@/lib/telemetry'
+
+/** App-root hydrator: loads the active wallet's created links into `requestLinksAtom` on unlock. */
+export function useRequestLinks(): void {
+  const setLinks = useSetAtom(requestLinksAtom)
+  const active = useAtomValue(activeShieldedWalletAtom)
+  const activeWalletId = active?.id ?? null
+  const activeStatus = active?.status ?? null
+
+  useEffect(() => {
+    let cancelled = false
+    setLinks([])
+    if (!activeWalletId || activeStatus !== 'unlocked') {
+      return () => {
+        cancelled = true
+      }
+    }
+    void (async () => {
+      try {
+        const links = await loadRequestLinks(activeWalletId)
+        if (cancelled) return
+        links.sort((a, b) => b.createdAt - a.createdAt)
+        setLinks(links)
+      } catch (err) {
+        trackError('useRequestLinks.hydrate', err)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [activeWalletId, activeStatus, setLinks])
+}
+
+/** Persist a newly created link + prepend it to the in-memory list (newest first). */
+export function useAddRequestLink(): (record: RequestLinkRecord) => Promise<void> {
+  const setLinks = useSetAtom(requestLinksAtom)
+  return useCallback(
+    async (record: RequestLinkRecord) => {
+      await saveRequestLink(record)
+      setLinks((prev) => [record, ...prev.filter((l) => l.requestId !== record.requestId)])
+    },
+    [setLinks],
+  )
+}

--- a/apps/armada-interface/src/lib/cache.ts
+++ b/apps/armada-interface/src/lib/cache.ts
@@ -37,7 +37,19 @@ function openDb(): Promise<IDBDatabase> {
         }
       }
     }
-    req.onsuccess = () => resolve(req.result)
+    req.onsuccess = () => {
+      const db = req.result
+      // If another tab (or an HMR-reloaded module) requests a version upgrade, close this
+      // connection so we don't BLOCK the upgrade. Without this, a stale connection opened at an
+      // older version wedges the upgrade indefinitely — and since openDb caches the connection,
+      // every subsequent cache read (tx history, request links, …) fails, so the whole activity
+      // feed vanishes. Dropping the cached promise lets the next op reopen at the new version.
+      db.onversionchange = () => {
+        db.close()
+        if (dbPromise === promise) dbPromise = null
+      }
+      resolve(db)
+    }
     // Clear the cached promise on failure so a later call can retry. Without
     // this, a single transient open error (quota, blocked upgrade, etc.) would
     // poison every cache op for the rest of the page lifetime.

--- a/apps/armada-interface/src/lib/cache.ts
+++ b/apps/armada-interface/src/lib/cache.ts
@@ -2,11 +2,26 @@
 // ABOUTME: Stub now (typed signatures only); implementation lands when first consumer needs it.
 
 const DB_NAME = 'armada-interface'
-const DB_VERSION = 1
+// v2: adds the `requestLinks` store (created payment-request links). The upgrade is additive —
+// onupgradeneeded creates any missing store, leaving existing stores + data intact.
+const DB_VERSION = 2
 
-export type StoreName = 'txHistory' | 'feeQuotes' | 'ens' | 'shieldedBalances' | 'meta'
+export type StoreName =
+  | 'txHistory'
+  | 'feeQuotes'
+  | 'ens'
+  | 'shieldedBalances'
+  | 'meta'
+  | 'requestLinks'
 
-const STORES: ReadonlyArray<StoreName> = ['txHistory', 'feeQuotes', 'ens', 'shieldedBalances', 'meta']
+const STORES: ReadonlyArray<StoreName> = [
+  'txHistory',
+  'feeQuotes',
+  'ens',
+  'shieldedBalances',
+  'meta',
+  'requestLinks',
+]
 
 let dbPromise: Promise<IDBDatabase> | null = null
 

--- a/apps/armada-interface/src/lib/payViaLink.test.ts
+++ b/apps/armada-interface/src/lib/payViaLink.test.ts
@@ -1,0 +1,156 @@
+// ABOUTME: Unit tests for the pay-via-link plumbing — URL build/parse, expiry, id, revoke stub.
+// ABOUTME: Address validation reuses the app's isShieldedAddress (0zk shape check).
+
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  REQUEST_LINK_EXPIRY_OPTIONS,
+  buildPayViaLinkUrl,
+  createPaymentRequestId,
+  formatPaymentLinkExpiry,
+  isPaymentLinkRevoked,
+  parsePayViaLinkSearch,
+  requestLinkExpiryMs,
+} from './payViaLink'
+
+// A shape-valid 0zk address (isShieldedAddress: /^0zk[a-zA-Z0-9]{32,}$/).
+const VALID_0ZK = '0zk1testrecipientaddress0000000000000000000000'
+const NOW = 1_700_000_000_000
+const HOUR = 3_600_000
+
+afterEach(() => {
+  window.sessionStorage.clear()
+})
+
+describe('buildPayViaLinkUrl', () => {
+  it('sets to/id/expires and points at /pay-via-link', () => {
+    const url = new URL(
+      buildPayViaLinkUrl({ recipientAddress: VALID_0ZK, requestId: 'req_a', expiresAt: NOW }),
+    )
+    expect(url.pathname).toBe('/pay-via-link')
+    expect(url.searchParams.get('to')).toBe(VALID_0ZK)
+    expect(url.searchParams.get('id')).toBe('req_a')
+    expect(url.searchParams.get('expires')).toBe(String(NOW))
+  })
+
+  it('omits amount + note when absent, includes + trims them when present', () => {
+    const without = new URL(
+      buildPayViaLinkUrl({ recipientAddress: VALID_0ZK, requestId: 'req_a', expiresAt: NOW }),
+    )
+    expect(without.searchParams.has('amount')).toBe(false)
+    expect(without.searchParams.has('note')).toBe(false)
+
+    const withExtras = new URL(
+      buildPayViaLinkUrl({
+        recipientAddress: VALID_0ZK,
+        requestId: 'req_a',
+        expiresAt: NOW,
+        amount: '  12.5  ',
+        note: '  Invoice 7  ',
+      }),
+    )
+    expect(withExtras.searchParams.get('amount')).toBe('12.5')
+    expect(withExtras.searchParams.get('note')).toBe('Invoice 7')
+  })
+})
+
+describe('parsePayViaLinkSearch', () => {
+  function search(params: Record<string, string>): string {
+    return `?${new URLSearchParams(params).toString()}`
+  }
+
+  it('accepts a well-formed link (with amount + note)', () => {
+    const result = parsePayViaLinkSearch(
+      search({ to: VALID_0ZK, id: 'req_a', expires: String(NOW + HOUR), amount: '25', note: 'hi' }),
+      NOW,
+    )
+    expect(result).toEqual({
+      status: 'ok',
+      params: { recipient: VALID_0ZK, requestId: 'req_a', expiresAt: NOW + HOUR, amount: '25', note: 'hi' },
+    })
+  })
+
+  it('accepts a link without an amount (amount-less request)', () => {
+    const result = parsePayViaLinkSearch(
+      search({ to: VALID_0ZK, id: 'req_a', expires: String(NOW + HOUR) }),
+      NOW,
+    )
+    expect(result.status).toBe('ok')
+    if (result.status === 'ok') expect(result.params.amount).toBeUndefined()
+  })
+
+  it('rejects a non-shielded recipient as invalid', () => {
+    const result = parsePayViaLinkSearch(
+      search({ to: '0xabc', id: 'req_a', expires: String(NOW + HOUR) }),
+      NOW,
+    )
+    expect(result.status).toBe('invalid')
+  })
+
+  it('rejects a missing id and a non-numeric expiry as invalid', () => {
+    expect(
+      parsePayViaLinkSearch(search({ to: VALID_0ZK, id: '', expires: String(NOW + HOUR) }), NOW).status,
+    ).toBe('invalid')
+    expect(
+      parsePayViaLinkSearch(search({ to: VALID_0ZK, id: 'req_a', expires: 'soon' }), NOW).status,
+    ).toBe('invalid')
+  })
+
+  it('reports expired when the timestamp is at or before now', () => {
+    const result = parsePayViaLinkSearch(
+      search({ to: VALID_0ZK, id: 'req_a', expires: String(NOW - 1) }),
+      NOW,
+    )
+    expect(result).toEqual({ status: 'expired', expiresAt: NOW - 1 })
+  })
+
+  it('rejects a malformed or non-positive amount as invalid', () => {
+    for (const amount of ['abc', '-5', '0']) {
+      const result = parsePayViaLinkSearch(
+        search({ to: VALID_0ZK, id: 'req_a', expires: String(NOW + HOUR), amount }),
+        NOW,
+      )
+      expect(result.status, `amount=${amount}`).toBe('invalid')
+    }
+  })
+
+  it('reports revoked when the id is in the (dormant) revoked set', () => {
+    window.sessionStorage.setItem('armada-revoked-payment-links', JSON.stringify(['req_a']))
+    const result = parsePayViaLinkSearch(
+      search({ to: VALID_0ZK, id: 'req_a', expires: String(NOW + HOUR) }),
+      NOW,
+    )
+    expect(result.status).toBe('revoked')
+  })
+})
+
+describe('isPaymentLinkRevoked', () => {
+  it('is false by default (no UI writes the revoked set today)', () => {
+    expect(isPaymentLinkRevoked('req_anything')).toBe(false)
+  })
+})
+
+describe('requestLinkExpiryMs', () => {
+  it('maps each known id to its ms and falls back to 7d', () => {
+    expect(requestLinkExpiryMs('1d')).toBe(86_400_000)
+    expect(requestLinkExpiryMs('7d')).toBe(7 * 86_400_000)
+    expect(requestLinkExpiryMs('30d')).toBe(30 * 86_400_000)
+    expect(REQUEST_LINK_EXPIRY_OPTIONS).toHaveLength(3)
+  })
+})
+
+describe('createPaymentRequestId', () => {
+  it('is req_-prefixed and unique per call', () => {
+    const a = createPaymentRequestId()
+    const b = createPaymentRequestId()
+    expect(a).toMatch(/^req_/)
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('formatPaymentLinkExpiry', () => {
+  it('renders Expired / singular / plural', () => {
+    expect(formatPaymentLinkExpiry(NOW - 1, NOW)).toBe('Expired')
+    expect(formatPaymentLinkExpiry(NOW + HOUR, NOW)).toBe('Expires in 1 day')
+    expect(formatPaymentLinkExpiry(NOW + 3 * 86_400_000, NOW)).toBe('Expires in 3 days')
+  })
+})

--- a/apps/armada-interface/src/lib/payViaLink.test.ts
+++ b/apps/armada-interface/src/lib/payViaLink.test.ts
@@ -5,11 +5,14 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   REQUEST_LINK_EXPIRY_OPTIONS,
   buildPayViaLinkUrl,
+  clearPendingPayViaLink,
   createPaymentRequestId,
   formatPaymentLinkExpiry,
   isPaymentLinkRevoked,
   parsePayViaLinkSearch,
+  readPendingPayViaLink,
   requestLinkExpiryMs,
+  writePendingPayViaLink,
 } from './payViaLink'
 
 // A shape-valid 0zk address (isShieldedAddress: /^0zk[a-zA-Z0-9]{32,}$/).
@@ -144,6 +147,23 @@ describe('createPaymentRequestId', () => {
     const b = createPaymentRequestId()
     expect(a).toMatch(/^req_/)
     expect(a).not.toBe(b)
+  })
+})
+
+describe('pending pay-via-link hand-off', () => {
+  const params = { recipient: VALID_0ZK, requestId: 'req_a', expiresAt: NOW, amount: '10', note: 'x' }
+
+  it('roundtrips through session storage and clears', () => {
+    expect(readPendingPayViaLink()).toBeNull()
+    writePendingPayViaLink(params)
+    expect(readPendingPayViaLink()).toEqual(params)
+    clearPendingPayViaLink()
+    expect(readPendingPayViaLink()).toBeNull()
+  })
+
+  it('returns null for a structurally incomplete stored payload', () => {
+    window.sessionStorage.setItem('armada-pending-pay-via-link', JSON.stringify({ recipient: VALID_0ZK }))
+    expect(readPendingPayViaLink()).toBeNull()
   })
 })
 

--- a/apps/armada-interface/src/lib/payViaLink.ts
+++ b/apps/armada-interface/src/lib/payViaLink.ts
@@ -1,0 +1,161 @@
+// ABOUTME: Pay-via-link plumbing — builds + parses the shareable payment-request URL that prefills a Send.
+// ABOUTME: A link is a self-contained deep link (recipient 0zk + amount + expiry + note); no on-chain or backend state.
+
+import { isShieldedAddress } from '@/lib/address'
+import { hasActiveAmount } from '@/utils/amountInput'
+import { parseUsdcInput } from '@/lib/format'
+
+const DAY_MS = 86_400_000
+
+export const REQUEST_LINK_EXPIRY_OPTIONS = [
+  { id: '1d', label: '1 day', ms: DAY_MS },
+  { id: '7d', label: '7 days', ms: 7 * DAY_MS },
+  { id: '30d', label: '30 days', ms: 30 * DAY_MS },
+] as const
+
+export type RequestLinkExpiryId = (typeof REQUEST_LINK_EXPIRY_OPTIONS)[number]['id']
+
+export const DEFAULT_REQUEST_LINK_EXPIRY_ID: RequestLinkExpiryId = '7d'
+
+export const REQUEST_NOTE_MAX_LENGTH = 120
+
+export function requestLinkExpiryMs(expiryId: RequestLinkExpiryId): number {
+  return REQUEST_LINK_EXPIRY_OPTIONS.find((option) => option.id === expiryId)?.ms ?? 7 * DAY_MS
+}
+
+/** Client-generated, non-secret request id. Not a security token — it only tags the link. */
+export function createPaymentRequestId(): string {
+  return `req_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+}
+
+/**
+ * Origin for shareable app URLs. Uses the live host in prod; on localhost an optional
+ * `VITE_PUBLIC_APP_ORIGIN` override lets a shared link point at a real host during testing.
+ */
+export function getPublicAppOrigin(): string {
+  const { origin, hostname } = window.location
+  const isLocal = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]'
+  if (!isLocal) return origin
+  const configured = import.meta.env.VITE_PUBLIC_APP_ORIGIN?.trim()
+  return configured ? configured.replace(/\/$/, '') : origin
+}
+
+export interface BuildPayViaLinkInput {
+  recipientAddress: string
+  requestId: string
+  expiresAt: number
+  amount?: string
+  note?: string
+}
+
+/** Builds `<origin>/pay-via-link?to=&id=&expires=&amount=&note=`. All params are plaintext. */
+export function buildPayViaLinkUrl({
+  recipientAddress,
+  requestId,
+  expiresAt,
+  amount,
+  note,
+}: BuildPayViaLinkInput): string {
+  const url = new URL('/pay-via-link', getPublicAppOrigin())
+  url.searchParams.set('to', recipientAddress)
+  url.searchParams.set('id', requestId)
+  url.searchParams.set('expires', String(expiresAt))
+
+  const trimmedAmount = amount?.trim()
+  if (trimmedAmount) url.searchParams.set('amount', trimmedAmount)
+
+  const trimmedNote = note?.trim()
+  if (trimmedNote) url.searchParams.set('note', trimmedNote)
+
+  return url.toString()
+}
+
+/** Human "Expires in N days" label. Note: expiry is a soft nudge — the timestamp is in the link
+ *  and only checked client-side, so it can't hard-prevent a payment (the address stays payable). */
+export function formatPaymentLinkExpiry(expiresAt: number, now = Date.now()): string {
+  const diffMs = expiresAt - now
+  if (diffMs <= 0) return 'Expired'
+  const diffDays = Math.ceil(diffMs / DAY_MS)
+  return diffDays === 1 ? 'Expires in 1 day' : `Expires in ${diffDays} days`
+}
+
+export interface PayViaLinkParams {
+  recipient: string
+  requestId: string
+  expiresAt: number
+  amount?: string
+  note?: string
+}
+
+export type PayViaLinkParseResult =
+  | { status: 'ok'; params: PayViaLinkParams }
+  | { status: 'invalid' }
+  | { status: 'expired'; expiresAt: number }
+  | { status: 'revoked' }
+
+// ---------------------------------------------------------------------------
+// Revocation — PLACEHOLDER. A link can only be truly revoked via shared state
+// (a backend list the payer's landing page queries), which does not exist yet.
+// The session-scoped store below is dormant: no UI writes to it today (the
+// Revoke button is disabled), so `isPaymentLinkRevoked` is always false. It
+// exists so the 'revoked' parse branch + the Link-revoked screen are ready to
+// wire once real revocation lands. Do NOT present revoke as a guarantee.
+// ---------------------------------------------------------------------------
+const REVOKED_PAYMENT_LINKS_KEY = 'armada-revoked-payment-links'
+
+function readRevokedPaymentLinkIds(): Set<string> {
+  if (typeof window === 'undefined') return new Set()
+  try {
+    const raw = window.sessionStorage.getItem(REVOKED_PAYMENT_LINKS_KEY)
+    if (!raw) return new Set()
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return new Set()
+    return new Set(parsed.filter((value): value is string => typeof value === 'string'))
+  } catch {
+    return new Set()
+  }
+}
+
+export function isPaymentLinkRevoked(requestId: string): boolean {
+  return readRevokedPaymentLinkIds().has(requestId)
+}
+
+/**
+ * Validates a `/pay-via-link` query string. Order matters: structural validity → revoked →
+ * expired → amount sanity. `now` is injectable for tests.
+ */
+export function parsePayViaLinkSearch(search: string, now = Date.now()): PayViaLinkParseResult {
+  const params = new URLSearchParams(search)
+  const recipient = params.get('to')?.trim() ?? ''
+  const requestId = params.get('id')?.trim() ?? ''
+  const expiresRaw = params.get('expires')?.trim() ?? ''
+  const amount = params.get('amount')?.trim() ?? ''
+  const note = params.get('note')?.trim() ?? ''
+
+  const expiresAt = Number.parseInt(expiresRaw, 10)
+  if (!isShieldedAddress(recipient) || !requestId || !Number.isFinite(expiresAt) || expiresAt <= 0) {
+    return { status: 'invalid' }
+  }
+
+  if (isPaymentLinkRevoked(requestId)) return { status: 'revoked' }
+
+  if (expiresAt <= now) return { status: 'expired', expiresAt }
+
+  if (amount) {
+    const parsed = parseUsdcInput(amount)
+    if (!hasActiveAmount(amount) || parsed.error || parsed.value <= 0n) {
+      return { status: 'invalid' }
+    }
+  }
+
+  return {
+    status: 'ok',
+    params: {
+      recipient,
+      requestId,
+      expiresAt,
+      amount: amount || undefined,
+      note: note || undefined,
+    },
+  }
+}

--- a/apps/armada-interface/src/lib/payViaLink.ts
+++ b/apps/armada-interface/src/lib/payViaLink.ts
@@ -120,6 +120,39 @@ export function isPaymentLinkRevoked(requestId: string): boolean {
   return readRevokedPaymentLinkIds().has(requestId)
 }
 
+// ---------------------------------------------------------------------------
+// Pending hand-off — carries a parsed link from the payer landing page to the
+// dashboard's Send flow across the client navigation (survives a full reload).
+// ---------------------------------------------------------------------------
+const PENDING_PAY_VIA_LINK_KEY = 'armada-pending-pay-via-link'
+
+export function writePendingPayViaLink(payload: PayViaLinkParams): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(PENDING_PAY_VIA_LINK_KEY, JSON.stringify(payload))
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+export function readPendingPayViaLink(): PayViaLinkParams | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.sessionStorage.getItem(PENDING_PAY_VIA_LINK_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as PayViaLinkParams
+    if (!parsed.recipient || !parsed.requestId || !parsed.expiresAt) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export function clearPendingPayViaLink(): void {
+  if (typeof window === 'undefined') return
+  window.sessionStorage.removeItem(PENDING_PAY_VIA_LINK_KEY)
+}
+
 /**
  * Validates a `/pay-via-link` query string. Order matters: structural validity → revoked →
  * expired → amount sanity. `now` is injectable for tests.

--- a/apps/armada-interface/src/lib/shielded/requestLinks.ts
+++ b/apps/armada-interface/src/lib/shielded/requestLinks.ts
@@ -1,0 +1,63 @@
+// ABOUTME: Persistence for created payment-request links — encrypted at rest under the per-wallet historyEncryptionKey.
+// ABOUTME: Mirrors tx-history storage (AES-256-GCM envelopes in IDB, foreign-wallet records skipped on decrypt).
+
+import { cacheAll, cacheDelete, cachePut } from '@/lib/cache'
+import { isEncryptedBlob, unwrap, wrap } from '@/lib/crypto/cache-cipher'
+import { getHistoryEncryptionKey, isUnlocked } from '@/lib/shielded/keyManager'
+import { trackError } from '@/lib/telemetry'
+
+const STORE = 'requestLinks' as const
+
+/**
+ * A payment-request link the user generated. Not a transaction — no chain, no funds; just a local
+ * artifact surfaced in Recent Activity (and re-openable at the Share-link step). `amount` is the
+ * raw USDC string as entered (bigint isn't JSON-serialisable through the cipher).
+ */
+export interface RequestLinkRecord {
+  requestId: string
+  paymentLink: string
+  amount: string
+  note?: string
+  expiresAt: number
+  createdAt: number
+  shieldedWalletId: string
+}
+
+/** Encrypt + persist one link under the active wallet's key. No-op when locked (can't encrypt). */
+export async function saveRequestLink(record: RequestLinkRecord): Promise<void> {
+  if (!isUnlocked()) return
+  try {
+    await cachePut(STORE, record.requestId, wrap(record, getHistoryEncryptionKey()))
+  } catch (err) {
+    trackError('shielded.requestLinks.save', err, {
+      scope: 'shielded.requestLinks',
+      message: 'idb write failed',
+    })
+  }
+}
+
+/** Load + decrypt this wallet's links. Foreign-wallet envelopes fail AES-GCM auth and are skipped. */
+export async function loadRequestLinks(walletId?: string): Promise<RequestLinkRecord[]> {
+  if (!walletId || !isUnlocked()) return []
+  const key = getHistoryEncryptionKey()
+  const rows = await cacheAll<unknown>(STORE)
+  const out: RequestLinkRecord[] = []
+  for (const { value } of rows) {
+    if (!isEncryptedBlob(value)) continue
+    try {
+      const rec = unwrap<RequestLinkRecord>(value, key)
+      if (rec.shieldedWalletId === walletId) out.push(rec)
+    } catch {
+      // Different wallet's record (wrong key) or corrupt blob — invisible by design.
+    }
+  }
+  return out
+}
+
+/** Delete this wallet's links (e.g. Clear-history / Reset). Requires an unlocked wallet to scope. */
+export async function clearRequestLinks(walletId?: string): Promise<void> {
+  const links = await loadRequestLinks(walletId)
+  for (const link of links) {
+    await cacheDelete(STORE, link.requestId)
+  }
+}

--- a/apps/armada-interface/src/main.tsx
+++ b/apps/armada-interface/src/main.tsx
@@ -38,6 +38,7 @@ setTheme(getSavedTheme() ?? 'light')
 import { Dashboard } from '@/pages/Dashboard'
 import { AddressBook } from '@/pages/AddressBook'
 import { Debug } from '@/pages/Debug'
+import { PayViaLinkLanding } from '@/pages/PayViaLinkLanding'
 
 import '@rainbow-me/rainbowkit/styles.css'
 import './index.css'
@@ -81,6 +82,9 @@ createRoot(document.getElementById('root')!).render(
               for isolation (overriding the default store via context). */}
           <BrowserRouter>
             <Routes>
+              {/* Standalone payer landing for a shared payment-request link — sits OUTSIDE the
+                  wallet-gated App shell so it renders for a payer who isn't onboarded yet. */}
+              <Route path="pay-via-link" element={<PayViaLinkLanding />} />
               <Route element={<App />}>
                 <Route index element={<Dashboard />} />
                 <Route path="address-book" element={<AddressBook />} />

--- a/apps/armada-interface/src/pages/CLAUDE.md
+++ b/apps/armada-interface/src/pages/CLAUDE.md
@@ -8,6 +8,7 @@ Top-level route components. Each is a thin shell that composes header chrome (fr
 | `Settings.tsx` | `/settings` | Wallet unlock, passphrase, export, reset, debug |
 | `AddressBook.tsx` | `/address-book` | Parked placeholder — not in nav until built |
 | `Debug.tsx` | `/debug` | Developer panel — contract addresses, per-chain balances. Faucet drip column appears only in local mode (no faucet contracts on Sepolia). |
+| `PayViaLinkLanding.tsx` | `/pay-via-link` | Payer's view of a shared payment-request link. Registered **outside** the `<App>` shell (no wallet gate) so an un-onboarded payer can view it. Validates the link (`parsePayViaLinkSearch`), shows amount/note/recipient + a QR; "Continue to pay" writes a pending hand-off + navigates to `/`, where `usePayViaLinkIntent` opens the Send flow prefilled. |
 
 ## Conventions
 

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Presentation from the armada-app mockup; wired to real shielded balance, yield, and tx history.
 
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
-import { useAtom, useAtomValue } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { ChartBarIcon } from '@heroicons/react/24/outline'
 import { BalanceCard } from '@/components/dashboard/BalanceCard'
 import { DepositTooltip } from '@/components/dashboard/DepositTooltip'
@@ -10,7 +10,7 @@ import { DASHBOARD_TOOLTIP_ENTER_DELAY_MS } from '@/components/dashboard/Balance
 import { DashboardScrollTopFade } from '@/components/dashboard/DashboardScrollTopFade'
 import { RecentActivityList, ActivityAllPanel } from '@/components/dashboard/RecentActivityList'
 import { ActivityReceipt } from '@/components/dashboard/ActivityReceipt'
-import { txListToActivityItems } from '@/components/dashboard/txActivityAdapter'
+import { buildActivityItems, type DashboardActivityItem } from '@/components/dashboard/txActivityAdapter'
 import { formatUsdcAmount } from '@/components/dashboard/dashboardFormat'
 import type { BalanceRollMode } from '@/components/dashboard/RollingBalanceValue'
 import { SyncGate, isInitialSyncGated } from '@/components/sync'
@@ -21,6 +21,7 @@ import { sharesToUsdc } from '@/lib/yield'
 import { openModalAtom, balanceHiddenAtom } from '@/state/ui'
 import { shieldedUsdcAtom, syncStateAtom, yieldSharesAtom, shieldedWalletAtom, evmAddressAtom } from '@/state/wallet'
 import { activeTxListAtom } from '@/state/tx'
+import { requestLinksAtom, requestShareIntentAtom } from '@/state/requestLinks'
 import styles from './Dashboard.module.css'
 
 /** USDC is a 6-decimal bigint; the card renders plain numbers. */
@@ -37,15 +38,32 @@ export function Dashboard() {
   const { rate: yieldRate } = useYieldRate()
   const shieldedWallet = useAtomValue(shieldedWalletAtom)
   const txList = useAtomValue(activeTxListAtom)
+  const requestLinks = useAtomValue(requestLinksAtom)
   const evmAddress = useAtomValue(evmAddressAtom)
 
   // Actions
   const openActionModal = useOpenActionModal()
   const openModal = useAtomValue(openModalAtom)
+  const setOpenModal = useSetAtom(openModalAtom)
+  const setShareIntent = useSetAtom(requestShareIntentAtom)
 
   // "All activity" side-panel + the per-tx receipt overlay (replaces the retired /history page).
   const [activityPanelOpen, setActivityPanelOpen] = useState(false)
   const [receiptId, setReceiptId] = useState<string | null>(null)
+
+  // Click routing: a created-link row re-opens the Request flow at its Share step; every other row
+  // opens the per-tx receipt.
+  function handleActivityItemClick(item: DashboardActivityItem) {
+    if (item.kind === 'requestLink') {
+      const link = requestLinks.find((l) => l.requestId === item.requestId)
+      if (link) {
+        setShareIntent(link)
+        setOpenModal('request')
+      }
+      return
+    }
+    setReceiptId(item.id)
+  }
 
   // Balance visibility is app-wide (shared with the wallet panel's hide toggle) via balanceHiddenAtom.
   const [balanceHidden, setBalanceHidden] = useAtom(balanceHiddenAtom)
@@ -80,8 +98,8 @@ export function Dashboard() {
   const vaultNumber = usdcToNumber(earningUsdc)
   const vaultApy = yieldRate !== null ? Number(yieldRate.apyBps) / 100 : undefined
   const activityItems = useMemo(
-    () => txListToActivityItems(txList, evmAddress),
-    [txList, evmAddress],
+    () => buildActivityItems(txList, requestLinks, evmAddress),
+    [txList, requestLinks, evmAddress],
   )
   const hasCompletedDeposit = txList.some(
     (r) => (r.kind === 'shield' || r.kind === 'shield-xchain') && r.executionState === 'completed',
@@ -152,7 +170,7 @@ export function Dashboard() {
             items={activityItems}
             balanceRevealed={!balanceHidden}
             onViewAll={() => setActivityPanelOpen(true)}
-            onItemClick={(item) => setReceiptId(item.id)}
+            onItemClick={handleActivityItemClick}
           />
         ) : null}
       </div>
@@ -163,7 +181,7 @@ export function Dashboard() {
         onClose={() => setActivityPanelOpen(false)}
         items={activityItems}
         balanceRevealed={!balanceHidden}
-        onItemClick={(item) => setReceiptId(item.id)}
+        onItemClick={handleActivityItemClick}
       />
       <ActivityReceipt
         record={txList.find((record) => record.id === receiptId) ?? null}

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Presentation from the armada-app mockup; wired to real shielded balance, yield, and tx history.
 
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 import { ChartBarIcon } from '@heroicons/react/24/outline'
 import { BalanceCard } from '@/components/dashboard/BalanceCard'
 import { DepositTooltip } from '@/components/dashboard/DepositTooltip'
@@ -41,7 +41,6 @@ export function Dashboard() {
 
   // Actions
   const openActionModal = useOpenActionModal()
-  const setOpenModal = useSetAtom(openModalAtom)
   const openModal = useAtomValue(openModalAtom)
 
   // "All activity" side-panel + the per-tx receipt overlay (replaces the retired /history page).
@@ -121,7 +120,7 @@ export function Dashboard() {
           onBalanceHiddenChange={setBalanceHidden}
           onSend={() => openActionModal('payment')}
           onDeposit={() => openActionModal('shield')}
-          onRequest={() => setOpenModal('receive')}
+          onRequest={() => openActionModal('request')}
           onEarn={() => openActionModal('yield-deposit')}
           onVaultOpen={() => openActionModal('yield-deposit')}
         />

--- a/apps/armada-interface/src/pages/PayViaLinkLanding.module.css
+++ b/apps/armada-interface/src/pages/PayViaLinkLanding.module.css
@@ -1,0 +1,287 @@
+/* ABOUTME: PayViaLinkLanding styles — full-bleed gradient page + frost request card with cascade enter. */
+/* ABOUTME: Ported from the armada-app mockup PayViaLinkLanding.module.css. */
+.page {
+  position: relative;
+  isolation: isolate;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: calc(var(--primitives-spacing-6) + var(--mobile-safe-area-top, 0px))
+    var(--primitives-spacing-6)
+    calc(var(--primitives-spacing-6) + var(--mobile-safe-area-bottom, 0px));
+  box-sizing: border-box;
+  background: var(--semantic-color-surface-bg);
+}
+
+.page::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  background: linear-gradient(
+    to bottom,
+    var(--semantic-color-brand-lavender) 0%,
+    var(--semantic-color-brand-gradient-rose) 50%,
+    var(--semantic-color-brand-amber) 100%
+  );
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.stack {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: calc(
+    var(--primitives-spacing-20) * 5 + var(--primitives-spacing-8) + var(--primitives-spacing-1) *
+      0.5
+  );
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--primitives-spacing-6);
+}
+
+.logoWrap {
+  display: flex;
+  justify-content: center;
+}
+
+.logo {
+  height: var(--primitives-spacing-8);
+  width: auto;
+}
+
+.card {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--primitives-spacing-10);
+  padding: var(--primitives-spacing-10);
+  box-sizing: border-box;
+  border-radius: calc(var(--semantic-borderRadius-modal) * 1px);
+  background: linear-gradient(
+    180deg,
+    var(--semantic-color-frost-raised) 0%,
+    var(--semantic-color-frost) 100%
+  );
+  backdrop-filter: blur(calc(var(--primitives-spacing-24) * 3 + var(--primitives-spacing-3)));
+  -webkit-backdrop-filter: blur(calc(var(--primitives-spacing-24) * 3 + var(--primitives-spacing-3)));
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+}
+
+.title {
+  margin: 0;
+  width: 100%;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  font-weight: var(--primitives-fontWeight-semibold);
+  line-height: var(--primitives-spacing-5);
+  letter-spacing: var(--primitives-letterSpacing-normal);
+  color: var(--semantic-color-text-primary);
+  text-align: left;
+}
+
+.amountValue {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  font-family: var(--primitives-fontFamily-mono), ui-monospace, monospace;
+  font-weight: var(--primitives-fontWeight-regular);
+  font-size: calc(var(--primitives-fontSize-4xl) * 1px);
+  line-height: 1;
+  color: var(--semantic-color-brand-ink);
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.body {
+  margin: 0;
+  width: 100%;
+  font-family: var(--semantic-typography-ui-body-sm-font-family);
+  font-size: var(--semantic-typography-ui-body-sm-font-size);
+  font-weight: var(--semantic-typography-ui-body-sm-font-weight);
+  line-height: var(--semantic-typography-ui-body-sm-line-height);
+  letter-spacing: var(--semantic-typography-ui-body-sm-letter-spacing);
+  color: var(--semantic-color-text-muted);
+  text-align: left;
+}
+
+.qrBox {
+  background: color-mix(in srgb, var(--primitives-color-neutral-50) 60%, transparent);
+  border-radius: calc(
+    (var(--primitives-borderRadius-lg) + var(--primitives-borderRadius-xl)) / 2 * 1px
+  );
+  color: var(--semantic-color-brand-ink);
+}
+
+.summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-2);
+  width: 100%;
+  margin: 0;
+}
+
+.summaryRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--primitives-spacing-3);
+  min-height: var(--primitives-spacing-5);
+  margin: 0;
+}
+
+.summaryLabel {
+  margin: 0;
+  font-family: var(--semantic-typography-ui-body-sm-font-family);
+  font-size: var(--semantic-typography-ui-body-sm-font-size);
+  font-weight: var(--semantic-typography-ui-body-sm-font-weight);
+  line-height: var(--primitives-spacing-5);
+  color: color-mix(in srgb, var(--semantic-color-text-primary) 80%, transparent);
+}
+
+.summaryValue {
+  margin: 0;
+  min-width: 0;
+  font-family: var(--primitives-fontFamily-mono), ui-monospace, monospace;
+  font-size: var(--semantic-typography-ui-body-sm-font-size);
+  font-weight: var(--primitives-fontWeight-medium);
+  line-height: var(--primitives-spacing-5);
+  color: var(--semantic-color-text-primary);
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.summaryNote {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-weight: var(--primitives-fontWeight-medium);
+}
+
+.expiryPill {
+  flex-shrink: 0;
+  margin: 0;
+  padding: 0 var(--primitives-spacing-3);
+  border-radius: calc(var(--primitives-borderRadius-full) * 1px);
+  background: var(--semantic-color-frost-raised);
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: var(--semantic-component-button-primary-sm-font-size);
+  font-weight: var(--primitives-fontWeight-medium);
+  line-height: var(--primitives-lineHeight-normal);
+  letter-spacing: var(--primitives-letterSpacing-wide);
+  color: var(--semantic-color-text-primary);
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.cta {
+  width: 100%;
+}
+
+@keyframes cascadeEnter {
+  from {
+    opacity: 0;
+    transform: translateY(var(--primitives-spacing-10));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes ctaEnter {
+  0% {
+    opacity: 0;
+    transform: translateY(0);
+  }
+
+  48% {
+    opacity: 1;
+    transform: translateY(calc(var(--primitives-spacing-3) * -1));
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.enter {
+  opacity: 0;
+  animation: cascadeEnter 360ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.enterLogo {
+  animation-delay: 0ms;
+}
+
+.enterTitle {
+  animation-delay: 70ms;
+}
+
+.enterAmount {
+  animation-delay: 140ms;
+}
+
+.enterBody {
+  animation-delay: 210ms;
+}
+
+.enterQr {
+  animation-delay: 280ms;
+}
+
+.enterSummary {
+  animation-delay: 350ms;
+}
+
+.enterCta {
+  animation-name: ctaEnter;
+  animation-duration: 520ms;
+  animation-timing-function: cubic-bezier(0.34, 1.15, 0.64, 1);
+  animation-delay: 420ms;
+}
+
+@media (max-width: 767px) {
+  .page {
+    justify-content: flex-start;
+    padding: calc(var(--primitives-spacing-5) + var(--mobile-safe-area-top, 0px))
+      var(--primitives-spacing-5)
+      calc(var(--primitives-spacing-5) + var(--mobile-safe-area-bottom, 0px));
+  }
+
+  .card {
+    gap: var(--primitives-spacing-8);
+    padding: var(--primitives-spacing-8);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  .enter {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/apps/armada-interface/src/pages/PayViaLinkLanding.test.tsx
+++ b/apps/armada-interface/src/pages/PayViaLinkLanding.test.tsx
@@ -1,0 +1,61 @@
+// ABOUTME: Tests for PayViaLinkLanding — renders per parse state + hands off a valid link to the Send flow.
+// ABOUTME: Uses MemoryRouter so useLocation() sees the link query; a '/' stub stands in for the dashboard.
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { PayViaLinkLanding } from './PayViaLinkLanding'
+
+const VALID_0ZK = '0zk1testrecipientaddress0000000000000000000000'
+const FUTURE = Date.now() + 7 * 86_400_000
+
+function renderAt(url: string) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        <Route path="/pay-via-link" element={<PayViaLinkLanding />} />
+        <Route path="/" element={<div>DASHBOARD</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+afterEach(() => {
+  window.sessionStorage.clear()
+})
+
+describe('PayViaLinkLanding', () => {
+  it('renders the request details for a valid link', () => {
+    renderAt(`/pay-via-link?to=${VALID_0ZK}&id=req_a&expires=${FUTURE}&amount=25&note=Invoice+7`)
+    expect(screen.getByRole('heading', { name: 'USDC payment request' })).toBeInTheDocument()
+    expect(screen.getByText('25.00')).toBeInTheDocument()
+    expect(screen.getByText('Invoice 7')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Scan to open payment request' })).toBeInTheDocument()
+  })
+
+  it('shows the invalid state for a non-shielded recipient', () => {
+    renderAt(`/pay-via-link?to=0xabc&id=req_a&expires=${FUTURE}`)
+    expect(screen.getByRole('heading', { name: 'This payment link is invalid' })).toBeInTheDocument()
+  })
+
+  it('shows the expired state for a past timestamp', () => {
+    renderAt(`/pay-via-link?to=${VALID_0ZK}&id=req_a&expires=1`)
+    expect(screen.getByRole('heading', { name: 'This payment link expired' })).toBeInTheDocument()
+  })
+
+  it('shows the revoked state when the id is in the revoked set', () => {
+    window.sessionStorage.setItem('armada-revoked-payment-links', JSON.stringify(['req_a']))
+    renderAt(`/pay-via-link?to=${VALID_0ZK}&id=req_a&expires=${FUTURE}`)
+    expect(screen.getByRole('heading', { name: 'This payment link was revoked' })).toBeInTheDocument()
+  })
+
+  it('Continue to pay writes the pending hand-off + navigates to the dashboard', async () => {
+    renderAt(`/pay-via-link?to=${VALID_0ZK}&id=req_a&expires=${FUTURE}&amount=25`)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue to pay' }))
+
+    await waitFor(() => expect(screen.getByText('DASHBOARD')).toBeInTheDocument())
+    const pending = JSON.parse(window.sessionStorage.getItem('armada-pending-pay-via-link') ?? 'null')
+    expect(pending).toMatchObject({ recipient: VALID_0ZK, requestId: 'req_a', amount: '25' })
+  })
+})

--- a/apps/armada-interface/src/pages/PayViaLinkLanding.tsx
+++ b/apps/armada-interface/src/pages/PayViaLinkLanding.tsx
@@ -1,0 +1,158 @@
+// ABOUTME: PayViaLinkLanding — the payer's view of a shared payment-request link (/pay-via-link).
+// ABOUTME: Validates the link, shows amount/note/recipient + a QR, and hands off to the real Send flow.
+
+import { useMemo, type ReactNode } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { ArmadaLogo, Button } from '@/design'
+import { PaymentLinkQrCode } from '@/components/payViaLink/PaymentLinkQrCode'
+import { formatUsdcAmount, parseUsdcInput, truncateArmadaAddress } from '@/lib/format'
+import {
+  formatPaymentLinkExpiry,
+  parsePayViaLinkSearch,
+  writePendingPayViaLink,
+} from '@/lib/payViaLink'
+import styles from './PayViaLinkLanding.module.css'
+
+function LandingFrame({ children }: { children: ReactNode }) {
+  return (
+    <main className={styles.page}>
+      <div className={styles.stack}>
+        <div className={`${styles.logoWrap} ${styles.enter} ${styles.enterLogo}`}>
+          <ArmadaLogo variant="full" markTone="deep" className={styles.logo} />
+        </div>
+        <div className={styles.card}>{children}</div>
+      </div>
+    </main>
+  )
+}
+
+export function PayViaLinkLanding() {
+  const navigate = useNavigate()
+  const { search } = useLocation()
+  const parsed = useMemo(() => parsePayViaLinkSearch(search), [search])
+
+  function goToApp() {
+    navigate('/')
+  }
+
+  function handleContinue() {
+    if (parsed.status !== 'ok') return
+    // Carry the request across the client navigation; the dashboard opens the Send flow prefilled.
+    writePendingPayViaLink(parsed.params)
+    navigate('/')
+  }
+
+  function GoToAppButton() {
+    return (
+      <div className={`${styles.actions} ${styles.enter} ${styles.enterCta}`}>
+        <Button
+          variant="secondary"
+          size="lg"
+          label="Go to Armada"
+          showIcon={false}
+          className={styles.cta}
+          onClick={goToApp}
+        />
+      </div>
+    )
+  }
+
+  if (parsed.status === 'invalid') {
+    return (
+      <LandingFrame>
+        <header className={`${styles.header} ${styles.enter} ${styles.enterTitle}`}>
+          <h1 className={styles.title}>This payment link is invalid</h1>
+          <p className={styles.body}>Check that the link is complete, then try again.</p>
+        </header>
+        <GoToAppButton />
+      </LandingFrame>
+    )
+  }
+
+  if (parsed.status === 'expired') {
+    return (
+      <LandingFrame>
+        <header className={`${styles.header} ${styles.enter} ${styles.enterTitle}`}>
+          <h1 className={styles.title}>This payment link expired</h1>
+          <p className={styles.body}>Ask the sender for a new link to complete the payment.</p>
+        </header>
+        <GoToAppButton />
+      </LandingFrame>
+    )
+  }
+
+  if (parsed.status === 'revoked') {
+    return (
+      <LandingFrame>
+        <header className={`${styles.header} ${styles.enter} ${styles.enterTitle}`}>
+          <h1 className={styles.title}>This payment link was revoked</h1>
+          <p className={styles.body}>
+            The sender cancelled this request. Ask them to send a new link.
+          </p>
+        </header>
+        <GoToAppButton />
+      </LandingFrame>
+    )
+  }
+
+  const { params } = parsed
+  const amountLabel = params.amount
+    ? formatUsdcAmount(parseUsdcInput(params.amount).value)
+    : null
+  const expiryLabel = formatPaymentLinkExpiry(params.expiresAt).replace(/^Expires /, 'Expire ')
+  const paymentUrl = window.location.href
+
+  return (
+    <LandingFrame>
+      <header className={styles.header}>
+        <h1 className={`${styles.title} ${styles.enter} ${styles.enterTitle}`}>
+          USDC payment request
+        </h1>
+        {amountLabel ? (
+          <p className={`${styles.amountValue} ${styles.enter} ${styles.enterAmount}`}>
+            {amountLabel}
+          </p>
+        ) : null}
+        <p className={`${styles.body} ${styles.enter} ${styles.enterBody}`}>
+          You&apos;ve been asked to send USDC privately through Armada.
+        </p>
+      </header>
+
+      <div className={`${styles.enter} ${styles.enterQr}`}>
+        <PaymentLinkQrCode
+          value={paymentUrl}
+          label="Scan to open payment request"
+          className={styles.qrBox}
+        />
+      </div>
+
+      <dl className={`${styles.summary} ${styles.enter} ${styles.enterSummary}`}>
+        {params.note ? (
+          <div className={styles.summaryRow}>
+            <dt className={styles.summaryLabel}>Note</dt>
+            <dd className={`${styles.summaryValue} ${styles.summaryNote}`}>{params.note}</dd>
+          </div>
+        ) : null}
+        <div className={styles.summaryRow}>
+          <dt className={styles.summaryLabel}>To</dt>
+          <dd className={styles.summaryValue}>{truncateArmadaAddress(params.recipient)}</dd>
+        </div>
+        <div className={styles.summaryRow}>
+          <dt className={styles.summaryLabel}>Expires</dt>
+          <dd className={styles.expiryPill}>{expiryLabel}</dd>
+        </div>
+      </dl>
+
+      <div className={`${styles.actions} ${styles.enter} ${styles.enterCta}`}>
+        <Button
+          variant="primary"
+          size="lg"
+          label="Continue to pay"
+          showIcon={false}
+          className={styles.cta}
+          onClick={handleContinue}
+        />
+      </div>
+    </LandingFrame>
+  )
+}

--- a/apps/armada-interface/src/state/CLAUDE.md
+++ b/apps/armada-interface/src/state/CLAUDE.md
@@ -11,6 +11,7 @@ Jotai atoms. **Read-mostly from components.** Write paths go through hooks or `s
 | `ui.ts` | `openModalAtom`, `balanceHiddenAtom`, `paymentIntentAtom` (pay-via-link → Send prefill hand-off) |
 | `history.ts` | `historyRecoveryAtom` (`{ state: 'idle'\|'scanning'\|'failed', error?, lastRecordCount? }`) + `historyRecoveryEpochAtom` (bumped by detector + Settings Re-scan). Read by `HistoryRecoveryBanner` and the History page empty state. |
 | `time.ts` | `nowAtom` — Date.now() snapshot driven by `useNowTicker`. Consumed by relative-time labels (TxRow). |
+| `requestLinks.ts` | `requestLinksAtom` (created payment-request links for the active wallet, hydrated by `useRequestLinks` from the encrypted per-wallet store) + `requestShareIntentAtom` (re-open the Request flow at the Share step from an activity row). |
 
 ## Conventions
 

--- a/apps/armada-interface/src/state/CLAUDE.md
+++ b/apps/armada-interface/src/state/CLAUDE.md
@@ -8,7 +8,7 @@ Jotai atoms. **Read-mostly from components.** Write paths go through hooks or `s
 | `wallet.ts` | `evmAddressAtom`, `shieldedWalletAtom`, `usdcBalancesAtom`, `shieldedUsdcAtom`, `yieldSharesAtom`, `syncStateAtom`, `syncRetryEpochAtom` (bumped by `useSyncRetry` to re-run the initial scan) |
 | `fees.ts` | `feeQuoteAtom`, `feeQuoteIsStaleAtom` (derived) |
 | `visibility.ts` | `tabVisibleAtom` (updated only by `useTabVisible()` — single listener) |
-| `ui.ts` | `openModalAtom` |
+| `ui.ts` | `openModalAtom`, `balanceHiddenAtom`, `paymentIntentAtom` (pay-via-link → Send prefill hand-off) |
 | `history.ts` | `historyRecoveryAtom` (`{ state: 'idle'\|'scanning'\|'failed', error?, lastRecordCount? }`) + `historyRecoveryEpochAtom` (bumped by detector + Settings Re-scan). Read by `HistoryRecoveryBanner` and the History page empty state. |
 | `time.ts` | `nowAtom` — Date.now() snapshot driven by `useNowTicker`. Consumed by relative-time labels (TxRow). |
 

--- a/apps/armada-interface/src/state/requestLinks.ts
+++ b/apps/armada-interface/src/state/requestLinks.ts
@@ -1,0 +1,14 @@
+// ABOUTME: Atoms for created payment-request links — the in-memory list + the "re-open at Share step" intent.
+// ABOUTME: The list is hydrated from the encrypted per-wallet store by useRequestLinks; RequestModal consumes the intent.
+
+import { atom } from 'jotai'
+import type { RequestLinkRecord } from '@/lib/shielded/requestLinks'
+
+/** Created payment-request links for the active wallet, newest first. Hydrated on unlock. */
+export const requestLinksAtom = atom<RequestLinkRecord[]>([])
+
+/**
+ * When set (by clicking a "Payment link created" activity row), RequestModal opens directly on the
+ * Share-link step seeded from this record, then clears it. Carries no funds/keys.
+ */
+export const requestShareIntentAtom = atom<RequestLinkRecord | null>(null)

--- a/apps/armada-interface/src/state/ui.ts
+++ b/apps/armada-interface/src/state/ui.ts
@@ -11,6 +11,7 @@ export type ModalKind =
   | 'yield-withdraw'
   | 'payment'
   | 'receive'
+  | 'request'
   | 'settings'
   | 'wallet-unlock'
   | 'wallet-reset'

--- a/apps/armada-interface/src/state/ui.ts
+++ b/apps/armada-interface/src/state/ui.ts
@@ -24,6 +24,18 @@ export type ActionModalKind = Exclude<
 export const openModalAtom = atom<ModalKind>(null)
 
 /**
+ * Pending payment-request hand-off from a `/pay-via-link` landing to the Send flow. When set, the
+ * app opens the `payment` modal and `SendModal` seeds the recipient (+ amount) from it, then clears
+ * it. Carries no funds/keys — just a prefill intent.
+ */
+export interface PaymentIntent {
+  recipient: string
+  amount?: string
+}
+
+export const paymentIntentAtom = atom<PaymentIntent | null>(null)
+
+/**
  * Whether balances are hidden across the app. Shared so the dashboard eye toggle and the wallet
  * panel's hide-balance control stay in sync — hiding in one place hides everywhere.
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "jotai": "^2.15.1",
         "level-js": "^6.1.0",
         "lucide-react": "^0.552.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.6.1",
@@ -20273,6 +20274,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/qrcode/node_modules/camelcase": {


### PR DESCRIPTION
Chunk 6c — Receive/Request/**Pay-via-link**. Adds the request-via-link flow, the payer landing, and a real hand-off into the existing Send flow. Built for real where the protocol allows; honestly inert where it needs infra we don't have yet.

## What's real
- **Request flow** (`components/request/RequestModal`, dashboard **Request** button): compose amount + expiry + note → generated **`/pay-via-link` URL** built from the connected wallet's real 0zk address (our origin), on `FlowShell`. Copy on the link screen.
- **Payer landing** (`pages/PayViaLinkLanding`, route `/pay-via-link`, outside the wallet gate): validates the link (`invalid | expired | revoked | ok`), shows amount/note/recipient + a **QR** (`qrcode.react`). "Continue to pay" writes a pending hand-off and — via `usePayViaLinkIntent` + a `paymentIntentAtom` seam in `SendModal` — drops the payer into a **prefilled Send** once unlocked. (Better than the mockup, whose landing just redirected.)
- **Plumbing** (`lib/payViaLink.ts`): URL build/parse, expiry helpers, request id, origin (`VITE_PUBLIC_APP_ORIGIN` localhost override), pending-link session hand-off.

## Honestly inert / deferred (no convincing fakes)
- **Revoke — disabled + "coming soon".** A session-local flag can't stop a payer who already has the link; real revocation needs shared backend state. The **Link-revoked screen is built and wired-ready** (renders on `RequestLinkScreen`'s `revoked` prop) but nothing sets it yet.
- **Per-request "paid" tracking — dropped.** No mock 60s auto-settle, no fake tx hash. Received payments surface through the normal activity/receipt path (6b); tying one back to a specific request would need memo-on-send tagging (not wired).
- **Expiry** is a soft nudge only (plaintext in the link, checked client-side) — copy avoids implying a hard guarantee.

## Decision to confirm
The mockup's desktop compose has **no** plain copy-address affordance (it's mobile-chooser-only). To preserve the amount-less "share my address" path on desktop without the mobile chrome, I added a subtle **"Copy your address instead"** link on the compose screen that opens the existing `ReceiveDialog`. Shout if you'd rather drop it or handle it differently. QR is landing-only (matches the mockup); easy to also add to your link screen if you want.

## Notes
- New dep `qrcode.react` → run `npm install --legacy-peer-deps` after pulling.
- New route `/pay-via-link`; new atom `paymentIntentAtom`.

Typecheck clean; full interface suite **1183 passing** (8 pre-existing OnboardingFlow skips). +31 tests across the three increments (plumbing, landing, Request flow, Send prefill).
