### PR TITLE
feat(interface): restyle shielded sync display — Armada tick ring

### DIFF
--- a/apps/armada-interface/src/components/sync/SyncGate.module.css
+++ b/apps/armada-interface/src/components/sync/SyncGate.module.css
@@ -1,53 +1,141 @@
 /* ABOUTME: SyncGate styling — centered, prominent initial-sync panel that stands in for the dashboard. */
 /* ABOUTME: Fills the main content area and centers a single narrow panel (progress meter or retry). */
 
-/* Top-anchored (not vertically centered) so the gate → dashboard handoff doesn't jump: the
-   dashboard content is top-aligned, so the gate must be too. A generous top pad keeps the panel
-   prominent in the upper-center while sharing that top anchor. */
+/* Centered horizontally, biased toward the upper-middle vertically (a large bottom pad lifts the
+   centered box above dead-center so it doesn't sit too far down the screen). */
 .root {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   width: 100%;
-  padding: var(--primitives-spacing-16) var(--primitives-spacing-4) var(--primitives-spacing-6);
+  flex: 1;
+  min-height: 60vh;
+  padding: var(--primitives-spacing-6) var(--primitives-spacing-4) 22vh;
 }
 
+/* Fixed box matching the balance card: the card stack is min(420px, 100%) and the card fills it,
+   so the meter takes that width and a fixed height. Content centers within the box. */
 .panel {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: var(--primitives-spacing-4);
-  width: 100%;
-  max-width: 440px;
+  width: min(420px, 100%);
+  height: auto;
   text-align: center;
+  box-sizing: border-box;
 }
 
+/* Same family as the body copy (ui sans), just a little larger + semibold for emphasis. Shared by
+   both the syncing ("Loading your private balance") and failed ("Sync interrupted") states. */
 .heading {
+  margin: 0;
+  font-family: var(--semantic-typography-body-font-family), sans-serif;
+  font-weight: var(--primitives-fontWeight-semibold);
+  font-size: calc(var(--primitives-fontSize-lg) * 1px);
+  line-height: var(--semantic-typography-body-line-height);
+  letter-spacing: var(--semantic-typography-body-letter-spacing);
   color: var(--semantic-color-text-primary);
 }
 
 .body {
-  color: var(--semantic-color-text-secondary);
+  margin: var(--primitives-spacing-2) 0 0;
   max-width: 38ch;
+  font-family: var(--semantic-typography-body-font-family), sans-serif;
+  font-weight: var(--semantic-typography-body-font-weight);
+  font-size: var(--semantic-typography-body-font-size);
+  line-height: var(--semantic-typography-body-line-height);
+  letter-spacing: var(--semantic-typography-body-letter-spacing);
+  color: var(--semantic-color-text-secondary);
 }
 
+/* Rotating tick ring around the Armada mark — mirrors the tx-processing ticker, retinted to the
+   theme lavender (the tx card's white ticks are an exception for its fixed gradient surface). */
+.tickRing {
+  --ring-size: 260px;
+  position: relative;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: var(--ring-size);
+  height: var(--ring-size);
+}
+
+.ringLogo {
+  position: relative;
+  z-index: 1;
+}
+
+.tick {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 1.5px;
+  height: var(--primitives-spacing-2);
+  border-radius: calc(var(--primitives-borderRadius-sm) * 0.5px);
+  background: var(--semantic-color-text-lavender);
+  transform-origin: 50% calc(var(--ring-size) / 2);
+  transform: translate(-50%, calc(var(--ring-size) / -2)) rotate(calc(var(--i) * 6deg));
+  opacity: 0.4;
+  animation: tickSweep 2.1s linear infinite;
+  animation-delay: calc(var(--i) * 0.035s);
+}
+
+@keyframes tickSweep {
+  0% {
+    opacity: 1;
+    width: 3px;
+  }
+
+  12% {
+    opacity: 0.7;
+    width: 2.25px;
+  }
+
+  30% {
+    opacity: 0.45;
+    width: 1.5px;
+  }
+
+  100% {
+    opacity: 0.4;
+    width: 1.5px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tick {
+    animation: none;
+    opacity: 0.55;
+    width: 1.5px;
+  }
+}
+
+/* Dead-centered over the logo, on top of the ring. */
 .pct {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 2;
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-md) * 1px);
+  font-weight: var(--primitives-fontWeight-medium);
   color: var(--semantic-color-text-lavender);
 }
 
