### PR TITLE
fix(interface): amount input validation + mockup error-display alignment

### DIFF
--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
@@ -206,6 +206,10 @@
   letter-spacing: 0;
 }
 
+.balanceTextError {
+  color: var(--semantic-color-status-error);
+}
+
 .feeText,
 .chainOptionLabel {
   font-family: var(--primitives-fontFamily-ui), sans-serif;
@@ -318,6 +322,11 @@
   color: var(--semantic-color-text-primary);
 }
 
+/* Error state — reddens the amount numeral (overrides the active colour; must follow it). */
+.amountDisplayError {
+  color: var(--semantic-color-status-error);
+}
+
 .amountInput {
   position: absolute;
   inset: 0;
@@ -382,6 +391,10 @@
   color: color-mix(in srgb, var(--semantic-color-text-primary) 38%, transparent);
 }
 
+.walletIconError {
+  color: var(--semantic-color-status-error);
+}
+
 .maxBtn {
   display: inline-flex;
   align-items: center;
@@ -405,12 +418,4 @@
 .maxBtn:focus-visible {
   outline: 2px solid var(--semantic-color-border-focus);
   outline-offset: 2px;
-}
-
-.amountError {
-  margin: 0;
-  text-align: center;
-  font-family: var(--primitives-fontFamily-ui), sans-serif;
-  font-size: calc(var(--primitives-fontSize-sm) * 1px);
-  color: var(--semantic-color-status-error);
 }

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.test.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.test.tsx
@@ -56,6 +56,30 @@ describe('DepositAmountCard — pendingBalance', () => {
   })
 })
 
