### PR TITLE
fix(interface): restore dashboard/sign-in gem wash (dark-mode Stage B regression)

### DIFF
--- a/apps/armada-interface/src/index.css
+++ b/apps/armada-interface/src/index.css
@@ -63,8 +63,9 @@ html {
 body {
   margin: 0;
   min-height: 100vh;
-  /* Match the mockup's dashboard shell: flat surface-bg in dark, a soft purple→amber wash in light. */
-  background-color: var(--semantic-color-surface-bg);
+  /* Transparent so the fixed z-index:-1 body::before gem wash shows. The base surface is on <html>
+     (above); an opaque body background here would paint over the negative-z pseudo and hide it. */
+  background-color: transparent;
   background-attachment: fixed;
   font-family: var(--primitives-fontFamily-ui);
   font-size: 15px;


### PR DESCRIPTION
The light-mode gem wash disappeared from the dashboard and sign-in page after the dark-mode Stage B gem-wash change (#511).

**Cause:** that change moved the wash to a fixed `body::before` overlay at `z-index: -1`, but left `body`'s own opaque `background-color: var(--semantic-color-surface-bg)` in place. A block element's background paints *after* its negative-z pseudo-element, so the opaque body background painted straight over the wash and hid it. (`<html>` already carries `surface-bg`, so the base surface is unaffected.)

**Fix:** make `body` transparent. `<html>`'s `surface-bg` fills the canvas, the `body::before` wash paints on top of it, and app content paints above the wash — so the gradient shows again (light), dark stays flat, and the theme-fade behavior from #511 is preserved.

One line; no other surfaces touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)