### PR TITLE
fix(interface): refetch fee quote at submit + re-review on fee change (fixes FEE_EXPIRED loop)

### DIFF
--- a/apps/armada-interface/src/components/flow/CLAUDE.md
+++ b/apps/armada-interface/src/components/flow/CLAUDE.md
@@ -9,7 +9,8 @@
 | `FlowShell` | **The live modal chrome.** Wraps the vendored `FlowModalOverlay + ModalShell + ModalStepSwitch` from `@/design` — logo + Steps progress + close + backdrop/focus-trap. Every feature modal renders this. Props: `open`, `onClose`, `flowLabel`, `steps`, `currentStep`, `status`, `hideSteps`, `exiting`, `stepKey`. |
 | `useFlowExit` | Close hook — plays `FlowShell`'s slide-down before running the real `onClose` (holds `exiting` for `MODAL_EXIT_TOTAL_MS`; closes synchronously under reduced motion). Each modal wires `const { exiting, requestClose: close } = useFlowExit(() => setOpenModal(null))` and passes `exiting` to `FlowShell`; the atom stays set until the animation ends so the step content stays frozen. |
 | `ProgressStep` | In-flight progress UI for any TxKind — calls `buildProcessingView(record)` and renders `components/tx/processing/TxProcessingLayout` off the live record. |
-| `ErrorStep` | Icon + headline + message + Try Again (disabled when `onRetry` omitted) + optional View Details. |
+| `ErrorStep` | Icon + headline + message + Try Again (disabled when `onRetry` omitted) + optional View Details. Copy comes from `lib/tx/errorCopy.ts` (shared with the ActivityReceipt). |
+| `FeeUpdatedBanner` | Warning-toned Review-step callout shown when a submit-time fee refetch changed the fee (`lib/tx/submitQuote.ts`). Each review step (`ShieldReviewStep` / `SendReviewStep` / `EarnReviewStep`) renders it when its flow reports `feeChanged`, so the user re-confirms the new amount instead of it silently swapping. |
 | `FlowAmountHero` | Big-numeral amount hero used inside step bodies. |
 | `WalletConfirmList` | Per-step "confirm in your wallet" checklist (shield signing sub-state). |
 | `overlayFlow.ts` | `overlayIndicatorStep` / `overlayIndicatorStatus` — map a step string → the ModalShell Steps indicator position + status (default/confirmed/error). Used by the feature modals. |

--- a/apps/armada-interface/src/components/flow/FeeUpdatedBanner/FeeUpdatedBanner.module.css
+++ b/apps/armada-interface/src/components/flow/FeeUpdatedBanner/FeeUpdatedBanner.module.css
@@ -1,0 +1,35 @@
+/* ABOUTME: FeeUpdatedBanner styling — a warning-toned callout (surface-raised + status-warning accent) using theme tokens. */
+
+.banner {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--primitives-spacing-3);
+  width: 100%;
+  padding: var(--primitives-spacing-3) var(--primitives-spacing-4);
+  border-radius: calc(var(--semantic-borderRadius-item) * 1px);
+  background: var(--semantic-color-surface-raised);
+  border-left: 3px solid var(--semantic-color-status-warning);
+  box-sizing: border-box;
+  text-align: left;
+}
+
+.iconTile {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--semantic-color-status-warning);
+}
+
+.icon {
+  width: var(--primitives-spacing-6);
+  height: var(--primitives-spacing-6);
+}
+
+.text {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  line-height: var(--primitives-lineHeight-normal);
+  color: var(--semantic-color-text-secondary);
+}

--- a/apps/armada-interface/src/components/flow/FeeUpdatedBanner/FeeUpdatedBanner.test.tsx
+++ b/apps/armada-interface/src/components/flow/FeeUpdatedBanner/FeeUpdatedBanner.test.tsx
@@ -1,0 +1,19 @@
+// ABOUTME: Render test for FeeUpdatedBanner — the review-step fee-changed callout.
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FeeUpdatedBanner } from './FeeUpdatedBanner'
+
+describe('FeeUpdatedBanner', () => {
+  it('renders the fee-changed callout with the review prompt', () => {
+    render(<FeeUpdatedBanner />)
+    const banner = screen.getByRole('status')
+    expect(banner).toHaveTextContent(/network fee changed/i)
+    expect(banner).toHaveTextContent(/review the updated amount/i)
+  })
+
+  it('appends the new fee when provided', () => {
+    render(<FeeUpdatedBanner feeLabel="$0.12" />)
+    expect(screen.getByRole('status')).toHaveTextContent(/changed to \$0\.12/i)
+  })
+})

