### PR TITLE
feat(interface): mockup catch-up Tier 3 — breakpoint split, %-of-balance presets, send titles, activity new-row enter

### DIFF
--- a/apps/armada-interface/src/components/OnboardingLayout/OnboardingLayout.module.css
+++ b/apps/armada-interface/src/components/OnboardingLayout/OnboardingLayout.module.css
@@ -86,7 +86,7 @@
   align-items: stretch;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .root {
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr;

--- a/apps/armada-interface/src/components/RelayerStatusBanner/RelayerStatusBanner.module.css
+++ b/apps/armada-interface/src/components/RelayerStatusBanner/RelayerStatusBanner.module.css
@@ -1,32 +1,29 @@
-/* ABOUTME: RelayerStatusBanner — warning surface that nudges users to the wallet-override path. */
-/* ABOUTME: Compact full-width banner with a status message + inline action button. */
+/* ABOUTME: RelayerStatusBanner — warning-toned callout nudging users to the wallet-submit path. */
+/* ABOUTME: Theme tokens throughout (surface-raised + status-warning accent), mirroring FeeUpdatedBanner. */
 
 .root {
   display: flex;
+  flex-direction: row;
   align-items: center;
   justify-content: space-between;
   gap: var(--primitives-spacing-3);
+  width: 100%;
   padding: var(--primitives-spacing-3) var(--primitives-spacing-4);
-  border-radius: var(--primitives-radius-md);
-  background: rgba(245, 158, 11, 0.10);
-  border: 1px solid rgba(245, 158, 11, 0.35);
-  color: var(--semantic-color-text-primary);
+  border-radius: calc(var(--semantic-borderRadius-item) * 1px);
+  background: var(--semantic-color-surface-raised);
+  border-left: 3px solid var(--semantic-color-status-warning);
+  box-sizing: border-box;
+  text-align: left;
 }
 
 .message {
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  line-height: var(--primitives-lineHeight-normal);
   color: var(--semantic-color-text-secondary);
 }
 
+/* The action is a design-system Button (secondary/sm); only stop it from shrinking in the row. */
 .action {
   flex-shrink: 0;
-  padding: var(--primitives-spacing-2) var(--primitives-spacing-3);
-  border-radius: var(--primitives-radius-sm);
-  background: var(--semantic-color-bg-card);
-  color: var(--semantic-color-text-accent);
-  border: 1px solid var(--semantic-color-border-default);
-  cursor: pointer;
-}
-
-.action:hover {
-  background: var(--semantic-color-bg-card-hover, var(--semantic-color-bg-card));
 }

--- a/apps/armada-interface/src/components/RelayerStatusBanner/RelayerStatusBanner.test.tsx
+++ b/apps/armada-interface/src/components/RelayerStatusBanner/RelayerStatusBanner.test.tsx
@@ -46,26 +46,23 @@ describe('<RelayerStatusBanner>', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('renders the banner with the relayer\'s status when degraded', () => {
-    // WHY: the status word must reach the user — "stale" vs "unhealthy" tell them whether to
-    // hand-fall-back now or wait. The role="status" container holds the message; assert against
-    // its textContent so the surrounding <strong> emphasis tag doesn't trip the matcher.
+  it('renders the degraded-relayer banner with the wallet-submit CTA', () => {
+    // WHY: when the relayer is degraded the user must know their tx may not broadcast and be
+    // offered the wallet path. Copy is static now (no dynamic status word from the payload).
     mockUseRelayerHealth.mockReturnValue({ isConfigured: true, isDegraded: true, data: { status: 'stale' } })
     const store = createStore()
     const { getByRole } = render(wrapWith(store, <RelayerStatusBanner isOpen />))
-    const statusRegion = getByRole('status')
-    expect(statusRegion.textContent).toMatch(/relayer is reporting/i)
-    expect(statusRegion.textContent).toMatch(/stale/i)
+    expect(getByRole('status').textContent).toMatch(/can't find an available relayer/i)
     expect(getByRole('button', { name: /Submit from my wallet instead/i })).toBeInTheDocument()
   })
 
-  it('falls back to "unreachable" when the hook returned no data', () => {
-    // WHY: a network-level failure has no `data.status` to read — the banner must still render
-    // something meaningful. "unreachable" is the right semantic distinction from "stale".
+  it('still renders the degraded banner when the hook returned no data', () => {
+    // WHY: a network-level failure has no `data.status`, but the banner must still surface — its
+    // copy no longer depends on the health payload.
     mockUseRelayerHealth.mockReturnValue({ isConfigured: true, isDegraded: true, data: undefined })
     const store = createStore()
     const { getByRole } = render(wrapWith(store, <RelayerStatusBanner isOpen />))
-    expect(getByRole('status').textContent).toMatch(/unreachable/i)
+    expect(getByRole('status').textContent).toMatch(/can't find an available relayer/i)
   })
 
   it('renders a distinct "no relayer configured" banner with a wallet-submit CTA (P0-10)', () => {

--- a/apps/armada-interface/src/components/RelayerStatusBanner/RelayerStatusBanner.tsx
+++ b/apps/armada-interface/src/components/RelayerStatusBanner/RelayerStatusBanner.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Offers a one-click "Submit from your wallet instead" path that toggles the persisted preference.
 
 import { useAtom } from 'jotai'
+import { Button } from '@/design'
 import { preferencesAtom } from '@/state/preferences'
 import { useRelayerHealth } from '@/hooks/useRelayerHealth'
 import styles from './RelayerStatusBanner.module.css'
@@ -21,7 +22,7 @@ export interface RelayerStatusBannerProps {
  * read `preferencesAtom.submitFromWallet` directly at submit-time.
  */
 export function RelayerStatusBanner({ isOpen }: RelayerStatusBannerProps) {
-  const { isDegraded, isConfigured, data } = useRelayerHealth({ enabled: isOpen })
+  const { isDegraded, isConfigured } = useRelayerHealth({ enabled: isOpen })
   // preferencesAtom is `atomWithStorage` → persisted to localStorage. The action button's flip
   // therefore SURVIVES page reload + session restart; reverting requires the Settings toggle.
   const [prefs, setPrefs] = useAtom(preferencesAtom)
@@ -38,13 +39,14 @@ export function RelayerStatusBanner({ isOpen }: RelayerStatusBannerProps) {
           No relayer is configured for this site. You can still submit transactions from your own
           wallet (you'll pay network gas).
         </div>
-        <button
-          type="button"
+        <Button
+          variant="secondary"
+          size="sm"
+          label="Submit from my wallet"
+          showIcon={false}
           className={styles.action}
           onClick={() => setPrefs({ ...prefs, submitFromWallet: true })}
-        >
-          Submit from my wallet
-        </button>
+        />
       </div>
     )
   }
@@ -52,21 +54,19 @@ export function RelayerStatusBanner({ isOpen }: RelayerStatusBannerProps) {
   // Relayer's fine — no banner, default relayer-mediated path proceeds.
   if (!isDegraded) return null
 
-  const statusLabel = data?.status ?? 'unreachable'
-
   return (
     <div className={styles.root} role="status" aria-live="polite">
       <div className={styles.message}>
-        The relayer is reporting <strong>{statusLabel}</strong>. Your transaction may not be
-        broadcast promptly.
+        Can't find an available relayer. Your transaction may not be broadcast promptly.
       </div>
-      <button
-        type="button"
+      <Button
+        variant="secondary"
+        size="sm"
+        label="Submit from my wallet instead"
+        showIcon={false}
         className={styles.action}
         onClick={() => setPrefs({ ...prefs, submitFromWallet: true })}
-      >
-        Submit from my wallet instead
-      </button>
+      />
     </div>
   )
 }

--- a/apps/armada-interface/src/components/dashboard/ActivityReceipt/ActivityReceipt.module.css
+++ b/apps/armada-interface/src/components/dashboard/ActivityReceipt/ActivityReceipt.module.css
@@ -132,7 +132,7 @@
   color: var(--semantic-color-text-muted);
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .root {
     padding: var(--primitives-spacing-5);
   }

--- a/apps/armada-interface/src/components/dashboard/BalanceCard/BalanceCard.module.css
+++ b/apps/armada-interface/src/components/dashboard/BalanceCard/BalanceCard.module.css
@@ -738,7 +738,7 @@
   padding-block: var(--primitives-spacing-2);
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .balanceClusterPrivate {
     cursor: pointer;
   }

--- a/apps/armada-interface/src/components/dashboard/RecentActivityList/RecentActivityList.module.css
+++ b/apps/armada-interface/src/components/dashboard/RecentActivityList/RecentActivityList.module.css
@@ -163,6 +163,17 @@
   outline-offset: calc(var(--primitives-spacing-1) * 1px);
 }
 
+/* A freshly-prepended top row slides+fades in on its own (reuses the list enter keyframe). */
+.itemEnter {
+  animation: activityEnter 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .itemEnter {
+    animation: none;
+  }
+}
+
 .iconBadge {
   width: var(--primitives-spacing-10);
   height: var(--primitives-spacing-10);
@@ -232,7 +243,7 @@
   text-decoration: line-through;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .copy {
     min-width: 0;
   }

--- a/apps/armada-interface/src/components/dashboard/RecentActivityList/RecentActivityList.tsx
+++ b/apps/armada-interface/src/components/dashboard/RecentActivityList/RecentActivityList.tsx
@@ -109,6 +109,23 @@ function ActivityListItems({
 }) {
   const isMobile = useMobileLayout()
   const [peekedId, setPeekedId] = useState<string | null>(null)
+  // Animate only a freshly-prepended top row (not the whole list, and not on first paint — the
+  // list-level enter handles that). Mirrors the mockup's enteringId/skipEnter.
+  const [enteringId, setEnteringId] = useState<string | null>(null)
+  const seenFirstIdRef = useRef<string | null>(null)
+  const skipEnterRef = useRef(true)
+  useEffect(() => {
+    const firstId = items[0]?.id ?? null
+    if (skipEnterRef.current) {
+      skipEnterRef.current = false
+      seenFirstIdRef.current = firstId
+      return
+    }
+    if (firstId && firstId !== seenFirstIdRef.current) {
+      setEnteringId(firstId)
+      seenFirstIdRef.current = firstId
+    }
+  }, [items])
 
   return (
     <ul className={styles.list}>
@@ -136,7 +153,9 @@ function ActivityListItems({
           <li key={item.id}>
             <button
               type="button"
-              className={styles.item}
+              className={[styles.item, enteringId === item.id ? styles.itemEnter : '']
+                .filter(Boolean)
+                .join(' ')}
               onClick={() => onItemClick?.(item)}
               {...peekHandlers}
             >

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
@@ -75,6 +75,13 @@ export interface DepositAmountCardProps {
    * when omitted the card falls back to the single `Max` button (driven by `onMax`).
    */
   maxInput?: bigint
+  /**
+   * Full (pre-fee) balance the percent pills take a share of — a % of this, capped at `maxInput`.
+   * When omitted the pills fall back to a share of `maxInput` (fine where the cap equals the balance,
+   * e.g. shield). Set on fee-on-top paths (send/withdraw/earn) so 25/50/75 land on round balance
+   * fractions rather than fractions of the fee-adjusted cap.
+   */
+  balanceRaw?: bigint
   error?: string
   /** Accessible name for the amount field (e.g. "Deposit amount", "Withdrawal amount"). */
   amountAriaLabel?: string
@@ -115,6 +122,7 @@ export function DepositAmountCard({
   flowBreakdown,
   onMax,
   maxInput,
+  balanceRaw,
   error,
   amountAriaLabel = 'Amount',
   inputRef,
@@ -209,11 +217,14 @@ export function DepositAmountCard({
     onAmountChange(nextAmount)
   }
 
-  // Percentage pills set the amount to a fraction of the raw input cap. Integer bigint math keeps
-  // full 6-decimal precision (no float rounding).
+  // Percentage pills set the amount to a share of the full balance (mockup parity), capped at the
+  // fee-aware `maxInput`. When `balanceRaw` isn't supplied (e.g. shield, where the cap equals the
+  // balance) they fall back to a share of the cap. Integer bigint math keeps full 6-decimal precision.
   function applyPercent(percent: bigint) {
     if (maxInput === undefined) return
-    applyPreset(formatUsdcPlain((maxInput * percent) / 100n))
+    const share = ((balanceRaw ?? maxInput) * percent) / 100n
+    const capped = share < maxInput ? share : maxInput
+    applyPreset(formatUsdcPlain(capped))
   }
 
   // Max reuses the caller's `onMax` when supplied so fee-on-top paths keep their exact cap, else it

--- a/apps/armada-interface/src/components/deposit/DepositReviewSummary/DepositReviewSummary.module.css
+++ b/apps/armada-interface/src/components/deposit/DepositReviewSummary/DepositReviewSummary.module.css
@@ -106,7 +106,7 @@
   text-align: left;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .privacyNotice {
     background: var(--semantic-color-control-tint);
   }

--- a/apps/armada-interface/src/components/onboarding/steps/AntiPhishChecksumStep.module.css
+++ b/apps/armada-interface/src/components/onboarding/steps/AntiPhishChecksumStep.module.css
@@ -36,7 +36,7 @@
   margin-top: var(--primitives-spacing-8);
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .footer {
     margin-top: var(--primitives-spacing-4);
   }

--- a/apps/armada-interface/src/components/onboarding/steps/CompleteStep.module.css
+++ b/apps/armada-interface/src/components/onboarding/steps/CompleteStep.module.css
@@ -29,7 +29,7 @@
   width: auto;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .actions {
     margin-top: var(--primitives-spacing-5);
   }

--- a/apps/armada-interface/src/components/onboarding/steps/PassphraseStep.module.css
+++ b/apps/armada-interface/src/components/onboarding/steps/PassphraseStep.module.css
@@ -88,7 +88,7 @@
   margin-top: var(--primitives-spacing-8);
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .footer {
     margin-top: var(--primitives-spacing-5);
   }

--- a/apps/armada-interface/src/components/onboarding/steps/SignEnrollmentStep.module.css
+++ b/apps/armada-interface/src/components/onboarding/steps/SignEnrollmentStep.module.css
@@ -43,7 +43,7 @@
   width: auto;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .actions {
     margin-top: var(--primitives-spacing-4);
   }

--- a/apps/armada-interface/src/components/onboarding/steps/WelcomeStep.module.css
+++ b/apps/armada-interface/src/components/onboarding/steps/WelcomeStep.module.css
@@ -36,7 +36,7 @@
   width: auto;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .actions {
     margin-top: var(--primitives-spacing-5);
   }

--- a/apps/armada-interface/src/components/payments/SendCompleteStep.module.css
+++ b/apps/armada-interface/src/components/payments/SendCompleteStep.module.css
@@ -100,7 +100,7 @@
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .root {
     padding: var(--primitives-spacing-5);
   }

--- a/apps/armada-interface/src/components/payments/SendCompleteStep.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendCompleteStep.test.tsx
@@ -26,9 +26,9 @@ function renderComplete(extras?: Partial<SendCompleteStepProps>) {
 }
 
 describe('<SendCompleteStep>', () => {
-  it('send: renders the "USDC send confirmed" title + date row + amount (privacy notice hidden)', () => {
+  it('send: renders the "USDC shielded transfer confirmed" title + date row + amount (privacy notice hidden)', () => {
     renderComplete({ recipient: VALID_0ZK })
-    expect(screen.getByText('USDC send confirmed')).toBeInTheDocument()
+    expect(screen.getByText('USDC shielded transfer confirmed')).toBeInTheDocument()
     expect(screen.getByText('Date and time')).toBeInTheDocument()
     // The privacy notice is only shown pre-confirmation; the confirmed view omits it.
     expect(screen.queryByText('Private transfer.')).toBeNull()

--- a/apps/armada-interface/src/components/payments/SendCompleteStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendCompleteStep.tsx
@@ -4,6 +4,7 @@
 import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { TransferReviewSummary } from './TransferReviewSummary'
 import { formatUsdcPlain } from '@/lib/format'
+import { isShieldedAddress } from '@/lib/address'
 import type { SendFlowVariant } from './SendRecipientStep'
 import styles from './SendCompleteStep.module.css'
 
@@ -44,7 +45,12 @@ export function SendCompleteStep({
   onViewExplorer,
   onGoToDashboard,
 }: SendCompleteStepProps) {
-  const title = variant === 'withdraw' ? 'USDC unshield confirmed' : 'USDC send confirmed'
+  const title =
+    variant === 'withdraw'
+      ? 'USDC unshield confirmed'
+      : isShieldedAddress(recipient)
+        ? 'USDC shielded transfer confirmed'
+        : 'USDC sent successfully'
 
   return (
     <div className={styles.root}>

--- a/apps/armada-interface/src/components/payments/SendInputStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendInputStep.tsx
@@ -108,6 +108,7 @@ export function SendInputStepContent({
           feeLoading={feeLoading}
           // maxInput drives the 25% / 50% / 75% / Max percent pills; onMax keeps the exact fee-aware cap.
           maxInput={maxInput}
+          balanceRaw={max}
           onMax={() => onAmountChange(formatUsdcPlain(maxInput))}
           error={amountError}
           amountAriaLabel={variant === 'withdraw' ? 'Withdrawal amount' : 'Send amount'}

--- a/apps/armada-interface/src/components/payments/SendModal.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.test.tsx
@@ -161,7 +161,7 @@ describe('<SendModal>', () => {
       intent: { recipient: VALID_0ZK, amount: '25' },
     })
     // Recipient + amount are both known, so the flow jumps past the recipient/amount steps.
-    expect(screen.getByRole('heading', { name: 'Review your USDC transfer' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Review your USDC shielded transfer' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Confirm send' })).toBeInTheDocument()
     expect(screen.queryByLabelText('Recipient address')).toBeNull()
     // The intent is consumed on open so it can't re-fire.

--- a/apps/armada-interface/src/components/payments/SendRecipientStep.module.css
+++ b/apps/armada-interface/src/components/payments/SendRecipientStep.module.css
@@ -315,7 +315,7 @@
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .card {
     padding: var(--primitives-spacing-5);
   }

--- a/apps/armada-interface/src/components/payments/SendRecipientStep.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendRecipientStep.test.tsx
@@ -31,9 +31,9 @@ describe('<SendRecipientStep>', () => {
     expect(screen.getByRole('heading', { name: /Send your USDC to:/ })).toBeInTheDocument()
   })
 
-  it('withdraw variant prompts "Where do you want to send your USDC?"', () => {
+  it('withdraw variant prompts "Where do you want to unshield your USDC?"', () => {
     setup({ variant: 'withdraw' })
-    expect(screen.getByRole('heading', { name: /Where do you want to send your USDC\?/ })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Where do you want to unshield your USDC\?/ })).toBeInTheDocument()
   })
 
   it('shows a disabled "Enter address" CTA while the recipient is empty', () => {

--- a/apps/armada-interface/src/components/payments/SendRecipientStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendRecipientStep.tsx
@@ -114,7 +114,8 @@ export function SendRecipientStep({
   const inputDisplayValue = inputFocused || !hasInput ? recipient : truncateAddress(recipientTrimmed)
 
   // The prompt differs by variant per design: withdraw leans into "where", send is imperative.
-  const title = variant === 'withdraw' ? 'Where do you want to send your USDC?' : 'Send your USDC to:'
+  const title =
+    variant === 'withdraw' ? 'Where do you want to unshield your USDC?' : 'Send your USDC to:'
 
   const canContinue = recipientValid && !destDeploymentError
 

--- a/apps/armada-interface/src/components/payments/SendReviewStep.module.css
+++ b/apps/armada-interface/src/components/payments/SendReviewStep.module.css
@@ -108,7 +108,7 @@
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .root {
     padding: var(--primitives-spacing-5);
   }

--- a/apps/armada-interface/src/components/payments/SendReviewStep.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendReviewStep.test.tsx
@@ -51,13 +51,13 @@ describe('<SendReviewStep>', () => {
 
   it('withdraw variant: uses the unshield title + "Confirm" label', () => {
     renderReview({ variant: 'withdraw', recipient: VALID_EVM, networkName: 'Anvil Hub (local)' })
-    expect(screen.getByText('Review your USDC unshield')).toBeInTheDocument()
+    expect(screen.getByText('Review unshielding transfer')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument()
   })
 
   it('send variant: uses the transfer title + fires onConfirm on the primary CTA', () => {
     const { onConfirm } = renderReview()
-    expect(screen.getByText('Review your USDC transfer')).toBeInTheDocument()
+    expect(screen.getByText('Review your USDC shielded transfer')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /Confirm send/ }))
     expect(onConfirm).toHaveBeenCalledTimes(1)
   })

--- a/apps/armada-interface/src/components/payments/SendReviewStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendReviewStep.tsx
@@ -5,6 +5,7 @@ import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { TransferReviewSummary } from './TransferReviewSummary'
 import { FeeUpdatedBanner } from '@/components/flow/FeeUpdatedBanner/FeeUpdatedBanner'
 import { formatUsdcPlain } from '@/lib/format'
+import { isShieldedAddress } from '@/lib/address'
 import type { SendFlowVariant } from './SendRecipientStep'
 import styles from './SendReviewStep.module.css'
 
@@ -46,7 +47,12 @@ export function SendReviewStep({
   onBack,
   onConfirm,
 }: SendReviewStepProps) {
-  const title = variant === 'withdraw' ? 'Review your USDC unshield' : 'Review your USDC transfer'
+  const title =
+    variant === 'withdraw'
+      ? 'Review unshielding transfer'
+      : isShieldedAddress(recipient)
+        ? 'Review your USDC shielded transfer'
+        : 'Review your USDC transfer'
   const confirmLabel = variant === 'withdraw' ? 'Confirm' : 'Confirm send'
 
   return (

--- a/apps/armada-interface/src/components/request/RequestReceiveScreen.module.css
+++ b/apps/armada-interface/src/components/request/RequestReceiveScreen.module.css
@@ -43,7 +43,7 @@
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .linkCard {
     padding: var(--primitives-spacing-5);
   }

--- a/apps/armada-interface/src/components/shield/ShieldCompleteStep.module.css
+++ b/apps/armada-interface/src/components/shield/ShieldCompleteStep.module.css
@@ -100,7 +100,7 @@
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .root {
     padding: var(--primitives-spacing-5);
   }

--- a/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
@@ -42,6 +42,11 @@ function unresolvedShield(amount: bigint): TxRecord {
 vi.mock('@/lib/tx/executor', async (importActual) => ({
   ...await importActual<typeof import('@/lib/tx/executor')>(),
   getIsLeader: () => true,
+  // No-op the executor so a submitted record deterministically sits at build-proof (the wallet
+  // step). With the real executor the shield handler can't complete in the test env and the record
+  // races to `failed`, flipping the step off `wallet` before the assertions can catch it. These
+  // tests exercise the submit → wallet-step UI orchestration, not real executor progression.
+  executeTx: () => {},
 }))
 
 vi.mock('@/hooks/useDisplayFees', () => ({

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -106,6 +106,7 @@ export function ShieldModal() {
       currentStep={currentStep}
       status={status}
     >
+      <RelayerStatusBanner isOpen={isOpen} />
       {step === 'input' && (
         <>
           <ShieldAmountStepContent
@@ -227,7 +228,6 @@ export function ShieldModal() {
           onRetry={active.onErrorPrimary}
         />
       )}
-      <RelayerStatusBanner isOpen={isOpen} />
     </FlowShell>
   )
 }

--- a/apps/armada-interface/src/components/shield/ShieldReviewStep.module.css
+++ b/apps/armada-interface/src/components/shield/ShieldReviewStep.module.css
@@ -115,7 +115,7 @@
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .root {
     padding: var(--primitives-spacing-5);
   }

--- a/apps/armada-interface/src/components/shield/ShieldWalletStep.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldWalletStep.test.tsx
@@ -14,7 +14,7 @@ describe('ShieldWalletStep', () => {
     ]
     render(<ShieldWalletStep steps={steps} />)
     expect(
-      screen.getByRole('heading', { name: 'Confirm transactions on your wallet' }),
+      screen.getByRole('heading', { name: 'Confirm transactions in your wallet' }),
     ).toBeInTheDocument()
     expect(screen.getByRole('list', { name: 'Wallet confirmations' })).toBeInTheDocument()
     expect(screen.getByText('Sign shield transaction')).toBeInTheDocument()

--- a/apps/armada-interface/src/components/shield/ShieldWalletStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldWalletStep.tsx
@@ -20,7 +20,7 @@ export function ShieldWalletStep({ steps }: ShieldWalletStepProps) {
   return (
     <div className={styles.column}>
       <div className={`${styles.body} ${modalStepBodyEnter}`}>
-        <h1 className={styles.title}>Confirm transactions on your wallet</h1>
+        <h1 className={styles.title}>Confirm transactions in your wallet</h1>
         <WalletConfirmList className={styles.confirmList} steps={steps} />
       </div>
       <div className={modalActionRowEnter}>

--- a/apps/armada-interface/src/components/tx/processing/processingView.test.ts
+++ b/apps/armada-interface/src/components/tx/processing/processingView.test.ts
@@ -32,13 +32,14 @@ describe('buildProcessingView', () => {
     const send = buildProcessingView(rec('unshield-local', 'build-proof', 'active'), {
       sendVariant: 'send',
     })
-    expect(send.cardCopy.title).toBe('Unshielding your USDC')
+    expect(send.cardCopy.title).toBe('Unshielding and sending your USDC')
+    expect(send.cardCopy.titleLines).toEqual(['Unshielding and sending', 'your USDC'])
 
     const withdraw = buildProcessingView(rec('unshield-local', 'build-proof', 'active'), {
       sendVariant: 'withdraw',
     })
-    expect(withdraw.cardCopy.title).toBe('Your unshield is in progress')
-    expect(withdraw.cardCopy.titleLines).toEqual(['Your unshield', 'is in progress'])
+    expect(withdraw.cardCopy.title).toBe('Unshielding your USDC')
+    expect(withdraw.cardCopy.titleLines).toEqual(['Unshielding your', 'USDC'])
   })
 
   it('snaps to the final stage and exposes the completedLabel when completed', () => {

--- a/apps/armada-interface/src/components/tx/processing/processingView.ts
+++ b/apps/armada-interface/src/components/tx/processing/processingView.ts
@@ -34,12 +34,15 @@ const STAGE_COPY: Record<TxKind, Record<string, StageCopyEntry>> = {
   },
   'unshield-local': {
     'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
-    'submit-relayer': { label: 'Submitting privately', subtitle: 'Relaying to the hub' },
-    'hub-confirmed': { label: 'Unshielding', subtitle: 'Sending USDC to your wallet', completedLabel: 'Unshielded' },
+    'submit-relayer': { label: 'Submitting transaction', subtitle: 'Relaying to public chain' },
+    // One kind-keyed entry serves both external-send and withdraw (accepted limitation): the mockup
+    // splits these by mode. We use the external-send subtitle (neutral — a withdraw also lands in an
+    // external wallet) + the unshield completedLabel (accurate for both).
+    'hub-confirmed': { label: 'Unshielding', subtitle: 'Sending USDC to external wallet', completedLabel: 'Unshielded' },
   },
   'unshield-xchain': {
     'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
-    'submit-relayer': { label: 'Submitting privately', subtitle: 'Relaying to the hub' },
+    'submit-relayer': { label: 'Submitting transaction', subtitle: 'Relaying to public chain' },
     'hub-burn-confirmed': { label: 'Bridging', subtitle: 'Confirmed on hub' },
     'iris-attestation-pending': { label: 'Bridging', subtitle: 'Waiting for cross-chain confirmation' },
     'iris-attestation-ready': { label: 'Bridging', subtitle: 'Cross-chain confirmation ready' },
@@ -48,21 +51,21 @@ const STAGE_COPY: Record<TxKind, Record<string, StageCopyEntry>> = {
   },
   'transfer-shielded': {
     'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
-    'submit-relayer': { label: 'Submitting privately', subtitle: 'Delivering to the recipient' },
-    'hub-confirmed': { label: 'Sending', subtitle: 'Confirming on chain', completedLabel: 'Sent' },
+    'submit-relayer': { label: 'Submitting transaction', subtitle: 'Relaying privately to recipient' },
+    'hub-confirmed': { label: 'Sending', subtitle: 'Delivering privately to recipient', completedLabel: 'Sent' },
   },
   'transfer-shielded-received': {
     observed: { label: 'Received', subtitle: 'Payment received', completedLabel: 'Received' },
   },
   'yield-deposit': {
     'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
-    'submit-relayer': { label: 'Submitting privately', subtitle: 'Relaying to the shielded vault' },
-    'hub-confirmed': { label: 'Adding to shielded vault', subtitle: 'Confirming on chain', completedLabel: 'Earning' },
+    'submit-relayer': { label: 'Submitting privately', subtitle: 'Relaying to shielded vault' },
+    'hub-confirmed': { label: 'Adding to shielded vault', subtitle: 'USDC is entering the shielded vault', completedLabel: 'Earning' },
   },
   'yield-withdraw': {
     'build-proof': { label: 'Preparing transaction', subtitle: 'Building zero-knowledge proof' },
-    'submit-relayer': { label: 'Submitting privately', subtitle: 'Relaying to the vault' },
-    'hub-confirmed': { label: 'Withdrawing', subtitle: 'Confirming on chain', completedLabel: 'Returned to balance' },
+    'submit-relayer': { label: 'Submitting privately', subtitle: 'Relaying to shielded vault' },
+    'hub-confirmed': { label: 'Withdrawing', subtitle: 'USDC is returning to your balance', completedLabel: 'Returned to balance' },
   },
 }
 
@@ -113,18 +116,25 @@ function resolveCardBase(record: TxRecord, sendVariant?: SendVariant): CardBase 
       return sendVariant === 'withdraw'
         ? {
             tag: 'Unshield in progress',
-            title: 'Your unshield is in progress',
-            titleLines: ['Your unshield', 'is in progress'],
+            title: 'Unshielding your USDC',
+            titleLines: ['Unshielding your', 'USDC'],
           }
-        : { tag: 'Send in progress', title: 'Unshielding your USDC' }
+        : {
+            tag: 'Send in progress',
+            title: 'Unshielding and sending your USDC',
+            titleLines: ['Unshielding and sending', 'your USDC'],
+          }
     case 'yield-deposit':
       return {
         tag: 'Deposit to shielded vault in progress',
-        title: 'Depositing USDC into the shielded vault',
+        title: 'Sending USDC to shielded vault',
         titleBreakAfter: 'USDC',
       }
     case 'yield-withdraw':
-      return { tag: 'Withdraw from shielded vault in progress', title: 'Your withdrawal is in progress' }
+      return {
+        tag: 'Withdraw from shielded vault in progress',
+        title: 'Withdraw from shielded vault in progress',
+      }
   }
 }
 

--- a/apps/armada-interface/src/components/yield/EarnCompleteStep.module.css
+++ b/apps/armada-interface/src/components/yield/EarnCompleteStep.module.css
@@ -100,7 +100,7 @@
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .root {
     padding: var(--primitives-spacing-5);
   }

--- a/apps/armada-interface/src/components/yield/EarnInputStep.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.test.tsx
@@ -81,12 +81,12 @@ describe('<EarnInputStep>', () => {
 
   it('uses the vault-deposit aria-label when tab=add', () => {
     setup({ tab: 'add' })
-    expect(screen.getByLabelText('Vault deposit amount')).toBeInTheDocument()
+    expect(screen.getByLabelText('Shielded vault deposit amount')).toBeInTheDocument()
   })
 
   it('uses the vault-withdraw aria-label when tab=withdraw', () => {
     setup({ tab: 'withdraw' })
-    expect(screen.getByLabelText('Vault withdrawal amount')).toBeInTheDocument()
+    expect(screen.getByLabelText('Shielded vault withdrawal amount')).toBeInTheDocument()
   })
 
   it('shows the syncing APY headline when rate is null', () => {
@@ -162,6 +162,6 @@ describe('<EarnInputStep>', () => {
     const cta = screen.getByRole('button', { name: 'Input amount' })
     fireEvent.click(cta)
     expect(props.onContinue).not.toHaveBeenCalled()
-    expect(screen.getByLabelText('Vault deposit amount')).toHaveFocus()
+    expect(screen.getByLabelText('Shielded vault deposit amount')).toHaveFocus()
   })
 })

--- a/apps/armada-interface/src/components/yield/EarnInputStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.tsx
@@ -182,6 +182,7 @@ export function EarnInputStepContent({
         feeLoading={feeLoading}
         // maxInput drives the 25% / 50% / 75% / Max percent pills; onMax keeps the exact fee-aware cap.
         maxInput={maxInput}
+        balanceRaw={max}
         onMax={() => onAmountChange(formatUsdcPlain(maxInput))}
         error={fieldError}
         amountAriaLabel={tab === 'add' ? 'Vault deposit amount' : 'Vault withdrawal amount'}

--- a/apps/armada-interface/src/components/yield/EarnInputStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.tsx
@@ -141,7 +141,7 @@ export function EarnInputStepContent({
   const fieldError = amountError ?? continueBlockedReason ?? undefined
 
   const question =
-    tab === 'add' ? 'Deposit USDC to the vault' : 'Withdraw USDC from the vault'
+    tab === 'add' ? 'Add USDC to the shielded vault' : 'Withdraw USDC from the shielded vault'
 
   return (
     <div className={`${styles.root} ${modalStepBodyEnter}`}>
@@ -185,7 +185,7 @@ export function EarnInputStepContent({
         balanceRaw={max}
         onMax={() => onAmountChange(formatUsdcPlain(maxInput))}
         error={fieldError}
-        amountAriaLabel={tab === 'add' ? 'Vault deposit amount' : 'Vault withdrawal amount'}
+        amountAriaLabel={tab === 'add' ? 'Shielded vault deposit amount' : 'Shielded vault withdrawal amount'}
         inputRef={inputRef}
       />
 

--- a/apps/armada-interface/src/components/yield/EarnModal.test.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.test.tsx
@@ -121,21 +121,21 @@ describe('<EarnModal>', () => {
 
   it('switching tabs clears the amount field', () => {
     renderModal({ open: 'yield-deposit', shielded: 10_000_000n })
-    fireEvent.change(screen.getByLabelText('Vault deposit amount'), { target: { value: '3' } })
+    fireEvent.change(screen.getByLabelText('Shielded vault deposit amount'), { target: { value: '3' } })
     fireEvent.click(screen.getByRole('tab', { name: 'Withdraw' }))
-    expect(screen.getByLabelText('Vault withdrawal amount')).toHaveValue('')
+    expect(screen.getByLabelText('Shielded vault withdrawal amount')).toHaveValue('')
   })
 
   it('advances to review on Continue with a valid amount (add tab)', () => {
     renderModal({ open: 'yield-deposit', shielded: 10_000_000n })
-    fireEvent.change(screen.getByLabelText('Vault deposit amount'), { target: { value: '3' } })
+    fireEvent.change(screen.getByLabelText('Shielded vault deposit amount'), { target: { value: '3' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
     expect(screen.getByRole('heading', { name: 'Review USDC shielded transfer to the vault' })).toBeInTheDocument()
   })
 
   it('Confirm submits the tx and advances to the progress step', async () => {
     renderModal({ open: 'yield-deposit', shielded: 10_000_000n })
-    fireEvent.change(screen.getByLabelText('Vault deposit amount'), { target: { value: '3' } })
+    fireEvent.change(screen.getByLabelText('Shielded vault deposit amount'), { target: { value: '3' } })
     fireEvent.click(screen.getByRole('button', { name: /Review/ }))
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /Confirm deposit/ }))

--- a/apps/armada-interface/src/components/yield/EarnReviewStep.module.css
+++ b/apps/armada-interface/src/components/yield/EarnReviewStep.module.css
@@ -121,7 +121,7 @@
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .root {
     padding: var(--primitives-spacing-5);
   }

--- a/apps/armada-interface/src/constants/viewportBreakpoints.ts
+++ b/apps/armada-interface/src/constants/viewportBreakpoints.ts
@@ -1,3 +1,3 @@
-// ABOUTME: Viewport breakpoint constants for responsive layout switching.
+// ABOUTME: Viewport breakpoint constants for responsive layout switching (phone chrome: bottom sheets, keypad, dashboard gutters).
 // ABOUTME: MOBILE_LAYOUT_MAX_WIDTH_PX drives useMobileLayout's matchMedia query.
-export const MOBILE_LAYOUT_MAX_WIDTH_PX = 767
+export const MOBILE_LAYOUT_MAX_WIDTH_PX = 479

--- a/apps/armada-interface/src/design/components/ModalShell/ModalShell.module.css
+++ b/apps/armada-interface/src/design/components/ModalShell/ModalShell.module.css
@@ -295,7 +295,7 @@ button.closeGhost:active:not(:disabled) {
   margin-top: calc(var(--primitives-spacing-16) + var(--primitives-spacing-2));
 }
 
-@media (min-width: 768px) {
+@media (min-width: 480px) {
   .content:not(.contentSimple) {
     /* Match dashboard cardStack padding-top (--semantic-spacing-page-block). */
     margin-top: calc(
@@ -379,7 +379,7 @@ button.closeGhost:active:not(:disabled) {
   animation-delay: calc(var(--modal-step-enter-delay, 360ms) + 570ms);
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .shell:not(.shellSimple) {
     padding-bottom: calc(var(--primitives-spacing-5) + var(--mobile-safe-area-bottom, 0px));
   }

--- a/apps/armada-interface/src/design/components/SidePanel/SidePanel.module.css
+++ b/apps/armada-interface/src/design/components/SidePanel/SidePanel.module.css
@@ -109,7 +109,7 @@
   to { transform: translateX(100%); }
 }
 
-@media (min-width: 768px) {
+@media (min-width: 480px) {
   .scrim {
     padding: var(--primitives-spacing-6);
   }

--- a/apps/armada-interface/src/hooks/useEarnBannerHandoff.ts
+++ b/apps/armada-interface/src/hooks/useEarnBannerHandoff.ts
@@ -26,13 +26,18 @@ export function useDepositTooltipHandoff(
   walletConnected: boolean,
   hasCompletedDeposit: boolean,
   dashboardBalance: number,
+  ready: boolean,
 ): DepositTooltipHandoff {
   const previousBalanceRef = useRef(dashboardBalance)
   const phaseRef = useRef<ShieldPromoPhase>('idle')
   const [, setHandoffEpoch] = useState(0)
 
   const previous = previousBalanceRef.current
-  if (previous !== dashboardBalance) {
+  if (!ready) {
+    // Until the dashboard has settled after load, track the balance as the baseline so the initial
+    // establishment (0 → real balance) isn't mistaken for a first shield and handed off.
+    previousBalanceRef.current = dashboardBalance
+  } else if (previous !== dashboardBalance) {
     if (previous <= 0 && dashboardBalance > 0) {
       phaseRef.current = 'keep'
     }
@@ -93,6 +98,7 @@ export function useEarnBannerHandoff(
   hasCompletedDeposit: boolean,
   earningBalance: number,
   dashboardBalance: number,
+  ready: boolean,
 ): EarnBannerHandoff {
   const previousEarningRef = useRef(earningBalance)
   const handoffRef = useRef<Handoff | null>(null)
@@ -100,7 +106,11 @@ export function useEarnBannerHandoff(
   const [, setHandoffEpoch] = useState(0)
 
   const previous = previousEarningRef.current
-  if (previous !== earningBalance) {
+  if (!ready) {
+    // Track the vault balance as the baseline until the dashboard settles, so an existing vault
+    // position establishing on load (0 → real) doesn't spuriously trigger a deposit/withdraw handoff.
+    previousEarningRef.current = earningBalance
+  } else if (previous !== earningBalance) {
     if (previous <= 0 && earningBalance > 0) {
       handoffRef.current = 'keep-banner'
       handoffEnterRef.current = false

--- a/apps/armada-interface/src/hooks/useMobileLayout.ts
+++ b/apps/armada-interface/src/hooks/useMobileLayout.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Hook reporting whether the viewport is in the touch-first mobile layout (≤767px).
+// ABOUTME: Hook reporting whether the viewport is in the phone layout (≤479px: bottom sheets, keypad).
 // ABOUTME: Ported from the armada-app design mockup.
 import { useSyncExternalStore } from 'react'
 import { MOBILE_LAYOUT_MAX_WIDTH_PX } from '@/constants/viewportBreakpoints'
@@ -19,7 +19,7 @@ function getMobileLayoutServerSnapshot() {
   return false
 }
 
-/** True when viewport width is ≤767px (touch-first mobile layout). */
+/** True when viewport width is ≤479px (touch-first mobile layout). */
 export function useMobileLayout() {
   return useSyncExternalStore(subscribe, getMobileLayoutSnapshot, getMobileLayoutServerSnapshot)
 }

--- a/apps/armada-interface/src/pages/Dashboard.module.css
+++ b/apps/armada-interface/src/pages/Dashboard.module.css
@@ -142,7 +142,7 @@
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .page {
     padding-bottom: var(--primitives-spacing-5);
   }

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -183,9 +183,13 @@ export function Dashboard() {
   // polish redesign — the more-menu that held it is gone).
   const showActivity = allActivityItems.length > 0
   // Earn promo banner — the two banners are mutually exclusive; earn only shows once the deposit
-  // tooltip is gone and the vault pays a real APY.
+  // tooltip is gone and the vault pays a real APY. Gated on `handoffReady` so it can't flash during
+  // load: yieldRate (→ earnApyAvailable) and the deferred `displayedVault` settle on different renders,
+  // so before the dashboard is ready there's a frame where apy looks available while the vault still
+  // reads 0 — which would briefly show the banner, then collapse it out.
   const earnApyAvailable = vaultApy !== undefined && vaultApy > 0
-  const showEarnBanner = earnBannerHandoff.showEarnBanner && !showDepositTooltip && earnApyAvailable
+  const showEarnBanner =
+    handoffReady && earnBannerHandoff.showEarnBanner && !showDepositTooltip && earnApyAvailable
   const earnBannerHandoffEnter =
     earnBannerHandoff.earnBannerHandoffEnter || (showEarnBanner && depositTooltipHandoff.revealEarnBanner)
   const earnBannerPersistVisible = earnBannerHandoff.earnBannerPersistVisible

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -83,6 +83,17 @@ export function Dashboard() {
   // flashing NEW then rolling. Mirrors the mockup, which defers the whole advance (value + roll)
   // until the user is back on the dashboard.
   const gated = isInitialSyncGated(shielded, sync.status)
+  // Prime the promo-banner handoffs one frame after the sync gate lifts, so the balance/vault values
+  // that establish on load form the baseline rather than a transition that flashes a banner.
+  const [handoffReady, setHandoffReady] = useState(false)
+  useEffect(() => {
+    if (gated) {
+      setHandoffReady(false)
+      return
+    }
+    const id = requestAnimationFrame(() => setHandoffReady(true))
+    return () => cancelAnimationFrame(id)
+  }, [gated])
   const liveBalance = usdcToNumber(displayBalance)
   const earningUsdc =
     yieldShares !== null && yieldRate !== null ? sharesToUsdc(yieldShares, yieldRate.rate) : 0n
@@ -149,8 +160,19 @@ export function Dashboard() {
   // Promo-banner handoff: after a first shield the deposit tooltip holds through the balance roll,
   // then collapses and hands off to the earn banner (and reverses on vault deposit/withdraw), rather
   // than the two banners swapping instantly. See useEarnBannerHandoff.
-  const depositTooltipHandoff = useDepositTooltipHandoff(walletConnected, hasCompletedDeposit, displayedBalance)
-  const earnBannerHandoff = useEarnBannerHandoff(walletConnected, hasCompletedDeposit, displayedVault, displayedBalance)
+  const depositTooltipHandoff = useDepositTooltipHandoff(
+    walletConnected,
+    hasCompletedDeposit,
+    displayedBalance,
+    handoffReady,
+  )
+  const earnBannerHandoff = useEarnBannerHandoff(
+    walletConnected,
+    hasCompletedDeposit,
+    displayedVault,
+    displayedBalance,
+    handoffReady,
+  )
   const showDepositTooltip = depositTooltipHandoff.showDepositTooltip
   const depositTooltipPersistVisible = depositTooltipHandoff.depositTooltipPersistVisible
   const depositTooltipExiting = depositTooltipHandoff.depositTooltipExiting

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -132,10 +132,12 @@ export function Dashboard() {
       setDisplayedVault(liveVault)
       return
     }
-    // Full precision (6 decimals) so the odometer digit counts line up with the card display.
+    // Roll-from precision must match each row's display so the odometer settles cleanly: the balance
+    // card shows full 6 decimals, the vault row shows 2 (VaultPositionBar's formatUsdcAmount default).
+    // Passing 6 for the vault made it spin 6 fraction digits then snap-truncate to 2.
     setRollMode('fromValue')
     setRollFromValue(formatUsdcAmount(displayedBalance, 6))
-    setVaultRollFromValue(vaultChanged ? formatUsdcAmount(displayedVault, 6) : undefined)
+    setVaultRollFromValue(vaultChanged ? formatUsdcAmount(displayedVault, 2) : undefined)
     setRollTrigger((t) => t + 1)
     setDisplayedBalance(liveBalance)
     setDisplayedVault(liveVault)

--- a/apps/armada-interface/src/pages/Dashboard.tsx
+++ b/apps/armada-interface/src/pages/Dashboard.tsx
@@ -83,17 +83,20 @@ export function Dashboard() {
   // flashing NEW then rolling. Mirrors the mockup, which defers the whole advance (value + roll)
   // until the user is back on the dashboard.
   const gated = isInitialSyncGated(shielded, sync.status)
-  // Prime the promo-banner handoffs one frame after the sync gate lifts, so the balance/vault values
-  // that establish on load form the baseline rather than a transition that flashes a banner.
+  // The vault position depends on yieldRate, which loads from a separate poll (useYieldRate) — later
+  // than the wallet scan the sync gate waits on. Only prime the promo-banner handoffs once BOTH the
+  // gate has lifted and the vault data has loaded, so the established balance/vault values form the
+  // baseline rather than a late 0 → real arrival that flashes a banner in and out.
+  const vaultLoaded = yieldShares !== null && yieldRate !== null
   const [handoffReady, setHandoffReady] = useState(false)
   useEffect(() => {
-    if (gated) {
+    if (gated || !vaultLoaded) {
       setHandoffReady(false)
       return
     }
     const id = requestAnimationFrame(() => setHandoffReady(true))
     return () => cancelAnimationFrame(id)
-  }, [gated])
+  }, [gated, vaultLoaded])
   const liveBalance = usdcToNumber(displayBalance)
   const earningUsdc =
     yieldShares !== null && yieldRate !== null ? sharesToUsdc(yieldShares, yieldRate.rate) : 0n

--- a/apps/armada-interface/src/pages/PayViaLinkLanding.module.css
+++ b/apps/armada-interface/src/pages/PayViaLinkLanding.module.css
@@ -294,7 +294,7 @@
   animation-delay: 420ms;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 479px) {
   .page {
     justify-content: flex-start;
     padding: calc(var(--primitives-spacing-5) + var(--mobile-safe-area-top, 0px))


### PR DESCRIPTION
Tier 3 of the mockup catch-up plus the dashboard-motion follow-up fixes that landed alongside it. **Now based directly on `main`** (Tier 2 / #514 merged; this was rebased to drop the shared commits, so the diff is Tier-3-only).

## Tier 3 items (all resolved to match the mockup)

1. **479/767 breakpoint split.** Phone chrome (bottom sheets, mobile keypad, dashboard phone-column/gutters) fires at ≤479px, not ≤767px — tablets (480–767) get the desktop dialog/layout. `MOBILE_LAYOUT_MAX_WIDTH_PX` 767→479 + every app-component breakpoint flipped. Marketing type-scale block stays 767 (matches the mockup's marketing breakpoint).
2. **Percent presets = share of balance.** 25/50/75 pills take a share of the full balance capped at the fee-aware max (`min(balance × %, maxInput)`). New optional `balanceRaw` prop on `DepositAmountCard`; shield unaffected.
3. **Recipient-aware send titles.** Withdraw → "unshield" wording; 0zk recipient → "shielded transfer" wording; public recipient → plain send wording.
4. **Activity new-row enter.** Only a freshly-prepended top row animates in (`enteringId`/`skipEnter`); first paint still uses the list-level cascade.

## Dashboard-motion + copy follow-ups (same branch)

- **Promo-banner handoff gating** — don't fire on initial balance/vault establishment; gate on vault data loaded, not just the sync gate.
- **Earn-banner load flash** — gate banner visibility on `handoffReady` so it no longer mounts-and-exits before the balance card paints.
- **Vault odometer precision** — roll-from value matches the 2-decimal display (no 6→2 truncation after the spin).
- **Relayer-unreachable banner** — copy ("Can't find an available relayer. Your transaction may not be broadcast promptly."), consistent top placement across flows, and theme-token restyle (radius/colors/button/typography).
- **Tx-progress/review copy** — match the mockup across send/unshield/earn (submit + hub-confirmed subtitles, hero titles), shield wallet step ("in your wallet"), earn amount title/aria. Fee row stays "Fees". External-send-vs-withdraw share one lifecycle entry (accepted limitation, documented in code).

## Verification
`tsc -b` clean; full interface suite green (171 files, 1 skipped). Test assertions updated for all changed copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)