### PR TITLE
fix(interface): all-activity panel shows full history (was capped at 8)

### DIFF
--- a/apps/armada-interface/src/components/dashboard/CLAUDE.md
+++ b/apps/armada-interface/src/components/dashboard/CLAUDE.md
@@ -13,7 +13,7 @@ Dashboard presentation, ported from the armada-app design mockup. Composed by `p
 | `SendButton`, `ShieldedUsdcBadge`, `TokenBadge` | Small presentational pieces of the card. |
 | `DepositTooltip` | First-run "Make your first deposit" callout under the card (empty state). |
 | `RecentActivityList` | Activity list — icon-badge rows with scrambled amounts + per-item peek. `variant="preview"` (dashboard, with "View all" → the `ActivityAllPanel`) or `variant="full"` (inside the panel). |
-| `ActivityAllPanel` | "All activity" SidePanel/BottomSheet — kind filters + tx-hash search over the full list; a row click opens the `ActivityReceipt`. Replaces the retired `/history` page. |
+| `ActivityAllPanel` | "All activity" SidePanel/BottomSheet — kind filters + tx-hash search over the full list; a row click opens the `ActivityReceipt`. Replaces the retired `/history` page. `Dashboard` feeds it the full activity list capped at `ACTIVITY_PANEL_MAX` (500, no virtualization); `truncatedCount` surfaces a "showing latest 500" note only when history exceeds the cap. The inline dashboard preview is a separate `ACTIVITY_PREVIEW_MAX` (8) slice. |
 | `ActivityKindFilters` / `ActivityTxHashSearch` | Toolbar controls for the panel (kind chips + hash search); predicates in `activityFilters.ts`. *(These + `ActivityAllPanel` live nested under `RecentActivityList/`, not as top-level dashboard siblings.)* |
 | `BalanceActionButton` | Labeled round action tile in the BalanceCard action row (Shield / Send / Request / Earn). |
 | `DashboardScrollTopFade` | Top-edge scroll fade over the card stack when activity scrolls. |

--- a/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityAllPanel/ActivityAllPanel.module.css
+++ b/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityAllPanel/ActivityAllPanel.module.css
@@ -8,3 +8,13 @@
 .toolbar {
   padding-inline: var(--primitives-spacing-3);
 }
+
+.truncationNote {
+  margin: 0;
+  padding: var(--primitives-spacing-4) var(--primitives-spacing-3);
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  line-height: var(--primitives-lineHeight-normal);
+  color: var(--semantic-color-text-muted);
+  text-align: center;
+}

--- a/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityAllPanel/ActivityAllPanel.test.tsx
+++ b/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityAllPanel/ActivityAllPanel.test.tsx
@@ -47,4 +47,11 @@ describe('ActivityAllPanel', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Withdraw' }))
     expect(screen.getByText('No transactions match your filters.')).toBeInTheDocument()
   })
+
+  it('shows the "showing latest N" note only when truncatedCount is set', () => {
+    const { rerender } = render(<ActivityAllPanel open onClose={() => {}} items={items} />)
+    expect(screen.queryByText(/most recent transactions/)).toBeNull()
+    rerender(<ActivityAllPanel open onClose={() => {}} items={items} truncatedCount={500} />)
+    expect(screen.getByText('Showing your 500 most recent transactions.')).toBeInTheDocument()
+  })
 })

--- a/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityAllPanel/ActivityAllPanel.tsx
+++ b/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityAllPanel/ActivityAllPanel.tsx
@@ -16,6 +16,8 @@ export interface ActivityAllPanelProps {
   open: boolean
   onClose: () => void
   items: readonly DashboardActivityItem[]
+  /** When set, the list was capped to this many rows — surfaces a "showing latest N" note. */
+  truncatedCount?: number
   balanceRevealed?: boolean
   onItemClick?: (item: DashboardActivityItem) => void
 }
@@ -24,6 +26,7 @@ export function ActivityAllPanel({
   open,
   onClose,
   items,
+  truncatedCount,
   balanceRevealed = true,
   onItemClick,
 }: ActivityAllPanelProps) {
@@ -70,6 +73,11 @@ export function ActivityAllPanel({
           onItemClick={handleItemClick}
         />
       )}
+      {truncatedCount != null ? (
+        <p className={panelStyles.truncationNote}>
+          Showing your {truncatedCount} most recent transactions.
+        </p>
+      ) : null}
     </>
   )
 

--- a/apps/armada-interface/src/components/dashboard/txActivityAdapter.test.ts
+++ b/apps/armada-interface/src/components/dashboard/txActivityAdapter.test.ts
@@ -155,4 +155,11 @@ describe('buildActivityItems', () => {
     )
     expect(buildActivityItems([], links, null, 3)).toHaveLength(3)
   })
+
+  it('returns every row when max is uncapped (Infinity) — the "all activity" panel path', () => {
+    const links = Array.from({ length: 12 }, (_, i) =>
+      makeLink({ requestId: `req_${i}`, createdAt: 1_000 + i }),
+    )
+    expect(buildActivityItems([], links, null, Infinity)).toHaveLength(12)
+  })
 })

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -29,6 +29,11 @@ function usdcToNumber(amount: bigint): number {
   return Number(amount) / 1e6
 }
 
+/** Rows shown in the dashboard's inline activity preview (the "View all" panel shows the rest). */
+const ACTIVITY_PREVIEW_MAX = 8
+/** Ceiling on the "all activity" panel — rendered without virtualization, so we bound the row count. */
+const ACTIVITY_PANEL_MAX = 500
+
 export function Dashboard() {
   // Data (all hooks run unconditionally, before the sync gate's early return).
   const shielded = useAtomValue(shieldedUsdcAtom)
@@ -97,17 +102,29 @@ export function Dashboard() {
     yieldShares !== null && yieldRate !== null ? sharesToUsdc(yieldShares, yieldRate.rate) : 0n
   const vaultNumber = usdcToNumber(earningUsdc)
   const vaultApy = yieldRate !== null ? Number(yieldRate.apyBps) / 100 : undefined
-  const activityItems = useMemo(
-    () => buildActivityItems(txList, requestLinks, evmAddress),
+  // Full activity list (uncapped) so the panel can show everything up to its ceiling and we can tell
+  // whether that ceiling was hit. The dashboard preview + the panel then slice their own views.
+  const allActivityItems = useMemo(
+    () => buildActivityItems(txList, requestLinks, evmAddress, Infinity),
     [txList, requestLinks, evmAddress],
   )
+  const previewActivityItems = useMemo(
+    () => allActivityItems.slice(0, ACTIVITY_PREVIEW_MAX),
+    [allActivityItems],
+  )
+  const panelActivityItems = useMemo(
+    () => allActivityItems.slice(0, ACTIVITY_PANEL_MAX),
+    [allActivityItems],
+  )
+  // Only surface the "showing latest 500" note when activity actually exceeds the ceiling.
+  const activityTruncated = allActivityItems.length > ACTIVITY_PANEL_MAX
   const hasCompletedDeposit = txList.some(
     (r) => (r.kind === 'shield' || r.kind === 'shield-xchain') && r.executionState === 'completed',
   )
   const showDepositTooltip = balanceNumber <= 0 && !hasCompletedDeposit
   // Activity shows automatically whenever there are items (the manual hide toggle was dropped in the
   // polish redesign — the more-menu that held it is gone).
-  const showActivity = activityItems.length > 0
+  const showActivity = allActivityItems.length > 0
   // Earn promo banner — nudge users with idle private USDC and no vault position yet to start earning.
   const showEarnBanner =
     !showDepositTooltip && balanceNumber > 0 && vaultNumber <= 0 && vaultApy !== undefined && vaultApy > 0
@@ -167,7 +184,7 @@ export function Dashboard() {
 
         {showActivity ? (
           <RecentActivityList
-            items={activityItems}
+            items={previewActivityItems}
             balanceRevealed={!balanceHidden}
             onViewAll={() => setActivityPanelOpen(true)}
             onItemClick={handleActivityItemClick}
@@ -179,7 +196,8 @@ export function Dashboard() {
       <ActivityAllPanel
         open={activityPanelOpen}
         onClose={() => setActivityPanelOpen(false)}
-        items={activityItems}
+        items={panelActivityItems}
+        truncatedCount={activityTruncated ? ACTIVITY_PANEL_MAX : undefined}
         balanceRevealed={!balanceHidden}
         onItemClick={handleActivityItemClick}
       />


### PR DESCRIPTION
The "all activity" panel (View all) only ever showed the **8 most recent** transactions.

### Cause
`Dashboard.tsx` built the activity list once via `buildActivityItems(txList, requestLinks, evmAddress)` — whose `max` **defaults to 8** — and passed that same 8-capped array to *both* the dashboard preview and the `ActivityAllPanel`. The panel does no slicing of its own, so its kind-filter + hash-search could only ever operate on those 8 rows.

### Fix
`Dashboard.tsx` now builds the full (uncapped) list, then derives two views:
- **Preview** (dashboard card) — `ACTIVITY_PREVIEW_MAX` (8), unchanged.
- **Panel** — `ACTIVITY_PANEL_MAX` (500). The panel renders without virtualization, so the count is bounded; a **"Showing your 500 most recent transactions."** note appears **only** when history actually exceeds 500.

No adapter/filter changes — the cap was purely a wiring default.

### Tests
- Adapter: `buildActivityItems(..., Infinity)` returns every row (the panel's full-list path).
- Panel: the truncation note shows only when `truncatedCount` is set.
- Full interface suite: **1202 passing / 8 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)