-.track {
-  width: 100%;
-  max-width: 320px;
-  height: 6px;
-  background: var(--semantic-color-border-default);
-  border-radius: 999px;
-  overflow: hidden;
+/* Keeps the number + "%" inline on a shared baseline (the .pct grid centers this as one item). */
+.pctValue {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 2px;
+  transform: translateX(2px);
 }
 
-.fill {
-  display: block;
-  height: 100%;
-  background: var(--semantic-color-text-lavender);
-  border-radius: 999px;
-  transition: width 200ms ease-out;
+/* The trailing "%" — a touch smaller + muted so the number reads as the focus. */
+.pctSymbol {
+  font-size: 0.8em;
+  color: var(--semantic-color-text-muted);
 }

--- a/apps/armada-interface/src/components/sync/SyncGate.test.tsx
+++ b/apps/armada-interface/src/components/sync/SyncGate.test.tsx
@@ -35,9 +35,10 @@ describe('<SyncGate>', () => {
     const store = createStore()
     store.set(syncStateAtom, { status: 'syncing', progress: 0.42 })
     render(wrap(store, <SyncGate />))
-    expect(screen.getByText('Loading your private balance')).toBeInTheDocument()
-    expect(screen.getByText('42%')).toBeInTheDocument()
-    expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('42')
+    // The percent lives in the ring's progressbar (number + "%" are separate nodes).
+    const meter = screen.getByRole('progressbar')
+    expect(meter).toHaveTextContent('42%')
+    expect(meter.getAttribute('aria-valuenow')).toBe('42')
     expect(screen.queryByRole('button', { name: /try again/i })).toBeNull()
   })
 
@@ -62,6 +63,6 @@ describe('<SyncGate>', () => {
     expect(store.get(syncStateAtom)).toEqual({ status: 'syncing', progress: 0 })
     // Epoch bump is what re-runs useShieldedBalanceSync's scan.
     expect(store.get(syncRetryEpochAtom)).toBe(1)
-    expect(screen.getByText('Loading your private balance')).toBeInTheDocument()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
 })

--- a/apps/armada-interface/src/components/sync/SyncGate.tsx
+++ b/apps/armada-interface/src/components/sync/SyncGate.tsx
@@ -1,11 +1,41 @@
 // ABOUTME: Full-area gate shown in place of the dashboard while the initial shielded-balance scan runs or after it fails.
 // ABOUTME: Centered progress meter while syncing; a "Try again" button (via useSyncRetry) when the scan failed.
 
+import { useMemo, type CSSProperties } from 'react'
 import { useAtomValue } from 'jotai'
-import { Button } from '@/design'
+import { Button, ArmadaSymbol } from '@/design'
 import { syncStateAtom, type SyncState } from '@/state/wallet'
 import { useSyncRetry } from '@/hooks/useSyncRetry'
 import styles from './SyncGate.module.css'
+
+/** Number of ticks in the animated ring (matches the tx-processing ticker). */
+const TICK_COUNT = 60
+
+/** Rotating tick ring with the Armada mark + live percent stacked at its center — the syncing hero. */
+function ArmadaTickRing({ pct }: { pct: number }) {
+  const ticks = useMemo(() => Array.from({ length: TICK_COUNT }, (_, i) => i), [])
+  return (
+    <div className={styles.tickRing}>
+      {ticks.map((i) => (
+        <span key={i} className={styles.tick} style={{ '--i': i } as CSSProperties} aria-hidden />
+      ))}
+      <ArmadaSymbol size={184} className={styles.ringLogo} />
+      <div
+        className={styles.pct}
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Shielded balance sync progress"
+      >
+        <span className={styles.pctValue}>
+          {pct}
+          <span className={styles.pctSymbol}>%</span>
+        </span>
+      </div>
+    </div>
+  )
+}
 
 /**
  * Whether the dashboard should be replaced by the sync gate. True until the wallet has a known
@@ -42,21 +72,9 @@ export function SyncGate() {
   return (
     <div className={styles.root} role="status" aria-live="polite">
       <div className={styles.panel}>
-        <h2 className={styles.heading}>Loading your private balance</h2>
-        <div className={styles.pct}>{pct}%</div>
-        <div
-          className={styles.track}
-          role="progressbar"
-          aria-valuenow={pct}
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-label="Shielded balance sync progress"
-        >
-          <div className={styles.fill} style={{ width: `${pct}%` }} />
-        </div>
+        <ArmadaTickRing pct={pct} />
         <p className={styles.body}>
-          First sign-in on this device — we walk the chain from the deploy block so any prior
-          activity for your wallet is fully discovered. Subsequent visits are instant.
+          Scanning the chain to load your private balance. This can take a moment.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Restyles the shielded-sync gate (`SyncGate`) — the full-screen display shown while the initial private-balance scan runs (and its failed state).

### Changes
- **Animated tick ring** around a centered **Armada logo** (mirrors the tx-processing ticker; retinted from that card's white-on-gradient exception to the theme lavender, same 60-tick sweep + reduced-motion fallback).
- **Live `%`** sits dead-center, overlaid on the logo (number at `md`; the `%` symbol a touch smaller + muted).
- Meter is centered in the viewport (biased slightly above center), no border.
- **Copy** is now agnostic (was first-sign-in-specific): *"Scanning the chain to load your private balance. This can take a moment."* The "Loading your private balance" heading was dropped from the syncing state.
- **Typography** uses semantic theme tokens for both states; the failed-state heading ("Sync interrupted") is body-family, a step larger + semibold.

Note: this branch briefly carried an on-demand `SyncGatePreview` harness (temp button on the dashboard) used to iterate on the styling; it's been removed and the branch squashed, so the diff here is the restyle only.

### Checks
- `tsc -b` clean; `SyncGate` tests updated for the new markup; full interface suite **1203 passing / 8 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)