### PR TITLE
feat(interface): recently-used addresses on the Send recipient step

### DIFF
--- a/apps/armada-interface/src/components/payments/CLAUDE.md
+++ b/apps/armada-interface/src/components/payments/CLAUDE.md
@@ -13,7 +13,8 @@ which the Unshield tab and `ActivityReceipt` reuse to render unshield reviews/re
 | Component | Purpose |
 |---|---|
 | `SendModal` | Orchestrator. Owns step + form state; derives `variant` from the open modal kind. Three `useTx` hooks mounted (`transfer-shielded` / `unshield-local` / `unshield-xchain`); the submitted one's record drives Progress + Complete. |
-| `SendRecipientStep` | First step. Editable recipient (0zk or 0x), a privacy indicator, and a destination-chain selector shown **only** for public 0x recipients. Continue is gated on a valid address. |
+| `SendRecipientStep` | First step. Editable recipient (0zk or 0x), a privacy indicator, a destination-chain selector shown **only** for public 0x recipients, and a **recent-recipients list** below the action row. Continue is gated on a valid address. |
+| `RecentAddressList` | Presentational "Recent address" list — previously-used recipients as one-tap rows (arrow badge + truncated address + relative time). Data comes from `useRecentRecipients` (derived from settled tx history); a click fills the recipient and restores its destination chain. Empty history renders nothing. Hidden on mobile once a valid address is typed. |
 | `SendInputStep` | Amount step. `DepositAmountCard` with the chain rendered **statically** (chosen on the recipient step). Gates Review on the amount only. |
 | `SendReviewStep` | Read-only echo. Shows the resolved mode label (Private transfer / External wallet) + cross-chain tag when applicable. Variant drives the headline + confirm label. |
 | `SendCompleteStep` | Frost-card confirmation; title by variant (send → "USDC send confirmed", withdraw → "USDC unshield confirmed"). |

