### PR TITLE
feat(interface): mockup catch-up Tier 2 — dashboard motion (intro cascade + promo/balance-roll handoff)

### DIFF
--- a/apps/armada-interface/src/components/dashboard/BalanceCard/BalanceCard.module.css
+++ b/apps/armada-interface/src/components/dashboard/BalanceCard/BalanceCard.module.css
@@ -110,7 +110,7 @@
 
 .vaultPositionEnter {
   opacity: 0;
-  animation: vaultPositionEnter 420ms cubic-bezier(0.22, 1, 0.36, 1) 820ms forwards;
+  animation: vaultPositionEnter 420ms cubic-bezier(0.22, 1, 0.36, 1) 700ms both;
 }
 
 @keyframes vaultPositionEnter {
@@ -345,7 +345,9 @@
 }
 
 .balanceClusterIntro .balanceValue {
-  animation: balanceFadeIn 920ms cubic-bezier(0.22, 1, 0.36, 1) 1280ms both;
+  /* Balance rides the hero card enter (RollingBalanceValue handles the roll-in from zero); no
+     separate late fade beat. */
+  animation: none;
 }
 
 .balanceClusterStable .balanceValue {
@@ -444,19 +446,19 @@
 }
 
 .actionEnter:nth-child(1) {
-  animation-delay: 560ms;
-}
-
-.actionEnter:nth-child(2) {
-  animation-delay: 630ms;
-}
-
-.actionEnter:nth-child(3) {
   animation-delay: 700ms;
 }
 
