### PR TITLE
feat(interface): mockup UX ports — incomplete-CTA nudge + ChainSelect mobile sheet

### DIFF
--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
@@ -78,6 +78,8 @@ export interface DepositAmountCardProps {
   error?: string
   /** Accessible name for the amount field (e.g. "Deposit amount", "Withdrawal amount"). */
   amountAriaLabel?: string
+  /** Ref onto the amount `<input>` — lets a sibling footer focus the field (e.g. the incomplete-CTA nudge). */
+  inputRef?: React.Ref<HTMLInputElement>
 }
 
 function ChainIcon({ chainId, label }: { chainId: number; label: string }) {
@@ -115,6 +117,7 @@ export function DepositAmountCard({
   maxInput,
   error,
   amountAriaLabel = 'Amount',
+  inputRef,
 }: DepositAmountCardProps) {
   const [menuOpen, setMenuOpen] = useState(false)
   const chainRootRef = useRef<HTMLDivElement>(null)
@@ -317,6 +320,7 @@ export function DepositAmountCard({
               {showActiveAmount ? displayAmount : '0'}
             </span>
             <input
+              ref={inputRef}
               id={amountInputId}
               type="text"
               inputMode="decimal"

--- a/apps/armada-interface/src/components/payments/SendInputStep.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendInputStep.test.tsx
@@ -74,10 +74,14 @@ describe('<SendInputStep>', () => {
     expect(props.onAmountChange).toHaveBeenCalledWith('2.5')
   })
 
-  it('gates Review on the amount — too much shows an error and disables Review', () => {
+  it('gates Review on the amount — too much shows an error and marks Review aria-disabled', () => {
     setup({ amountStr: '10', maxInput: 5_000_000n, max: 5_000_000n })
     expect(screen.getByText(/more than you can send/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
+    // The incomplete CTA keeps its DOM click (for the nudge) but is aria-disabled.
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    )
   })
 
   it('enables Review + fires onContinue for a valid amount', () => {
@@ -86,6 +90,15 @@ describe('<SendInputStep>', () => {
     expect(review).not.toBeDisabled()
     fireEvent.click(review)
     expect(props.onContinue).toHaveBeenCalledTimes(1)
+  })
+
+  it('tapping the disabled "Input amount" CTA nudges the field (focus) instead of continuing', () => {
+    const props = setup({ amountStr: '' })
+    const cta = screen.getByRole('button', { name: 'Input amount' })
+    fireEvent.click(cta)
+    // Routed to onDisabledClick → focuses the amount input, does NOT advance the flow.
+    expect(props.onContinue).not.toHaveBeenCalled()
+    expect(screen.getByLabelText('Send amount')).toHaveFocus()
   })
 
   it('fires onBack from the Back button', () => {

--- a/apps/armada-interface/src/components/payments/SendInputStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendInputStep.tsx
@@ -1,11 +1,12 @@
 // ABOUTME: Send/Withdraw amount step — DepositAmountCard (no chain row; chosen on the recipient step) + percent pills + gas notice.
 // ABOUTME: Recipient + chain live on the preceding recipient step, so this step gates only on the amount.
 
-import { useMemo } from 'react'
+import { useMemo, useRef, type Ref } from 'react'
 import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { DepositAmountCard } from '@/components/deposit/DepositAmountCard/DepositAmountCard'
 import { depositOverlayShellStyles } from '@/components/deposit/DepositOverlayShell/DepositOverlayShell'
 import { GasBalanceNotice } from '@/components/ui'
+import { useNudgeShake } from '@/hooks/useNudgeShake'
 import type { DisplayFees } from '@/lib/fees/displayFees'
 import type { FlowFeeBreakdown } from '@/components/ui/FeeBreakdownTooltip'
 import { useGasBalanceWarning } from '@/hooks/useGasBalanceWarning'
@@ -39,6 +40,10 @@ export interface SendInputStepProps {
   gaslessMode?: boolean
   onBack: () => void
   onContinue: () => void
+  /** Ref onto the amount input so the footer's incomplete-CTA nudge can focus the field. */
+  inputRef?: Ref<HTMLInputElement>
+  /** Called when the disabled "Input amount" CTA is tapped — focuses the amount field alongside the shake. */
+  onIncompleteContinue?: () => void
 }
 
 export function SendInputStepContent({
@@ -54,6 +59,7 @@ export function SendInputStepContent({
   feeLoading = false,
   gasChainId,
   gaslessMode = true,
+  inputRef,
 }: Pick<
   SendInputStepProps,
   | 'variant'
@@ -68,6 +74,7 @@ export function SendInputStepContent({
   | 'feeLoading'
   | 'gasChainId'
   | 'gaslessMode'
+  | 'inputRef'
 >) {
   const allChains = useMemo(
     () => getAllChainIdentities().map((c) => ({ chainId: c.chainId, label: c.name })),
@@ -104,6 +111,7 @@ export function SendInputStepContent({
           onMax={() => onAmountChange(formatUsdcPlain(maxInput))}
           error={amountError}
           amountAriaLabel={variant === 'withdraw' ? 'Withdrawal amount' : 'Send amount'}
+          inputRef={inputRef}
         />
         {showGasNotice ? (
           <GasBalanceNotice
@@ -121,10 +129,15 @@ export function SendInputStepFooter({
   maxInput,
   onBack,
   onContinue,
-}: Pick<SendInputStepProps, 'amountStr' | 'maxInput' | 'onBack' | 'onContinue'>) {
+  onIncompleteContinue,
+}: Pick<
+  SendInputStepProps,
+  'amountStr' | 'maxInput' | 'onBack' | 'onContinue' | 'onIncompleteContinue'
+>) {
   const { value: amount, error: parseError } = parseUsdcInput(amountStr)
   const tooMuch = amount > maxInput
   const canReview = hasActiveAmount(amountStr) && !tooMuch && !parseError
+  const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
 
   return (
     <div className={`${depositOverlayShellStyles.buttonRow} ${modalActionRowEnter}`}>
@@ -142,16 +155,27 @@ export function SendInputStepFooter({
         showIcon={false}
         disabled={!canReview}
         onClick={onContinue}
+        onDisabledClick={() => {
+          nudge()
+          onIncompleteContinue?.()
+        }}
+        shaking={shaking}
+        onShakeAnimationEnd={onShakeAnimationEnd}
       />
     </div>
   )
 }
 
 export function SendInputStep(props: SendInputStepProps) {
+  // The step is the common parent of the amount card + footer, so it owns the ref shared between them.
+  const amountInputRef = useRef<HTMLInputElement>(null)
   return (
     <>
-      <SendInputStepContent {...props} />
-      <SendInputStepFooter {...props} />
+      <SendInputStepContent {...props} inputRef={amountInputRef} />
+      <SendInputStepFooter
+        {...props}
+        onIncompleteContinue={() => amountInputRef.current?.focus()}
+      />
     </>
   )
 }

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -117,6 +117,9 @@ export function SendModal() {
   // Double-submit guard (P0-7): ref = synchronous gate (state is async), state = button disable.
   const submittingRef = useRef(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  // Shared across the amount step's card + footer (siblings) so tapping the disabled "Input amount"
+  // CTA can focus the amount field alongside the shake.
+  const amountInputRef = useRef<HTMLInputElement>(null)
 
   // Source data. `max` (and the fee-on-top guard) draws from SPENDABLE only, so a not-yet-final
   // ("pending") note can't be selected; `pendingUsdc` is display-only (0 on local Anvil).
@@ -461,6 +464,7 @@ export function SendModal() {
             // SendModal's three kinds default to the relayer path; user pays gas only when
             // they've toggled Preferences → "Submit transactions from my wallet".
             gaslessMode={!prefs.submitFromWallet}
+            inputRef={amountInputRef}
           />
           <ForceOutcomeSelect />
           <SendInputStepFooter
@@ -468,6 +472,7 @@ export function SendModal() {
             maxInput={inputMax}
             onBack={() => setStep('recipient')}
             onContinue={() => setStep('review')}
+            onIncompleteContinue={() => amountInputRef.current?.focus()}
           />
         </>
       )}

--- a/apps/armada-interface/src/components/shield/ShieldAmountStep.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldAmountStep.test.tsx
@@ -87,7 +87,7 @@ describe('ShieldAmountStepContent (direction)', () => {
 describe('ShieldAmountStepFooter (Review gating)', () => {
   it('disables Review when the amount is empty', () => {
     renderFooter('')
-    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toHaveAttribute('aria-disabled', 'true')
   })
 
   it("labels the CTA 'Input amount' when there is no valid amount", () => {
@@ -99,12 +99,12 @@ describe('ShieldAmountStepFooter (Review gating)', () => {
 
   it('disables Review when the amount is 0', () => {
     renderFooter('0')
-    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toHaveAttribute('aria-disabled', 'true')
   })
 
   it('disables Review when the amount exceeds maxInput', () => {
     renderFooter('200') // maxInput = 100 USDC
-    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toHaveAttribute('aria-disabled', 'true')
   })
 
   it('enables Review for a positive amount within maxInput', () => {
@@ -114,7 +114,7 @@ describe('ShieldAmountStepFooter (Review gating)', () => {
 
   it('rejects an amount at or below the relayer-fee floor (shield)', () => {
     renderFooter('1', 1_000_000n) // minAmount = 1 USDC; amount = 1 → not > fee
-    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toHaveAttribute('aria-disabled', 'true')
   })
 
   it('fires onContinue / onCancel from the CTAs', () => {
@@ -123,5 +123,26 @@ describe('ShieldAmountStepFooter (Review gating)', () => {
     expect(onContinue).toHaveBeenCalled()
     fireEvent.click(screen.getByRole('button', { name: /Cancel/ }))
     expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('taps to nudge: the disabled "Input amount" CTA fires onIncompleteContinue, not onContinue', () => {
+    const onContinue = vi.fn()
+    const onIncompleteContinue = vi.fn()
+    render(
+      <ShieldAmountStepFooter
+        amountStr=""
+        maxInput={100_000_000n}
+        minAmount={0n}
+        onContinue={onContinue}
+        onCancel={vi.fn()}
+        onIncompleteContinue={onIncompleteContinue}
+      />,
+    )
+    const cta = screen.getByRole('button', { name: 'Input amount' })
+    // With an onDisabledClick handler wired, the incomplete CTA stays DOM-clickable but aria-disabled.
+    expect(cta).toHaveAttribute('aria-disabled', 'true')
+    fireEvent.click(cta)
+    expect(onContinue).not.toHaveBeenCalled()
+    expect(onIncompleteContinue).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/armada-interface/src/components/shield/ShieldAmountStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldAmountStep.tsx
@@ -1,8 +1,10 @@
 // ABOUTME: Shared amount step for the Shield/Unshield tabbed modal — DepositAmountCard with the direction tabs in its header + a chain picker.
 // ABOUTME: Direction-agnostic: the caller (ShieldModal) feeds it the active flow's values; footer gates Review on amount (+ shield's fee floor).
 
+import type { Ref } from 'react'
 import { Button } from '@/design'
 import { ChainSelect, GasBalanceNotice, SegmentedControl } from '@/components/ui'
+import { useNudgeShake } from '@/hooks/useNudgeShake'
 import { DepositAmountCard } from '@/components/deposit/DepositAmountCard/DepositAmountCard'
 import { depositOverlayShellStyles } from '@/components/deposit/DepositOverlayShell/DepositOverlayShell'
 import type { FlowFeeBreakdown } from '@/components/ui/FeeBreakdownTooltip'
@@ -42,6 +44,8 @@ interface ShieldAmountStepContentProps {
   gaslessMode?: boolean
   /** Chain whose native balance is checked for the wallet-submit gas notice. */
   gasChainId: number
+  /** Ref onto the amount input so the footer's incomplete-CTA nudge can focus the field. */
+  inputRef?: Ref<HTMLInputElement>
 }
 
 export function ShieldAmountStepContent({
@@ -60,6 +64,7 @@ export function ShieldAmountStepContent({
   feeLoading = false,
   gaslessMode = true,
   gasChainId,
+  inputRef,
 }: ShieldAmountStepContentProps) {
   const gasWarning = useGasBalanceWarning(gasChainId)
   const showGasNotice = !gaslessMode && gasWarning.show
@@ -110,6 +115,7 @@ export function ShieldAmountStepContent({
         maxInput={maxInput}
         error={errorMessage}
         amountAriaLabel={amountAriaLabel}
+        inputRef={inputRef}
       />
       {showGasNotice ? (
         <GasBalanceNotice
@@ -128,6 +134,8 @@ interface ShieldAmountStepFooterProps {
   minAmount: bigint
   onCancel: () => void
   onContinue: () => void
+  /** Called when the disabled "Input amount" CTA is tapped — focuses the amount field alongside the shake. */
+  onIncompleteContinue?: () => void
 }
 
 export function ShieldAmountStepFooter({
@@ -136,11 +144,13 @@ export function ShieldAmountStepFooter({
   minAmount,
   onCancel,
   onContinue,
+  onIncompleteContinue,
 }: ShieldAmountStepFooterProps) {
   const { value: amount, error: parseError } = parseUsdcInput(amountStr)
   const tooMuch = amount > maxInput
   const tooSmall = minAmount > 0n && amount > 0n && amount <= minAmount
   const canReview = hasActiveAmount(amountStr) && !tooMuch && !tooSmall && !parseError
+  const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
 
   return (
     <div className={depositOverlayShellStyles.buttonRow}>
@@ -152,6 +162,12 @@ export function ShieldAmountStepFooter({
         showIcon={false}
         disabled={!canReview}
         onClick={onContinue}
+        onDisabledClick={() => {
+          nudge()
+          onIncompleteContinue?.()
+        }}
+        shaking={shaking}
+        onShakeAnimationEnd={onShakeAnimationEnd}
       />
     </div>
   )

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: ShieldModal — Shield/Unshield tabbed flow. Dumb renderer composing useShieldFlow + useUnshieldFlow.
 // ABOUTME: Shield = public → private; Unshield = private → your own EVM wallet (to-chain picker). The typed amount carries across the tab toggle.
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { openModalAtom } from '@/state/ui'
 import { preferencesAtom } from '@/state/preferences'
@@ -53,6 +53,9 @@ export function ShieldModal() {
   const shieldFlow = useShieldFlow(isOpen)
   const unshieldFlow = useUnshieldFlow(isOpen)
   const { exiting, requestClose: close } = useFlowExit(() => setOpenModal(null))
+  // Shared across the amount step's card + footer (siblings) so tapping the disabled "Input amount"
+  // CTA can focus the amount field alongside the shake.
+  const amountInputRef = useRef<HTMLInputElement>(null)
 
   function handleTabChange(next: ShieldTab) {
     if (next === tab) return
@@ -125,6 +128,7 @@ export function ShieldModal() {
             feeLoading={active.feeLoading}
             gaslessMode={isShield ? shieldFlow.useGasless : !prefs.submitFromWallet}
             gasChainId={isShield ? shieldFlow.fromChainId : hubChainId}
+            inputRef={amountInputRef}
           />
           <ShieldAmountStepFooter
             amountStr={active.amountStr}
@@ -132,6 +136,7 @@ export function ShieldModal() {
             minAmount={isShield ? shieldFlow.minAmount : 0n}
             onCancel={close}
             onContinue={active.onContinueToReview}
+            onIncompleteContinue={() => amountInputRef.current?.focus()}
           />
         </>
       )}

--- a/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.module.css
+++ b/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.module.css
@@ -108,6 +108,17 @@
     color-mix(in srgb, var(--semantic-color-surface-bg) 55%, transparent);
 }
 
+/* Option list inside the mobile BottomSheet — the sheet supplies the chrome (surface, radius,
+   scrim), so this is a plain full-width stack with no popover positioning/border/shadow. */
+.sheetList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-1);
+}
+
 .option {
   display: flex;
   align-items: center;

--- a/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.test.tsx
+++ b/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.test.tsx
@@ -4,6 +4,10 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ChainSelect } from './ChainSelect'
+import { useMobileLayout } from '@/hooks/useMobileLayout'
+
+// Default desktop (inline popover); the mobile test overrides to exercise the BottomSheet path.
+vi.mock('@/hooks/useMobileLayout', () => ({ useMobileLayout: vi.fn(() => false) }))
 
 const MAINNET = { chainId: 1, domain: 0, name: 'Mainnet', rpcUrls: ['x'] as const }
 const OPTIMISM = { chainId: 10, domain: 2, name: 'Optimism', rpcUrls: ['y'] as const }
@@ -45,5 +49,17 @@ describe('<ChainSelect>', () => {
     render(<ChainSelect value={31337} onChange={() => {}} label="From chain" disabled />)
     expect(screen.queryByRole('button')).toBeNull()
     expect(screen.getByLabelText('From chain')).toBeInTheDocument()
+  })
+
+  it('on mobile, the trigger targets a dialog and options open in the bottom sheet', () => {
+    vi.mocked(useMobileLayout).mockReturnValue(true)
+    const onChange = vi.fn()
+    render(<ChainSelect value={31337} onChange={onChange} label="From chain" />)
+    const trigger = screen.getByLabelText('From chain')
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog')
+    fireEvent.click(trigger)
+    fireEvent.click(screen.getByRole('option', { name: /Anvil Client A/ }))
+    expect(onChange).toHaveBeenCalledWith(31338)
+    vi.mocked(useMobileLayout).mockReturnValue(false)
   })
 })

--- a/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.tsx
+++ b/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.tsx
@@ -5,6 +5,8 @@ import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { ChevronDownIcon } from '@heroicons/react/24/solid'
 import { getAllChainIdentities, type ChainIdentity } from '@/config/network'
 import { chainIconForChainId } from '@/components/ui/chainIcons'
+import { useMobileLayout } from '@/hooks/useMobileLayout'
+import { BottomSheet } from '@/design'
 import styles from './ChainSelect.module.css'
 
 const ICON_SIZE = 32
@@ -43,6 +45,8 @@ export function ChainSelect({ value, onChange, chains, label, disabled, classNam
   const listboxId = useId()
   const rootRef = useRef<HTMLDivElement>(null)
   const [menuOpen, setMenuOpen] = useState(false)
+  // On phones the option list opens as a BottomSheet instead of the inline popover (mockup 748ba20).
+  const isMobile = useMobileLayout()
 
   // useMemo so the default chain list is stable across renders without re-running getAllChainIdentities.
   const options = useMemo(() => chains ?? getAllChainIdentities(), [chains])
@@ -50,7 +54,9 @@ export function ChainSelect({ value, onChange, chains, label, disabled, classNam
   const selectable = !disabled && options.length > 1
 
   useEffect(() => {
-    if (!menuOpen) return
+    // The mobile BottomSheet owns its own dismissal (scrim + Escape), so the outside-click handler
+    // is desktop-only.
+    if (!menuOpen || isMobile) return
     function handlePointerDown(event: MouseEvent) {
       if (!rootRef.current?.contains(event.target as Node)) {
         setMenuOpen(false)
@@ -58,7 +64,7 @@ export function ChainSelect({ value, onChange, chains, label, disabled, classNam
     }
     document.addEventListener('mousedown', handlePointerDown)
     return () => document.removeEventListener('mousedown', handlePointerDown)
-  }, [menuOpen])
+  }, [menuOpen, isMobile])
 
   function selectChain(nextId: number) {
     onChange(nextId)
@@ -67,15 +73,30 @@ export function ChainSelect({ value, onChange, chains, label, disabled, classNam
 
   const cls = [styles.root, className].filter(Boolean).join(' ')
 
+  const optionItems = options.map(option => (
+    <li key={option.chainId} role="presentation">
+      <button
+        type="button"
+        role="option"
+        aria-selected={option.chainId === value}
+        className={styles.option}
+        onClick={() => selectChain(option.chainId)}
+      >
+        <ChainIcon chainId={option.chainId} name={option.name} />
+        <span className={styles.optionLabel}>{option.name}</span>
+      </button>
+    </li>
+  ))
+
   return (
     <div className={cls} ref={rootRef}>
       {selectable ? (
         <button
           type="button"
           className={styles.trigger}
-          aria-haspopup="listbox"
+          aria-haspopup={isMobile ? 'dialog' : 'listbox'}
           aria-expanded={menuOpen}
-          aria-controls={listboxId}
+          aria-controls={isMobile ? undefined : listboxId}
           aria-label={label}
           onClick={() => setMenuOpen(open => !open)}
         >
@@ -96,23 +117,23 @@ export function ChainSelect({ value, onChange, chains, label, disabled, classNam
         </div>
       )}
 
-      {menuOpen && selectable ? (
+      {menuOpen && selectable && !isMobile ? (
         <ul id={listboxId} className={styles.menu} role="listbox" aria-label="Network">
-          {options.map(option => (
-            <li key={option.chainId} role="presentation">
-              <button
-                type="button"
-                role="option"
-                aria-selected={option.chainId === value}
-                className={styles.option}
-                onClick={() => selectChain(option.chainId)}
-              >
-                <ChainIcon chainId={option.chainId} name={option.name} />
-                <span className={styles.optionLabel}>{option.name}</span>
-              </button>
-            </li>
-          ))}
+          {optionItems}
         </ul>
+      ) : null}
+
+      {selectable && isMobile ? (
+        <BottomSheet
+          open={menuOpen}
+          onClose={() => setMenuOpen(false)}
+          title="Network"
+          ariaLabel="Network"
+        >
+          <ul className={styles.sheetList} role="listbox" aria-label="Network">
+            {optionItems}
+          </ul>
+        </BottomSheet>
       ) : null}
     </div>
   )

--- a/apps/armada-interface/src/components/yield/EarnInputStep.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.test.tsx
@@ -106,7 +106,11 @@ describe('<EarnInputStep>', () => {
 
   it('disables Review when amount exceeds maxInput', () => {
     setup({ max: 1_000_000n, amountStr: '5' })
-    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
+    // The incomplete CTA keeps its DOM click (for the nudge) but is aria-disabled.
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    )
     expect(screen.getByRole('alert')).toHaveTextContent(/more than you can add/i)
   })
 
@@ -146,7 +150,18 @@ describe('<EarnInputStep>', () => {
         onContinue={vi.fn()}
       />,
     )
-    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Review|Input amount/ })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    )
     expect(screen.getByRole('alert')).toHaveTextContent(/cover the 0\.50 fee/)
+  })
+
+  it('tapping the disabled "Input amount" CTA nudges the field (focus) instead of continuing', () => {
+    const props = setup({ tab: 'add', amountStr: '' })
+    const cta = screen.getByRole('button', { name: 'Input amount' })
+    fireEvent.click(cta)
+    expect(props.onContinue).not.toHaveBeenCalled()
+    expect(screen.getByLabelText('Vault deposit amount')).toHaveFocus()
   })
 })

--- a/apps/armada-interface/src/components/yield/EarnInputStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.tsx
@@ -1,13 +1,14 @@
 // ABOUTME: Earn amount step — APY intro banner (DepositTooltip) above a chain-less DepositAmountCard whose in-card header holds the Add/Withdraw SegmentedControl.
 // ABOUTME: The vault has no chain selection; the banner headline is driven by the live vault rate and shows on both tabs (matches the mockup).
 
-import { useMemo } from 'react'
+import { useMemo, useRef, type Ref } from 'react'
 import { ChartBarIcon } from '@heroicons/react/24/solid'
 import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { DepositAmountCard } from '@/components/deposit/DepositAmountCard/DepositAmountCard'
 import { depositOverlayShellStyles } from '@/components/deposit/DepositOverlayShell/DepositOverlayShell'
 import { DepositTooltip } from '@/components/dashboard/DepositTooltip'
 import { GasBalanceNotice, SegmentedControl } from '@/components/ui'
+import { useNudgeShake } from '@/hooks/useNudgeShake'
 import type { DisplayFees } from '@/lib/fees/displayFees'
 import type { FlowFeeBreakdown } from '@/components/ui/FeeBreakdownTooltip'
 import { useGasBalanceWarning } from '@/hooks/useGasBalanceWarning'
@@ -59,6 +60,10 @@ export interface EarnInputStepProps {
   continueBlockedReason?: string | null
   onCancel: () => void
   onContinue: () => void
+  /** Ref onto the amount input so the footer's incomplete-CTA nudge can focus the field. */
+  inputRef?: Ref<HTMLInputElement>
+  /** Called when the disabled "Input amount" CTA is tapped — focuses the amount field alongside the shake. */
+  onIncompleteContinue?: () => void
 }
 
 function formatApy(rate: YieldRate | null): string {
@@ -91,6 +96,7 @@ export function EarnInputStepContent({
   gaslessMode = true,
   rate,
   continueBlockedReason,
+  inputRef,
 }: Pick<
   EarnInputStepProps,
   | 'tab'
@@ -107,6 +113,7 @@ export function EarnInputStepContent({
   | 'gaslessMode'
   | 'rate'
   | 'continueBlockedReason'
+  | 'inputRef'
 >) {
   const hub = getNetworkConfig().hub
   const chains = useMemo(
@@ -178,6 +185,7 @@ export function EarnInputStepContent({
         onMax={() => onAmountChange(formatUsdcPlain(maxInput))}
         error={fieldError}
         amountAriaLabel={tab === 'add' ? 'Vault deposit amount' : 'Vault withdrawal amount'}
+        inputRef={inputRef}
       />
 
       {showGasNotice ? (
@@ -196,14 +204,21 @@ export function EarnInputStepFooter({
   continueBlockedReason,
   onCancel,
   onContinue,
+  onIncompleteContinue,
 }: Pick<
   EarnInputStepProps,
-  'amountStr' | 'maxInput' | 'continueBlockedReason' | 'onCancel' | 'onContinue'
+  | 'amountStr'
+  | 'maxInput'
+  | 'continueBlockedReason'
+  | 'onCancel'
+  | 'onContinue'
+  | 'onIncompleteContinue'
 >) {
   const { value: amount, error: parseError } = parseUsdcInput(amountStr)
   const tooMuch = amount > maxInput
   const canReview =
     hasActiveAmount(amountStr) && !tooMuch && !parseError && !continueBlockedReason
+  const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
 
   return (
     <div className={`${depositOverlayShellStyles.buttonRow} ${modalActionRowEnter}`}>
@@ -221,16 +236,27 @@ export function EarnInputStepFooter({
         showIcon={false}
         disabled={!canReview}
         onClick={onContinue}
+        onDisabledClick={() => {
+          nudge()
+          onIncompleteContinue?.()
+        }}
+        shaking={shaking}
+        onShakeAnimationEnd={onShakeAnimationEnd}
       />
     </div>
   )
 }
 
 export function EarnInputStep(props: EarnInputStepProps) {
+  // The step is the common parent of the amount card + footer, so it owns the ref shared between them.
+  const amountInputRef = useRef<HTMLInputElement>(null)
   return (
     <>
-      <EarnInputStepContent {...props} />
-      <EarnInputStepFooter {...props} />
+      <EarnInputStepContent {...props} inputRef={amountInputRef} />
+      <EarnInputStepFooter
+        {...props}
+        onIncompleteContinue={() => amountInputRef.current?.focus()}
+      />
     </>
   )
 }

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -56,6 +56,9 @@ export function EarnModal() {
   // Double-submit guard (P0-7): ref = synchronous gate (state is async), state = button disable.
   const submittingRef = useRef(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  // Shared across the amount step's card + footer (siblings) so tapping the disabled "Input amount"
+  // CTA can focus the amount field alongside the shake.
+  const amountInputRef = useRef<HTMLInputElement>(null)
 
   // Source data. The USDC leg (deposit amount + the withdraw-fee reserve + the fee-on-top guard) draws
   // from SPENDABLE only, so a not-yet-final ("pending") note can't be used; `pendingUsdc` is
@@ -342,6 +345,7 @@ export function EarnModal() {
             gaslessMode={!effectiveUseWalletOverride}
             rate={yieldRate}
             continueBlockedReason={withdrawFeeBlockedReason}
+            inputRef={amountInputRef}
           />
           <EarnInputStepFooter
             amountStr={amountStr}
@@ -349,6 +353,7 @@ export function EarnModal() {
             continueBlockedReason={withdrawFeeBlockedReason}
             onCancel={close}
             onContinue={() => setStep('review')}
+            onIncompleteContinue={() => amountInputRef.current?.focus()}
           />
         </>
       )}

--- a/apps/armada-interface/src/design/components/Button/Button.module.css
+++ b/apps/armada-interface/src/design/components/Button/Button.module.css
@@ -21,8 +21,11 @@
   box-sizing: border-box;
 }
 .btn:focus-visible { box-shadow: 0 0 0 2px var(--semantic-color-border-focus); }
-.btn:active:not(:disabled) { transform: translateY(1px); }
-.btn:disabled { opacity: 0.4; cursor: not-allowed; transform: none; }
+.btn:active:not(:disabled):not([aria-disabled='true']) { transform: translateY(1px); }
+/* Muted styling keys off [aria-disabled] too: a CTA kept DOM-clickable for the incomplete-nudge
+   (shake) is `aria-disabled` rather than natively `disabled`, but must still LOOK disabled. */
+.btn:disabled,
+.btn[aria-disabled='true'] { opacity: 0.4; cursor: not-allowed; transform: none; }
 
 .loading {
   cursor: wait;
@@ -68,6 +71,36 @@
 @keyframes buttonSpin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+/* One-shot nudge shake for an incomplete/disabled CTA (see useNudgeShake). Reduced-motion no-op. */
+.shake {
+  animation: incompleteCtaShake 400ms ease-in-out;
+}
+
+@keyframes incompleteCtaShake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(calc(var(--primitives-spacing-1) * -1));
+  }
+  40% {
+    transform: translateX(var(--primitives-spacing-1));
+  }
+  60% {
+    transform: translateX(calc(var(--primitives-spacing-1) * -0.5));
+  }
+  80% {
+    transform: translateX(calc(var(--primitives-spacing-1) * 0.5));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shake {
+    animation: none;
   }
 }
 

--- a/apps/armada-interface/src/design/components/Button/Button.tsx
+++ b/apps/armada-interface/src/design/components/Button/Button.tsx
@@ -21,6 +21,16 @@ export interface ButtonProps {
   /** Keeps the default variant colors and shows a spinner (does not apply muted disabled styles). */
   loading?: boolean
   onClick?: () => void
+  /**
+   * Fired when the control is disabled/incomplete; keeps the button clickable so a nudge (shake +
+   * focus the missing field) can run instead of the button being an inert dead-zone. When set and
+   * `disabled`, the click routes here instead of `onClick`.
+   */
+  onDisabledClick?: () => void
+  /** When true, plays a one-shot horizontal shake (reduced-motion no-op). Pair with `onShakeAnimationEnd`. */
+  shaking?: boolean
+  /** Clears the shake once the animation finishes; wire to `useNudgeShake().onShakeAnimationEnd`. */
+  onShakeAnimationEnd?: (event: React.AnimationEvent<HTMLButtonElement>) => void
   style?: React.CSSProperties
   className?: string
   type?: 'button' | 'submit' | 'reset'
@@ -52,6 +62,9 @@ export function Button({
   disabled = false,
   loading = false,
   onClick,
+  onDisabledClick,
+  shaking = false,
+  onShakeAnimationEnd,
   className,
   type = 'button',
   style,
@@ -62,6 +75,10 @@ export function Button({
   // Loading occupies the trailing slot even when showIcon is false, so the spinner has room.
   const showTrailing = showIcon || loading
 
+  // When disabled with an `onDisabledClick` handler (and not loading), keep the button clickable so a
+  // nudge can run; the native `disabled` attribute would swallow the click and make the CTA inert.
+  const interceptDisabledClick = Boolean(disabled && onDisabledClick && !loading)
+
   const cls = [
     styles.btn,
     styles[variant],
@@ -69,6 +86,7 @@ export function Button({
     !showTrailing && styles.noIcon,
     loading && styles.loading,
     leadingIcon && styles.leading,
+    shaking && styles.shake,
     className ?? '',
   ]
     .filter(Boolean)
@@ -78,9 +96,21 @@ export function Button({
     <button
       type={type}
       className={cls}
-      disabled={disabled && !loading}
+      disabled={disabled && !loading && !interceptDisabledClick}
+      aria-disabled={disabled || undefined}
       aria-busy={loading || undefined}
-      onClick={loading ? undefined : onClick}
+      onClick={
+        loading
+          ? undefined
+          : () => {
+              if (disabled) {
+                onDisabledClick?.()
+                return
+              }
+              onClick?.()
+            }
+      }
+      onAnimationEnd={onShakeAnimationEnd}
       style={style}
     >
       {leadingIcon ? (

--- a/apps/armada-interface/src/hooks/useNudgeShake.test.tsx
+++ b/apps/armada-interface/src/hooks/useNudgeShake.test.tsx
@@ -1,0 +1,77 @@
+// ABOUTME: Unit tests for useNudgeShake — reduced-motion skips the shake; a nudge flips shaking on (rAF) and clears on animation end.
+// ABOUTME: Stubs matchMedia + requestAnimationFrame so the one-shot shake resolves synchronously.
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import type { AnimationEvent } from 'react'
+import { act, renderHook } from '@testing-library/react'
+import { useNudgeShake } from './useNudgeShake'
+
+function stubReducedMotion(reduced: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    (query: string) =>
+      ({
+        matches: query.includes('prefers-reduced-motion') ? reduced : false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList,
+  )
+}
+
+/** Run the rAF callback synchronously so the shake flips on within a single act(). */
+function stubSyncRaf() {
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0)
+    return 0
+  })
+}
+
+function animationEnd(target: EventTarget, currentTarget: EventTarget): AnimationEvent<HTMLElement> {
+  return { target, currentTarget } as unknown as AnimationEvent<HTMLElement>
+}
+
+describe('useNudgeShake', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not shake when the user prefers reduced motion', () => {
+    stubReducedMotion(true)
+    const { result } = renderHook(() => useNudgeShake())
+    act(() => result.current.nudge())
+    expect(result.current.shaking).toBe(false)
+  })
+
+  it('shakes on nudge when motion is allowed, then clears on a matching animation end', () => {
+    stubReducedMotion(false)
+    stubSyncRaf()
+    const { result } = renderHook(() => useNudgeShake())
+
+    act(() => result.current.nudge())
+    expect(result.current.shaking).toBe(true)
+
+    const el = document.createElement('button')
+    act(() => result.current.onShakeAnimationEnd(animationEnd(el, el)))
+    expect(result.current.shaking).toBe(false)
+  })
+
+  it('ignores an animation end bubbled from a child (target !== currentTarget)', () => {
+    stubReducedMotion(false)
+    stubSyncRaf()
+    const { result } = renderHook(() => useNudgeShake())
+
+    act(() => result.current.nudge())
+    expect(result.current.shaking).toBe(true)
+
+    const parent = document.createElement('button')
+    const child = document.createElement('span')
+    act(() => result.current.onShakeAnimationEnd(animationEnd(child, parent)))
+    // Still shaking — a bubbled child event must not clear the parent's shake.
+    expect(result.current.shaking).toBe(true)
+  })
+})

--- a/apps/armada-interface/src/hooks/useNudgeShake.ts
+++ b/apps/armada-interface/src/hooks/useNudgeShake.ts
@@ -1,0 +1,29 @@
+// ABOUTME: One-shot "nudge" shake state for incomplete-CTA affordances — trigger a single shake, skip under reduced motion.
+// ABOUTME: Returns { shaking, nudge, onShakeAnimationEnd }; wire onShakeAnimationEnd to the shaking element's onAnimationEnd.
+
+import { useCallback, useState, type AnimationEvent } from 'react'
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+/** One-shot CSS shake class; skipped when the user prefers reduced motion. */
+export function useNudgeShake() {
+  const [shaking, setShaking] = useState(false)
+
+  const nudge = useCallback(() => {
+    if (prefersReducedMotion()) return
+    setShaking(false)
+    requestAnimationFrame(() => {
+      setShaking(true)
+    })
+  }, [])
+
+  const onShakeAnimationEnd = useCallback((event: AnimationEvent<HTMLElement>) => {
+    if (event.target !== event.currentTarget) return
+    setShaking(false)
+  }, [])
+
+  return { shaking, nudge, onShakeAnimationEnd }
+}


### PR DESCRIPTION
Two additive UX ports from the mockup (`d31913c`, `748ba20`). No behavior/product changes beyond the interactions below.

## Nudge an incomplete CTA (`d31913c`)
Clicking the **disabled primary CTA** on an amount step (our "Input amount" button) now **shakes it once and focuses the amount input** — reinforcing the disabled-CTA affordance. Reduced-motion-aware (shake no-ops).
- New `useNudgeShake` hook + a `.shake` keyframe on the vendored `@/design` Button.
- Button gains `onDisabledClick` / `shaking` / `onShakeAnimationEnd`. When `disabled && onDisabledClick`, the button stays DOM-clickable (so the nudge can run) and is `aria-disabled` instead of natively `disabled` — the muted styling now keys off `[aria-disabled]` too, so it still *looks* disabled.
- Focus is wired from each modal (the common parent of the amount card + footer) via an `inputRef` threaded into `DepositAmountCard`.

## ChainSelect → bottom sheet on phones (`748ba20`)
The network picker (already a custom accessible listbox, shared across Shield / Send / deposit card) now opens its options in a **`BottomSheet` on phones** (`useMobileLayout`) instead of the inline popover; desktop keeps the popover. Hover states already existed. Trigger `aria-haspopup` flips `listbox`↔`dialog`; the mobile sheet owns its own dismissal.

## Not ported
`748ba20`'s premise ("network picker is a custom listbox") already matched ours, so no rebuild was needed — only the mobile-sheet behavior.

## Testing
`npm run typecheck` + `npm run test` — 1238 pass, 8 skipped. New tests: `useNudgeShake`, disabled-CTA nudge path across the three amount steps, and the ChainSelect mobile path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