+describe('DepositAmountCard — amount typing', () => {
+  it('passes a leading 0 / . through instead of discarding it (sub-one amounts are typeable)', () => {
+    // Regression: the card used to rewrite `0`/`.` to '' via hasActiveAmount, so a user could not
+    // start typing "0.5" — the leading 0 or . vanished. Each keystroke must now commit forward.
+    const onAmountChange = vi.fn()
+    renderCard({ amount: '', onAmountChange, amountAriaLabel: 'Deposit amount' })
+    const input = screen.getByLabelText('Deposit amount')
+    fireEvent.change(input, { target: { value: '0' } })
+    expect(onAmountChange).toHaveBeenLastCalledWith('0')
+    fireEvent.change(input, { target: { value: '.' } })
+    expect(onAmountChange).toHaveBeenLastCalledWith('.')
+  })
+
+  it('caps typed input at 6 decimals and collapses leading zeros', () => {
+    const onAmountChange = vi.fn()
+    renderCard({ amount: '', onAmountChange, amountAriaLabel: 'Deposit amount' })
+    const input = screen.getByLabelText('Deposit amount')
+    fireEvent.change(input, { target: { value: '1.1234567' } })
+    expect(onAmountChange).toHaveBeenLastCalledWith('1.123456')
+    fireEvent.change(input, { target: { value: '05' } })
+    expect(onAmountChange).toHaveBeenLastCalledWith('5')
+  })
+})
+
 describe('DepositAmountCard — presets + amount roll', () => {
   it('commits a fraction of maxInput when a percentage pill is clicked', () => {
     const onAmountChange = vi.fn()

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.test.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.test.tsx
@@ -78,6 +78,18 @@ describe('DepositAmountCard — amount typing', () => {
     fireEvent.change(input, { target: { value: '05' } })
     expect(onAmountChange).toHaveBeenLastCalledWith('5')
   })
+
+  it('renders the amount with thousand grouping while storing it ungrouped', () => {
+    // The input shows "1,000,000" but the sanitizer strips the commas on the next keystroke.
+    const onAmountChange = vi.fn()
+    renderCard({ amount: '1000000', onAmountChange, amountAriaLabel: 'Deposit amount' })
+    expect(screen.getByLabelText('Deposit amount')).toHaveValue('1,000,000')
+  })
+
+  it('surfaces the amount error as an above-field alert (tooltip), not inline below', () => {
+    renderCard({ amount: '5', error: "That's more than you can deposit" })
+    expect(screen.getByRole('alert')).toHaveTextContent("That's more than you can deposit")
+  })
 })
 
 describe('DepositAmountCard — presets + amount roll', () => {

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
@@ -190,8 +190,12 @@ export function DepositAmountCard({
   function handleAmountInput(raw: string) {
     clearAmountRoll()
     pendingRollFromRef.current = null
-    const next = sanitizeAmountInput(raw)
-    onAmountChange(hasActiveAmount(next) ? next : '')
+    // Pass the sanitized value straight through — including forward-typing states like `0`, `.`,
+    // and `0.` that `hasActiveAmount` reports false. Rewriting those to `''` (the previous
+    // behaviour) discarded a leading `0`/`.` keystroke, making sub-one amounts impossible to type.
+    // `hasActiveAmount` still gates display styling (`showActiveAmount`) and the `amount > 0n`
+    // submit checks, so a bare `0`/`.` never advances the flow.
+    onAmountChange(sanitizeAmountInput(raw))
   }
 
   /** Mark the current display as the roll origin, then apply the preset amount (the effect rolls it). */
@@ -306,6 +310,11 @@ export function DepositAmountCard({
               id={amountInputId}
               type="text"
               inputMode="decimal"
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+              data-1p-ignore
+              data-lpignore="true"
               className={[styles.amountInput, isAmountRolling && styles.amountValueHidden]
                 .filter(Boolean)
                 .join(' ')}
@@ -336,7 +345,7 @@ export function DepositAmountCard({
         <div className={`armada-text-ui-label-md ${styles.feeCaption}`} role="status">
           {showFee && displayFees ? (
             <>
-              <span>+ ${formatUsdcAmount(totalFeeRaw, { decimals: 2 })} FEE</span>
+              <span>+ ${formatUsdcAmount(totalFeeRaw)} FEE</span>
               <FeeBreakdownTooltip
                 fees={displayFees}
                 isLoading={feeLoading}

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
@@ -3,8 +3,9 @@
 
 import { useEffect, useId, useRef, useState, type ReactNode } from 'react'
 import { ChevronDownIcon, WalletIcon } from '@heroicons/react/24/solid'
-import { hasActiveAmount, sanitizeAmountInput } from '@/utils/amountInput'
+import { formatAmountInputDisplay, hasActiveAmount, sanitizeAmountInput } from '@/utils/amountInput'
 import { chainIconForChainId } from '@/components/ui/chainIcons'
+import { AmountFieldWarning } from '@/components/ui/AmountFieldWarning'
 import { FeeBreakdownTooltip, type FlowFeeBreakdown } from '@/components/ui/FeeBreakdownTooltip'
 import { RollingBalanceValue } from '@/components/dashboard/RollingBalanceValue'
 import {
@@ -119,6 +120,7 @@ export function DepositAmountCard({
   const chainRootRef = useRef<HTMLDivElement>(null)
   const listboxId = useId()
   const amountInputId = useId()
+  const amountErrorId = useId()
 
   const selected = chains.find((c) => c.chainId === chainId) ?? chains[0]
   const chainSelectable = Boolean(onChainIdChange) && chains.length > 1
@@ -224,6 +226,12 @@ export function DepositAmountCard({
 
   const showActiveAmount = hasActiveAmount(amount)
   const isAmountRolling = amountRoll !== null
+  // Thousand-grouped for display only ("1,000,000"); the stored `amount` stays ungrouped and the
+  // sanitizer strips the commas back out on the next keystroke (mockup parity).
+  const displayAmount = formatAmountInputDisplay(amount)
+  // Any validation error (over-balance, below-minimum, parse, withdraw fee-shortfall) reddens the
+  // amount numeral + balance row (mockup parity) alongside the above-field warning tooltip.
+  const hasError = Boolean(error)
 
   // Total displayed fee (protocol + broadcaster + CCTP). Rendered as the under-amount caption
   // ("+ $X.XX FEE") once an amount is entered and the fee is non-zero — matching the mockup, which
@@ -289,6 +297,7 @@ export function DepositAmountCard({
       <div className={styles.amountStack}>
         <label className={styles.amountWrapper} htmlFor={amountInputId}>
           <span className={styles.visuallyHidden}>{amountAriaLabel}</span>
+          <AmountFieldWarning id={amountErrorId} visible={Boolean(error)} message={error ?? ''}>
           <span
             className={[styles.amountField, showActiveAmount && styles.amountFieldHasValue]
               .filter(Boolean)
@@ -298,13 +307,14 @@ export function DepositAmountCard({
               className={[
                 styles.amountDisplay,
                 showActiveAmount && styles.amountDisplayActive,
+                hasError && styles.amountDisplayError,
                 isAmountRolling && styles.amountValueHidden,
               ]
                 .filter(Boolean)
                 .join(' ')}
               aria-hidden="true"
             >
-              {showActiveAmount ? amount : '0'}
+              {showActiveAmount ? displayAmount : '0'}
             </span>
             <input
               id={amountInputId}
@@ -318,18 +328,19 @@ export function DepositAmountCard({
               className={[styles.amountInput, isAmountRolling && styles.amountValueHidden]
                 .filter(Boolean)
                 .join(' ')}
-              value={amount}
+              value={displayAmount}
               onChange={(e) => handleAmountInput(e.target.value)}
               aria-label={amountAriaLabel}
               aria-invalid={Boolean(error)}
+              aria-describedby={error ? amountErrorId : undefined}
               readOnly={isAmountRolling}
             />
             {isAmountRolling && amountRoll ? (
               <span className={styles.amountRollLayer} aria-hidden>
                 <RollingBalanceValue
                   key={amountRoll.trigger}
-                  value={amountRoll.toValue}
-                  fromValue={amountRoll.fromValue}
+                  value={formatAmountInputDisplay(amountRoll.toValue)}
+                  fromValue={formatAmountInputDisplay(amountRoll.fromValue)}
                   mode="fromValue"
                   rollTrigger={amountRoll.trigger}
                   rollStartMs={0}
@@ -337,6 +348,7 @@ export function DepositAmountCard({
               </span>
             ) : null}
           </span>
+          </AmountFieldWarning>
         </label>
 
         {/* Fee caption (mockup): "+ $X.XX FEE" directly under the amount. The line is always
@@ -358,18 +370,22 @@ export function DepositAmountCard({
         </div>
       </div>
 
-      {error ? (
-        <p className={styles.amountError} role="alert">
-          {error}
-        </p>
-      ) : null}
       </div>
 
       <div className={styles.bottomRow}>
         <div className={styles.balanceControls}>
           <div className={styles.balanceGroup}>
-            <WalletIcon className={styles.walletIcon} aria-hidden />
-            <span className={styles.balanceText}>
+            <WalletIcon
+              className={[styles.walletIcon, hasError && styles.walletIconError]
+                .filter(Boolean)
+                .join(' ')}
+              aria-hidden
+            />
+            <span
+              className={[styles.balanceText, hasError && styles.balanceTextError]
+                .filter(Boolean)
+                .join(' ')}
+            >
               {balance}
               {pendingBalance ? ` · ${pendingBalance} pending` : ''}
             </span>

--- a/apps/armada-interface/src/components/payments/SendInputStep.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendInputStep.test.tsx
@@ -76,8 +76,8 @@ describe('<SendInputStep>', () => {
 
   it('gates Review on the amount — too much shows an error and disables Review', () => {
     setup({ amountStr: '10', maxInput: 5_000_000n, max: 5_000_000n })
-    expect(screen.getByText(/exceeds your private balance/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Review/ })).toBeDisabled()
+    expect(screen.getByText(/more than you can send/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
   })
 
   it('enables Review + fires onContinue for a valid amount', () => {

--- a/apps/armada-interface/src/components/payments/SendInputStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendInputStep.tsx
@@ -81,7 +81,7 @@ export function SendInputStepContent({
   const showGasNotice = !gaslessMode && gasWarning.show
   const tooMuch = amount > maxInput
   const amountError = usdcInputErrorMessage(parseError)
-    ?? (tooMuch ? 'Amount exceeds your private balance after fees.' : undefined)
+    ?? (tooMuch ? "That's more than you can send" : undefined)
 
   return (
     <div className={`${styles.sendContent} ${modalStepBodyEnter}`}>
@@ -138,7 +138,7 @@ export function SendInputStepFooter({
       <Button
         variant="primary"
         size="lg"
-        label="Review"
+        label={canReview ? 'Review' : 'Input amount'}
         showIcon={false}
         disabled={!canReview}
         onClick={onContinue}

--- a/apps/armada-interface/src/components/shield/ShieldAmountStep.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldAmountStep.test.tsx
@@ -87,17 +87,24 @@ describe('ShieldAmountStepContent (direction)', () => {
 describe('ShieldAmountStepFooter (Review gating)', () => {
   it('disables Review when the amount is empty', () => {
     renderFooter('')
-    expect(screen.getByRole('button', { name: /Review/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
+  })
+
+  it("labels the CTA 'Input amount' when there is no valid amount", () => {
+    // Mockup parity: the disabled primary CTA is instructional ("Input amount"), not a dead "Review".
+    // The enabled-state "Review" label is covered by 'enables Review for a positive amount'.
+    renderFooter('')
+    expect(screen.getByRole('button', { name: 'Input amount' })).toBeInTheDocument()
   })
 
   it('disables Review when the amount is 0', () => {
     renderFooter('0')
-    expect(screen.getByRole('button', { name: /Review/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
   })
 
   it('disables Review when the amount exceeds maxInput', () => {
     renderFooter('200') // maxInput = 100 USDC
-    expect(screen.getByRole('button', { name: /Review/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
   })
 
   it('enables Review for a positive amount within maxInput', () => {
@@ -107,7 +114,7 @@ describe('ShieldAmountStepFooter (Review gating)', () => {
 
   it('rejects an amount at or below the relayer-fee floor (shield)', () => {
     renderFooter('1', 1_000_000n) // minAmount = 1 USDC; amount = 1 → not > fee
-    expect(screen.getByRole('button', { name: /Review/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
   })
 
   it('fires onContinue / onCancel from the CTAs', () => {

--- a/apps/armada-interface/src/components/shield/ShieldAmountStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldAmountStep.tsx
@@ -73,9 +73,13 @@ export function ShieldAmountStepContent({
   const tooSmall = minAmount > 0n && amount > 0n && amount <= minAmount
   const errorMessage =
     usdcInputErrorMessage(parseError) ??
-    (tooMuch ? 'Amount exceeds your available balance.' : undefined) ??
+    (tooMuch
+      ? isShield
+        ? "That's more than you can deposit"
+        : "That's more than you can unshield"
+      : undefined) ??
     (tooSmall
-      ? `Amount must be greater than the relayer fee (${formatUsdcPlain(minAmount)} USDC).`
+      ? `That's below the relayer fee (${formatUsdcPlain(minAmount)} USDC)`
       : undefined)
 
   return (
@@ -144,7 +148,7 @@ export function ShieldAmountStepFooter({
       <Button
         variant="primary"
         size="lg"
-        label="Review"
+        label={canReview ? 'Review' : 'Input amount'}
         showIcon={false}
         disabled={!canReview}
         onClick={onContinue}

--- a/apps/armada-interface/src/components/ui/AmountFieldWarning/AmountFieldWarning.module.css
+++ b/apps/armada-interface/src/components/ui/AmountFieldWarning/AmountFieldWarning.module.css
@@ -1,0 +1,13 @@
+/* ABOUTME: Positioning wrapper for the amount-field warning tooltip (relative anchor + above-the-field offset). */
+/* ABOUTME: Visual styling comes from the composed @/design Tooltip .tooltip/.action classes; this only positions. */
+
+.wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.tooltip {
+  bottom: calc(100% + var(--primitives-spacing-4));
+}

--- a/apps/armada-interface/src/components/ui/AmountFieldWarning/AmountFieldWarning.test.tsx
+++ b/apps/armada-interface/src/components/ui/AmountFieldWarning/AmountFieldWarning.test.tsx
@@ -1,0 +1,28 @@
+// ABOUTME: Render tests for AmountFieldWarning — the above-field alert tooltip for amount validation errors.
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AmountFieldWarning } from './AmountFieldWarning'
+
+describe('<AmountFieldWarning>', () => {
+  it('shows the message as an alert above its children when visible', () => {
+    render(
+      <AmountFieldWarning id="warn" visible message="That's more than you can deposit">
+        <input aria-label="Amount" />
+      </AmountFieldWarning>,
+    )
+    expect(screen.getByRole('alert')).toHaveTextContent("That's more than you can deposit")
+    // The field it wraps is still rendered.
+    expect(screen.getByLabelText('Amount')).toBeInTheDocument()
+  })
+
+  it('renders no alert when not visible', () => {
+    render(
+      <AmountFieldWarning id="warn" visible={false} message="hidden">
+        <input aria-label="Amount" />
+      </AmountFieldWarning>,
+    )
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.getByLabelText('Amount')).toBeInTheDocument()
+  })
+})

--- a/apps/armada-interface/src/components/ui/AmountFieldWarning/AmountFieldWarning.tsx
+++ b/apps/armada-interface/src/components/ui/AmountFieldWarning/AmountFieldWarning.tsx
@@ -1,0 +1,34 @@
+// ABOUTME: Persistent action-style tooltip shown above the amount field for any amount validation error
+// ABOUTME: (over-balance, below-minimum, parse). Ported from the mockup's AmountExceededWarning; composes the @/design action-tooltip styling.
+
+import type { ReactNode } from 'react'
+import tooltipStyles from '@/design/components/Tooltip/Tooltip.module.css'
+import styles from './AmountFieldWarning.module.css'
+
+export interface AmountFieldWarningProps {
+  /** Id wired to the input's `aria-describedby` so the alert is announced. */
+  id: string
+  /** Whether the tooltip is shown (an error message is present). */
+  visible: boolean
+  /** The validation message to display. */
+  message: string
+  /** The amount field the tooltip is positioned above. */
+  children: ReactNode
+}
+
+export function AmountFieldWarning({ id, visible, message, children }: AmountFieldWarningProps) {
+  return (
+    <div className={styles.wrapper}>
+      {visible ? (
+        <div
+          id={id}
+          className={[tooltipStyles.tooltip, tooltipStyles.action, styles.tooltip].join(' ')}
+          role="alert"
+        >
+          <p className={tooltipStyles.actionText}>{message}</p>
+        </div>
+      ) : null}
+      {children}
+    </div>
+  )
+}

--- a/apps/armada-interface/src/components/ui/AmountFieldWarning/index.ts
+++ b/apps/armada-interface/src/components/ui/AmountFieldWarning/index.ts
@@ -1,0 +1,3 @@
+// ABOUTME: Barrel for the AmountFieldWarning primitive — the above-field amount-error tooltip.
+
+export { AmountFieldWarning, type AmountFieldWarningProps } from './AmountFieldWarning'

--- a/apps/armada-interface/src/components/ui/AmountInput/AmountInput.tsx
+++ b/apps/armada-interface/src/components/ui/AmountInput/AmountInput.tsx
@@ -119,6 +119,11 @@ export function AmountInput({
             className={styles.displayInput}
             type="text"
             inputMode="decimal"
+            autoComplete="off"
+            autoCorrect="off"
+            spellCheck={false}
+            data-1p-ignore
+            data-lpignore="true"
             value={value}
             onChange={e => handleChange(e.target.value)}
             onBlur={onBlur}
@@ -170,6 +175,11 @@ export function AmountInput({
           className={styles.compactInput}
           type="text"
           inputMode="decimal"
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
+          data-1p-ignore
+          data-lpignore="true"
           value={value}
           onChange={e => handleChange(e.target.value)}
           onBlur={onBlur}

--- a/apps/armada-interface/src/components/ui/RecipientInput/RecipientInput.tsx
+++ b/apps/armada-interface/src/components/ui/RecipientInput/RecipientInput.tsx
@@ -67,6 +67,8 @@ export function RecipientInput({
           autoCorrect="off"
           autoCapitalize="none"
           spellCheck={false}
+          data-1p-ignore
+          data-lpignore="true"
           className={styles.input}
           value={value}
           placeholder={placeholder}

--- a/apps/armada-interface/src/components/yield/EarnInputStep.module.css
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.module.css
@@ -16,14 +16,3 @@
   color: var(--semantic-color-text-primary);
   text-align: center;
 }
-
-/* Pre-flight gate (e.g. Withdraw fee shortfall). */
-.blockedReason {
-  font-family: var(--primitives-fontFamily-ui), sans-serif;
-  font-size: calc(var(--primitives-fontSize-sm) * 1px);
-  color: var(--semantic-color-status-warning);
-  background: rgba(251, 191, 36, 0.08);
-  border: 1px solid rgba(251, 191, 36, 0.3);
-  border-radius: calc(var(--semantic-borderRadius-input) * 1px);
-  padding: var(--primitives-spacing-3) var(--primitives-spacing-4);
-}

--- a/apps/armada-interface/src/components/yield/EarnInputStep.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.test.tsx
@@ -106,13 +106,13 @@ describe('<EarnInputStep>', () => {
 
   it('disables Review when amount exceeds maxInput', () => {
     setup({ max: 1_000_000n, amountStr: '5' })
-    expect(screen.getByRole('button', { name: /Review/ })).toBeDisabled()
-    expect(screen.getByRole('alert')).toHaveTextContent(/exceeds your private balance/i)
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
+    expect(screen.getByRole('alert')).toHaveTextContent(/more than you can add/i)
   })
 
   it('shows the withdraw-specific over-max error when tab=withdraw', () => {
     setup({ tab: 'withdraw', max: 1_000_000n, amountStr: '5' })
-    expect(screen.getByRole('alert')).toHaveTextContent(/exceeds your earning balance/i)
+    expect(screen.getByRole('alert')).toHaveTextContent(/more than you can withdraw/i)
   })
 
   it('enables Review when amount is positive and within maxInput', () => {
@@ -126,7 +126,7 @@ describe('<EarnInputStep>', () => {
     expect(props.onTabChange).toHaveBeenCalledWith('withdraw')
   })
 
-  it('disables Review and surfaces the inline reason when continueBlockedReason is set', () => {
+  it('disables Review and surfaces the reason in the amount-field tooltip when continueBlockedReason is set', () => {
     // WHY: the withdraw broadcaster fee comes from the user's pre-existing private USDC (not
     // from the redeem proceeds), so the modal must gate submit when private USDC < fee.
     render(
@@ -141,12 +141,12 @@ describe('<EarnInputStep>', () => {
         feeLoading={false}
         gasChainId={31337}
         rate={null}
-        continueBlockedReason="You need at least 0.50 USDC in your private balance to cover the withdrawal fee."
+        continueBlockedReason="Not enough private USDC to cover the 0.50 fee — add some first"
         onCancel={vi.fn()}
         onContinue={vi.fn()}
       />,
     )
-    expect(screen.getByRole('button', { name: /Review/ })).toBeDisabled()
-    expect(screen.getByRole('alert')).toHaveTextContent(/0\.50 USDC in your private balance/)
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
+    expect(screen.getByRole('alert')).toHaveTextContent(/cover the 0\.50 fee/)
   })
 })

--- a/apps/armada-interface/src/components/yield/EarnInputStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.tsx
@@ -125,9 +125,13 @@ export function EarnInputStepContent({
     usdcInputErrorMessage(parseError)
     ?? (tooMuch
       ? tab === 'add'
-        ? 'Amount exceeds your private balance after fees.'
-        : 'Amount exceeds your earning balance after fees.'
+        ? "That's more than you can add"
+        : "That's more than you can withdraw"
       : undefined)
+  // Surface the withdraw fee-shortfall pre-flight block through the same amount-field tooltip as the
+  // amount errors. An active amount error takes precedence (immediate feedback on what's being typed);
+  // once the amount is otherwise valid the standing shortfall shows.
+  const fieldError = amountError ?? continueBlockedReason ?? undefined
 
   const question =
     tab === 'add' ? 'Deposit USDC to the vault' : 'Withdraw USDC from the vault'
@@ -172,7 +176,7 @@ export function EarnInputStepContent({
         // maxInput drives the 25% / 50% / 75% / Max percent pills; onMax keeps the exact fee-aware cap.
         maxInput={maxInput}
         onMax={() => onAmountChange(formatUsdcPlain(maxInput))}
-        error={amountError}
+        error={fieldError}
         amountAriaLabel={tab === 'add' ? 'Vault deposit amount' : 'Vault withdrawal amount'}
       />
 
@@ -181,12 +185,6 @@ export function EarnInputStepContent({
           nativeSymbol={gasWarning.nativeSymbol}
           formattedBalance={gasWarning.formattedBalance}
         />
-      ) : null}
-
-      {continueBlockedReason ? (
-        <div className={styles.blockedReason} role="alert">
-          {continueBlockedReason}
-        </div>
       ) : null}
     </div>
   )
@@ -219,7 +217,7 @@ export function EarnInputStepFooter({
       <Button
         variant="primary"
         size="lg"
-        label="Review"
+        label={canReview ? 'Review' : 'Input amount'}
         showIcon={false}
         disabled={!canReview}
         onClick={onContinue}

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -155,7 +155,7 @@ export function EarnModal() {
   // we don't know the number yet.
   const withdrawFeeShortfall = tab === 'withdraw' && fee > 0n && spendableUsdc < fee
   const withdrawFeeBlockedReason: string | null = withdrawFeeShortfall
-    ? `You need at least ${formatUsdcAmount(fee)} USDC in your private balance to cover the withdrawal fee. Add USDC from another source before withdrawing.`
+    ? `Not enough private USDC to cover the ${formatUsdcAmount(fee)} fee — add some first`
     : null
   // Composed gate for the review step — sync gate OR private-USDC shortfall.
   const submitBlockedReason: string | null = syncGate.reason || withdrawFeeBlockedReason

--- a/apps/armada-interface/src/lib/format.test.ts
+++ b/apps/armada-interface/src/lib/format.test.ts
@@ -35,6 +35,13 @@ describe('formatUsdcAmount', () => {
     expect(formatUsdcAmount(1_234_567_890n, { decimals: 4 })).toBe('1,234.5679')
     expect(formatUsdcAmount(1_500_000n, { decimals: 0 })).toBe('2')
   })
+  it('reveals sub-cent precision (2–6 fraction digits) by default', () => {
+    // Committed figures (fees, net, totals) must not round a real sub-cent value away to "0.00".
+    expect(formatUsdcAmount(500_000n)).toBe('0.50') // whole cents keep the 2-decimal minimum
+    expect(formatUsdcAmount(1_004_000n)).toBe('1.004') // sub-cent tenths shown
+    expect(formatUsdcAmount(496_905_432n)).toBe('496.905432') // full 6-decimal precision when present
+    expect(formatUsdcAmount(1n)).toBe('0.000001') // the smallest USDC unit is visible, not "0.00"
+  })
 })
 
 describe('parseUsdcInput', () => {

--- a/apps/armada-interface/src/lib/format.ts
+++ b/apps/armada-interface/src/lib/format.ts
@@ -107,7 +107,7 @@ export function parseUsdcInput(input: string): UsdcInputResult {
 export function usdcInputErrorMessage(error: UsdcInputError | undefined): string | undefined {
   switch (error) {
     case 'too-many-decimals': return 'USDC has at most 6 decimal places.'
-    case 'negative': return 'Amount cannot be negative.'
+    case 'negative': return "Amounts can't be negative."
     case 'invalid': return 'Enter a valid number.'
     case undefined: return undefined
   }

--- a/apps/armada-interface/src/lib/format.ts
+++ b/apps/armada-interface/src/lib/format.ts
@@ -13,15 +13,24 @@ export function formatUsdcPlain(amount: bigint): string {
 }
 
 /**
- * Format a USDC raw amount as a locale-grouped number string with a fixed number of decimals.
- * Suitable for the BalanceHero display ("12,481.22") and similar large-number presentations.
+ * Format a USDC raw amount as a locale-grouped number string.
+ *
+ * Default (no `decimals`): 2–6 fraction digits — normal amounts read "12,481.22", but sub-cent
+ * precision (down to USDC's 1e-6 unit) is revealed when present, so committed figures (fees, net,
+ * totals, wallet-signature labels) never round a real sub-cent value away to "0.00". Pass a fixed
+ * `decimals` where a rigid width is wanted (e.g. a strict 2dp caption).
  */
 export function formatUsdcAmount(amount: bigint, options?: { decimals?: number }): string {
-  const decimals = options?.decimals ?? 2
   const dollars = Number(amount) / 1e6
+  if (options?.decimals !== undefined) {
+    return dollars.toLocaleString('en-US', {
+      minimumFractionDigits: options.decimals,
+      maximumFractionDigits: options.decimals,
+    })
+  }
   return dollars.toLocaleString('en-US', {
-    minimumFractionDigits: decimals,
-    maximumFractionDigits: decimals,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 6,
   })
 }
 

--- a/apps/armada-interface/src/utils/amountInput.test.ts
+++ b/apps/armada-interface/src/utils/amountInput.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Covers digit/dot filtering, the 6-decimal cap, leading-zero collapse, and forward-typing states (0, ., 0.).
 
 import { describe, it, expect } from 'vitest'
-import { sanitizeAmountInput, hasActiveAmount } from './amountInput'
+import { sanitizeAmountInput, hasActiveAmount, formatAmountInputDisplay } from './amountInput'
 
 describe('sanitizeAmountInput', () => {
   it('keeps digits and a single decimal point', () => {
@@ -33,6 +33,25 @@ describe('sanitizeAmountInput', () => {
     expect(sanitizeAmountInput('1.1234567')).toBe('1.123456') // 7th digit dropped
     expect(sanitizeAmountInput('1.123456')).toBe('1.123456') // exactly 6 kept
     expect(sanitizeAmountInput('0.0000001')).toBe('0.000000') // sub-1e-6 clamped, not errored
+  })
+})
+
+describe('formatAmountInputDisplay', () => {
+  it('groups the integer part with thousand separators', () => {
+    expect(formatAmountInputDisplay('1000')).toBe('1,000')
+    expect(formatAmountInputDisplay('1000000')).toBe('1,000,000')
+    expect(formatAmountInputDisplay('1234567.89')).toBe('1,234,567.89')
+  })
+  it('preserves the decimal suffix verbatim (mid-entry dots survive)', () => {
+    expect(formatAmountInputDisplay('1000.')).toBe('1,000.')
+    expect(formatAmountInputDisplay('12.5')).toBe('12.5')
+  })
+  it('adds a leading zero to a bare fraction for display only', () => {
+    expect(formatAmountInputDisplay('.5')).toBe('0.5')
+    expect(formatAmountInputDisplay('.')).toBe('0.')
+  })
+  it('returns empty for empty input', () => {
+    expect(formatAmountInputDisplay('')).toBe('')
   })
 })
 

--- a/apps/armada-interface/src/utils/amountInput.test.ts
+++ b/apps/armada-interface/src/utils/amountInput.test.ts
@@ -1,0 +1,51 @@
+// ABOUTME: Unit tests for the deposit/send/earn amount-field sanitizer + active-amount predicate.
+// ABOUTME: Covers digit/dot filtering, the 6-decimal cap, leading-zero collapse, and forward-typing states (0, ., 0.).
+
+import { describe, it, expect } from 'vitest'
+import { sanitizeAmountInput, hasActiveAmount } from './amountInput'
+
+describe('sanitizeAmountInput', () => {
+  it('keeps digits and a single decimal point', () => {
+    expect(sanitizeAmountInput('12.34')).toBe('12.34')
+    expect(sanitizeAmountInput('1.2.3')).toBe('1.23') // extra dots dropped
+    expect(sanitizeAmountInput('$1,500.00')).toBe('1500.00') // strips commas + currency chars
+    expect(sanitizeAmountInput('abc4d2')).toBe('42') // non-numeric stripped
+  })
+
+  it('preserves the forward-typing states needed for a sub-one amount', () => {
+    // Regression: a leading `0`/`.` must survive so `0.5` / `.5` are typeable (previously discarded).
+    expect(sanitizeAmountInput('0')).toBe('0')
+    expect(sanitizeAmountInput('.')).toBe('.')
+    expect(sanitizeAmountInput('0.')).toBe('0.')
+    expect(sanitizeAmountInput('0.5')).toBe('0.5')
+    expect(sanitizeAmountInput('.5')).toBe('.5')
+  })
+
+  it('collapses redundant leading zeros but keeps a lone 0 and 0.', () => {
+    expect(sanitizeAmountInput('05')).toBe('5')
+    expect(sanitizeAmountInput('007')).toBe('7')
+    expect(sanitizeAmountInput('0')).toBe('0')
+    expect(sanitizeAmountInput('00')).toBe('0')
+    expect(sanitizeAmountInput('0.5')).toBe('0.5')
+  })
+
+  it('caps the fractional portion at 6 decimals (USDC precision)', () => {
+    expect(sanitizeAmountInput('1.1234567')).toBe('1.123456') // 7th digit dropped
+    expect(sanitizeAmountInput('1.123456')).toBe('1.123456') // exactly 6 kept
+    expect(sanitizeAmountInput('0.0000001')).toBe('0.000000') // sub-1e-6 clamped, not errored
+  })
+})
+
+describe('hasActiveAmount', () => {
+  it('is false for empty / zero / bare-dot states', () => {
+    expect(hasActiveAmount('')).toBe(false)
+    expect(hasActiveAmount('.')).toBe(false)
+    expect(hasActiveAmount('0')).toBe(false)
+    expect(hasActiveAmount('0.00')).toBe(false)
+  })
+  it('is true for a mid-decimal entry or any non-zero amount', () => {
+    expect(hasActiveAmount('0.')).toBe(true) // mid-typing
+    expect(hasActiveAmount('0.5')).toBe(true)
+    expect(hasActiveAmount('10')).toBe(true)
+  })
+})

--- a/apps/armada-interface/src/utils/amountInput.ts
+++ b/apps/armada-interface/src/utils/amountInput.ts
@@ -25,6 +25,24 @@ export function sanitizeAmountInput(raw: string): string {
   return out.replace(/^0+(?=\d)/, '')
 }
 
+/**
+ * Format a sanitized amount for display with en-US thousand grouping (1,000 / 1,000,000). The
+ * decimal suffix is preserved verbatim (so mid-entry "1,000." keeps its trailing dot), and a bare
+ * fraction gains a leading zero for display (".5" → "0.5"). The stored value stays ungrouped —
+ * `sanitizeAmountInput` strips the commas back out on the next keystroke.
+ */
+export function formatAmountInputDisplay(sanitized: string): string {
+  if (!sanitized) return ''
+  const decimalIndex = sanitized.indexOf('.')
+  const intPart = decimalIndex === -1 ? sanitized : sanitized.slice(0, decimalIndex)
+  const decSuffix = decimalIndex === -1 ? '' : sanitized.slice(decimalIndex)
+  if (!intPart) {
+    return decSuffix ? `0${decSuffix}` : ''
+  }
+  const formattedInt = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+  return `${formattedInt}${decSuffix}`
+}
+
 /** True when the user has a non-zero amount or is mid-decimal entry (e.g. "0."). */
 export function hasActiveAmount(value: string): boolean {
   const trimmed = value.trim()

--- a/apps/armada-interface/src/utils/amountInput.ts
+++ b/apps/armada-interface/src/utils/amountInput.ts
@@ -1,10 +1,17 @@
-/** Sanitize free-form decimal entry (digits + single dot). */
+/** Sanitize free-form decimal entry (digits + single dot), capped at USDC's 6 decimal places. */
 export function sanitizeAmountInput(raw: string): string {
   const normalized = raw.replace(/,/g, '')
   let out = ''
   let seenDecimal = false
+  let fractionDigits = 0
   for (const char of normalized) {
     if (char >= '0' && char <= '9') {
+      // Cap the fractional portion at USDC's 6 decimals — drop a 7th digit rather than let it
+      // fall through to parseUsdcInput's `too-many-decimals` error (which reads the amount as 0).
+      if (seenDecimal) {
+        if (fractionDigits >= 6) continue
+        fractionDigits += 1
+      }
       out += char
       continue
     }
@@ -13,7 +20,9 @@ export function sanitizeAmountInput(raw: string): string {
       out += char
     }
   }
-  return out
+  // Drop redundant leading zeros in the integer part ("05" → "5") while preserving a lone "0" and
+  // the "0." a user needs to type a sub-one amount forward.
+  return out.replace(/^0+(?=\d)/, '')
 }
 
 /** True when the user has a non-zero amount or is mid-decimal entry (e.g. "0."). */


### PR DESCRIPTION
Input-validation pass on the amount fields across shield / send / earn, plus aligning the amount-field error display with the designer mockup. Two commits.

## Input validation
- **6-decimal precision** — `formatUsdcAmount` default is now 2–6 fraction digits, so committed figures (fees, net, totals, wallet-signature labels, request/pay amounts) reveal sub-cent precision instead of rounding to `0.00`. The deposit/send/earn sanitizer now caps entry at 6 decimals (parity with `AmountInput`).
- **Autofill suppression** — `autoComplete="off"` + `data-1p-ignore` / `data-lpignore` + `spellCheck={false}` on the amount inputs (and `RecipientInput`) to kill the browser history dropdown + password-manager icons.
- **Leading `0` / `.`** — the card no longer rewrites `0`/`.`/`0.` to `''`, so sub-one amounts (`0.5`, `.5`) are typeable; redundant leading zeros collapse (`05`→`5`).

## Error display — mockup alignment
- **Above-field tooltip** — new `AmountFieldWarning` (reusing the vendored `@/design` action-tooltip) replaces the inline-below error text. Covers the whole `error` channel: over-balance, shield below-minimum, parse errors, and the Earn withdraw **fee-shortfall** (moved off its separate footer block into the tooltip).
- **Red-on-error** — amount numeral + balance text + wallet icon go red when there's an error (matches the mockup).
- **CTA label** — the primary button reads **"Input amount"** when there's no valid amount (disabled), **"Review"** once valid.
- **Thousand grouping** — the amount input displays grouped ("1,000,000"); stored value stays ungrouped.
- **Friendlier copy** — per-flow strings in the mockup's voice ("That's more than you can deposit / send / add / withdraw / unshield", "That's below the relayer fee (X USDC)", "Not enough private USDC to cover the X fee — add some first").

## Testing
`npm run typecheck` + `npm run test` (1231 pass). New/updated unit tests for the sanitizer (6-cap, leading-zero, grouping), `formatUsdcAmount` sub-cent, the dynamic CTA label, `AmountFieldWarning`, and the new copy across the three flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
