### PR TITLE
feat(interface): mockup catch-up Tier 1 — copy, motion & polish

### DIFF
--- a/apps/armada-interface/index.html
+++ b/apps/armada-interface/index.html
@@ -2,6 +2,15 @@
 <html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
+    <!-- Apply the saved theme before first paint so a dark-mode user doesn't flash light on reload. -->
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem('armada-theme')
+          if (t === 'dark' || t === 'light') document.documentElement.setAttribute('data-theme', t)
+        } catch (e) {}
+      })()
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -9,7 +18,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Charis+SIL:ital,wght@0,400;0,700;1,400&family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet" />
     <title>Armada App — Dashboard</title>
   </head>
-  <body class="dark">
+  <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/apps/armada-interface/src/components/dashboard/RollingBalanceValue/RollingBalanceValue.tsx
+++ b/apps/armada-interface/src/components/dashboard/RollingBalanceValue/RollingBalanceValue.tsx
@@ -49,38 +49,73 @@ function tokenizeBalance(value: string): BalanceToken[] {
   return tokens
 }
 
+function parseAmountParts(value: string): { intDigits: number[]; fracDigits: number[] } {
+  const cleaned = value.replace(/,/g, '')
+  const dot = cleaned.indexOf('.')
+  const intPart = (dot === -1 ? cleaned : cleaned.slice(0, dot)) || '0'
+  const fracPart = dot === -1 ? '' : cleaned.slice(dot + 1)
+  return {
+    intDigits: intPart.split('').map((char) => Number(char)),
+    fracDigits: fracPart.split('').map((char) => Number(char)),
+  }
+}
+
+function groupedIntegerSkeleton(intDigits: number[]): string {
+  return intDigits.join('').replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+}
+
+// Split into integer/fraction and pad each side independently so digits stay aligned on the
+// decimal point across a roll — otherwise a width change (e.g. 1,000.00 → 250.00) misaligns the
+// from/to digit columns and the roll passes through garbage intermediate numbers.
 function buildDisplayTokens(
   toValue: string,
   mode: BalanceRollMode,
   fromValue?: string,
 ): DisplayToken[] {
-  const toTokens = tokenizeBalance(toValue)
-  const fromDigits =
-    mode === 'fromValue' && fromValue
-      ? tokenizeBalance(fromValue)
-          .filter((token): token is Extract<BalanceToken, { type: 'digit' }> => token.type === 'digit')
-          .map((token) => token.digit)
-      : []
-
-  const toDigitCount = toTokens.filter((token) => token.type === 'digit').length
-  while (fromDigits.length < toDigitCount) {
-    fromDigits.unshift(0)
+  if (mode !== 'fromValue' || !fromValue) {
+    return tokenizeBalance(toValue).map((token, index, tokens) => {
+      if (token.type === 'separator') return { type: 'separator', char: token.char, key: token.key }
+      const digitIndex = tokens.slice(0, index).filter((item) => item.type === 'digit').length
+      return {
+        type: 'digit',
+        key: token.key,
+        digitIndex,
+        fromDigit: 0,
+        toDigit: token.digit,
+      }
+    })
   }
 
+  const from = parseAmountParts(fromValue)
+  const to = parseAmountParts(toValue)
+  const intWidth = Math.max(from.intDigits.length, to.intDigits.length, 1)
+  const fracWidth = Math.max(from.fracDigits.length, to.fracDigits.length)
+
+  while (from.intDigits.length < intWidth) from.intDigits.unshift(0)
+  while (to.intDigits.length < intWidth) to.intDigits.unshift(0)
+  while (from.fracDigits.length < fracWidth) from.fracDigits.push(0)
+  while (to.fracDigits.length < fracWidth) to.fracDigits.push(0)
+
+  const skeleton =
+    fracWidth > 0
+      ? `${groupedIntegerSkeleton(to.intDigits)}.${'0'.repeat(fracWidth)}`
+      : groupedIntegerSkeleton(to.intDigits)
+
+  const fromDigits = [...from.intDigits, ...from.fracDigits]
+  const toDigits = [...to.intDigits, ...to.fracDigits]
   let digitIndex = 0
 
-  return toTokens.map((token) => {
+  return tokenizeBalance(skeleton).map((token) => {
     if (token.type === 'separator') {
       return { type: 'separator', char: token.char, key: token.key }
     }
 
-    const fromDigit = mode === 'fromZero' ? 0 : (fromDigits[digitIndex] ?? 0)
     const displayDigit: DisplayDigit = {
       type: 'digit',
       key: token.key,
       digitIndex,
-      fromDigit,
-      toDigit: token.digit,
+      fromDigit: fromDigits[digitIndex] ?? 0,
+      toDigit: toDigits[digitIndex] ?? 0,
     }
     digitIndex += 1
     return displayDigit

--- a/apps/armada-interface/src/components/dashboard/VaultPositionBar/VaultPositionBar.tsx
+++ b/apps/armada-interface/src/components/dashboard/VaultPositionBar/VaultPositionBar.tsx
@@ -132,7 +132,7 @@ export function VaultPositionBar({
   }
 
   return (
-    <div className={styles.root} aria-label="Vault position" {...peekHandlers}>
+    <div className={styles.root} aria-label="Shielded vault position" {...peekHandlers}>
       {content}
     </div>
   )

--- a/apps/armada-interface/src/components/tx/processing/processingView.ts
+++ b/apps/armada-interface/src/components/tx/processing/processingView.ts
@@ -56,8 +56,8 @@ const STAGE_COPY: Record<TxKind, Record<string, StageCopyEntry>> = {
   },
   'yield-deposit': {
     'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
-    'submit-relayer': { label: 'Submitting privately', subtitle: 'Relaying to the vault' },
-    'hub-confirmed': { label: 'Adding to vault', subtitle: 'Confirming on chain', completedLabel: 'Earning' },
+    'submit-relayer': { label: 'Submitting privately', subtitle: 'Relaying to the shielded vault' },
+    'hub-confirmed': { label: 'Adding to shielded vault', subtitle: 'Confirming on chain', completedLabel: 'Earning' },
   },
   'yield-withdraw': {
     'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
@@ -119,12 +119,12 @@ function resolveCardBase(record: TxRecord, sendVariant?: SendVariant): CardBase 
         : { tag: 'Send in progress', title: 'Unshielding your USDC' }
     case 'yield-deposit':
       return {
-        tag: 'Deposit to vault in progress',
-        title: 'Depositing USDC into the vault',
+        tag: 'Deposit to shielded vault in progress',
+        title: 'Depositing USDC into the shielded vault',
         titleBreakAfter: 'USDC',
       }
     case 'yield-withdraw':
-      return { tag: 'Withdrawal from vault in progress', title: 'Your withdrawal is in progress' }
+      return { tag: 'Withdraw from shielded vault in progress', title: 'Your withdrawal is in progress' }
   }
 }
 

--- a/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.module.css
+++ b/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.module.css
@@ -105,6 +105,11 @@
   height: var(--primitives-spacing-5);
   color: var(--semantic-color-text-secondary);
   flex-shrink: 0;
+  transition: transform 0.15s ease;
+}
+
+.trigger[aria-expanded='true'] .chevron {
+  transform: rotate(180deg);
 }
 
 .menu {
@@ -114,10 +119,13 @@
   right: 0;
   z-index: 20;
   margin: 0;
-  padding: var(--primitives-spacing-1);
+  padding: var(--primitives-spacing-2);
   list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-spacing-1);
   background: var(--semantic-color-surface-tooltip);
-  border: calc(var(--primitives-borderWidth-default) * 1px) solid var(--semantic-color-border-default);
+  border: none;
   border-radius: calc(var(--semantic-borderRadius-card) * 1px);
   box-shadow: 0 var(--primitives-spacing-3) var(--primitives-spacing-6)
     color-mix(in srgb, var(--semantic-color-surface-bg) 55%, transparent);
@@ -137,32 +145,56 @@
 .option {
   display: flex;
   align-items: center;
-  gap: var(--primitives-spacing-2);
+  gap: var(--primitives-spacing-3);
   width: 100%;
+  min-height: var(--primitives-spacing-11);
   padding: var(--primitives-spacing-2) var(--primitives-spacing-3);
   border: none;
-  border-radius: calc(var(--primitives-borderRadius-sm) * 1px);
+  border-radius: calc(var(--semantic-borderRadius-item) * 1px);
   background: transparent;
   cursor: pointer;
   text-align: left;
-}
-
-.option:hover {
-  background: var(--semantic-color-surface-raised-hover);
+  box-sizing: border-box;
+  font-weight: var(--primitives-fontWeight-regular);
+  transition: background 0.15s ease;
 }
 
 .option[aria-selected='true'] {
+  background: var(--semantic-color-surface-raised-pressed);
+  font-weight: var(--primitives-fontWeight-medium);
+}
+
+.option:active {
   background: var(--semantic-color-surface-raised-pressed);
 }
 
 .option:focus-visible {
   outline: calc(var(--primitives-borderWidth-default) * 1px) solid var(--semantic-color-border-focus);
-  outline-offset: calc(var(--primitives-spacing-1) * -0.5);
+  outline-offset: calc(var(--primitives-spacing-1) * 0.5);
+}
+
+/* Hover only on real pointers so touch taps don't leave a sticky highlight. */
+@media (hover: hover) and (pointer: fine) {
+  .option:hover {
+    background: var(--semantic-color-surface-raised-hover);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chevron,
+  .option {
+    transition: none;
+  }
+}
+
+/* Comfortable touch targets for the mobile option sheet. */
+.sheetList .option {
+  min-height: var(--primitives-spacing-12);
+  padding-block: var(--primitives-spacing-3);
 }
 
 .optionLabel {
   font-family: var(--primitives-fontFamily-ui), sans-serif;
-  font-weight: var(--primitives-fontWeight-regular);
   font-size: calc(var(--primitives-fontSize-base) * 1px);
   color: var(--semantic-color-text-primary);
 }

--- a/apps/armada-interface/src/components/yield/EarnCompleteStep.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnCompleteStep.test.tsx
@@ -10,7 +10,7 @@ const RATE: YieldRate = { rate: 1_000_000_000_000_000_000n, apyBps: 420n, fetche
 const CONFIRMED_AT = 1_700_000_000_000
 
 describe('<EarnCompleteStep>', () => {
-  it("add tab: 'USDC deposit complete' title + Add-to-vault summary", () => {
+  it("add tab: 'USDC shielded transfer to vault complete' title + Add-to-vault summary", () => {
     render(
       <EarnCompleteStep
         tab="add"
@@ -25,7 +25,7 @@ describe('<EarnCompleteStep>', () => {
         onGoToDashboard={() => {}}
       />,
     )
-    expect(screen.getByRole('heading', { name: 'USDC deposit complete' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'USDC shielded transfer to vault complete' })).toBeInTheDocument()
     expect(screen.getByText('Add to vault')).toBeInTheDocument()
     expect(screen.getByText('Your deposit')).toBeInTheDocument()
     expect(screen.getByText('Total deducted from balance')).toBeInTheDocument()

--- a/apps/armada-interface/src/components/yield/EarnCompleteStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnCompleteStep.tsx
@@ -38,7 +38,7 @@ export function EarnCompleteStep({
   onViewExplorer,
   onGoToDashboard,
 }: EarnCompleteStepProps) {
-  const title = tab === 'add' ? 'USDC deposit complete' : 'USDC withdrawal complete'
+  const title = tab === 'add' ? 'USDC shielded transfer to vault complete' : 'USDC withdrawal complete'
 
   return (
     <div className={styles.root}>

--- a/apps/armada-interface/src/components/yield/EarnInputStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.tsx
@@ -27,8 +27,8 @@ const TABS = [
 ] as const
 
 /** Static copy for the APY intro banner (the live rate fills the headline). */
-const EARN_APY_BANNER_BODY = 'Deposit into the vault and start earning now.'
-const EARN_APY_BANNER_TOOLTIP = 'The APY is an estimate from recent vault performance.'
+const EARN_APY_BANNER_BODY = "Add USDC to Armada's shielded vault and start earning now."
+const EARN_APY_BANNER_TOOLTIP = 'The APY is an estimate from recent shielded vault performance.'
 
 export interface EarnInputStepProps {
   tab: EarnTab

--- a/apps/armada-interface/src/components/yield/EarnModal.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.test.tsx
@@ -130,7 +130,7 @@ describe('<EarnModal>', () => {
     renderModal({ open: 'yield-deposit', shielded: 10_000_000n })
     fireEvent.change(screen.getByLabelText('Vault deposit amount'), { target: { value: '3' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
-    expect(screen.getByRole('heading', { name: 'Review your USDC deposit' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Review USDC shielded transfer to the vault' })).toBeInTheDocument()
   })
 
   it('Confirm submits the tx and advances to the progress step', async () => {

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.test.tsx
@@ -23,13 +23,13 @@ function setupAdd() {
 }
 
 describe('<EarnReviewStep>', () => {
-  it("tab=add: title 'Review your USDC deposit' and mode 'Add to vault'", () => {
+  it("tab=add: title 'Review USDC shielded transfer to the vault' and mode 'Add to vault'", () => {
     setupAdd()
-    expect(screen.getByRole('heading', { name: 'Review your USDC deposit' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Review USDC shielded transfer to the vault' })).toBeInTheDocument()
     expect(screen.getByText('Add to vault')).toBeInTheDocument()
   })
 
-  it("tab=withdraw: title 'Review your USDC withdrawal' and mode 'Withdraw from vault'", () => {
+  it("tab=withdraw: title 'Review USDC withdraw from shielded vault' and mode 'Withdraw from vault'", () => {
     render(
       <EarnReviewStep
         tab="withdraw"
@@ -42,7 +42,7 @@ describe('<EarnReviewStep>', () => {
         onConfirm={() => {}}
       />,
     )
-    expect(screen.getByRole('heading', { name: 'Review your USDC withdrawal' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Review USDC withdraw from shielded vault' })).toBeInTheDocument()
     expect(screen.getByText('Withdraw from shielded vault')).toBeInTheDocument()
   })
 

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.tsx
@@ -45,7 +45,8 @@ export function EarnReviewStep({
   onBack,
   onConfirm,
 }: EarnReviewStepProps) {
-  const title = tab === 'add' ? 'Review your USDC deposit' : 'Review your USDC withdrawal'
+  const title =
+    tab === 'add' ? 'Review USDC shielded transfer to the vault' : 'Review USDC withdraw from shielded vault'
   const confirmLabel = tab === 'add' ? 'Confirm deposit' : 'Confirm withdrawal'
 
   return (
@@ -71,8 +72,8 @@ export function EarnReviewStep({
 
         {tab === 'withdraw' ? (
           <p className={styles.slippageNotice}>
-            The vault rate moves with each new block. Your final USDC may differ slightly from this
-            quote.
+            The shielded vault rate moves with each new block. Your final USDC may differ slightly
+            from this quote.
           </p>
         ) : null}
 

--- a/apps/armada-interface/src/design/components/BottomSheet/BottomSheet.module.css
+++ b/apps/armada-interface/src/design/components/BottomSheet/BottomSheet.module.css
@@ -58,7 +58,7 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--primitives-spacing-3);
-  padding-inline: var(--primitives-spacing-5);
+  padding: var(--primitives-spacing-5);
   padding-bottom: var(--primitives-spacing-3);
   flex-shrink: 0;
 }

--- a/apps/armada-interface/src/index.css
+++ b/apps/armada-interface/src/index.css
@@ -74,13 +74,26 @@ body {
   color: var(--semantic-color-text-primary);
 }
 
-[data-theme="light"] body {
-  background-image: linear-gradient(
+/* Always paint the gem wash as a fixed overlay and fade its opacity between themes — gradients
+   can't interpolate, so toggling a background-image would hard-cut on theme swap. Full-strength
+   brand colors at 0.4 opacity over surface-bg match the old 40% color-mix in light. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background: linear-gradient(
     to bottom,
-    color-mix(in srgb, var(--semantic-color-brand-lavender) 40%, var(--semantic-color-surface-bg)) 0%,
-    color-mix(in srgb, var(--semantic-color-brand-gradient-rose) 40%, var(--semantic-color-surface-bg)) 50%,
-    color-mix(in srgb, var(--semantic-color-brand-amber) 40%, var(--semantic-color-surface-bg)) 100%
+    var(--semantic-color-brand-lavender) 0%,
+    var(--semantic-color-brand-gradient-rose) 50%,
+    var(--semantic-color-brand-amber) 100%
   );
+  opacity: 0;
+}
+
+[data-theme="light"] body::before {
+  opacity: 0.4;
 }
 
 * {


### PR DESCRIPTION
Catches up `apps/armada-interface` to mockup commits since `8dc3e28` that the redesign port skipped — the low-risk, self-contained **Tier 1** items surfaced by a commit-by-commit audit. Tier 2 (intro-cascade re-timing + promo↔balance-roll sequencing) and Tier 3 (479/767 breakpoint split, percent-of-balance presets, send-flow title nuances) will follow separately.

### Changes

**Copy — "shielded vault" naming (`538bbd2`)**
Earn/yield strings now say "shielded vault" to match the mockup: `EarnInputStep` promo + APY caption, `EarnReviewStep` titles + rate note, `EarnCompleteStep` title, `VaultPositionBar` aria, and yield-deposit/withdraw copy in `processingView.ts`. Adopted the mockup's literal strings where it has them; applied minimal `vault`→`shielded vault` renames where our processing structure has no mockup equivalent.

**Odometer decimal alignment (`8c18f1b`)**
`RollingBalanceValue.buildDisplayTokens` now splits integer/fraction and pads each side independently (ported `parseAmountParts` + `groupedIntegerSkeleton`), so preset/Max taps in the amount cards stay aligned on the decimal instead of rolling through garbage intermediate numbers (e.g. `0,025.00`).

**Gem-wash theme fade (`ba1120a`)**
The dashboard wash was a `background-image` toggled per `[data-theme]`, which hard-cut on theme swap (gradients can't interpolate). Now an always-painted `body::before` overlay whose opacity fades 0.4↔0 — the existing `*::before` opacity transition carries the crossfade. Light appearance unchanged.

**Dark-reload FOUC (`6997608`/`66f39ce`)**
Added an inline pre-paint script in `index.html` that applies the saved theme before first paint, so a dark-mode user no longer flashes light on reload. Also removed a stale `<body class="dark">` leftover (no `dark:` variants / `darkMode` config exist, so it was dead).

**Network picker polish (`748ba20`)**
`ChainSelect`: chevron rotates on open; option rows get the mockup's touch-target min-height, gap, radius, transition, `:active`, and selected font-weight; hover is gated behind `@media (hover: hover)` (no sticky hover on touch) with a `prefers-reduced-motion` block; menu chrome drops its border; mobile sheet options get comfortable touch targets.

**BottomSheet header inset (`3fc905c`)**
Base `BottomSheet.header` gains the top inset the mockup added, so non-activity sheets (e.g. the network picker sheet) get the intended title gap.

### Testing
- `npm run typecheck --workspace=@armada/interface` — clean
- `npm run test --workspace=@armada/interface` — 171 files pass, 1 skipped (updated earn copy assertions)

### Out of scope
Marketing-homepage / demo-wallet / audit-doc mockup commits (our app has no such surfaces). `TechnicalDetailsDisclosure` is intentionally kept (legitimately wired here, unlike the mockup which deleted it as a lab surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)