--- a/apps/armada-interface/src/components/payments/RecentAddressList.module.css
+++ b/apps/armada-interface/src/components/payments/RecentAddressList.module.css
@@ -1,0 +1,106 @@
+/* ABOUTME: Send flow "Recent address" list styles — ported from the armada-app SendRecipientScreen recent section. */
+/* ABOUTME: A labelled column of frosted recipient rows; enters after the card + CTAs, matching the step's staggered motion. */
+
+.recentSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-2);
+  width: 100%;
+  opacity: 0;
+  animation: recentSectionEnter 360ms cubic-bezier(0.22, 1, 0.36, 1)
+    calc(var(--modal-step-enter-delay, 360ms) + 500ms) both;
+}
+
+@keyframes recentSectionEnter {
+  from {
+    opacity: 0;
+    transform: translateY(var(--primitives-spacing-10));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.recentLabel {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  font-weight: var(--primitives-fontWeight-regular);
+  color: var(--semantic-color-text-muted);
+}
+
+.recentList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-2);
+  width: 100%;
+}
+
+.recentItem {
+  display: flex;
+  align-items: center;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+  min-height: var(--primitives-spacing-16);
+  padding: var(--primitives-spacing-3);
+  border: none;
+  border-radius: calc(var(--primitives-spacing-5) / 2);
+  background: color-mix(in srgb, var(--primitives-color-neutral-50) 20%, transparent);
+  cursor: pointer;
+  text-align: left;
+  box-sizing: border-box;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+.recentItem:hover {
+  background: var(--semantic-color-surface-hover);
+}
+
+.recentItem:active {
+  transform: translateY(1px);
+}
+
+.recentIconBadge {
+  width: var(--primitives-spacing-10);
+  height: var(--primitives-spacing-10);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: calc(var(--semantic-borderRadius-item) * 1px);
+  background: color-mix(in srgb, var(--primitives-color-purple-500) 15%, transparent);
+  color: var(--semantic-color-text-primary);
+}
+
+.recentIcon {
+  width: var(--primitives-spacing-5);
+  height: var(--primitives-spacing-5);
+}
+
+.recentAddress {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-base) * 1px);
+  font-weight: var(--primitives-fontWeight-medium);
+  color: var(--semantic-color-text-primary);
+}
+
+.recentTime {
+  flex-shrink: 0;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  color: var(--semantic-color-text-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .recentSection {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/apps/armada-interface/src/components/payments/RecentAddressList.test.tsx
+++ b/apps/armada-interface/src/components/payments/RecentAddressList.test.tsx
@@ -1,0 +1,39 @@
+// ABOUTME: Tests for RecentAddressList — renders label + truncated address + relative time; row click fires onSelect; empty renders nothing.
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { RecentAddressList } from './RecentAddressList'
+import type { RecentRecipient } from '@/lib/tx/recentRecipients'
+
+const NOW = 1_000_000_000_000
+const EVM_A = '0x1111111111111111111111111111111111111111'
+const EVM_B = '0x2222222222222222222222222222222222222222'
+
+const ITEMS: RecentRecipient[] = [
+  { address: EVM_A, kind: 'unshield-local', destChainId: 31337, lastAt: NOW - 3 * 86_400_000 },
+  { address: EVM_B, kind: 'unshield-xchain', destChainId: 84532, lastAt: NOW - 60_000 },
+]
+
+describe('<RecentAddressList>', () => {
+  it('renders the label, a truncated address, and a relative time per item', () => {
+    render(<RecentAddressList items={ITEMS} onSelect={vi.fn()} now={NOW} />)
+    expect(screen.getByText('Recent address')).toBeInTheDocument()
+    // Middle-truncated address (first 6 + "..." + last 4), not the full string.
+    expect(screen.getByText('0x1111...1111')).toBeInTheDocument()
+    expect(screen.getByText('3d ago')).toBeInTheDocument()
+    expect(screen.getByText('1m ago')).toBeInTheDocument()
+  })
+
+  it('fires onSelect with the clicked item', () => {
+    const onSelect = vi.fn()
+    render(<RecentAddressList items={ITEMS} onSelect={onSelect} now={NOW} />)
+    fireEvent.click(screen.getAllByRole('button')[0]!)
+    expect(onSelect).toHaveBeenCalledWith(ITEMS[0])
+  })
+
+  it('renders nothing when there are no recent addresses', () => {
+    const { container } = render(<RecentAddressList items={[]} onSelect={vi.fn()} now={NOW} />)
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByText('Recent address')).toBeNull()
+  })
+})

--- a/apps/armada-interface/src/components/payments/RecentAddressList.tsx
+++ b/apps/armada-interface/src/components/payments/RecentAddressList.tsx
@@ -1,0 +1,37 @@
+// ABOUTME: Send flow's "Recent address" list — previously-used recipients as tappable rows (arrow badge + truncated address + relative time).
+// ABOUTME: Presentational; data is derived by useRecentRecipients and a row click fills the recipient (+ restores its chain) in SendModal.
+
+import { ArrowRightIcon } from '@heroicons/react/24/outline'
+import { truncateAddress, formatRelativeTime } from '@/lib/format'
+import type { RecentRecipient } from '@/lib/tx/recentRecipients'
+import styles from './RecentAddressList.module.css'
+
+export interface RecentAddressListProps {
+  items: RecentRecipient[]
+  onSelect: (item: RecentRecipient) => void
+  /** Wall-clock now (ms) for the relative-time labels; injectable so tests are deterministic. */
+  now?: number
+}
+
+export function RecentAddressList({ items, onSelect, now = Date.now() }: RecentAddressListProps) {
+  if (items.length === 0) return null
+
+  return (
+    <div className={styles.recentSection}>
+      <span className={styles.recentLabel}>Recent address</span>
+      <ul className={styles.recentList}>
+        {items.map((item) => (
+          <li key={item.address}>
+            <button type="button" className={styles.recentItem} onClick={() => onSelect(item)}>
+              <span className={styles.recentIconBadge} aria-hidden>
+                <ArrowRightIcon className={styles.recentIcon} strokeWidth={1.5} />
+              </span>
+              <span className={styles.recentAddress}>{truncateAddress(item.address)}</span>
+              <span className={styles.recentTime}>{formatRelativeTime(item.lastAt, now)}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -14,6 +14,8 @@ import {
   shieldedWalletAtom,
 } from '@/state/wallet'
 import { useTx } from '@/hooks/useTx'
+import { useRecentRecipients } from '@/hooks/useRecentRecipients'
+import type { RecentRecipient } from '@/lib/tx/recentRecipients'
 import { useFees } from '@/hooks/useFees'
 import { useSpendableSyncGate } from '@/hooks/useSpendableSyncGate'
 import { getChainById, getNetworkConfig } from '@/config/network'
@@ -156,6 +158,14 @@ export function SendModal() {
   const destDeploymentError = destHasDeployment
     ? undefined
     : 'This destination chain has no deployment manifest. Pick another chain.'
+
+  // Recently-used recipients (from settled history) offered on the recipient step. Selecting one
+  // fills the address and restores its destination chain (0zk transfers have none → back to hub).
+  const recentAddresses = useRecentRecipients(5)
+  function handleSelectRecent(item: RecentRecipient) {
+    setRecipient(item.address)
+    setDestChainId(item.destChainId ?? hubChainId)
+  }
 
   // Three useTx hooks mounted; only one gets a record per flow.
   const txTransfer = useTx({ kind: 'transfer-shielded' })
@@ -400,6 +410,8 @@ export function SendModal() {
           destChainId={destChainId}
           onDestChainIdChange={setDestChainId}
           destDeploymentError={destDeploymentError}
+          recentAddresses={recentAddresses}
+          onSelectRecent={handleSelectRecent}
           onCancel={close}
           onContinue={() => setStep('input')}
         />

--- a/apps/armada-interface/src/components/payments/SendRecipientStep.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendRecipientStep.test.tsx
@@ -16,6 +16,8 @@ function setup(extras?: Partial<SendRecipientStepProps>) {
     destChainId: extras?.destChainId ?? 31337,
     onDestChainIdChange: extras?.onDestChainIdChange ?? vi.fn(),
     destDeploymentError: extras?.destDeploymentError,
+    recentAddresses: extras?.recentAddresses ?? [],
+    onSelectRecent: extras?.onSelectRecent ?? vi.fn(),
     onCancel: extras?.onCancel ?? vi.fn(),
     onContinue: extras?.onContinue ?? vi.fn(),
   }
@@ -87,5 +89,20 @@ describe('<SendRecipientStep>', () => {
     const props = setup()
     fireEvent.click(screen.getByRole('button', { name: /Cancel/ }))
     expect(props.onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the recent-recipients list and fires onSelectRecent on a row click', () => {
+    const recent = [
+      { address: VALID_EVM, kind: 'unshield-local' as const, destChainId: 31337, lastAt: 0 },
+    ]
+    const props = setup({ recentAddresses: recent })
+    expect(screen.getByText('Recent address')).toBeInTheDocument()
+    fireEvent.click(screen.getByText(/0x1234\.\.\.5678/))
+    expect(props.onSelectRecent).toHaveBeenCalledWith(recent[0])
+  })
+
+  it('omits the recent section when there is no history', () => {
+    setup({ recentAddresses: [] })
+    expect(screen.queryByText('Recent address')).toBeNull()
   })
 })

--- a/apps/armada-interface/src/components/payments/SendRecipientStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendRecipientStep.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Send/Withdraw recipient step — a frost card (title + address input with Clear + a paste row that
-// ABOUTME: previews a valid 0zk/0x on the clipboard + public-only chain selector + privacy badge once valid) over an always-visible Cancel / Continue action row.
+// ABOUTME: previews a valid 0zk/0x on the clipboard + public-only chain selector + privacy badge once valid) over an always-visible Cancel / Continue action row + a recent-recipients list.
 
 import { useEffect, useState } from 'react'
 import { XMarkIcon, GlobeAltIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline'
@@ -8,6 +8,9 @@ import iconButtonStyles from '@/design/components/IconButton/IconButton.module.c
 import { ChainSelect } from '@/components/ui'
 import { isShieldedAddress, validateEvmAddress } from '@/lib/address'
 import { truncateAddress } from '@/lib/format'
+import { useMobileLayout } from '@/hooks/useMobileLayout'
+import { RecentAddressList } from './RecentAddressList'
+import type { RecentRecipient } from '@/lib/tx/recentRecipients'
 import styles from './SendRecipientStep.module.css'
 
 /** Which flow the shared Send/Withdraw modal is running as — drives minimal copy differences. */
@@ -30,6 +33,10 @@ export interface SendRecipientStepProps {
   onDestChainIdChange: (chainId: number) => void
   /** Surfaced when the chosen public destination chain has no deployment manifest. */
   destDeploymentError?: string
+  /** Previously-used recipients, newest-first — rendered as one-tap rows below the action row. */
+  recentAddresses: RecentRecipient[]
+  /** Fills the recipient (and restores its destination chain) from a recent row. */
+  onSelectRecent: (item: RecentRecipient) => void
   /** Dismisses the flow — wired to the modal's close in SendModal. */
   onCancel: () => void
   onContinue: () => void
@@ -42,10 +49,13 @@ export function SendRecipientStep({
   destChainId,
   onDestChainIdChange,
   destDeploymentError,
+  recentAddresses,
+  onSelectRecent,
   onCancel,
   onContinue,
 }: SendRecipientStepProps) {
   const [inputFocused, setInputFocused] = useState(false)
+  const isMobile = useMobileLayout()
   // Trimmed clipboard content (null if empty / unreadable), used by the paste row. Probed on open +
   // whenever the tab regains focus (the user may copy then return).
   const [clipboardText, setClipboardText] = useState<string | null>(null)
@@ -231,6 +241,12 @@ export function SendRecipientStep({
           onClick={onContinue}
         />
       </div>
+
+      {/* Recent recipients — hidden on mobile once a valid address is entered so the keyboard + CTAs
+          own the viewport (matches the mockup); empty history renders nothing. */}
+      {!(isMobile && recipientValid) ? (
+        <RecentAddressList items={recentAddresses} onSelect={onSelectRecent} />
+      ) : null}
     </div>
   )
 }

--- a/apps/armada-interface/src/hooks/CLAUDE.md
+++ b/apps/armada-interface/src/hooks/CLAUDE.md
@@ -23,6 +23,7 @@ One concern per hook. Hooks own the React lifecycle (effects, subscriptions, tim
 | `useRequestLinks()` / `useAddRequestLink()` | Hydrator (mount at App root) loads the active wallet's created payment-request links from the encrypted `requestLinks` store into `requestLinksAtom` on unlock; `useAddRequestLink` persists a new link + prepends it. Drives the "Payment link created" activity rows. | Working |
 | `useShieldFlow(isOpen)` | Shield (deposit) flow controller — owns form/fee/kind/submit/step orchestration for the Shield tab (`shield` / `shield-xchain`, gasless-wrapper vs direct). Consumed by the dumb `ShieldModal`. | Working |
 | `useUnshieldFlow(isOpen)` | Unshield-to-own-wallet flow controller — recipient pinned to the connected wallet; a to-chain picker drives `unshield-local` / `unshield-xchain`. The Shield modal's Unshield tab consumes it. | Working |
+| `useRecentRecipients(limit)` | Reads `txListAtom` and derives the Send flow's recent-recipients list (dedupe/sort/cap in `lib/tx/recentRecipients`). Settled sends only; each entry carries its destination chain. | Working |
 
 ## Conventions
 

--- a/apps/armada-interface/src/hooks/useRecentRecipients.ts
+++ b/apps/armada-interface/src/hooks/useRecentRecipients.ts
@@ -1,0 +1,18 @@
+// ABOUTME: Reads settled tx history from txListAtom and derives the Send flow's recent-recipients list.
+// ABOUTME: Thin wrapper so components stay dumb — the dedupe/sort/cap logic lives in lib/tx/recentRecipients.
+
+import { useMemo } from 'react'
+import { useAtomValue } from 'jotai'
+import { txListAtom } from '@/state/tx'
+import { getNetworkConfig } from '@/config/network'
+import { deriveRecentRecipients, type RecentRecipient } from '@/lib/tx/recentRecipients'
+
+/** The user's `limit` most recently used distinct recipients, newest-first. Empty when no history. */
+export function useRecentRecipients(limit = 5): RecentRecipient[] {
+  const records = useAtomValue(txListAtom)
+  const hubChainId = getNetworkConfig().hub.chainId
+  return useMemo(
+    () => deriveRecentRecipients(records, { hubChainId, limit }),
+    [records, hubChainId, limit],
+  )
+}

--- a/apps/armada-interface/src/lib/tx/CLAUDE.md
+++ b/apps/armada-interface/src/lib/tx/CLAUDE.md
@@ -12,6 +12,7 @@ Transaction lifecycle model. The most important architectural surface in this ap
 | `storage.ts` | IDB persistence: `putTxIfFresh` (OCC enforced via `updatedSeq`), `putTx` (unconditional, hydration only), `loadAllTx`, `deleteTx`. |
 | `executor.ts` | **Module-scope** execution engine. Runs stage handlers outside React, owns AbortControllers, leader-elected via `navigator.locks`. |
 | `poller.ts` | Generic abortable / jittered / backoff-aware poll loop. Stage-specific adapters (Iris, RPC, relayer) plug in here. |
+| `recentRecipients.ts` | Pure `deriveRecentRecipients(records, {hubChainId, limit})` — the Send flow's recent-recipients list from settled history (dedupe by normalized address, newest-first, completed-only, per-kind destination chain). Consumed via `hooks/useRecentRecipients`. |
 
 ## Invariants
 

--- a/apps/armada-interface/src/lib/tx/recentRecipients.test.ts
+++ b/apps/armada-interface/src/lib/tx/recentRecipients.test.ts
@@ -1,0 +1,96 @@
+// ABOUTME: Tests for deriveRecentRecipients — dedupe by normalized address, newest-first, cap, completed-only, per-kind chain.
+
+import { describe, it, expect } from 'vitest'
+import { deriveRecentRecipients } from './recentRecipients'
+import type { TxRecord, TxKind, TxExecutionState } from './types'
+
+const HUB = 31337
+const CLIENT = 84532
+
+const EVM_A = '0x1111111111111111111111111111111111111111'
+const EVM_B = '0x2222222222222222222222222222222222222222'
+const ZK_A = '0zk' + 'a'.repeat(40)
+
+function rec(o: {
+  kind: TxKind
+  createdAt: number
+  executionState?: TxExecutionState
+  recipient?: string
+  toChainId?: number
+}): TxRecord {
+  return {
+    id: `id-${o.createdAt}`,
+    kind: o.kind,
+    executionState: o.executionState ?? 'completed',
+    stage: 'hub-confirmed',
+    stagesCompleted: [],
+    updatedSeq: 1,
+    createdAt: o.createdAt,
+    updatedAt: o.createdAt,
+    meta: { recipient: o.recipient, toChainId: o.toChainId },
+    artifacts: {},
+    walletContext: { evmAddress: '0xabc', shieldedWalletId: 'w', sourceChainId: HUB },
+  } as unknown as TxRecord
+}
+
+describe('deriveRecentRecipients', () => {
+  it('returns [] for empty history', () => {
+    expect(deriveRecentRecipients([], { hubChainId: HUB })).toEqual([])
+  })
+
+  it('dedupes by normalized address (case-insensitive for 0x), keeping the newest occurrence', () => {
+    // Same address, differing only in body case (real checksummed addresses keep a lowercase 0x prefix).
+    const lower = '0x' + 'ab'.repeat(20)
+    const upperBody = '0x' + 'AB'.repeat(20)
+    const records = [
+      rec({ kind: 'unshield-local', createdAt: 100, recipient: lower }),
+      rec({ kind: 'unshield-local', createdAt: 300, recipient: upperBody }),
+    ]
+    const out = deriveRecentRecipients(records, { hubChainId: HUB })
+    expect(out).toHaveLength(1)
+    expect(out[0]?.lastAt).toBe(300)
+    expect(out[0]?.destChainId).toBe(HUB)
+  })
+
+  it('orders newest-first and caps at the limit', () => {
+    const records = Array.from({ length: 8 }, (_, i) =>
+      rec({ kind: 'unshield-local', createdAt: i * 100, recipient: `0x${String(i).repeat(40)}` }),
+    )
+    const out = deriveRecentRecipients(records, { hubChainId: HUB, limit: 5 })
+    expect(out).toHaveLength(5)
+    expect(out.map((r) => r.lastAt)).toEqual([700, 600, 500, 400, 300])
+  })
+
+  it('counts only settled (completed) sends', () => {
+    const records = [
+      rec({ kind: 'unshield-local', createdAt: 100, recipient: EVM_A, executionState: 'failed' }),
+      rec({ kind: 'unshield-local', createdAt: 200, recipient: EVM_B, executionState: 'active' }),
+    ]
+    expect(deriveRecentRecipients(records, { hubChainId: HUB })).toEqual([])
+  })
+
+  it('restores the destination chain per kind (xchain→toChainId, local→hub, transfer→undefined)', () => {
+    const records = [
+      rec({ kind: 'unshield-xchain', createdAt: 300, recipient: EVM_A, toChainId: CLIENT }),
+      rec({ kind: 'unshield-local', createdAt: 200, recipient: EVM_B }),
+      rec({ kind: 'transfer-shielded', createdAt: 100, recipient: ZK_A }),
+    ]
+    const out = deriveRecentRecipients(records, { hubChainId: HUB })
+    expect(out.map((r) => [r.kind, r.destChainId])).toEqual([
+      ['unshield-xchain', CLIENT],
+      ['unshield-local', HUB],
+      ['transfer-shielded', undefined],
+    ])
+  })
+
+  it('skips records with no recipient (e.g. shields, received transfers)', () => {
+    const records = [
+      rec({ kind: 'shield', createdAt: 300 }),
+      rec({ kind: 'transfer-shielded', createdAt: 200 }), // received transfer — no recipient meta
+      rec({ kind: 'unshield-local', createdAt: 100, recipient: EVM_A }),
+    ]
+    const out = deriveRecentRecipients(records, { hubChainId: HUB })
+    expect(out).toHaveLength(1)
+    expect(out[0]?.address).toBe(EVM_A)
+  })
+})

--- a/apps/armada-interface/src/lib/tx/recentRecipients.ts
+++ b/apps/armada-interface/src/lib/tx/recentRecipients.ts
@@ -1,0 +1,78 @@
+// ABOUTME: Derives the Send flow's "recently used addresses" list from settled tx history —
+// ABOUTME: dedupes recipients by normalized address, newest-first, capped, each carrying its destination chain.
+
+import type { TxRecord } from './types'
+
+/** A recipient the user has previously sent to, surfaced as a one-tap option in the Send flow. */
+export interface RecentRecipient {
+  /** The recipient address exactly as recorded (`0x…` public wallet or `0zk…` shielded). */
+  address: string
+  /** Which flow produced it — kept so the caller can restore the destination chain on select. */
+  kind: 'transfer-shielded' | 'unshield-local' | 'unshield-xchain'
+  /**
+   * Destination chain to restore when re-selecting a public recipient. `undefined` for a shielded
+   * (`0zk`) transfer, which has no destination-chain concept.
+   */
+  destChainId?: number
+  /** `createdAt` (ms) of the most recent send to this address — drives the relative-time label. */
+  lastAt: number
+}
+
+const RECIPIENT_KINDS = ['transfer-shielded', 'unshield-local', 'unshield-xchain'] as const
+type RecipientKind = (typeof RECIPIENT_KINDS)[number]
+
+function isRecipientKind(kind: string): kind is RecipientKind {
+  return (RECIPIENT_KINDS as readonly string[]).includes(kind)
+}
+
+/** Public (`0x`) addresses compare case-insensitively; shielded (`0zk`) addresses are case-sensitive. */
+function dedupeKey(address: string): string {
+  return address.startsWith('0x') ? address.toLowerCase() : address
+}
+
+export interface DeriveRecentOptions {
+  /** Hub chain id — the destination to restore for same-chain (`unshield-local`) recipients. */
+  hubChainId: number
+  /** Maximum entries to return. */
+  limit?: number
+}
+
+/**
+ * Reduce a tx history to the most recent distinct recipients.
+ *
+ * Only settled (`completed`) sends count — a failed or in-flight attempt's (possibly typo'd)
+ * address shouldn't linger as a suggestion. Records are walked newest-first so the first occurrence
+ * of each address wins the dedupe and carries its latest timestamp. Received-transfer records carry
+ * no `recipient` (we didn't choose it) and are naturally skipped.
+ */
+export function deriveRecentRecipients(
+  records: readonly TxRecord[],
+  { hubChainId, limit = 5 }: DeriveRecentOptions,
+): RecentRecipient[] {
+  const sorted = [...records].sort((a, b) => b.createdAt - a.createdAt)
+  const seen = new Set<string>()
+  const out: RecentRecipient[] = []
+
+  for (const record of sorted) {
+    if (record.executionState !== 'completed') continue
+    if (!isRecipientKind(record.kind)) continue
+
+    const meta = record.meta as { recipient?: string; toChainId?: number }
+    const address = meta.recipient
+    if (!address) continue
+
+    const key = dedupeKey(address)
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    const destChainId =
+      record.kind === 'unshield-xchain' ? meta.toChainId
+      : record.kind === 'unshield-local' ? hubChainId
+      : undefined
+
+    out.push({ address, kind: record.kind, destChainId, lastAt: record.createdAt })
+    if (out.length >= limit) break
+  }
+
+  return out
+}


### PR DESCRIPTION
Adds the mockup's **recent-recipients list** to the Send flow's recipient step — one-tap rows below the Cancel/Continue actions.

### Behaviour
- **Real data, not demo:** derived from settled (`completed`) tx history — `transfer-shielded` (0zk), `unshield-local` (0x/hub), and `unshield-xchain` (0x/client) records carry `meta.recipient`. Deduped by normalized address (0x case-insensitive), newest-first, capped at **5**.
- **Selecting a row** fills the recipient and **restores its destination chain** (xchain → recorded `toChainId`, local → hub, 0zk transfer → hub/none).
- **Empty history renders nothing** (no fake placeholders); hidden on mobile once a valid address is typed.
- Own connected address is intentionally **included** (per scoping).

### Shape
- `lib/tx/recentRecipients.ts` — pure `deriveRecentRecipients` (dedupe/sort/cap/chain).
- `hooks/useRecentRecipients` — atom-backed selector (keeps the component dumb).
- `components/payments/RecentAddressList` — presentational list, styles ported from the mockup.
- Wired through `SendModal` → `SendRecipientStep`.

### Tests
Derivation (dedupe/sort/cap/completed-only/per-kind chain/skip-no-recipient), list render+click+empty, and recipient-step wiring. Full interface suite: **1200 passing / 8 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)