--- a/apps/armada-interface/src/components/flow/FeeUpdatedBanner/FeeUpdatedBanner.tsx
+++ b/apps/armada-interface/src/components/flow/FeeUpdatedBanner/FeeUpdatedBanner.tsx
@@ -1,0 +1,24 @@
+// ABOUTME: Review-step banner shown when the relayer's fee changed between review and submit — the modal re-reviews instead of silently swapping the fee.
+// ABOUTME: Presentational; the review step renders it above the summary when its flow reports feeChanged.
+
+import { InformationCircleIcon } from '@heroicons/react/24/outline'
+import styles from './FeeUpdatedBanner.module.css'
+
+export interface FeeUpdatedBannerProps {
+  /** Optional formatted new fee (e.g. "$0.12") — appended to the copy when provided. */
+  feeLabel?: string
+}
+
+export function FeeUpdatedBanner({ feeLabel }: FeeUpdatedBannerProps) {
+  return (
+    <div className={styles.banner} role="status" aria-live="polite">
+      <span className={styles.iconTile} aria-hidden>
+        <InformationCircleIcon className={styles.icon} strokeWidth={1.75} />
+      </span>
+      <span className={styles.text}>
+        The network fee changed{feeLabel ? ` to ${feeLabel}` : ''}. Review the updated amount, then
+        confirm to continue.
+      </span>
+    </div>
+  )
+}

--- a/apps/armada-interface/src/components/payments/SendModal.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.test.tsx
@@ -50,6 +50,27 @@ vi.mock('@/hooks/useGasBalanceWarning', () => ({
   }),
 }))
 
+// Submit always refetches a fresh quote (fee-refresh fix). Mock useFees so refresh() resolves the
+// fake quote deterministically (the real refresh() hits fetchFees → network, unreachable in jsdom).
+const hoistedFees = vi.hoisted(() => ({
+  quote: {
+    cacheId: 'test-cache',
+    expiresAt: 0,
+    chainId: 31337,
+    broadcasterShieldedAddress: '0zk' + 'a'.repeat(64),
+    fees: { transfer: '0', unshield: '0', crossContract: '0', crossChainShield: '0', crossChainUnshield: '0', shield: '0', shieldXchain: '0' },
+  },
+}))
+vi.mock('@/hooks/useFees', () => ({
+  useFees: () => ({
+    quote: hoistedFees.quote,
+    isStale: false,
+    isUnavailable: false,
+    refresh: vi.fn(async () => hoistedFees.quote),
+  }),
+  FEES_QUERY_KEY: ['fees'],
+}))
+
 // The private-send submit path strict-validates the 0zk recipient via the SDK
 // (validateShieldedAddressStrict → dynamic import), which crashes jsdom at load. Keep the sync
 // validators real; stub only the strict async check to pass for the test's fake 0zk fixture.

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -29,6 +29,7 @@ import { cctpFastFeeForAmount, computeFeeBreakdown, userFeeForKind } from '@/lib
 import { isShieldedAddress, validateShieldedAddressStrict } from '@/lib/address'
 import { displayTxHash, txExplorerUrl } from '@/lib/explorer'
 import { canRetryTx } from '@/lib/tx/executor'
