### PR TITLE
feat(interface): rename pool flows Deposit/Withdraw → Shield/Unshield

### DIFF
--- a/apps/armada-interface/src/components/dashboard/ActivityReceipt/ActivityReceipt.test.tsx
+++ b/apps/armada-interface/src/components/dashboard/ActivityReceipt/ActivityReceipt.test.tsx
@@ -24,12 +24,12 @@ function shieldRecord(): TxRecord {
 describe('<ActivityReceipt>', () => {
   it('renders nothing when record is null', () => {
     render(<ActivityReceipt record={null} open onClose={vi.fn()} />)
-    expect(screen.queryByText('USDC deposit')).toBeNull()
+    expect(screen.queryByText('USDC shield')).toBeNull()
   })
 
   it('shows the deposit title + amount + a summary row', () => {
     render(<ActivityReceipt record={shieldRecord()} open onClose={vi.fn()} />)
-    expect(screen.getByText('USDC deposit')).toBeInTheDocument()
+    expect(screen.getByText('USDC shield')).toBeInTheDocument()
     expect(screen.getByText('100.5')).toBeInTheDocument()
     // The reused DepositReviewSummary surfaces the confirmed "Date and time" row.
     expect(screen.getByText('Date and time')).toBeInTheDocument()

--- a/apps/armada-interface/src/components/dashboard/ActivityReceipt/ActivityReceipt.tsx
+++ b/apps/armada-interface/src/components/dashboard/ActivityReceipt/ActivityReceipt.tsx
@@ -34,11 +34,11 @@ const DEPOSIT_STEPS = ['Amount', 'Review', 'Confirm']
 const SEND_STEPS = ['Recipient', 'Amount', 'Review', 'Confirm']
 
 interface ReceiptView {
-  /** Header label (matches the originating flow: Deposit / Send / Withdraw / Earn). */
+  /** Header label (matches the originating flow: Shield / Send / Unshield / Earn). */
   flowLabel: string
   /** The originating flow's step-bar labels, rendered confirmed (all filled). */
   steps: string[]
-  /** In-card title (e.g. "USDC deposit"). */
+  /** In-card title (e.g. "USDC shield"). */
   title: string
   /** Gross USDC amount (raw 6-decimal) shown in the big-numeral block. */
   amount: bigint
@@ -70,9 +70,9 @@ function buildReceiptView(record: TxRecord, ownWalletAddress?: string): ReceiptV
       const fee = meta.feeAmount ?? null
       const netAmount = fee ? meta.amount - fee : meta.amount
       return {
-        flowLabel: 'Deposit',
+        flowLabel: 'Shield',
         steps: DEPOSIT_STEPS,
-        title: 'USDC deposit',
+        title: 'USDC shield',
         amount: meta.amount,
         explorerUrl,
         status,
@@ -104,9 +104,9 @@ function buildReceiptView(record: TxRecord, ownWalletAddress?: string): ReceiptV
             ? getNetworkConfig().hub.name
             : undefined
       return {
-        flowLabel: asWithdraw ? 'Withdraw' : 'Send',
+        flowLabel: asWithdraw ? 'Unshield' : 'Send',
         steps: SEND_STEPS,
-        title: asWithdraw ? 'USDC withdrawal' : 'USDC sent',
+        title: asWithdraw ? 'USDC unshield' : 'USDC sent',
         amount: meta.amount,
         explorerUrl,
         status,

--- a/apps/armada-interface/src/components/dashboard/DepositTooltip/DepositTooltip.tsx
+++ b/apps/armada-interface/src/components/dashboard/DepositTooltip/DepositTooltip.tsx
@@ -11,7 +11,7 @@ const TOOLTIP_ICON_PX = 34
 
 const DEFAULT_HEADLINE = 'Shield your USDC'
 const DEFAULT_BODY =
-  "Depositing into Armada's shielded pool is the first step to move funds privately."
+  "Shielding into Armada's shielded pool is the first step to move funds privately."
 
 export interface DepositTooltipProps {
   variant?: 'default' | 'v2'

--- a/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityAllPanel/ActivityAllPanel.test.tsx
+++ b/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityAllPanel/ActivityAllPanel.test.tsx
@@ -9,7 +9,7 @@ const items: DashboardActivityItem[] = [
   {
     id: 'a',
     kind: 'deposit',
-    label: 'Deposit from Base',
+    label: 'Shield from Base',
     amount: 5,
     occurredAt: Date.now(),
     txHash: '0xaaa111',
@@ -31,7 +31,7 @@ const items: DashboardActivityItem[] = [
 describe('ActivityAllPanel', () => {
   it('renders the filtered activity list when open', () => {
     render(<ActivityAllPanel open onClose={() => {}} items={items} />)
-    expect(screen.getByText('Deposit from Base')).toBeInTheDocument()
+    expect(screen.getByText('Shield from Base')).toBeInTheDocument()
     expect(screen.getByText('Private transfer')).toBeInTheDocument()
   })
 
@@ -41,12 +41,12 @@ describe('ActivityAllPanel', () => {
       target: { value: '0xnope' },
     })
     expect(screen.getByText('No transactions match your filters.')).toBeInTheDocument()
-    expect(screen.queryByText('Deposit from Base')).not.toBeInTheDocument()
+    expect(screen.queryByText('Shield from Base')).not.toBeInTheDocument()
   })
 
   it('filters by kind chip', () => {
     render(<ActivityAllPanel open onClose={() => {}} items={items} />)
-    fireEvent.click(screen.getByRole('tab', { name: 'Withdraw' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Unshield' }))
     expect(screen.getByText('No transactions match your filters.')).toBeInTheDocument()
   })
 

--- a/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityKindFilters/ActivityKindFilters.test.tsx
+++ b/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityKindFilters/ActivityKindFilters.test.tsx
@@ -7,14 +7,14 @@ import { ActivityKindFilters } from './ActivityKindFilters'
 describe('ActivityKindFilters', () => {
   it('renders every kind chip', () => {
     render(<ActivityKindFilters value="all" onChange={() => {}} />)
-    for (const label of ['All', 'Deposit', 'Withdraw', 'Sent', 'Received']) {
+    for (const label of ['All', 'Shield', 'Unshield', 'Sent', 'Received']) {
       expect(screen.getByRole('tab', { name: label })).toBeInTheDocument()
     }
   })
 
   it('marks the active chip as selected', () => {
     render(<ActivityKindFilters value="deposit" onChange={() => {}} />)
-    expect(screen.getByRole('tab', { name: 'Deposit' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: 'Shield' })).toHaveAttribute('aria-selected', 'true')
     expect(screen.getByRole('tab', { name: 'All' })).toHaveAttribute('aria-selected', 'false')
   })
 

--- a/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityKindFilters/ActivityKindFilters.tsx
+++ b/apps/armada-interface/src/components/dashboard/RecentActivityList/ActivityKindFilters/ActivityKindFilters.tsx
@@ -1,4 +1,4 @@
-// ABOUTME: Segmented kind-filter chips for the activity panel — All / Deposit / Withdraw / Sent / Requests / Received / Earn.
+// ABOUTME: Segmented kind-filter chips for the activity panel — All / Shield / Unshield / Sent / Requests / Received / Earn.
 // ABOUTME: Ported from the armada-app mockup; the chip id equals the activity kind so the predicate is a direct match.
 
 import styles from './ActivityKindFilters.module.css'
@@ -14,8 +14,8 @@ export type ActivityKindFilter =
 
 const FILTERS: Array<{ id: ActivityKindFilter; label: string }> = [
   { id: 'all', label: 'All' },
-  { id: 'deposit', label: 'Deposit' },
-  { id: 'withdraw', label: 'Withdraw' },
+  { id: 'deposit', label: 'Shield' },
+  { id: 'withdraw', label: 'Unshield' },
   { id: 'send', label: 'Sent' },
   { id: 'requestLink', label: 'Requests' },
   { id: 'receive', label: 'Received' },

--- a/apps/armada-interface/src/components/dashboard/RecentActivityList/RecentActivityList.tsx
+++ b/apps/armada-interface/src/components/dashboard/RecentActivityList/RecentActivityList.tsx
@@ -237,7 +237,7 @@ export function RecentActivityList({
           </span>
           <p className={styles.emptyTitle}>No activity yet</p>
           <p className={styles.emptyBody}>
-            Deposits, sends, and earn moves will show up here.
+            Shields, sends, and earn moves will show up here.
           </p>
         </div>
       ) : isPreview ? (

--- a/apps/armada-interface/src/components/dashboard/VaultPositionBar/VaultPositionBar.tsx
+++ b/apps/armada-interface/src/components/dashboard/VaultPositionBar/VaultPositionBar.tsx
@@ -64,7 +64,7 @@ export function VaultPositionBar({
     earnedAmount !== undefined ? formatEarnedSoFarAmount(earnedAmount) : '???'
   const formattedApy = `${apy.toFixed(1)}%`
   const earningLabel = formatVaultEarningLabel(apy)
-  const amountLabel = balanceRevealed ? `${formattedBalance} USDC` : 'Vault balance hidden'
+  const amountLabel = balanceRevealed ? `${formattedBalance} USDC` : 'Shielded vault balance hidden'
   const earnedLabel = balanceRevealed ? `${formattedEarned} earned` : 'Earned amount hidden'
   const apyLabel = balanceRevealed ? earningLabel : 'APY hidden'
   const peekHandlers = hidePeekEventHandlers(
@@ -122,7 +122,7 @@ export function VaultPositionBar({
       <button
         type="button"
         className={styles.root}
-        aria-label="Manage vault"
+        aria-label="Manage shielded vault"
         onClick={onOpen}
         {...peekHandlers}
       >

--- a/apps/armada-interface/src/components/dashboard/txActivityAdapter.test.ts
+++ b/apps/armada-interface/src/components/dashboard/txActivityAdapter.test.ts
@@ -54,7 +54,7 @@ describe('txRecordToActivityItem', () => {
     const item = txRecordToActivityItem(makeRecord('shield', { amount: 1_500_000n }))
     expect(item.kind).toBe('deposit')
     expect(item.amount).toBe(1.5)
-    expect(item.label).toBe('Deposit')
+    expect(item.label).toBe('Shield')
     expect(item.pending).toBe(false)
   })
 

--- a/apps/armada-interface/src/components/dashboard/txActivityAdapter.ts
+++ b/apps/armada-interface/src/components/dashboard/txActivityAdapter.ts
@@ -118,7 +118,7 @@ export function txRecordToActivityItem(
     return {
       ...base,
       kind: withdraw ? 'withdraw' : 'send',
-      label: withdraw ? 'Withdrawn to your wallet' : recordTitle(record),
+      label: withdraw ? 'Unshielded to your wallet' : recordTitle(record),
       amount: -usdcToNumber(record.meta.amount),
     }
   }

--- a/apps/armada-interface/src/components/shield/ShieldAmountStep.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldAmountStep.test.tsx
@@ -65,7 +65,7 @@ describe('ShieldAmountStepContent (direction)', () => {
   it('shows shield copy + both tabs on the shield tab', () => {
     renderContent('shield')
     expect(screen.getByText('Shield your USDC')).toBeInTheDocument()
-    expect(screen.getByLabelText('Deposit amount')).toBeInTheDocument()
+    expect(screen.getByLabelText('Shield amount')).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Shield' })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Unshield' })).toBeInTheDocument()
   })

--- a/apps/armada-interface/src/components/shield/ShieldAmountStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldAmountStep.tsx
@@ -66,7 +66,7 @@ export function ShieldAmountStepContent({
 
   const isShield = tab === 'shield'
   const title = isShield ? 'Shield your USDC' : 'Unshield your USDC'
-  const amountAriaLabel = isShield ? 'Deposit amount' : 'Unshield amount'
+  const amountAriaLabel = isShield ? 'Shield amount' : 'Unshield amount'
 
   const { value: amount, error: parseError } = parseUsdcInput(amountStr)
   const tooMuch = amount > maxInput
@@ -75,7 +75,7 @@ export function ShieldAmountStepContent({
     usdcInputErrorMessage(parseError) ??
     (tooMuch
       ? isShield
-        ? "That's more than you can deposit"
+        ? "That's more than you can shield"
         : "That's more than you can unshield"
       : undefined) ??
     (tooSmall

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.test.tsx
@@ -25,7 +25,7 @@ function setup(overrides?: { explorerUrl?: string }) {
 describe('<ShieldCompleteStep>', () => {
   it('renders the headline, the amount in the coin+amount block, and the chain name', () => {
     setup()
-    expect(screen.getByRole('heading', { name: 'USDC deposit confirmed' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'USDC shield confirmed' })).toBeInTheDocument()
     // Gross amount renders full-precision in the coin block; net amount ("250.50 USDC") is the
     // summary Total row, a distinct node — so the exact-text query still resolves the block.
     expect(screen.getByText('250.5')).toBeInTheDocument()

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.tsx
@@ -1,4 +1,4 @@
-// ABOUTME: Shield complete step — frost card with left-aligned "USDC deposit confirmed" title + big mono deposited-amount, shared DepositReviewSummary (with date/time), and explorer/dashboard CTAs.
+// ABOUTME: Shield complete step — frost card with left-aligned "USDC shield confirmed" title + big mono shielded-amount, shared DepositReviewSummary (with date/time), and explorer/dashboard CTAs.
 // ABOUTME: Mirrors the deposit-confirmed reference — no divider between the summary card and the button row.
 
 import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
@@ -41,7 +41,7 @@ export function ShieldCompleteStep({
     <div className={styles.root}>
       <div className={`${styles.body} ${modalStepBodyEnter}`}>
         <div className={styles.titleBlock}>
-          <h1 className={styles.title}>USDC deposit confirmed</h1>
+          <h1 className={styles.title}>USDC shield confirmed</h1>
           <div className={styles.amountRow}>
             <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
           </div>

--- a/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
@@ -138,14 +138,14 @@ describe('<ShieldModal>', () => {
   it('renders the input step when open', () => {
     renderModal({ open: true, max: 10_000_000n })
     expect(screen.getByRole('dialog', { name: 'Shield' })).toBeInTheDocument()
-    expect(screen.getByLabelText('Deposit amount')).toBeInTheDocument()
+    expect(screen.getByLabelText('Shield amount')).toBeInTheDocument()
   })
 
   it('advances to the review step after entering a valid amount', () => {
     renderModal({ open: true, max: 10_000_000n })
-    fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '5' } })
+    fireEvent.change(screen.getByLabelText('Shield amount'), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
-    expect(screen.getByRole('heading', { name: 'Review your USDC deposit' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Review your USDC shield' })).toBeInTheDocument()
     // Amount renders full-precision ("5") in the big amount block and 2dp in the summary total
     // ("5.00 USDC"); match the summary total.
     expect(screen.getAllByText(/5\.00/).length).toBeGreaterThanOrEqual(1)
@@ -153,10 +153,10 @@ describe('<ShieldModal>', () => {
 
   it('Back from review returns to the input step', () => {
     renderModal({ open: true, max: 10_000_000n })
-    fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '5' } })
+    fireEvent.change(screen.getByLabelText('Shield amount'), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
     fireEvent.click(screen.getByRole('button', { name: /^Back/ }))
-    expect(screen.getByLabelText('Deposit amount')).toBeInTheDocument()
+    expect(screen.getByLabelText('Shield amount')).toBeInTheDocument()
   })
 
   it('Cancel closes the modal', () => {
@@ -167,7 +167,7 @@ describe('<ShieldModal>', () => {
 
   it('Confirm submits the tx and advances to the dedicated wallet step', async () => {
     renderModal({ open: true, max: 10_000_000n })
-    fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '5' } })
+    fireEvent.change(screen.getByLabelText('Shield amount'), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^Confirm$/ }))
@@ -178,12 +178,12 @@ describe('<ShieldModal>', () => {
     await waitFor(() => {
       expect(screen.getByRole('list', { name: 'Wallet confirmations' })).toBeInTheDocument()
     })
-    expect(screen.getByText('Preparing your deposit…')).toBeInTheDocument()
+    expect(screen.getByText('Preparing your shield…')).toBeInTheDocument()
   })
 
   it('does not create a second record when Confirm is double-clicked (P0-7)', async () => {
     const store = renderModal({ open: true, max: 10_000_000n })
-    fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '5' } })
+    fireEvent.change(screen.getByLabelText('Shield amount'), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
     const confirm = screen.getByRole('button', { name: /^Confirm$/ })
     // Fire twice before React can flush the disabled state — the synchronous submittingRef guard
@@ -201,7 +201,7 @@ describe('<ShieldModal>', () => {
   it('warns at review when an unresolved same-amount deposit may still be on-chain (S-L7)', () => {
     const store = renderModal({ open: true, max: 10_000_000n })
     store.set(txListAtom, [unresolvedShield(5_000_000n)])
-    fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '5' } })
+    fireEvent.change(screen.getByLabelText('Shield amount'), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
     expect(screen.getByText(/may still be processing on chain/i)).toBeInTheDocument()
   })
@@ -209,14 +209,14 @@ describe('<ShieldModal>', () => {
   it('does not warn when the unresolved deposit is a different amount (S-L7)', () => {
     const store = renderModal({ open: true, max: 10_000_000n })
     store.set(txListAtom, [unresolvedShield(5_000_000n)])
-    fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '7' } })
+    fireEvent.change(screen.getByLabelText('Shield amount'), { target: { value: '7' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
     expect(screen.queryByText(/may still be processing/i)).toBeNull()
   })
 
   it('in-flight tx is dismissible — closing backgrounds the tx without cancelling it (S-M2)', async () => {
     const store = renderModal({ open: true, max: 10_000_000n })
-    fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '5' } })
+    fireEvent.change(screen.getByLabelText('Shield amount'), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^Confirm$/ }))
@@ -244,7 +244,7 @@ describe('<ShieldModal> — Shield/Unshield tabs', () => {
 
   it('opens on the Unshield tab from openModal=unshield', () => {
     renderModal({ open: true, kind: 'unshield', spendable: 10_000_000n, evm: EVM })
-    expect(screen.getByRole('dialog', { name: 'Withdraw' })).toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: 'Unshield' })).toBeInTheDocument()
     expect(screen.getByText('Unshield your USDC')).toBeInTheDocument()
     expect(screen.getByLabelText('Unshield amount')).toBeInTheDocument()
   })
@@ -258,7 +258,7 @@ describe('<ShieldModal> — Shield/Unshield tabs', () => {
 
   it('carries the typed amount across the Shield → Unshield toggle', () => {
     renderModal({ open: true, kind: 'shield', max: 10_000_000n, spendable: 10_000_000n, evm: EVM })
-    fireEvent.change(screen.getByLabelText('Deposit amount'), { target: { value: '7' } })
+    fireEvent.change(screen.getByLabelText('Shield amount'), { target: { value: '7' } })
     fireEvent.click(screen.getByRole('tab', { name: 'Unshield' }))
     expect(screen.getByLabelText('Unshield amount')).toHaveValue('7')
   })

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -98,7 +98,7 @@ export function ShieldModal() {
       onClose={close}
       exiting={exiting}
       stepKey={step}
-      flowLabel={isShield ? 'Shield' : 'Withdraw'}
+      flowLabel={isShield ? 'Shield' : 'Unshield'}
       steps={steps}
       currentStep={currentStep}
       status={status}

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.tsx
@@ -47,7 +47,7 @@ export function ShieldReviewStep({
     <div className={styles.root}>
       <div className={`${styles.body} ${modalStepBodyEnter}`}>
         <div className={styles.titleBlock}>
-          <h1 className={styles.title}>Review your USDC deposit</h1>
+          <h1 className={styles.title}>Review your USDC shield</h1>
           <div className={styles.amountRow}>
             <span className={styles.amountValue}>{formatUsdcPlain(amount)}</span>
           </div>
@@ -69,8 +69,8 @@ export function ShieldReviewStep({
           <div className={styles.caution} role="alert">
             <AlertTriangle size={16} className={styles.cautionIcon} aria-hidden="true" />
             <span>
-              A deposit of this amount may still be processing on chain. Submitting again could
-              deposit twice — check Recent Activity first.
+              A shield of this amount may still be processing on chain. Submitting again could
+              shield twice — check Recent Activity first.
             </span>
           </div>
         ) : null}

--- a/apps/armada-interface/src/components/shield/ShieldWalletStep.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldWalletStep.test.tsx
@@ -10,22 +10,22 @@ describe('ShieldWalletStep', () => {
   it('renders the checklist under the mockup title, with the "Preparing…" footer while pending', () => {
     const steps: WalletStep[] = [
       { label: 'Approve 5.00 USDC', status: 'pending' },
-      { label: 'Sign deposit transaction', status: 'pending' },
+      { label: 'Sign shield transaction', status: 'pending' },
     ]
     render(<ShieldWalletStep steps={steps} />)
     expect(
       screen.getByRole('heading', { name: 'Confirm transactions on your wallet' }),
     ).toBeInTheDocument()
     expect(screen.getByRole('list', { name: 'Wallet confirmations' })).toBeInTheDocument()
-    expect(screen.getByText('Sign deposit transaction')).toBeInTheDocument()
+    expect(screen.getByText('Sign shield transaction')).toBeInTheDocument()
     // Proof still building → honest "preparing" footer (no prompt live yet).
-    expect(screen.getByText('Preparing your deposit…')).toBeInTheDocument()
+    expect(screen.getByText('Preparing your shield…')).toBeInTheDocument()
   })
 
   it('switches the footer to "Waiting for wallet confirmation" once a prompt is live', () => {
     const steps: WalletStep[] = [
       { label: 'Approve 5.00 USDC', status: 'loading' },
-      { label: 'Sign deposit transaction', status: 'pending' },
+      { label: 'Sign shield transaction', status: 'pending' },
     ]
     render(<ShieldWalletStep steps={steps} />)
     expect(screen.getByText('Waiting for wallet confirmation')).toBeInTheDocument()

--- a/apps/armada-interface/src/components/shield/ShieldWalletStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldWalletStep.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Shield wallet-approve step — the mockup's dedicated "step 3" wallet page (centered title + approve/sign checklist + footer).
-// ABOUTME: Footer transitions "Preparing your deposit…" (proof building, no prompt yet) → "Waiting for wallet confirmation" (a prompt is live).
+// ABOUTME: Footer transitions "Preparing your shield…" (proof building, no prompt yet) → "Waiting for wallet confirmation" (a prompt is live).
 
 import { modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { WalletConfirmList } from '@/components/flow/WalletConfirmList/WalletConfirmList'
@@ -15,7 +15,7 @@ export function ShieldWalletStep({ steps }: ShieldWalletStepProps) {
   // every row is `pending` — surface the honest "preparing" copy so the user isn't told to confirm
   // a prompt that hasn't popped yet.
   const prompting = steps.some((s) => s.status === 'loading')
-  const footer = prompting ? 'Waiting for wallet confirmation' : 'Preparing your deposit…'
+  const footer = prompting ? 'Waiting for wallet confirmation' : 'Preparing your shield…'
 
   return (
     <div className={styles.column}>

--- a/apps/armada-interface/src/components/tx/processing/processingView.test.ts
+++ b/apps/armada-interface/src/components/tx/processing/processingView.test.ts
@@ -37,15 +37,15 @@ describe('buildProcessingView', () => {
     const withdraw = buildProcessingView(rec('unshield-local', 'build-proof', 'active'), {
       sendVariant: 'withdraw',
     })
-    expect(withdraw.cardCopy.title).toBe('Your withdraw is in progress')
-    expect(withdraw.cardCopy.titleLines).toEqual(['Your withdraw', 'is in progress'])
+    expect(withdraw.cardCopy.title).toBe('Your unshield is in progress')
+    expect(withdraw.cardCopy.titleLines).toEqual(['Your unshield', 'is in progress'])
   })
 
   it('snaps to the final stage and exposes the completedLabel when completed', () => {
     const view = buildProcessingView(rec('shield', 'hub-confirmed', 'completed'))
     expect(view.completed).toBe(true)
     expect(view.activeStageIndex).toBe(view.stages.length - 1)
-    expect(view.stages.find((s) => s.id === 'hub-confirmed')?.completedLabel).toBe('Deposited')
+    expect(view.stages.find((s) => s.id === 'hub-confirmed')?.completedLabel).toBe('Shielded')
   })
 
   it('renders the real (granular) xchain stages, not a fixed 3', () => {

--- a/apps/armada-interface/src/components/tx/processing/processingView.ts
+++ b/apps/armada-interface/src/components/tx/processing/processingView.ts
@@ -13,15 +13,15 @@ interface StageCopyEntry {
 }
 
 /**
- * Per-(kind, stage) processing copy. Labels are active-tense ("Depositing") with a `completedLabel`
- * for the final row ("Deposited"); subtitles echo the mockup's supporting line. Stage ids MUST match
+ * Per-(kind, stage) processing copy. Labels are active-tense ("Shielding") with a `completedLabel`
+ * for the final row ("Shielded"); subtitles echo the mockup's supporting line. Stage ids MUST match
  * `lifecycleFor(kind).stages` — every id a kind can reach needs an entry here.
  */
 const STAGE_COPY: Record<TxKind, Record<string, StageCopyEntry>> = {
   shield: {
     'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
     'submit-relayer': { label: 'Submitting transaction', subtitle: 'Confirm in your wallet' },
-    'hub-confirmed': { label: 'Depositing', subtitle: 'Confirming on chain', completedLabel: 'Deposited' },
+    'hub-confirmed': { label: 'Shielding', subtitle: 'Confirming on chain', completedLabel: 'Shielded' },
   },
   'shield-xchain': {
     'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
@@ -29,13 +29,13 @@ const STAGE_COPY: Record<TxKind, Record<string, StageCopyEntry>> = {
     'client-burn-confirmed': { label: 'Bridging', subtitle: 'Confirmed on source chain' },
     'iris-attestation-pending': { label: 'Bridging', subtitle: 'Waiting for cross-chain confirmation' },
     'iris-attestation-ready': { label: 'Bridging', subtitle: 'Cross-chain confirmation ready' },
-    'hub-mint-pending': { label: 'Depositing', subtitle: 'Delivering to your private balance' },
-    'hub-mint-confirmed': { label: 'Depositing', subtitle: 'Confirming on chain', completedLabel: 'Deposited' },
+    'hub-mint-pending': { label: 'Shielding', subtitle: 'Delivering to your private balance' },
+    'hub-mint-confirmed': { label: 'Shielding', subtitle: 'Confirming on chain', completedLabel: 'Shielded' },
   },
   'unshield-local': {
     'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
     'submit-relayer': { label: 'Submitting privately', subtitle: 'Relaying to the hub' },
-    'hub-confirmed': { label: 'Withdrawing', subtitle: 'Sending USDC to your wallet', completedLabel: 'Withdrawn' },
+    'hub-confirmed': { label: 'Unshielding', subtitle: 'Sending USDC to your wallet', completedLabel: 'Unshielded' },
   },
   'unshield-xchain': {
     'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
@@ -96,7 +96,7 @@ function resolveCardBase(record: TxRecord, sendVariant?: SendVariant): CardBase 
     case 'shield':
     case 'shield-xchain':
       return {
-        tag: 'Deposit in progress',
+        tag: 'Shield in progress',
         title: 'Your USDC is being shielded',
         titleLines: ['Your USDC is', 'being shielded'],
       }
@@ -112,9 +112,9 @@ function resolveCardBase(record: TxRecord, sendVariant?: SendVariant): CardBase 
     case 'unshield-xchain':
       return sendVariant === 'withdraw'
         ? {
-            tag: 'Withdrawal in progress',
-            title: 'Your withdraw is in progress',
-            titleLines: ['Your withdraw', 'is in progress'],
+            tag: 'Unshield in progress',
+            title: 'Your unshield is in progress',
+            titleLines: ['Your unshield', 'is in progress'],
           }
         : { tag: 'Send in progress', title: 'Unshielding your USDC' }
     case 'yield-deposit':

--- a/apps/armada-interface/src/components/tx/stageCopy.test.ts
+++ b/apps/armada-interface/src/components/tx/stageCopy.test.ts
@@ -30,9 +30,9 @@ describe('stageCopy', () => {
 
 describe('kindTitle', () => {
   it('returns the short title per kind', () => {
-    expect(kindTitle('shield')).toBe('Deposit')
-    expect(kindTitle('unshield-local')).toBe('Withdraw')
-    expect(kindTitle('unshield-xchain')).toBe('Withdraw')
+    expect(kindTitle('shield')).toBe('Shield')
+    expect(kindTitle('unshield-local')).toBe('Unshield')
+    expect(kindTitle('unshield-xchain')).toBe('Unshield')
     expect(kindTitle('transfer-shielded')).toBe('Private transfer')
     expect(kindTitle('transfer-shielded-received')).toBe('Received')
     expect(kindTitle('yield-deposit')).toBe('Vault deposit')
@@ -49,7 +49,7 @@ describe('recordTitle', () => {
       artifacts: {},
       walletContext: { evmAddress: undefined, shieldedWalletId: '', sourceChainId: 31337 },
     }
-    expect(recordTitle(record)).toMatch(/^Deposit from /)
+    expect(recordTitle(record)).toMatch(/^Shield from /)
   })
 
   it('names the 0x recipient for a public unshield (external send / withdraw)', () => {

--- a/apps/armada-interface/src/components/tx/stageCopy.ts
+++ b/apps/armada-interface/src/components/tx/stageCopy.ts
@@ -17,7 +17,7 @@ const COPY: Record<TxKind, Partial<Record<string, CopyEntry>>> = {
   shield: {
     'build-proof': 'Preparing transaction',
     'submit-relayer': { waiting: 'Confirm in your wallet', active: 'Submitting transaction' },
-    'hub-confirmed': 'Deposited',
+    'hub-confirmed': 'Shielded',
   },
   'shield-xchain': {
     'build-proof': 'Preparing transaction',
@@ -26,12 +26,12 @@ const COPY: Record<TxKind, Partial<Record<string, CopyEntry>>> = {
     'iris-attestation-pending': 'Waiting for cross-chain confirmation',
     'iris-attestation-ready': 'Cross-chain confirmation ready',
     'hub-mint-pending': 'Delivering to private balance',
-    'hub-mint-confirmed': 'Deposited',
+    'hub-mint-confirmed': 'Shielded',
   },
   'unshield-local': {
     'build-proof': 'Preparing transaction',
     'submit-relayer': 'Submitting privately',
-    'hub-confirmed': 'Withdrawn',
+    'hub-confirmed': 'Unshielded',
   },
   'unshield-xchain': {
     'build-proof': 'Preparing transaction',
@@ -79,15 +79,15 @@ export function stageCopy(
 
 /** Short title used in lists (Recent Activity, In Progress) and in modal headers. */
 const KIND_TITLES: Record<TxKind, string> = {
-  shield: 'Deposit',
+  shield: 'Shield',
   // Cross-chain shield surfaces under the same modal/CTA as same-chain shield; the kind
-  // distinction is purely for the lifecycle. From the user's perspective both are deposits.
-  'shield-xchain': 'Deposit',
-  // Withdraw and Send-External both produce `unshield-*` records — there's no separate kind
+  // distinction is purely for the lifecycle. From the user's perspective both are shields.
+  'shield-xchain': 'Shield',
+  // Unshield and Send-External both produce `unshield-*` records — there's no separate kind
   // for "Payment" because the contract paths are identical. The UI distinguishes the user's
   // intent (self vs other) via the modal they started from + the recipient field default.
-  'unshield-local': 'Withdraw',
-  'unshield-xchain': 'Withdraw',
+  'unshield-local': 'Unshield',
+  'unshield-xchain': 'Unshield',
   'transfer-shielded': 'Private transfer',
   // Incoming private transfer reconstructed from chain — someone sent USDC to our 0zk address.
   'transfer-shielded-received': 'Received',
@@ -114,7 +114,7 @@ export function recordTitle(record: TxRecord): string {
       // Shields carry the source chain they deposited/bridged from.
       const meta = record.meta as { fromChainId?: number }
       const chain = meta.fromChainId !== undefined ? getChainById(meta.fromChainId) : undefined
-      return chain ? `Deposit from ${chain.name}` : 'Deposit'
+      return chain ? `Shield from ${chain.name}` : 'Shield'
     }
     case 'unshield-local':
     case 'unshield-xchain': {

--- a/apps/armada-interface/src/components/yield/EarnCompleteStep.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnCompleteStep.test.tsx
@@ -48,7 +48,7 @@ describe('<EarnCompleteStep>', () => {
     expect(
       screen.getByRole('heading', { name: 'USDC withdrawal complete' }),
     ).toBeInTheDocument()
-    expect(screen.getByText('Withdraw from vault')).toBeInTheDocument()
+    expect(screen.getByText('Withdraw from shielded vault')).toBeInTheDocument()
     expect(screen.getByText('Your withdrawal')).toBeInTheDocument()
     // Past-tense on the confirmed screen (review says "You'll receive…"), net of the fee.
     expect(screen.getByText('Received into private balance')).toBeInTheDocument()

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.test.tsx
@@ -43,7 +43,7 @@ describe('<EarnReviewStep>', () => {
       />,
     )
     expect(screen.getByRole('heading', { name: 'Review your USDC withdrawal' })).toBeInTheDocument()
-    expect(screen.getByText('Withdraw from vault')).toBeInTheDocument()
+    expect(screen.getByText('Withdraw from shielded vault')).toBeInTheDocument()
   })
 
   it('APY shows syncing copy when rate is null', () => {

--- a/apps/armada-interface/src/components/yield/EarnReviewSummary/EarnReviewSummary.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewSummary/EarnReviewSummary.test.tsx
@@ -27,7 +27,7 @@ describe('<EarnReviewSummary>', () => {
     expect(screen.getByText('101.00 USDC')).toBeInTheDocument()
   })
 
-  it('withdraw tab: Mode "Withdraw from vault", "Your withdrawal", and the net-of-fee received total', () => {
+  it('withdraw tab: Mode "Withdraw from shielded vault", "Your withdrawal", and the net-of-fee received total', () => {
     // The broadcaster fee is unshielded from existing private USDC, so the net into private
     // balance is amount − fee (50 − 0.50 = 49.50), not the full withdrawal.
     render(
@@ -40,7 +40,7 @@ describe('<EarnReviewSummary>', () => {
         netLabel="You'll receive into private balance"
       />,
     )
-    expect(screen.getByText('Withdraw from vault')).toBeInTheDocument()
+    expect(screen.getByText('Withdraw from shielded vault')).toBeInTheDocument()
     expect(screen.getByText('Your withdrawal')).toBeInTheDocument()
     expect(screen.getByText("You'll receive into private balance")).toBeInTheDocument()
     expect(screen.getByText('49.50 USDC')).toBeInTheDocument()

--- a/apps/armada-interface/src/components/yield/EarnReviewSummary/EarnReviewSummary.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewSummary/EarnReviewSummary.tsx
@@ -50,7 +50,7 @@ export function EarnReviewSummary({
   confirmedAt,
   showApy = true,
 }: EarnReviewSummaryProps) {
-  const modeLabel = tab === 'add' ? 'Add to vault' : 'Withdraw from vault'
+  const modeLabel = tab === 'add' ? 'Add to vault' : 'Withdraw from shielded vault'
   const amountLabel = tab === 'add' ? 'Your deposit' : 'Your withdrawal'
   return (
     <div className={styles.summary}>

--- a/apps/armada-interface/src/hooks/useHistoryRecovery.ts
+++ b/apps/armada-interface/src/hooks/useHistoryRecovery.ts
@@ -234,7 +234,7 @@ export function useHistoryRecovery(): void {
           // Match on sourceTxHash OR destTxHash (T-H2): a completed cross-chain shield stores the
           // hub MINT hash in destTxHash (sourceTxHash holds the client burn). The SDK surfaces the
           // hub mint as a Shield history item; matching only sourceTxHash misses the authored
-          // record and synthesizes a second permanent "Deposit" row for the same funds.
+          // record and synthesizes a second permanent "Shield" row for the same funds.
           findExistingByHash: (hash) =>
             store.get(txListAtom).find(
               r =>

--- a/apps/armada-interface/src/hooks/useShieldFlow.ts
+++ b/apps/armada-interface/src/hooks/useShieldFlow.ts
@@ -207,17 +207,17 @@ export function useShieldFlow(isOpen: boolean): ShieldFlow {
     protocolFee: protocolFee + cctpFee,
     // Routes the `shield` kind through the gasless `fee-from-recipient` model when the wrapper
     // path is active — without this the helper falls back to `no-fee` and the tooltip's
-    // "You'll deposit" line skips the broadcaster fee (recipientReceives misses one deduction).
+    // "You'll shield" line skips the broadcaster fee (recipientReceives misses one deduction).
     gasless: useGasless,
   })
-  // Tooltip-ready breakdown — surfaces broadcaster fee + "You'll deposit" + "Total deducted"
+  // Tooltip-ready breakdown — surfaces broadcaster fee + "You'll shield" + "Total deducted"
   // bullets inside FeeBreakdownTooltip so the input UI stays clean (no inline FeeSummary rows).
   const flowBreakdown: FlowFeeBreakdown = {
     broadcasterFee: fee,
     cctpFee: cctpFee > 0n ? cctpFee : undefined,
     recipientReceives: netAmount,
     totalDeducted,
-    recipientLabel: "You'll deposit",
+    recipientLabel: "You'll shield",
   }
   // Minimum valid amount = the live fee. Below or equal to it the wrapper's `shieldAmount =
   // totalAmount - fee` would underflow / be zero. Surfaced via ShieldInputStep's `minAmount`

--- a/apps/armada-interface/src/lib/tx/shieldWalletSteps.test.ts
+++ b/apps/armada-interface/src/lib/tx/shieldWalletSteps.test.ts
@@ -27,7 +27,7 @@ describe('shieldWalletSteps', () => {
     const steps = shieldWalletSteps(null, 5_000_000n)
     expect(steps.map(s => s.label)).toEqual([
       'Approve 5.00 USDC',
-      'Submit 5.00 USDC deposit',
+      'Submit 5.00 USDC shield',
     ])
   })
 
@@ -39,7 +39,7 @@ describe('shieldWalletSteps', () => {
       artifacts: { approveSkipped: true },
     }
     const steps = shieldWalletSteps(record, 5_000_000n)
-    expect(steps.map(s => s.label)).toEqual(['Submit 5.00 USDC deposit'])
+    expect(steps.map(s => s.label)).toEqual(['Submit 5.00 USDC shield'])
     expect(steps[0].status).toBe('loading')
   })
 
@@ -51,7 +51,7 @@ describe('shieldWalletSteps', () => {
       stagesCompleted: [],
     }
     const buildingSteps = shieldWalletSteps(building, 5_000_000n)
-    expect(buildingSteps.map(s => s.label)).toEqual(['Authorize 5.00 USDC', 'Sign deposit transaction'])
+    expect(buildingSteps.map(s => s.label)).toEqual(['Authorize 5.00 USDC', 'Sign shield transaction'])
     expect(buildingSteps.map(s => s.status)).toEqual(['loading', 'pending'])
 
     // Intermediate: permit signed (permitSigned artifact) but ShieldIntent still pending —

--- a/apps/armada-interface/src/lib/tx/shieldWalletSteps.ts
+++ b/apps/armada-interface/src/lib/tx/shieldWalletSteps.ts
@@ -58,7 +58,7 @@ export function shieldWalletSteps(
     return [
       { label: `Authorize ${amountLabel} USDC`, status: permitDone ? 'done' : 'loading' },
       {
-        label: 'Sign deposit transaction',
+        label: 'Sign shield transaction',
         status: authorized ? 'done' : permitDone ? 'loading' : 'pending',
       },
     ]
@@ -89,8 +89,8 @@ export function shieldWalletSteps(
 
   const depositLabel =
     record?.kind === 'shield-xchain'
-      ? `Submit ${amountLabel} USDC cross-chain deposit`
-      : `Submit ${amountLabel} USDC deposit`
+      ? `Submit ${amountLabel} USDC cross-chain shield`
+      : `Submit ${amountLabel} USDC shield`
 
   steps.push({
     label: depositLabel,


### PR DESCRIPTION
Mirrors the design mockup, which renamed the **privacy-pool flows** from "Deposit/Withdraw" to **"Shield/Unshield"** (`538bbd2`, `015a1cf`). Copy only — no behavior, no identifier changes.

## Scope
- **Shield flow** (`shield` / `shield-xchain`): Deposit→Shield, Depositing→Shielding, Deposited→Shielded — titles, review/complete, wallet-step, activity, receipt, processing, and the exceed-error ("That's more than you can shield").
- **Unshield flow** (`unshield-local` / `unshield-xchain`): Withdraw→Unshield across the same surfaces.
- **Vault** keeps its verbs (`Add to vault` / `Withdraw`), with the mockup's "shielded vault" wording where it changed (`Withdraw from shielded vault`, `Manage shielded vault`, `Shielded vault balance hidden`).
- **Send** and received-transfer copy unchanged.

## Not touched
Code identifiers stay put: `TxKind`/`ModalKind` values, `DashboardActivityKind` ids (`deposit`/`withdraw`), component/folder names (`DepositAmountCard`, `deposit/`, `DepositReviewSummary`, `DepositTooltip`), CSS classes, `kindTitle` `Vault deposit`/`Vault withdrawal`.

Central copy source is `components/tx/stageCopy.ts` (+ `processing/processingView.ts`). All affected test assertions updated.

## Testing
`npm run typecheck` + `npm run test` — 1231 pass, 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