-.actionEnter:nth-child(4) {
+.actionEnter:nth-child(2) {
   animation-delay: 770ms;
+}
+
+.actionEnter:nth-child(3) {
+  animation-delay: 840ms;
+}
+
+.actionEnter:nth-child(4) {
+  animation-delay: 910ms;
 }
 
 .actionRowV2 {
@@ -471,12 +473,12 @@
 }
 
 .actionRowV2 .actionEnter:nth-child(2) {
-  animation-delay: 630ms;
+  animation-delay: 770ms;
 }
 
 .actionRowV2 .actionEnter:nth-child(3) {
   flex-shrink: 0;
-  animation-delay: 700ms;
+  animation-delay: 840ms;
 }
 
 .actionRowV2 .sendButton {

--- a/apps/armada-interface/src/components/dashboard/BalanceCard/BalanceCard.module.css
+++ b/apps/armada-interface/src/components/dashboard/BalanceCard/BalanceCard.module.css
@@ -99,37 +99,95 @@
   gap: var(--primitives-spacing-5);
 }
 
+/* Grid wrapper enables the collapse enter/exit (grid-template-rows 1fr↔0fr) so the vault row grows
+   in / shrinks out on vault deposit/withdraw rather than popping. */
 .vaultPositionWrap {
   width: 100%;
+  display: grid;
+  grid-template-rows: 1fr;
+}
+
+.vaultPositionInner {
+  min-height: 0;
+  overflow: hidden;
 }
 
 .vaultPositionVisible {
   opacity: 1;
   transform: none;
+  grid-template-rows: 1fr;
 }
 
+/* Page-load / first-reveal enter — delayed to ride the intro cascade. */
 .vaultPositionEnter {
-  opacity: 0;
   animation: vaultPositionEnter 420ms cubic-bezier(0.22, 1, 0.36, 1) 700ms both;
+}
+
+/* Mid-session appearance (vault deposit) — grows in immediately, in sync with the balance roll. */
+.vaultPositionEnterSync {
+  animation: vaultPositionEnter 520ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* Vault emptied (full withdraw) — collapses out. */
+.vaultPositionExit {
+  animation: vaultPositionExit 360ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.vaultPositionEnter,
+.vaultPositionEnterSync,
+.vaultPositionExit {
+  overflow: hidden;
 }
 
 @keyframes vaultPositionEnter {
   from {
     opacity: 0;
-    transform: translateY(var(--primitives-spacing-2));
+    grid-template-rows: 0fr;
+    max-height: 0;
+    margin-block-start: calc(-1 * var(--balance-card-padding));
   }
 
   to {
     opacity: 1;
-    transform: translateY(0);
+    grid-template-rows: 1fr;
+    max-height: calc(var(--primitives-spacing-20) + var(--primitives-spacing-16));
+    margin-block-start: 0;
+  }
+}
+
+@keyframes vaultPositionExit {
+  from {
+    opacity: 1;
+    grid-template-rows: 1fr;
+    max-height: calc(var(--primitives-spacing-20) + var(--primitives-spacing-16));
+    margin-block-start: 0;
+  }
+
+  to {
+    opacity: 0;
+    grid-template-rows: 0fr;
+    max-height: 0;
+    margin-block-start: calc(-1 * var(--balance-card-padding));
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .vaultPositionEnter {
+  .vaultPositionEnter,
+  .vaultPositionEnterSync,
+  .vaultPositionExit {
     animation: none;
     opacity: 1;
     transform: none;
+    grid-template-rows: 1fr;
+    max-height: none;
+    margin-block-start: 0;
+  }
+
+  .vaultPositionExit {
+    opacity: 0;
+    grid-template-rows: 0fr;
+    max-height: 0;
+    margin-block-start: calc(-1 * var(--balance-card-padding));
   }
 }
 

--- a/apps/armada-interface/src/components/dashboard/BalanceCard/BalanceCard.tsx
+++ b/apps/armada-interface/src/components/dashboard/BalanceCard/BalanceCard.tsx
@@ -17,6 +17,7 @@ import {
   BALANCE_REVEAL_DURATION_MS,
   BALANCE_ROLL_DIGIT_STAGGER_MS,
   balanceRevealRollDurationMs,
+  vaultPositionExitDurationMs,
 } from './balanceRevealMotion'
 import { VaultPositionBar } from '@/components/dashboard/VaultPositionBar'
 import { useDashboardBackground } from '@/hooks/useDashboardBackground'
@@ -261,16 +262,42 @@ export function BalanceCard({
     </span>
   )
 
+  // Vault row enter/exit state machine. `sync` enter = mid-session appearance (vault deposit, in
+  // step with the balance roll); the plain enter = first page-load reveal; exit = collapse-out when
+  // the vault is fully withdrawn (kept mounted through the exit animation so it can shrink).
+  const lastPositiveVaultRef = useRef(vaultBalance > 0 ? vaultBalance : 0)
+  if (vaultBalance > 0) lastPositiveVaultRef.current = vaultBalance
+
   const showVaultPosition = vaultBalance > 0 || vaultTransferRollActive
   const vaultBarWasRevealed = useRef(vaultBalance > 0)
+  const [vaultExiting, setVaultExiting] = useState(false)
+  const vaultMounted = showVaultPosition || vaultExiting
+  const vaultEnterSync =
+    showVaultPosition && !vaultExiting && !vaultBarWasRevealed.current && vaultTransferRollActive
   const shouldAnimateVaultEnter =
-    showVaultPosition && !vaultBarWasRevealed.current && !vaultTransferRollActive
+    showVaultPosition && !vaultExiting && !vaultBarWasRevealed.current && !vaultTransferRollActive
 
   if (showVaultPosition) {
     vaultBarWasRevealed.current = true
-  } else {
-    vaultBarWasRevealed.current = false
   }
+
+  useEffect(() => {
+    if (showVaultPosition) {
+      setVaultExiting(false)
+      return
+    }
+    if (lastPositiveVaultRef.current <= 0) {
+      vaultBarWasRevealed.current = false
+      return
+    }
+    vaultBarWasRevealed.current = false
+    setVaultExiting(true)
+    const timer = window.setTimeout(() => {
+      setVaultExiting(false)
+      lastPositiveVaultRef.current = 0
+    }, vaultPositionExitDurationMs())
+    return () => window.clearTimeout(timer)
+  }, [showVaultPosition])
 
   return (
     <div className={styles.cardShell}>
@@ -384,22 +411,31 @@ export function BalanceCard({
           </div>
         </div>
 
-        {showVaultPosition ? (
+        {vaultMounted ? (
           <div
             className={[
               styles.vaultPositionWrap,
-              shouldAnimateVaultEnter ? styles.vaultPositionEnter : styles.vaultPositionVisible,
+              vaultExiting
+                ? styles.vaultPositionExit
+                : vaultEnterSync
+                  ? styles.vaultPositionEnterSync
+                  : shouldAnimateVaultEnter
+                    ? styles.vaultPositionEnter
+                    : styles.vaultPositionVisible,
             ].join(' ')}
           >
-            <VaultPositionBar
-              balance={vaultBalance}
-              apy={vaultApy}
-              vaultRollActive={vaultTransferRollActive}
-              vaultRollFromValue={vaultRollFromValue}
-              vaultRollTrigger={balanceRollTrigger}
-              balanceHidden={balanceHidden}
-              onOpen={onVaultOpen ?? onEarn}
-            />
+            <div className={styles.vaultPositionInner}>
+              <VaultPositionBar
+                balance={vaultBalance}
+                apy={vaultApy}
+                vaultRollActive={vaultTransferRollActive && !vaultExiting}
+                vaultRollFromValue={vaultRollFromValue}
+                vaultRollTrigger={balanceRollTrigger}
+                keepMounted={vaultExiting}
+                balanceHidden={balanceHidden}
+                onOpen={onVaultOpen ?? onEarn}
+              />
+            </div>
           </div>
         ) : null}
       </div>

--- a/apps/armada-interface/src/components/dashboard/BalanceCard/balanceRevealMotion.ts
+++ b/apps/armada-interface/src/components/dashboard/BalanceCard/balanceRevealMotion.ts
@@ -1,9 +1,14 @@
-// ABOUTME: Timing constants and helpers for the BalanceCard reveal, digit roll, and action-enter animations.
-// ABOUTME: Ported from the armada-app design mockup.
-/** Keep in sync with BalanceCard.module.css balance reveal keyframes. */
-export const BALANCE_REVEAL_DELAY_MS = 1280
-export const BALANCE_REVEAL_DURATION_MS = 920
-export const BALANCE_REVEAL_SPLIT_AT = 0.42
+// ABOUTME: Timing constants and helpers for the BalanceCard reveal, digit roll, action-enter, and
+// ABOUTME: promo-banner handoff animations. Ported from the armada-app design mockup (ba1120a/5c2b3e8).
+
+/** Keep in sync with BalanceCard.module.css `.card` enter. */
+export const DASHBOARD_CARD_ENTER_DELAY_MS = 220
+export const DASHBOARD_CARD_ENTER_DURATION_MS = 480
+
+/** Intro amount rides with the hero card (not a late second beat). */
+export const BALANCE_REVEAL_DELAY_MS = DASHBOARD_CARD_ENTER_DELAY_MS
+export const BALANCE_REVEAL_DURATION_MS = DASHBOARD_CARD_ENTER_DURATION_MS
+export const BALANCE_REVEAL_SPLIT_AT = 0
 
 /** Digit odometer roll — intentionally longer than the balance reveal split window. */
 export const BALANCE_ROLL_DURATION_MS = 1000
@@ -11,11 +16,44 @@ export const BALANCE_ROLL_DIGIT_STAGGER_MS = 70
 
 /** Action button enter — keep in sync with BalanceCard.module.css `.actionEnter`. */
 export const BALANCE_ACTION_BUTTON_ENTER_MS = 520
-export const BALANCE_DEPOSIT_BUTTON_ENTER_DELAY_MS = 630
+export const BALANCE_ACTION_BUTTON_STAGGER_MS = 70
+/** First action after the hero card (incl. balance) has landed. */
+export const BALANCE_ACTION_BUTTON_FIRST_DELAY_MS =
+  DASHBOARD_CARD_ENTER_DELAY_MS + DASHBOARD_CARD_ENTER_DURATION_MS
+export const BALANCE_DEPOSIT_BUTTON_ENTER_DELAY_MS = BALANCE_ACTION_BUTTON_FIRST_DELAY_MS
+export const BALANCE_ACTION_BUTTON_LAST_DELAY_MS =
+  BALANCE_ACTION_BUTTON_FIRST_DELAY_MS + BALANCE_ACTION_BUTTON_STAGGER_MS * 3
 
-/** Tooltip appears shortly after the deposit button finishes entering. */
+/** Banner after the last action button finishes entering. */
 export const DASHBOARD_TOOLTIP_ENTER_DELAY_MS =
-  BALANCE_DEPOSIT_BUTTON_ENTER_DELAY_MS + BALANCE_ACTION_BUTTON_ENTER_MS + 180
+  BALANCE_ACTION_BUTTON_LAST_DELAY_MS + BALANCE_ACTION_BUTTON_ENTER_MS + 180
+
+/** Keep in sync with Dashboard.module.css `.tooltipEnter` duration. */
+export const DASHBOARD_TOOLTIP_ENTER_MS = 360
+
+/** Keep in sync with Dashboard.module.css `.tooltipHandoffEnter` / `.tooltipHandoffExit`. */
+export const PROMO_BANNER_HANDOFF_MS = 360
+
+/** Pause after the shield promo collapses before the earn banner grows in. */
+export const SHIELD_TO_EARN_PAUSE_MS = 280
+
+/** Keep in sync with BalanceCard.module.css `.vaultPositionEnter`. */
+export const VAULT_POSITION_ENTER_DELAY_MS = BALANCE_ACTION_BUTTON_FIRST_DELAY_MS
+export const VAULT_POSITION_ENTER_DURATION_MS = 420
+export const VAULT_POSITION_ENTER_SETTLE_MS =
+  VAULT_POSITION_ENTER_DELAY_MS + VAULT_POSITION_ENTER_DURATION_MS
+
+/** Keep in sync with BalanceCard.module.css `.vaultPositionEnterSync`. */
+export const VAULT_POSITION_SYNC_ENTER_MS = 520
+
+/** Keep in sync with BalanceCard.module.css `.vaultPositionExit`. */
+export const VAULT_POSITION_EXIT_DURATION_MS = 360
+
+/** Pause after the vault row has finished hiding before the earn banner returns. */
+export const VAULT_BANNER_AFTER_EXIT_MS = 560
+
+/** Beat after the earn modal closes so the dashboard can paint before balances roll. */
+export const VAULT_WITHDRAW_DASHBOARD_HOLD_MS = 640
 
 /** Pause after balance motion before the activity panel enters. */
 export const ACTIVITY_REVEAL_BUFFER_MS = 240
@@ -28,12 +66,89 @@ export function balanceRevealRollDurationMs(): number {
   return BALANCE_ROLL_DURATION_MS
 }
 
+export function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+export function vaultPositionEnterSettleMs(): number {
+  return prefersReducedMotion() ? 0 : VAULT_POSITION_ENTER_SETTLE_MS
+}
+
+export function vaultPositionExitDurationMs(): number {
+  return prefersReducedMotion() ? 0 : VAULT_POSITION_EXIT_DURATION_MS
+}
+
+export function vaultWithdrawDashboardHoldMs(): number {
+  return prefersReducedMotion() ? 0 : VAULT_WITHDRAW_DASHBOARD_HOLD_MS
+}
+
+export function balanceRollSettleMs(formattedBalance: string): number {
+  const digitCount = formattedBalance.replace(/\D/g, '').length
+  const stagger = Math.max(0, digitCount - 1) * BALANCE_ROLL_DIGIT_STAGGER_MS
+  return BALANCE_ROLL_DURATION_MS + stagger + 80
+}
+
+export function vaultBannerAfterDepositMs(formattedBalance: string): number {
+  if (prefersReducedMotion()) return 0
+  return Math.max(balanceRollSettleMs(formattedBalance), VAULT_POSITION_SYNC_ENTER_MS) + 120
+}
+
+export function vaultBannerAfterWithdrawMs(formattedBalance: string): number {
+  if (prefersReducedMotion()) return 0
+  return (
+    balanceRollSettleMs(formattedBalance) +
+    VAULT_POSITION_EXIT_DURATION_MS +
+    VAULT_BANNER_AFTER_EXIT_MS
+  )
+}
+
 export function activityRevealDelayAfterIntroMs(): number {
-  return BALANCE_REVEAL_DELAY_MS + BALANCE_REVEAL_DURATION_MS + ACTIVITY_REVEAL_BUFFER_MS
+  return (
+    BALANCE_ACTION_BUTTON_LAST_DELAY_MS + BALANCE_ACTION_BUTTON_ENTER_MS + ACTIVITY_REVEAL_BUFFER_MS
+  )
+}
+
+export function activityRevealDelayAfterPromoMs(): number {
+  return DASHBOARD_TOOLTIP_ENTER_DELAY_MS + DASHBOARD_TOOLTIP_ENTER_MS + ACTIVITY_REVEAL_BUFFER_MS
+}
+
+/** Page-load cascade: hero → actions → banner → activity. Later reveals use 0. */
+export function dashboardActivityEnterDelayMs(
+  hasPromoBanner: boolean,
+  isInitialPaint: boolean,
+): number {
+  if (!isInitialPaint) return 0
+  const afterIntro = activityRevealDelayAfterIntroMs()
+  if (!hasPromoBanner) return afterIntro
+  return Math.max(afterIntro, activityRevealDelayAfterPromoMs())
+}
+
+export function shieldBannerExitSettleMs(): number {
+  if (prefersReducedMotion()) return 0
+  return PROMO_BANNER_HANDOFF_MS + SHIELD_TO_EARN_PAUSE_MS
+}
+
+export function activityRevealDelayAfterFirstShieldMs(formattedBalance: string): number {
+  if (prefersReducedMotion()) return 80
+  return (
+    vaultBannerAfterDepositMs(formattedBalance) +
+    shieldBannerExitSettleMs() +
+    PROMO_BANNER_HANDOFF_MS +
+    ACTIVITY_REVEAL_BUFFER_MS
+  )
+}
+
+/** After a vault deposit: wait for the earn banner to collapse, then reveal the new activity row. */
+export function activityRevealDelayAfterVaultDepositMs(formattedBalance: string): number {
+  if (prefersReducedMotion()) return 80
+  return (
+    vaultBannerAfterDepositMs(formattedBalance) +
+    PROMO_BANNER_HANDOFF_MS +
+    ACTIVITY_REVEAL_BUFFER_MS
+  )
 }
 
 export function activityRevealDelayAfterRollMs(formattedBalance: string): number {
-  const digitCount = formattedBalance.replace(/\D/g, '').length
-  const stagger = Math.max(0, digitCount - 1) * BALANCE_ROLL_DIGIT_STAGGER_MS
-  return BALANCE_ROLL_DURATION_MS + stagger + 80 + ACTIVITY_REVEAL_BUFFER_MS
+  return balanceRollSettleMs(formattedBalance) + ACTIVITY_REVEAL_BUFFER_MS
 }

--- a/apps/armada-interface/src/components/dashboard/RecentActivityList/RecentActivityList.module.css
+++ b/apps/armada-interface/src/components/dashboard/RecentActivityList/RecentActivityList.module.css
@@ -10,7 +10,10 @@
   display: flex;
   flex-direction: column;
   gap: var(--primitives-spacing-4);
-  animation: activityEnter 480ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  /* On the dashboard, the enter is delayed until the hero → actions → banner cascade finishes
+     (Dashboard sets --dashboard-activity-enter-delay). Defaults to 0 elsewhere (e.g. the panel). */
+  animation: activityEnter 480ms cubic-bezier(0.22, 1, 0.36, 1)
+    var(--dashboard-activity-enter-delay, 0ms) both;
 }
 
 @keyframes activityEnter {

--- a/apps/armada-interface/src/components/dashboard/VaultPositionBar/VaultPositionBar.tsx
+++ b/apps/armada-interface/src/components/dashboard/VaultPositionBar/VaultPositionBar.tsx
@@ -30,6 +30,8 @@ export interface VaultPositionBarProps {
    */
   balanceRevealed?: boolean
   balanceHidden?: boolean
+  /** Keep rendering the last value while the row plays its collapse-out (vault fully withdrawn). */
+  keepMounted?: boolean
   onOpen?: () => void
 }
 
@@ -42,6 +44,7 @@ export function VaultPositionBar({
   vaultRollTrigger = 0,
   balanceRevealed: balanceRevealedProp,
   balanceHidden,
+  keepMounted = false,
   onOpen,
 }: VaultPositionBarProps) {
   const isMobile = useMobileLayout()
@@ -54,7 +57,7 @@ export function VaultPositionBar({
         : false
   const balanceRevealed = !effectiveHidden || peekVault
 
-  if (balance <= 0 && !vaultRollActive) return null
+  if (balance <= 0 && !vaultRollActive && !keepMounted) return null
 
   const formattedBalance = formatUsdcAmount(balance)
   // Real accrued yield isn't computed yet (it needs vault cost-basis tracking). When no explicit

--- a/apps/armada-interface/src/hooks/useEarnBannerHandoff.ts
+++ b/apps/armada-interface/src/hooks/useEarnBannerHandoff.ts
@@ -1,0 +1,141 @@
+// ABOUTME: Dashboard promo-banner handoff hooks — sequence the deposit tooltip and earn banner with
+// ABOUTME: the balance/vault odometer rolls instead of swapping instantly. Ported from armada-app (5c2b3e8).
+
+import { useEffect, useRef, useState } from 'react'
+import {
+  shieldBannerExitSettleMs,
+  vaultBannerAfterDepositMs,
+  vaultBannerAfterWithdrawMs,
+} from '@/components/dashboard/BalanceCard/balanceRevealMotion'
+import { formatUsdcAmount } from '@/components/dashboard/dashboardFormat'
+
+export interface DepositTooltipHandoff {
+  showDepositTooltip: boolean
+  depositTooltipPersistVisible: boolean
+  depositTooltipExiting: boolean
+  revealEarnBanner: boolean
+}
+
+type ShieldPromoPhase = 'idle' | 'keep' | 'exit' | 'done'
+
+/**
+ * After a first shield, keep the deposit promo until the balance finishes rolling,
+ * collapse it, then allow the earn banner to enter.
+ */
+export function useDepositTooltipHandoff(
+  walletConnected: boolean,
+  hasCompletedDeposit: boolean,
+  dashboardBalance: number,
+): DepositTooltipHandoff {
+  const previousBalanceRef = useRef(dashboardBalance)
+  const phaseRef = useRef<ShieldPromoPhase>('idle')
+  const [, setHandoffEpoch] = useState(0)
+
+  const previous = previousBalanceRef.current
+  if (previous !== dashboardBalance) {
+    if (previous <= 0 && dashboardBalance > 0) {
+      phaseRef.current = 'keep'
+    }
+    previousBalanceRef.current = dashboardBalance
+  }
+
+  const phase = phaseRef.current
+
+  useEffect(() => {
+    if (phase !== 'keep') return
+    const timer = window.setTimeout(() => {
+      phaseRef.current = 'exit'
+      setHandoffEpoch((epoch) => epoch + 1)
+    }, vaultBannerAfterDepositMs(formatUsdcAmount(dashboardBalance)))
+    return () => window.clearTimeout(timer)
+  }, [phase, dashboardBalance])
+
+  useEffect(() => {
+    if (phase !== 'exit') return
+    const timer = window.setTimeout(() => {
+      phaseRef.current = 'done'
+      setHandoffEpoch((epoch) => epoch + 1)
+    }, shieldBannerExitSettleMs())
+    return () => window.clearTimeout(timer)
+  }, [phase])
+
+  const natural = walletConnected && !hasCompletedDeposit && dashboardBalance <= 0
+  const showDepositTooltip = natural || phase === 'keep' || phase === 'exit'
+
+  return {
+    showDepositTooltip,
+    depositTooltipPersistVisible: phase === 'keep',
+    depositTooltipExiting: phase === 'exit',
+    revealEarnBanner: phase === 'done',
+  }
+}
+
+export interface EarnBannerHandoff {
+  showEarnBanner: boolean
+  /** Grow the banner in immediately — do not reserve empty delayed-tooltip space. */
+  earnBannerHandoffEnter: boolean
+  /** Banner is already on screen — do not restart the page-load enter animation. */
+  earnBannerPersistVisible: boolean
+}
+
+type Handoff = 'keep-banner' | 'keep-hidden'
+
+/**
+ * After a first vault deposit, keep the earn banner until the vault row has
+ * appeared and the balances have finished rolling.
+ * After a full vault withdraw, keep the banner hidden until the vault row has rolled
+ * to zero, exited, and the post-exit pause has elapsed.
+ *
+ * Decides on the same render as the balance change so the banner slot cannot flash empty.
+ */
+export function useEarnBannerHandoff(
+  walletConnected: boolean,
+  hasCompletedDeposit: boolean,
+  earningBalance: number,
+  dashboardBalance: number,
+): EarnBannerHandoff {
+  const previousEarningRef = useRef(earningBalance)
+  const handoffRef = useRef<Handoff | null>(null)
+  const handoffEnterRef = useRef(false)
+  const [, setHandoffEpoch] = useState(0)
+
+  const previous = previousEarningRef.current
+  if (previous !== earningBalance) {
+    if (previous <= 0 && earningBalance > 0) {
+      handoffRef.current = 'keep-banner'
+      handoffEnterRef.current = false
+    } else if (previous > 0 && earningBalance <= 0) {
+      handoffRef.current = 'keep-hidden'
+      handoffEnterRef.current = true
+    } else {
+      handoffRef.current = null
+    }
+    previousEarningRef.current = earningBalance
+  }
+
+  const handoff = handoffRef.current
+
+  useEffect(() => {
+    if (!handoff) return
+    const delay =
+      handoff === 'keep-banner'
+        ? vaultBannerAfterDepositMs(formatUsdcAmount(Math.max(dashboardBalance, earningBalance)))
+        : vaultBannerAfterWithdrawMs(formatUsdcAmount(dashboardBalance))
+    const timer = window.setTimeout(() => {
+      handoffRef.current = null
+      setHandoffEpoch((epoch) => epoch + 1)
+    }, delay)
+    return () => window.clearTimeout(timer)
+  }, [handoff, earningBalance, dashboardBalance])
+
+  const eligible = walletConnected && hasCompletedDeposit
+  let showEarnBanner = eligible && earningBalance <= 0
+  if (handoff === 'keep-banner') showEarnBanner = eligible
+  if (handoff === 'keep-hidden') showEarnBanner = false
+
+  return {
+    showEarnBanner,
+    earnBannerHandoffEnter: showEarnBanner && handoffEnterRef.current,
+    earnBannerPersistVisible: showEarnBanner && handoff === 'keep-banner',
+  }
+}

--- a/apps/armada-interface/src/index.css
+++ b/apps/armada-interface/src/index.css
@@ -63,8 +63,9 @@ html {
 body {
   margin: 0;
   min-height: 100vh;
-  /* Match the mockup's dashboard shell: flat surface-bg in dark, a soft purple→amber wash in light. */
-  background-color: var(--semantic-color-surface-bg);
+  /* Transparent so the fixed z-index:-1 body::before gem wash shows. The base surface is on <html>
+     (above); an opaque body background here would paint over the negative-z pseudo and hide it. */
+  background-color: transparent;
   background-attachment: fixed;
   font-family: var(--primitives-fontFamily-ui);
   font-size: 15px;

--- a/apps/armada-interface/src/pages/Dashboard.module.css
+++ b/apps/armada-interface/src/pages/Dashboard.module.css
@@ -12,12 +12,15 @@
 }
 
 .cardStack {
+  /* Gap between stacked cards; the promo-banner handoff collapse animates a matching negative margin
+     (--dashboard-promo-gap) to close the gap as a banner exits. */
+  --dashboard-promo-gap: var(--primitives-spacing-6);
   width: min(420px, 100%);
   margin-inline: auto;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--primitives-spacing-6);
+  gap: var(--dashboard-promo-gap);
 }
 
 /* BalanceCard and RecentActivityList self-fill to 100%; the DepositTooltip keeps its natural
@@ -26,11 +29,77 @@
 /* Tooltip/earn-banner slot: fades up shortly after the balance card's action row finishes entering,
    so the callout arrives after the numbers settle rather than all at once. Delay comes from the
    caller via --dashboard-tooltip-enter-delay (mockup DASHBOARD_TOOLTIP_ENTER_DELAY_MS). */
-.tooltipEnter {
+/* Promo-banner slot. The grid wrapper enables the collapse handoff (grid-template-rows 1fr↔0fr);
+   the animation class on the same element drives the enter/exit beat. */
+.cardStackTooltip {
   width: 100%;
-  display: flex;
-  justify-content: center;
+  display: grid;
+  grid-template-rows: 1fr;
+}
+
+.cardStackTooltipInner {
+  min-height: 0;
+  overflow: visible;
+}
+
+.tooltipEnter {
   animation: dashboardTooltipFade 360ms ease-out var(--dashboard-tooltip-enter-delay, 1330ms) both;
+}
+
+/* Already on screen (handoff keep phase) — no enter animation. */
+.tooltipVisible {
+  opacity: 1;
+}
+
+/* Grow-in / collapse handoff between the deposit tooltip and the earn banner. */
+.tooltipHandoffEnter {
+  animation: dashboardTooltipHandoffEnter 360ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.tooltipHandoffExit {
+  animation: dashboardTooltipHandoffExit 360ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.tooltipHandoffEnter,
+.tooltipHandoffExit {
+  overflow: hidden;
+}
+
+.tooltipHandoffExit .cardStackTooltipInner,
+.tooltipHandoffEnter:not(.tooltipHandoffSettled) .cardStackTooltipInner {
+  overflow: hidden;
+}
+
+@keyframes dashboardTooltipHandoffEnter {
+  from {
+    opacity: 0;
+    grid-template-rows: 0fr;
+    max-height: 0;
+    margin-block-start: calc(-1 * var(--dashboard-promo-gap));
+  }
+
+  to {
+    opacity: 1;
+    grid-template-rows: 1fr;
+    max-height: calc(var(--primitives-spacing-24) * 2);
+    margin-block-start: 0;
+  }
+}
+
+@keyframes dashboardTooltipHandoffExit {
+  from {
+    opacity: 1;
+    grid-template-rows: 1fr;
+    max-height: calc(var(--primitives-spacing-24) * 2);
+    margin-block-start: 0;
+  }
+
+  to {
+    opacity: 0;
+    grid-template-rows: 0fr;
+    max-height: 0;
+    margin-block-start: calc(-1 * var(--dashboard-promo-gap));
+  }
 }
 
 /* Passthrough wrapper — carries the activity enter-delay var to RecentActivityList, which owns the
@@ -52,10 +121,24 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .tooltipEnter {
+  .tooltipEnter,
+  .tooltipHandoffEnter,
+  .tooltipHandoffExit {
     animation: none;
     opacity: 1;
     transform: none;
+  }
+
+  .tooltipHandoffEnter {
+    grid-template-rows: 1fr;
+    max-height: none;
+    margin-block-start: 0;
+  }
+
+  .tooltipHandoffExit {
+    opacity: 0;
+    grid-template-rows: 0fr;
+    max-height: 0;
   }
 }
 

--- a/apps/armada-interface/src/pages/Dashboard.module.css
+++ b/apps/armada-interface/src/pages/Dashboard.module.css
@@ -33,6 +33,12 @@
   animation: dashboardTooltipFade 360ms ease-out var(--dashboard-tooltip-enter-delay, 1330ms) both;
 }
 
+/* Passthrough wrapper — carries the activity enter-delay var to RecentActivityList, which owns the
+   enter animation. Full width so it stays a proper flex item in the card stack. */
+.activityEnter {
+  width: 100%;
+}
+
 @keyframes dashboardTooltipFade {
   from {
     opacity: 0;

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -84,36 +84,48 @@ export function Dashboard() {
   // until the user is back on the dashboard.
   const gated = isInitialSyncGated(shielded, sync.status)
   const liveBalance = usdcToNumber(displayBalance)
+  const earningUsdc =
+    yieldShares !== null && yieldRate !== null ? sharesToUsdc(yieldShares, yieldRate.rate) : 0n
+  const liveVault = usdcToNumber(earningUsdc)
+  const vaultApy = yieldRate !== null ? Number(yieldRate.apyBps) / 100 : undefined
+  // Both the private balance and the vault position are held while a tx modal is open (or the sync
+  // gate is up), then advance together with a single roll trigger on return — so the balance roll,
+  // the vault-row grow-in, and the earn-banner handoff all play on the dashboard rather than behind
+  // the modal. vaultFromValue is set only when the vault actually moved (earn deposit/withdraw).
+  // Mirrors the mockup's applyEarnVisibleBalance.
   const [displayedBalance, setDisplayedBalance] = useState(liveBalance)
+  const [displayedVault, setDisplayedVault] = useState(liveVault)
   const [rollTrigger, setRollTrigger] = useState(0)
   const [rollMode, setRollMode] = useState<BalanceRollMode>('fromZero')
   const [rollFromValue, setRollFromValue] = useState<string | undefined>(undefined)
+  const [vaultRollFromValue, setVaultRollFromValue] = useState<string | undefined>(undefined)
   const lastLiveRef = useRef<number | null>(null)
+  const lastVaultRef = useRef<number>(liveVault)
   // Captures whether the activity list was on screen at the first real (post-sync-gate) dashboard
   // paint. Only that initial paint cascades activity in last; later reveals enter immediately.
   const activityVisibleOnPaintRef = useRef<boolean | null>(null)
   useEffect(() => {
     if (gated || openModal !== null) return
-    const prevLive = lastLiveRef.current
-    if (prevLive === liveBalance) return
+    const balanceChanged = lastLiveRef.current !== liveBalance
+    const vaultChanged = lastVaultRef.current !== liveVault
+    if (!balanceChanged && !vaultChanged) return
+    const firstEstablishment = lastLiveRef.current === null
     lastLiveRef.current = liveBalance
+    lastVaultRef.current = liveVault
     // First establishment (the initial reveal) doesn't roll — the intro roll-from-zero handles it.
-    if (prevLive === null) {
+    if (firstEstablishment) {
       setDisplayedBalance(liveBalance)
+      setDisplayedVault(liveVault)
       return
     }
     // Full precision (6 decimals) so the odometer digit counts line up with the card display.
     setRollMode('fromValue')
     setRollFromValue(formatUsdcAmount(displayedBalance, 6))
+    setVaultRollFromValue(vaultChanged ? formatUsdcAmount(displayedVault, 6) : undefined)
     setRollTrigger((t) => t + 1)
     setDisplayedBalance(liveBalance)
-  }, [gated, openModal, liveBalance, displayedBalance])
-
-  // Derived vault position + activity.
-  const earningUsdc =
-    yieldShares !== null && yieldRate !== null ? sharesToUsdc(yieldShares, yieldRate.rate) : 0n
-  const vaultNumber = usdcToNumber(earningUsdc)
-  const vaultApy = yieldRate !== null ? Number(yieldRate.apyBps) / 100 : undefined
+    setDisplayedVault(liveVault)
+  }, [gated, openModal, liveBalance, liveVault, displayedBalance, displayedVault])
   // Full activity list (uncapped) so the panel can show everything up to its ceiling and we can tell
   // whether that ceiling was hit. The dashboard preview + the panel then slice their own views.
   const allActivityItems = useMemo(
@@ -138,7 +150,7 @@ export function Dashboard() {
   // then collapses and hands off to the earn banner (and reverses on vault deposit/withdraw), rather
   // than the two banners swapping instantly. See useEarnBannerHandoff.
   const depositTooltipHandoff = useDepositTooltipHandoff(walletConnected, hasCompletedDeposit, displayedBalance)
-  const earnBannerHandoff = useEarnBannerHandoff(walletConnected, hasCompletedDeposit, vaultNumber, displayedBalance)
+  const earnBannerHandoff = useEarnBannerHandoff(walletConnected, hasCompletedDeposit, displayedVault, displayedBalance)
   const showDepositTooltip = depositTooltipHandoff.showDepositTooltip
   const depositTooltipPersistVisible = depositTooltipHandoff.depositTooltipPersistVisible
   const depositTooltipExiting = depositTooltipHandoff.depositTooltipExiting
@@ -185,7 +197,8 @@ export function Dashboard() {
           balanceRollTrigger={rollTrigger}
           balanceRollMode={rollMode}
           balanceRollFromValue={rollFromValue}
-          vaultBalance={vaultNumber}
+          vaultBalance={displayedVault}
+          vaultRollFromValue={vaultRollFromValue}
           vaultApy={vaultApy}
           armadaAddress={shieldedWallet.shieldedAddress}
           balanceHidden={balanceHidden}

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -6,7 +6,10 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { ChartBarIcon } from '@heroicons/react/24/outline'
 import { BalanceCard } from '@/components/dashboard/BalanceCard'
 import { DepositTooltip } from '@/components/dashboard/DepositTooltip'
-import { DASHBOARD_TOOLTIP_ENTER_DELAY_MS } from '@/components/dashboard/BalanceCard/balanceRevealMotion'
+import {
+  DASHBOARD_TOOLTIP_ENTER_DELAY_MS,
+  dashboardActivityEnterDelayMs,
+} from '@/components/dashboard/BalanceCard/balanceRevealMotion'
 import { DashboardScrollTopFade } from '@/components/dashboard/DashboardScrollTopFade'
 import { RecentActivityList, ActivityAllPanel } from '@/components/dashboard/RecentActivityList'
 import { ActivityReceipt } from '@/components/dashboard/ActivityReceipt'
@@ -82,6 +85,9 @@ export function Dashboard() {
   const [rollFromValue, setRollFromValue] = useState<string | undefined>(undefined)
   const [pendingRollFrom, setPendingRollFrom] = useState<string | undefined>(undefined)
   const prevBalanceRef = useRef<number | null>(null)
+  // Captures whether the activity list was on screen at the first real (post-sync-gate) dashboard
+  // paint. Only that initial paint cascades activity in last; later reveals enter immediately.
+  const activityVisibleOnPaintRef = useRef<boolean | null>(null)
   useEffect(() => {
     const prev = prevBalanceRef.current
     prevBalanceRef.current = balanceNumber
@@ -139,6 +145,19 @@ export function Dashboard() {
     return <SyncGate />
   }
 
+  // Page-load cascade: activity enters last, after the hero → actions → banner beats. Captured on the
+  // first post-gate paint so activity that appears later (e.g. after a tx) just enters immediately.
+  if (activityVisibleOnPaintRef.current === null) {
+    activityVisibleOnPaintRef.current = showActivity
+  }
+  const activityEnterDelayMs = dashboardActivityEnterDelayMs(
+    showDepositTooltip || showEarnBanner,
+    activityVisibleOnPaintRef.current,
+  )
+  const activityEnterStyle = {
+    '--dashboard-activity-enter-delay': `${activityEnterDelayMs}ms`,
+  } as CSSProperties
+
   return (
     <div className={styles.page}>
       <DashboardScrollTopFade enabled={showActivity} />
@@ -174,8 +193,8 @@ export function Dashboard() {
               badgeBackground="white"
               iconTileTone="purple"
               headline={`Earn ~${(vaultApy ?? 0).toFixed(1)}% APY`}
-              body="Deposit into the vault and start earning now."
-              infoTooltip="The APY is an estimate from recent vault performance."
+              body="Add USDC to Armada's shielded vault and start earning now."
+              infoTooltip="The APY is an estimate from recent shielded vault performance."
               ariaLabel={`Estimated yearly yield ~${(vaultApy ?? 0).toFixed(1)}%`}
               onDeposit={() => openActionModal('yield-deposit')}
             />
@@ -183,12 +202,14 @@ export function Dashboard() {
         ) : null}
 
         {showActivity ? (
-          <RecentActivityList
-            items={previewActivityItems}
-            balanceRevealed={!balanceHidden}
-            onViewAll={() => setActivityPanelOpen(true)}
-            onItemClick={handleActivityItemClick}
-          />
+          <div className={styles.activityEnter} style={activityEnterStyle}>
+            <RecentActivityList
+              items={previewActivityItems}
+              balanceRevealed={!balanceHidden}
+              onViewAll={() => setActivityPanelOpen(true)}
+              onItemClick={handleActivityItemClick}
+            />
+          </div>
         ) : null}
       </div>
 

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Dashboard page — centered Private-USDC BalanceCard + deposit tooltip + recent activity.
 // ABOUTME: Presentation from the armada-app mockup; wired to real shielded balance, yield, and tx history.
 
-import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { ChartBarIcon } from '@heroicons/react/24/outline'
 import { BalanceCard } from '@/components/dashboard/BalanceCard'
@@ -12,6 +12,7 @@ import {
 } from '@/components/dashboard/BalanceCard/balanceRevealMotion'
 import { DashboardScrollTopFade } from '@/components/dashboard/DashboardScrollTopFade'
 import { RecentActivityList, ActivityAllPanel } from '@/components/dashboard/RecentActivityList'
+import { useDepositTooltipHandoff, useEarnBannerHandoff } from '@/hooks/useEarnBannerHandoff'
 import { ActivityReceipt } from '@/components/dashboard/ActivityReceipt'
 import { buildActivityItems, type DashboardActivityItem } from '@/components/dashboard/txActivityAdapter'
 import { formatUsdcAmount } from '@/components/dashboard/dashboardFormat'
@@ -127,13 +128,25 @@ export function Dashboard() {
   const hasCompletedDeposit = txList.some(
     (r) => (r.kind === 'shield' || r.kind === 'shield-xchain') && r.executionState === 'completed',
   )
-  const showDepositTooltip = balanceNumber <= 0 && !hasCompletedDeposit
+  const walletConnected = evmAddress !== null
+  // Promo-banner handoff: after a first shield the deposit tooltip holds through the balance roll,
+  // then collapses and hands off to the earn banner (and reverses on vault deposit/withdraw), rather
+  // than the two banners swapping instantly. See useEarnBannerHandoff.
+  const depositTooltipHandoff = useDepositTooltipHandoff(walletConnected, hasCompletedDeposit, balanceNumber)
+  const earnBannerHandoff = useEarnBannerHandoff(walletConnected, hasCompletedDeposit, vaultNumber, balanceNumber)
+  const showDepositTooltip = depositTooltipHandoff.showDepositTooltip
+  const depositTooltipPersistVisible = depositTooltipHandoff.depositTooltipPersistVisible
+  const depositTooltipExiting = depositTooltipHandoff.depositTooltipExiting
   // Activity shows automatically whenever there are items (the manual hide toggle was dropped in the
   // polish redesign — the more-menu that held it is gone).
   const showActivity = allActivityItems.length > 0
-  // Earn promo banner — nudge users with idle private USDC and no vault position yet to start earning.
-  const showEarnBanner =
-    !showDepositTooltip && balanceNumber > 0 && vaultNumber <= 0 && vaultApy !== undefined && vaultApy > 0
+  // Earn promo banner — the two banners are mutually exclusive; earn only shows once the deposit
+  // tooltip is gone and the vault pays a real APY.
+  const earnApyAvailable = vaultApy !== undefined && vaultApy > 0
+  const showEarnBanner = earnBannerHandoff.showEarnBanner && !showDepositTooltip && earnApyAvailable
+  const earnBannerHandoffEnter =
+    earnBannerHandoff.earnBannerHandoffEnter || (showEarnBanner && depositTooltipHandoff.revealEarnBanner)
+  const earnBannerPersistVisible = earnBannerHandoff.earnBannerPersistVisible
 
   // Tooltip/earn-banner enter delay — fades up after the balance card's action row settles.
   const tooltipEnterStyle = {
@@ -180,13 +193,29 @@ export function Dashboard() {
         />
 
         {showDepositTooltip ? (
-          <div className={styles.tooltipEnter} style={tooltipEnterStyle}>
-            <DepositTooltip stretch onDeposit={() => openActionModal('shield')} />
+          <div
+            className={[
+              styles.cardStackTooltip,
+              depositTooltipExiting
+                ? styles.tooltipHandoffExit
+                : depositTooltipPersistVisible
+                  ? styles.tooltipVisible
+                  : styles.tooltipEnter,
+            ].join(' ')}
+            style={depositTooltipPersistVisible || depositTooltipExiting ? undefined : tooltipEnterStyle}
+          >
+            <div className={styles.cardStackTooltipInner}>
+              <DepositTooltip stretch onDeposit={() => openActionModal('shield')} />
+            </div>
           </div>
         ) : null}
 
         {showEarnBanner ? (
-          <div className={styles.tooltipEnter} style={tooltipEnterStyle}>
+          <EarnBannerSlot
+            handoffEnter={earnBannerHandoffEnter}
+            persistVisible={earnBannerPersistVisible}
+            tooltipEnterStyle={tooltipEnterStyle}
+          >
             <DepositTooltip
               stretch
               BadgeIcon={ChartBarIcon}
@@ -198,7 +227,7 @@ export function Dashboard() {
               ariaLabel={`Estimated yearly yield ~${(vaultApy ?? 0).toFixed(1)}%`}
               onDeposit={() => openActionModal('yield-deposit')}
             />
-          </div>
+          </EarnBannerSlot>
         ) : null}
 
         {showActivity ? (
@@ -228,6 +257,58 @@ export function Dashboard() {
         open={receiptId !== null}
         onClose={() => setReceiptId(null)}
       />
+    </div>
+  )
+}
+
+/**
+ * Earn-banner slot. When it enters via a handoff (after a first shield / vault deposit) it grows in
+ * with the collapse animation; on a plain page load it uses the delayed fade. `handoffSettled` drops
+ * the collapse constraint once the grow-in animation finishes so the banner sits normally.
+ */
+function EarnBannerSlot({
+  handoffEnter,
+  persistVisible,
+  tooltipEnterStyle,
+  children,
+}: {
+  handoffEnter: boolean
+  persistVisible: boolean
+  tooltipEnterStyle?: CSSProperties
+  children: ReactNode
+}) {
+  const [handoffSettled, setHandoffSettled] = useState(!handoffEnter)
+
+  useEffect(() => {
+    if (!handoffEnter) {
+      setHandoffSettled(true)
+      return
+    }
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setHandoffSettled(true)
+      return
+    }
+    setHandoffSettled(false)
+  }, [handoffEnter])
+
+  const enterClass = handoffEnter
+    ? styles.tooltipHandoffEnter
+    : persistVisible
+      ? styles.tooltipVisible
+      : styles.tooltipEnter
+
+  return (
+    <div
+      className={[styles.cardStackTooltip, enterClass, handoffSettled ? styles.tooltipHandoffSettled : '']
+        .filter(Boolean)
+        .join(' ')}
+      style={handoffEnter || persistVisible ? undefined : tooltipEnterStyle}
+      onAnimationEnd={(event) => {
+        if (event.target !== event.currentTarget) return
+        setHandoffSettled(true)
+      }}
+    >
+      <div className={styles.cardStackTooltipInner}>{children}</div>
     </div>
   )
 }

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -228,25 +228,24 @@ export function Dashboard() {
           </div>
         ) : null}
 
-        {showEarnBanner ? (
-          <EarnBannerSlot
-            handoffEnter={earnBannerHandoffEnter}
-            persistVisible={earnBannerPersistVisible}
-            tooltipEnterStyle={tooltipEnterStyle}
-          >
-            <DepositTooltip
-              stretch
-              BadgeIcon={ChartBarIcon}
-              badgeBackground="white"
-              iconTileTone="purple"
-              headline={`Earn ~${(vaultApy ?? 0).toFixed(1)}% APY`}
-              body="Add USDC to Armada's shielded vault and start earning now."
-              infoTooltip="The APY is an estimate from recent shielded vault performance."
-              ariaLabel={`Estimated yearly yield ~${(vaultApy ?? 0).toFixed(1)}%`}
-              onDeposit={() => openActionModal('yield-deposit')}
-            />
-          </EarnBannerSlot>
-        ) : null}
+        <EarnBannerSlot
+          show={showEarnBanner}
+          handoffEnter={earnBannerHandoffEnter}
+          persistVisible={earnBannerPersistVisible}
+          tooltipEnterStyle={tooltipEnterStyle}
+        >
+          <DepositTooltip
+            stretch
+            BadgeIcon={ChartBarIcon}
+            badgeBackground="white"
+            iconTileTone="purple"
+            headline={`Earn ~${(vaultApy ?? 0).toFixed(1)}% APY`}
+            body="Add USDC to Armada's shielded vault and start earning now."
+            infoTooltip="The APY is an estimate from recent shielded vault performance."
+            ariaLabel={`Estimated yearly yield ~${(vaultApy ?? 0).toFixed(1)}%`}
+            onDeposit={() => openActionModal('yield-deposit')}
+          />
+        </EarnBannerSlot>
 
         {showActivity ? (
           <div className={styles.activityEnter} style={activityEnterStyle}>
@@ -280,22 +279,44 @@ export function Dashboard() {
 }
 
 /**
- * Earn-banner slot. When it enters via a handoff (after a first shield / vault deposit) it grows in
- * with the collapse animation; on a plain page load it uses the delayed fade. `handoffSettled` drops
- * the collapse constraint once the grow-in animation finishes so the banner sits normally.
+ * Earn-banner slot. Owns its own mount lifecycle so it can animate out: it stays mounted after
+ * `show` goes false to play the collapse-out, then unmounts. When it enters via a handoff (after a
+ * first shield / vault deposit) it grows in with the collapse animation; on a plain page load it uses
+ * the delayed fade. `handoffSettled` drops the collapse constraint once the grow-in finishes so the
+ * banner sits normally.
  */
 function EarnBannerSlot({
+  show,
   handoffEnter,
   persistVisible,
   tooltipEnterStyle,
   children,
 }: {
+  show: boolean
   handoffEnter: boolean
   persistVisible: boolean
   tooltipEnterStyle?: CSSProperties
   children: ReactNode
 }) {
+  const [rendered, setRendered] = useState(show)
+  const [exiting, setExiting] = useState(false)
   const [handoffSettled, setHandoffSettled] = useState(!handoffEnter)
+
+  useEffect(() => {
+    if (show) {
+      setRendered(true)
+      setExiting(false)
+      return
+    }
+    if (!rendered) return
+    // Hide requested while on screen — collapse out, then unmount (or unmount immediately if the
+    // user prefers reduced motion).
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setRendered(false)
+      return
+    }
+    setExiting(true)
+  }, [show, rendered])
 
   useEffect(() => {
     if (!handoffEnter) {
@@ -309,20 +330,33 @@ function EarnBannerSlot({
     setHandoffSettled(false)
   }, [handoffEnter])
 
-  const enterClass = handoffEnter
-    ? styles.tooltipHandoffEnter
-    : persistVisible
-      ? styles.tooltipVisible
-      : styles.tooltipEnter
+  if (!rendered) return null
+
+  const enterClass = exiting
+    ? styles.tooltipHandoffExit
+    : handoffEnter
+      ? styles.tooltipHandoffEnter
+      : persistVisible
+        ? styles.tooltipVisible
+        : styles.tooltipEnter
 
   return (
     <div
-      className={[styles.cardStackTooltip, enterClass, handoffSettled ? styles.tooltipHandoffSettled : '']
+      className={[
+        styles.cardStackTooltip,
+        enterClass,
+        handoffSettled && !exiting ? styles.tooltipHandoffSettled : '',
+      ]
         .filter(Boolean)
         .join(' ')}
-      style={handoffEnter || persistVisible ? undefined : tooltipEnterStyle}
+      style={exiting || handoffEnter || persistVisible ? undefined : tooltipEnterStyle}
       onAnimationEnd={(event) => {
         if (event.target !== event.currentTarget) return
+        if (exiting) {
+          setExiting(false)
+          setRendered(false)
+          return
+        }
         setHandoffSettled(true)
       }}
     >

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -1,7 +1,15 @@
 // ABOUTME: Dashboard page — centered Private-USDC BalanceCard + deposit tooltip + recent activity.
 // ABOUTME: Presentation from the armada-app mockup; wired to real shielded balance, yield, and tx history.
 
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { ChartBarIcon } from '@heroicons/react/24/outline'
 import { BalanceCard } from '@/components/dashboard/BalanceCard'
@@ -96,7 +104,10 @@ export function Dashboard() {
     // Match the card's full-precision display (up to 6 decimals) so the odometer digit counts line up.
     setPendingRollFrom(formatUsdcAmount(prev, 6))
   }, [balanceNumber])
-  useEffect(() => {
+  // Layout effect (not useEffect) so the roll trigger fires before the browser paints when a modal
+  // closes: otherwise the card paints the NEW balance statically for a frame, then jumps back to the
+  // OLD value to start the roll. Running pre-paint means the first painted frame is already OLD→NEW.
+  useLayoutEffect(() => {
     if (openModal !== null || pendingRollFrom === undefined) return
     setRollMode('fromValue')
     setRollFromValue(pendingRollFrom)

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -1,15 +1,7 @@
 // ABOUTME: Dashboard page — centered Private-USDC BalanceCard + deposit tooltip + recent activity.
 // ABOUTME: Presentation from the armada-app mockup; wired to real shielded balance, yield, and tx history.
 
-import {
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-  type CSSProperties,
-  type ReactNode,
-} from 'react'
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { ChartBarIcon } from '@heroicons/react/24/outline'
 import { BalanceCard } from '@/components/dashboard/BalanceCard'
@@ -85,35 +77,37 @@ export function Dashboard() {
   // Balance visibility is app-wide (shared with the wallet panel's hide toggle) via balanceHiddenAtom.
   const [balanceHidden, setBalanceHidden] = useAtom(balanceHiddenAtom)
 
-  // Balance odometer roll: intro roll from zero on first paint, then roll from the previous value
-  // whenever the balance changes (e.g. after a deposit settles). The roll is deferred until no tx
-  // modal is open, so it plays on the dashboard rather than behind a modal.
-  const balanceNumber = usdcToNumber(displayBalance)
+  // Balance odometer roll. The *displayed* balance lags the live atom while a tx modal is open (or
+  // while the initial sync gate is up), then advances to the live value together with the roll
+  // trigger — so the card holds the OLD number and rolls to the NEW one on return, rather than
+  // flashing NEW then rolling. Mirrors the mockup, which defers the whole advance (value + roll)
+  // until the user is back on the dashboard.
+  const gated = isInitialSyncGated(shielded, sync.status)
+  const liveBalance = usdcToNumber(displayBalance)
+  const [displayedBalance, setDisplayedBalance] = useState(liveBalance)
   const [rollTrigger, setRollTrigger] = useState(0)
   const [rollMode, setRollMode] = useState<BalanceRollMode>('fromZero')
   const [rollFromValue, setRollFromValue] = useState<string | undefined>(undefined)
-  const [pendingRollFrom, setPendingRollFrom] = useState<string | undefined>(undefined)
-  const prevBalanceRef = useRef<number | null>(null)
+  const lastLiveRef = useRef<number | null>(null)
   // Captures whether the activity list was on screen at the first real (post-sync-gate) dashboard
   // paint. Only that initial paint cascades activity in last; later reveals enter immediately.
   const activityVisibleOnPaintRef = useRef<boolean | null>(null)
   useEffect(() => {
-    const prev = prevBalanceRef.current
-    prevBalanceRef.current = balanceNumber
-    if (prev === null || prev === balanceNumber) return
-    // Match the card's full-precision display (up to 6 decimals) so the odometer digit counts line up.
-    setPendingRollFrom(formatUsdcAmount(prev, 6))
-  }, [balanceNumber])
-  // Layout effect (not useEffect) so the roll trigger fires before the browser paints when a modal
-  // closes: otherwise the card paints the NEW balance statically for a frame, then jumps back to the
-  // OLD value to start the roll. Running pre-paint means the first painted frame is already OLD→NEW.
-  useLayoutEffect(() => {
-    if (openModal !== null || pendingRollFrom === undefined) return
+    if (gated || openModal !== null) return
+    const prevLive = lastLiveRef.current
+    if (prevLive === liveBalance) return
+    lastLiveRef.current = liveBalance
+    // First establishment (the initial reveal) doesn't roll — the intro roll-from-zero handles it.
+    if (prevLive === null) {
+      setDisplayedBalance(liveBalance)
+      return
+    }
+    // Full precision (6 decimals) so the odometer digit counts line up with the card display.
     setRollMode('fromValue')
-    setRollFromValue(pendingRollFrom)
+    setRollFromValue(formatUsdcAmount(displayedBalance, 6))
     setRollTrigger((t) => t + 1)
-    setPendingRollFrom(undefined)
-  }, [openModal, pendingRollFrom])
+    setDisplayedBalance(liveBalance)
+  }, [gated, openModal, liveBalance, displayedBalance])
 
   // Derived vault position + activity.
   const earningUsdc =
@@ -143,8 +137,8 @@ export function Dashboard() {
   // Promo-banner handoff: after a first shield the deposit tooltip holds through the balance roll,
   // then collapses and hands off to the earn banner (and reverses on vault deposit/withdraw), rather
   // than the two banners swapping instantly. See useEarnBannerHandoff.
-  const depositTooltipHandoff = useDepositTooltipHandoff(walletConnected, hasCompletedDeposit, balanceNumber)
-  const earnBannerHandoff = useEarnBannerHandoff(walletConnected, hasCompletedDeposit, vaultNumber, balanceNumber)
+  const depositTooltipHandoff = useDepositTooltipHandoff(walletConnected, hasCompletedDeposit, displayedBalance)
+  const earnBannerHandoff = useEarnBannerHandoff(walletConnected, hasCompletedDeposit, vaultNumber, displayedBalance)
   const showDepositTooltip = depositTooltipHandoff.showDepositTooltip
   const depositTooltipPersistVisible = depositTooltipHandoff.depositTooltipPersistVisible
   const depositTooltipExiting = depositTooltipHandoff.depositTooltipExiting
@@ -165,7 +159,7 @@ export function Dashboard() {
   } as CSSProperties
 
   // Gate the dashboard behind the initial shielded-balance sync. The navbar (AppLayout) stays visible.
-  if (isInitialSyncGated(shielded, sync.status)) {
+  if (gated) {
     return <SyncGate />
   }
 
@@ -187,7 +181,7 @@ export function Dashboard() {
       <DashboardScrollTopFade enabled={showActivity} />
       <div className={styles.cardStack}>
         <BalanceCard
-          balance={balanceNumber}
+          balance={displayedBalance}
           balanceRollTrigger={rollTrigger}
           balanceRollMode={rollMode}
           balanceRollFromValue={rollFromValue}


### PR DESCRIPTION
Tier 2 of the mockup catch-up (after Tier 1 #512): the dashboard motion system, ported from the armada-app mockup's `ba1120a` / `5c2b3e8` / `d31913c`.

## What's in it

**2a — intro cascade re-timing** (`f2e217ec`)
- Rewrote `balanceRevealMotion.ts` to the mockup's card-enter-relative timing. Balance now rides the hero card (roll from zero at 220ms) instead of a late 1280ms beat; action buttons stagger after the card lands (700/770/840/910ms); vault row enters at 700ms; activity enters **last** via a computed `--dashboard-activity-enter-delay` (captured at first post-gate paint).

**2b-i — promo-banner handoff** (`c95f9083`)
- Ported `useDepositTooltipHandoff` + `useEarnBannerHandoff` (adapted to our `displayedBalance`/`displayedVault`/`hasCompletedDeposit`). After a first shield the deposit tooltip holds through the balance roll, collapses, then hands off to the earn banner — via a grid-collapse (`tooltipHandoffEnter/Exit`) instead of an instant swap.

**2b-ii — vault-row sync-enter/exit** (`e10d08ca`)
- Vault row grows in (`vaultPositionEnterSync`) on deposit and collapses out (`vaultPositionExit`) on full withdraw, via a `vaultExiting`/`vaultMounted` state machine + a `keepMounted` prop on `VaultPositionBar`.

**Fixes found during QA**
- Balance roll flashed the NEW value before rolling on modal return → hold a `displayedBalance` that lags the live atom while a modal/sync-gate is up, advancing value+roll together on return (`488820dd`→`84da0368`; first attempt reverted).
- Vault-row grow-in + earn-banner handoff played *behind* the open modal → defer the vault balance too and wire a shared vault roll (`vaultFromValue`), mirroring the mockup's `applyEarnVisibleBalance` (`a5147e51`).
- Earn banner now actively **collapses out** on hide (beyond the mockup, whose slot is enter-only) (`c69b43b0`).

## Note
Includes `cd503922`, the gem-wash regression fix also open as **#513**. Merge #513 first and this rebases cleanly (the identical commit drops out); if this merges first, #513 becomes a no-op. No conflict either way.

## Verification
`tsc -b` clean; full interface suite green (171 files, 1 skipped). Motion is validated by visual QA (balance/vault rolls only fire on real tx settle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)