+import { resolveFreshQuote } from '@/lib/tx/submitQuote'
 import { trackError } from '@/lib/telemetry'
 import { assertSpendableForFeeOnTop } from '@/lib/tx/spendable'
 import {
@@ -90,6 +91,10 @@ export function SendModal() {
   const [errorAtStep, setErrorAtStep] = useState<FlowVisibleStep | undefined>(undefined)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [submittedKind, setSubmittedKind] = useState<SubmittedKind | null>(null)
+  // Set when a submit-time fee refetch returned a different fee than the one on Review — the flow
+  // stays on Review with the FeeUpdatedBanner so the user re-confirms the new amount. Reset on any
+  // amount change (the reviewed fee is recomputed then anyway).
+  const [feeChanged, setFeeChanged] = useState(false)
 
   // Seed the flow synchronously when it opens from a pay-via-link intent, so the modal starts on
   // Review (recipient + amount are both known) rather than flashing the Recipient step. This runs
@@ -122,7 +127,9 @@ export function SendModal() {
   const max = shieldedUsdcSpendable ?? 0n
   const pendingUsdc = (shieldedUsdc ?? 0n) - max
   const { value: amount } = parseUsdcInput(amountStr)
-  const { quote, isStale, refresh } = useFees()
+  const { quote, refresh } = useFees()
+  // The reviewed fee is recomputed on every amount change, so clear any prior fee-changed flag.
+  useEffect(() => { setFeeChanged(false) }, [amountStr])
   // Gate Confirm while the initial shielded-balance sync is incomplete. Every kind spends the
   // user's shielded USDC, so the same gate applies.
   const syncGate = useSpendableSyncGate()
@@ -271,10 +278,21 @@ export function SendModal() {
     try {
       // null ⇒ submit refused on a follower tab (useTx.submit toasts + persists nothing); stay on review.
       let submittedId: string | null = null
-      // Re-quote if the cached fee is stale — see ShieldModal for the rationale.
-      const activeQuote = quote && !isStale ? quote : await refresh()
+      // Always refetch a fresh cacheId before proof gen (a stale cacheId is the FEE_EXPIRED cause).
+      // If the fee moved since Review, don't submit — bounce back with the FeeUpdatedBanner so the
+      // user re-confirms the new amount ("what you saw is what you pay").
+      const { quote: activeQuote, feeChanged: changed } = await resolveFreshQuote({
+        refresh,
+        reviewedFee: fee,
+        feeOf: (s) => userFeeForKind(computedKind, amount, s),
+      })
       if (!activeQuote) {
         throw new Error('Could not fetch a current fee quote — please try again.')
+      }
+      if (changed) {
+        setFeeChanged(true)
+        setStep('review')
+        return
       }
       const feeCacheId = activeQuote.cacheId
       // S-M5: re-validate amount + the FRESH relayer fee against the balance before proof gen. All
@@ -464,6 +482,7 @@ export function SendModal() {
           networkName={networkName}
           recipientWalletProvider={recipientWalletProvider}
           submitBlockedReason={syncGate.reason}
+          feeUpdated={feeChanged}
           onBack={() => setStep('input')}
           isSubmitting={isSubmitting}
           onConfirm={handleSubmit}

--- a/apps/armada-interface/src/components/payments/SendReviewStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendReviewStep.tsx
@@ -3,6 +3,7 @@
 
 import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { TransferReviewSummary } from './TransferReviewSummary'
+import { FeeUpdatedBanner } from '@/components/flow/FeeUpdatedBanner/FeeUpdatedBanner'
 import { formatUsdcPlain } from '@/lib/format'
 import type { SendFlowVariant } from './SendRecipientStep'
 import styles from './SendReviewStep.module.css'
@@ -24,6 +25,8 @@ export interface SendReviewStepProps {
   submitBlockedReason?: string | null
   /** True while a submit is in flight — disables Confirm so a double-click can't create two txs. */
   isSubmitting?: boolean
+  /** True when a submit-time fee refetch changed the fee — surfaces the FeeUpdatedBanner. */
+  feeUpdated?: boolean
   onBack: () => void
   onConfirm: () => void
 }
@@ -39,6 +42,7 @@ export function SendReviewStep({
   recipientWalletProvider,
   submitBlockedReason,
   isSubmitting,
+  feeUpdated,
   onBack,
   onConfirm,
 }: SendReviewStepProps) {
@@ -54,6 +58,8 @@ export function SendReviewStep({
             <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
           </div>
         </div>
+
+        {feeUpdated ? <FeeUpdatedBanner /> : null}
 
         <TransferReviewSummary
           recipient={recipient}

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -148,6 +148,7 @@ export function ShieldModal() {
             shieldedAddress={shieldFlow.shieldedAddress}
             isSubmitting={shieldFlow.isSubmitting}
             duplicateWarning={shieldFlow.duplicateWarning}
+            feeUpdated={shieldFlow.feeChanged}
             onBack={shieldFlow.onBackToInput}
             onConfirm={shieldFlow.submit}
           />
@@ -162,6 +163,7 @@ export function ShieldModal() {
             networkName={unshieldFlow.networkName}
             recipientWalletProvider={unshieldFlow.recipientWalletProvider}
             submitBlockedReason={unshieldFlow.submitBlockedReason}
+            feeUpdated={unshieldFlow.feeChanged}
             onBack={unshieldFlow.onBackToInput}
             isSubmitting={unshieldFlow.isSubmitting}
             onConfirm={unshieldFlow.submit}

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.tsx
@@ -4,6 +4,7 @@
 import { AlertTriangle } from 'lucide-react'
 import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { DepositReviewSummary } from '@/components/deposit/DepositReviewSummary'
+import { FeeUpdatedBanner } from '@/components/flow/FeeUpdatedBanner/FeeUpdatedBanner'
 import { formatUsdcPlain } from '@/lib/format'
 import styles from './ShieldReviewStep.module.css'
 
@@ -22,6 +23,8 @@ export interface ShieldReviewStepProps {
   isSubmitting?: boolean
   /** S-L7: an unresolved same-amount deposit may still be on-chain — surface a non-blocking caution. */
   duplicateWarning?: boolean
+  /** True when a submit-time fee refetch changed the fee — surfaces the FeeUpdatedBanner. */
+  feeUpdated?: boolean
   onBack: () => void
   onConfirm: () => void
 }
@@ -36,6 +39,7 @@ export function ShieldReviewStep({
   shieldedAddress,
   isSubmitting,
   duplicateWarning,
+  feeUpdated,
   onBack,
   onConfirm,
 }: ShieldReviewStepProps) {
@@ -48,6 +52,8 @@ export function ShieldReviewStep({
             <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
           </div>
         </div>
+
+        {feeUpdated ? <FeeUpdatedBanner /> : null}
 
         <DepositReviewSummary
           fromChainId={fromChainId}

--- a/apps/armada-interface/src/components/yield/EarnModal.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.test.tsx
@@ -46,6 +46,27 @@ vi.mock('@/lib/tx/storage', () => ({
   loadAllTx: vi.fn(async () => []),
 }))
 
+// Submit always refetches a fresh quote (fee-refresh fix). Mock useFees so refresh() resolves the
+// fake quote deterministically (the real refresh() hits fetchFees → network, unreachable in jsdom).
+const hoistedFees = vi.hoisted(() => ({
+  quote: {
+    cacheId: 'test-cache',
+    expiresAt: 0,
+    chainId: 31337,
+    broadcasterShieldedAddress: '0zk' + 'a'.repeat(64),
+    fees: { transfer: '0', unshield: '0', crossContract: '0', crossChainShield: '0', crossChainUnshield: '0', shield: '0', shieldXchain: '0' },
+  },
+}))
+vi.mock('@/hooks/useFees', () => ({
+  useFees: () => ({
+    quote: hoistedFees.quote,
+    isStale: false,
+    isUnavailable: false,
+    refresh: vi.fn(async () => hoistedFees.quote),
+  }),
+  FEES_QUERY_KEY: ['fees'],
+}))
+
 const FAKE_QUOTE = {
   cacheId: 'test-cache',
   expiresAt: Date.now() + 5 * 60_000,

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -17,6 +17,7 @@ import { computeFeeBreakdown, userFeeForKind } from '@/lib/relayer'
 import { isShieldedAddress } from '@/lib/address'
 import { displayTxHash, txExplorerUrl } from '@/lib/explorer'
 import { canRetryTx } from '@/lib/tx/executor'
+import { resolveFreshQuote } from '@/lib/tx/submitQuote'
 import { sharesToUsdc } from '@/lib/yield'
 import { assertSpendableForFeeOnTop } from '@/lib/tx/spendable'
 import {
@@ -72,7 +73,10 @@ export function EarnModal() {
   const pendingUsdc = tab === 'add' ? (shieldedUsdc ?? 0n) - spendableUsdc : 0n
 
   const { value: amount } = parseUsdcInput(amountStr)
-  const { quote, isStale, refresh } = useFees()
+  // Set when a submit-time fee refetch changed the fee — keeps the flow on Review with the banner.
+  const [feeChanged, setFeeChanged] = useState(false)
+  useEffect(() => { setFeeChanged(false) }, [amountStr])
+  const { quote, refresh } = useFees()
   // Yield ops spend the user's shielded USDC (deposit) or shielded yield shares (withdraw).
   // Either way, we need a successful first sync before letting the user submit.
   const syncGate = useSpendableSyncGate()
@@ -213,9 +217,20 @@ export function EarnModal() {
     try {
       // null ⇒ submit refused on a follower tab (useTx.submit toasts + persists nothing); stay on review.
       let submittedId: string | null = null
-      const activeQuote = quote && !isStale ? quote : await refresh()
+      // Always refetch a fresh cacheId before proof gen (a stale cacheId is the FEE_EXPIRED cause);
+      // if the fee moved since Review, bounce back with the banner rather than silently swapping it.
+      const { quote: activeQuote, feeChanged: changed } = await resolveFreshQuote({
+        refresh,
+        reviewedFee: fee,
+        feeOf: (s) => userFeeForKind(yieldKind, amount, s),
+      })
       if (!activeQuote) {
         throw new Error('Could not fetch a current fee quote — please try again.')
+      }
+      if (changed) {
+        setFeeChanged(true)
+        setStep('review')
+        return
       }
       const feeCacheId = activeQuote.cacheId
       // Same broadcaster address guard as Send / Unshield — fail fast if the relayer published
@@ -347,6 +362,7 @@ export function EarnModal() {
           netAmount={displayNetAmount}
           netLabel={displayNetLabel}
           submitBlockedReason={submitBlockedReason}
+          feeUpdated={feeChanged}
           onBack={() => setStep('input')}
           isSubmitting={isSubmitting}
           onConfirm={handleSubmit}

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
@@ -3,6 +3,7 @@
 
 import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { EarnReviewSummary } from './EarnReviewSummary'
+import { FeeUpdatedBanner } from '@/components/flow/FeeUpdatedBanner/FeeUpdatedBanner'
 import { formatUsdcPlain } from '@/lib/format'
 import type { YieldRate } from '@/hooks/useYieldRate'
 import type { EarnTab } from './EarnInputStep'
@@ -25,6 +26,8 @@ export interface EarnReviewStepProps {
   submitBlockedReason?: string | null
   /** True while a submit is in flight — disables Confirm so a double-click can't create two txs. */
   isSubmitting?: boolean
+  /** True when a submit-time fee refetch changed the fee — surfaces the FeeUpdatedBanner. */
+  feeUpdated?: boolean
   onBack: () => void
   onConfirm: () => void
 }
@@ -38,6 +41,7 @@ export function EarnReviewStep({
   netLabel,
   submitBlockedReason,
   isSubmitting,
+  feeUpdated,
   onBack,
   onConfirm,
 }: EarnReviewStepProps) {
@@ -53,6 +57,8 @@ export function EarnReviewStep({
             <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
           </div>
         </div>
+
+        {feeUpdated ? <FeeUpdatedBanner /> : null}
 
         <EarnReviewSummary
           tab={tab}

--- a/apps/armada-interface/src/hooks/useShieldFlow.ts
+++ b/apps/armada-interface/src/hooks/useShieldFlow.ts
@@ -18,6 +18,7 @@ import { getNetworkConfig } from '@/config/network'
 import { loadDeployments } from '@/config/deployments'
 import { formatUsdc, parseUsdcInput } from '@/lib/format'
 import { canRetryTx } from '@/lib/tx/executor'
+import { resolveFreshQuote } from '@/lib/tx/submitQuote'
 import { hasUnresolvedShield } from '@/lib/tx/duplicateGuard'
 import {
   shieldWalletSteps,
@@ -66,6 +67,8 @@ export interface ShieldFlow {
   minAmount: bigint
   useGasless: boolean
   duplicateWarning: boolean
+  /** True when a submit-time fee refetch changed the fee — the review step shows the FeeUpdatedBanner. */
+  feeChanged: boolean
   // Review addresses
   evmAddress?: string
   walletProvider?: string
@@ -103,6 +106,8 @@ export function useShieldFlow(isOpen: boolean): ShieldFlow {
   const [errorAtStep, setErrorAtStep] = useState<FlowVisibleStep | undefined>(undefined)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [submittedKind, setSubmittedKind] = useState<SubmittedKind | null>(null)
+  // Set when a submit-time fee refetch changed the fee — keeps the flow on Review with the banner.
+  const [feeChanged, setFeeChanged] = useState(false)
   // Double-submit guard (P0-7). The ref is the synchronous gate (state updates are async, so a
   // rapid second click would otherwise pass an `isSubmitting` state check); the state drives the
   // Confirm button's disabled prop so the button visibly locks during the pre-submit refresh().
@@ -112,6 +117,8 @@ export function useShieldFlow(isOpen: boolean): ShieldFlow {
   const balances = useBalances()
   const max = balances.unshielded[fromChainId] ?? 0n
   const { value: amount } = parseUsdcInput(amountStr)
+  // The reviewed fee is recomputed on every amount change, so clear any prior fee-changed flag.
+  useEffect(() => { setFeeChanged(false) }, [amountStr])
 
   // S-L7: warn (non-blocking) at review when an unresolved same-amount deposit may still be on
   // chain — between a POLL_TIMEOUT'd shield and history recovery confirming it, re-depositing the
@@ -160,7 +167,7 @@ export function useShieldFlow(isOpen: boolean): ShieldFlow {
   // gas costs do (Base Sepolia ≠ Ethereum Sepolia). Pass `fromChainId` so useFees fetches the
   // matching schedule from `/fees?chainId=...`.
   const feeChainId = computedKind === 'shield-xchain' && useGasless ? fromChainId : undefined
-  const { quote, isStale, refresh } = useFees({ chainId: feeChainId })
+  const { quote, refresh } = useFees({ chainId: feeChainId })
   // Display fee — for the gasless `shield` path this reads `quote.fees.shield`; for gasless
   // `shield-xchain` it reads `quote.fees.shieldXchain` from the source chain's quote. Direct
   // paths preserve their existing semantics (0 for hub shield, CCTP fast-fee estimate for
@@ -268,11 +275,20 @@ export function useShieldFlow(isOpen: boolean): ShieldFlow {
       // null ⇒ submit was refused on a follower tab (useTx.submit toasts + persists nothing); we
       // keep the user on the review step rather than advancing to a never-driven progress spinner.
       let submittedId: string | null = null
-      // Submit with a fresh cacheId — if the cached quote is within the staleness window the
-      // modal sat through, re-quote first so the relayer doesn't reject with FEE_EXPIRED.
-      const activeQuote = quote && !isStale ? quote : await refresh()
+      // Always refetch a fresh cacheId before proof gen (a stale cacheId is the FEE_EXPIRED cause);
+      // if the fee moved since Review, bounce back with the banner rather than silently swapping it.
+      const { quote: activeQuote, feeChanged: changed } = await resolveFreshQuote({
+        refresh,
+        reviewedFee: fee,
+        feeOf: (s) => userFeeForKind(computedKind, amount, s, { gasless: useGasless }),
+      })
       if (!activeQuote) {
         throw new Error('Could not fetch a current fee quote — please try again.')
+      }
+      if (changed) {
+        setFeeChanged(true)
+        setStep('review')
+        return
       }
       if (computedKind === 'shield') {
         setSubmittedKind('shield')
@@ -407,6 +423,7 @@ export function useShieldFlow(isOpen: boolean): ShieldFlow {
     minAmount,
     useGasless,
     duplicateWarning,
+    feeChanged,
     evmAddress,
     walletProvider: connector?.name,
     shieldedAddress: shieldedWallet.shieldedAddress,

--- a/apps/armada-interface/src/hooks/useUnshieldFlow.ts
+++ b/apps/armada-interface/src/hooks/useUnshieldFlow.ts
@@ -16,6 +16,7 @@ import { findDeploymentForChain, loadDeployments, type ResolvedDeployments } fro
 import { parseUsdcInput } from '@/lib/format'
 import { isShieldedAddress } from '@/lib/address'
 import { canRetryTx } from '@/lib/tx/executor'
+import { resolveFreshQuote } from '@/lib/tx/submitQuote'
 import { trackError } from '@/lib/telemetry'
 import { assertSpendableForFeeOnTop } from '@/lib/tx/spendable'
 import type { FlowStep, FlowVisibleStep } from '@/components/flow'
@@ -45,6 +46,8 @@ export interface UnshieldFlow {
   flowBreakdown: FlowFeeBreakdown
   /** Inclusive fee (broadcaster + on-chain protocol + CCTP) shown on the review/complete cards. */
   feeInclusive: bigint
+  /** True when a submit-time fee refetch changed the fee — the review step shows the FeeUpdatedBanner. */
+  feeChanged: boolean
   totalDeducted: bigint
   inputMax: bigint
   isXchain: boolean
@@ -87,6 +90,8 @@ export function useUnshieldFlow(isOpen: boolean): UnshieldFlow {
   const [errorAtStep, setErrorAtStep] = useState<FlowVisibleStep | undefined>(undefined)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [submittedKind, setSubmittedKind] = useState<SubmittedKind | null>(null)
+  // Set when a submit-time fee refetch changed the fee — keeps the flow on Review with the banner.
+  const [feeChanged, setFeeChanged] = useState(false)
   const submittingRef = useRef(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
@@ -97,7 +102,9 @@ export function useUnshieldFlow(isOpen: boolean): UnshieldFlow {
   const max = shieldedUsdcSpendable ?? 0n
   const pendingUsdc = (shieldedUsdc ?? 0n) - max
   const { value: amount } = parseUsdcInput(amountStr)
-  const { quote, isStale, refresh } = useFees()
+  // The reviewed fee is recomputed on every amount change, so clear any prior fee-changed flag.
+  useEffect(() => { setFeeChanged(false) }, [amountStr])
+  const { quote, refresh } = useFees()
   // Gate Confirm while the initial shielded-balance sync is incomplete — every unshield spends
   // the user's shielded USDC.
   const syncGate = useSpendableSyncGate()
@@ -202,10 +209,20 @@ export function useUnshieldFlow(isOpen: boolean): UnshieldFlow {
     setSubmitError(null)
     try {
       let submittedId: string | null = null
-      // Re-quote if the cached fee is stale — see ShieldModal for the rationale.
-      const activeQuote = quote && !isStale ? quote : await refresh()
+      // Always refetch a fresh cacheId before proof gen (a stale cacheId is the FEE_EXPIRED cause);
+      // if the fee moved since Review, bounce back with the banner rather than silently swapping it.
+      const { quote: activeQuote, feeChanged: changed } = await resolveFreshQuote({
+        refresh,
+        reviewedFee: fee,
+        feeOf: (s) => userFeeForKind(computedKind, amount, s),
+      })
       if (!activeQuote) {
         throw new Error('Could not fetch a current fee quote — please try again.')
+      }
+      if (changed) {
+        setFeeChanged(true)
+        setStep('review')
+        return
       }
       const feeCacheId = activeQuote.cacheId
       // S-M5: re-validate amount + the FRESH relayer fee against the balance before proof gen. Both
@@ -291,6 +308,7 @@ export function useUnshieldFlow(isOpen: boolean): UnshieldFlow {
     feeLoading,
     flowBreakdown,
     feeInclusive,
+    feeChanged,
     totalDeducted,
     inputMax,
     isXchain,

--- a/apps/armada-interface/src/lib/tx/CLAUDE.md
+++ b/apps/armada-interface/src/lib/tx/CLAUDE.md
@@ -13,6 +13,8 @@ Transaction lifecycle model. The most important architectural surface in this ap
 | `executor.ts` | **Module-scope** execution engine. Runs stage handlers outside React, owns AbortControllers, leader-elected via `navigator.locks`. |
 | `poller.ts` | Generic abortable / jittered / backoff-aware poll loop. Stage-specific adapters (Iris, RPC, relayer) plug in here. |
 | `recentRecipients.ts` | Pure `deriveRecentRecipients(records, {hubChainId, limit})` — the Send flow's recent-recipients list from settled history (dedupe by normalized address, newest-first, completed-only, per-kind destination chain). Consumed via `hooks/useRecentRecipients`. |
+| `submitQuote.ts` | `resolveFreshQuote({refresh, reviewedFee, feeOf})` — every submit path (shield/unshield/transfer/yield) refetches a fresh `cacheId` right before proof gen (a stale cacheId is the relayer `FEE_EXPIRED` cause) and flags `feeChanged` when the fresh fee differs from the reviewed one, so the modal re-reviews (FeeUpdatedBanner) instead of silently swapping the fee. |
+| `errorCopy.ts` | `TX_ERROR_COPY` + `resolveTxErrorCopy(error, fallback)` — category-aware failed/cancelled copy shared by the live `ErrorStep` modal + the `ActivityReceipt`. |
 
 ## Invariants
 

--- a/apps/armada-interface/src/lib/tx/submitQuote.test.ts
+++ b/apps/armada-interface/src/lib/tx/submitQuote.test.ts
@@ -1,0 +1,49 @@
+// ABOUTME: Tests for resolveFreshQuote — always refetches; flags feeChanged only when the fresh fee differs from the reviewed one.
+
+import { describe, it, expect, vi } from 'vitest'
+import { resolveFreshQuote } from './submitQuote'
+import type { FeeSchedule } from '@/lib/relayer'
+
+function quote(cacheId: string, transfer: string): FeeSchedule {
+  return {
+    cacheId,
+    expiresAt: 0,
+    chainId: 31337,
+    broadcasterShieldedAddress: '0zk',
+    fees: {
+      transfer,
+      unshield: '0',
+      crossContract: '0',
+      crossChainShield: '0',
+      crossChainUnshield: '0',
+      shield: '0',
+      shieldXchain: '0',
+    },
+  } as unknown as FeeSchedule
+}
+
+const feeOf = (s: FeeSchedule) => BigInt(s.fees.transfer)
+
+describe('resolveFreshQuote', () => {
+  it('same fee → not changed (submit with the fresh cacheId)', async () => {
+    const refresh = vi.fn(async () => quote('fresh-cache', '100'))
+    const result = await resolveFreshQuote({ refresh, reviewedFee: 100n, feeOf })
+    expect(refresh).toHaveBeenCalledOnce()
+    expect(result.feeChanged).toBe(false)
+    expect(result.quote?.cacheId).toBe('fresh-cache') // fresh cacheId even when the fee is identical
+  })
+
+  it('different fee → changed (caller re-reviews)', async () => {
+    const refresh = vi.fn(async () => quote('fresh-cache', '250'))
+    const result = await resolveFreshQuote({ refresh, reviewedFee: 100n, feeOf })
+    expect(result.feeChanged).toBe(true)
+    expect(result.quote?.cacheId).toBe('fresh-cache')
+  })
+
+  it('relayer unreachable (null) → quote null, not changed', async () => {
+    const refresh = vi.fn(async () => null)
+    const result = await resolveFreshQuote({ refresh, reviewedFee: 100n, feeOf })
+    expect(result.quote).toBeNull()
+    expect(result.feeChanged).toBe(false)
+  })
+})

--- a/apps/armada-interface/src/lib/tx/submitQuote.ts
+++ b/apps/armada-interface/src/lib/tx/submitQuote.ts
@@ -1,0 +1,36 @@
+// ABOUTME: Submit-time fee-quote refresh + reviewed-vs-fresh fee compare, shared by the shield/unshield/transfer/yield submit paths.
+// ABOUTME: Always refetches a fresh cacheId before proof gen (a stale cacheId is the FEE_EXPIRED cause); flags when the fee changed so the modal re-reviews instead of silently swapping the reviewed fee.
+
+import type { FeeSchedule } from '@/lib/relayer'
+
+export interface ResolveFreshQuoteResult {
+  /** The freshly fetched quote to submit with; null when the relayer couldn't be reached. */
+  quote: FeeSchedule | null
+  /** True when the fresh fee differs from what the user reviewed — the caller should re-review (not submit). */
+  feeChanged: boolean
+}
+
+/**
+ * Force a fresh quote and compare its fee against the one the user reviewed.
+ *
+ *   - `quote === null`   → relayer unreachable; the caller surfaces "could not fetch a quote".
+ *   - `feeChanged`       → the fee moved since Review; the caller bounces to Review (don't submit).
+ *   - otherwise          → submit with `quote` (a fresh `cacheId`; the fee matches what was reviewed).
+ *
+ * Always refetches — never reuses the cached quote — so the `cacheId` frozen into the proof is as
+ * fresh as possible before the 20–30s proof generation, which is where a stale cacheId turns into a
+ * relayer `FEE_EXPIRED`. A rotated `cacheId`/broadcaster address with an UNCHANGED fee flows through
+ * transparently; only a fee-value change gates re-review, preserving "what you saw is what you pay".
+ *
+ * `feeOf` extracts the comparable fee (the relayer tier for the kind). Exact bigint equality — fees
+ * are integer amounts, no tolerance.
+ */
+export async function resolveFreshQuote(args: {
+  refresh: () => Promise<FeeSchedule | null>
+  reviewedFee: bigint
+  feeOf: (schedule: FeeSchedule) => bigint
+}): Promise<ResolveFreshQuoteResult> {
+  const quote = await args.refresh()
+  if (!quote) return { quote: null, feeChanged: false }
+  return { quote, feeChanged: args.feeOf(quote) !== args.reviewedFee }
+}


### PR DESCRIPTION
Fixes two `FEE_EXPIRED` bugs:
1. **Intermittent first-attempt failure** — the interface reused a cached fee `cacheId` for up to 4 min on its own clock, so a quote the relayer had already rotated/expired got frozen into the proof.
2. **The loop** — after "Start over" on a `FEE_EXPIRED`, the flow re-submitted the *same* dead `cacheId` (still "fresh" by our clock) and failed again until a tab refresh.

### The fix (fix 2 in the diagnosis — it subsumes fix 1)
Every submit path now **always refetches a fresh quote right before proof gen** instead of trusting the client-clock staleness window. New shared helper `lib/tx/submitQuote.ts::resolveFreshQuote({ refresh, reviewedFee, feeOf })`:
- refetches → freshest `cacheId` goes into the proof (kills the intermittent failure);
- **self-heals the loop** — Start-over → next submit refetches → new `cacheId` (no tab refresh);
- **compares the fresh fee to the reviewed fee** (exact bigint): if unchanged, submit with the fresh `cacheId` transparently; if it moved, **don't submit** — bounce to Review with a `FeeUpdatedBanner` so the user re-confirms. Preserves "what you saw is what you pay". A rotated `cacheId`/broadcaster address with an unchanged fee flows through silently.

Because every submit already refetches, the separate "invalidate-on-FEE_EXPIRED" idea is redundant — this covers both bugs.

### Scope
All four submit flows: `SendModal`, `useShieldFlow` (Shield), `useUnshieldFlow` (Unshield), `EarnModal`. New `FeeUpdatedBanner` (theme-tokened, `status-warning` accent) rendered by `ShieldReviewStep` / `SendReviewStep` / `EarnReviewStep` when the flow reports `feeChanged` (reset on any amount change).

### Cost / caveat
One extra `/fees` round-trip per submit (fast). A quote can still rotate *during* the 20–30s proof gen after the refetch — that residual tail surfaces as a normal `FEE_EXPIRED` that now self-heals on the next Start-over (no loop, no refresh).

### Tests
`resolveFreshQuote` (same/different/null), `FeeUpdatedBanner` render, and the flow test mocks updated for the always-refetch path. Full interface suite **1213 passing / 8 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)