### PR TITLE
fix(interface): amount-step motion — card transitions in + incomplete-CTA nudge

### DIFF
--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.test.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.test.tsx
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { incompleteCtaShakeClass } from '@/design'
 import { formatUsdcPlain } from '@/lib/format'
 import { DepositAmountCard } from './DepositAmountCard'
 
@@ -165,5 +166,19 @@ describe('DepositAmountCard — presets + amount roll', () => {
       />,
     )
     expect(screen.getByLabelText('Deposit amount')).not.toHaveAttribute('readonly')
+  })
+})
+
+describe('DepositAmountCard — incomplete-CTA nudge shake', () => {
+  // The mockup nudges by shaking the amount CARD (not the button) to point the eye at the empty
+  // field; the modal drives this via the `shaking` prop when the disabled "Input amount" CTA is tapped.
+  it('applies the shake class to the card root when shaking', () => {
+    const { container } = renderCard({ shaking: true })
+    expect((container.firstChild as HTMLElement).className).toContain(incompleteCtaShakeClass)
+  })
+
+  it('does not apply the shake class when not shaking', () => {
+    const { container } = renderCard()
+    expect((container.firstChild as HTMLElement).className).not.toContain(incompleteCtaShakeClass)
   })
 })

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/dashboard/BalanceCard/balanceRevealMotion'
 import { formatUsdcAmount, formatUsdcPlain } from '@/lib/format'
 import type { DisplayFees } from '@/lib/fees/displayFees'
+import { incompleteCtaShakeClass } from '@/design'
 import styles from './DepositAmountCard.module.css'
 
 const ICON_SIZE = 32
@@ -87,6 +88,13 @@ export interface DepositAmountCardProps {
   amountAriaLabel?: string
   /** Ref onto the amount `<input>` — lets a sibling footer focus the field (e.g. the incomplete-CTA nudge). */
   inputRef?: React.Ref<HTMLInputElement>
+  /**
+   * When true, plays a one-shot shake on the card — the incomplete-CTA nudge (mockup: the field the
+   * disabled "Input amount" CTA points at shakes, not the button). Pair with `onShakeAnimationEnd`.
+   */
+  shaking?: boolean
+  /** Clears the shake once the animation finishes; wire to `useNudgeShake().onShakeAnimationEnd`. */
+  onShakeAnimationEnd?: (event: React.AnimationEvent<HTMLDivElement>) => void
 }
 
 function ChainIcon({ chainId, label }: { chainId: number; label: string }) {
@@ -126,6 +134,8 @@ export function DepositAmountCard({
   error,
   amountAriaLabel = 'Amount',
   inputRef,
+  shaking = false,
+  onShakeAnimationEnd,
 }: DepositAmountCardProps) {
   const [menuOpen, setMenuOpen] = useState(false)
   const chainRootRef = useRef<HTMLDivElement>(null)
@@ -256,7 +266,10 @@ export function DepositAmountCard({
   const showFee = showActiveAmount && displayFees !== undefined && totalFeeRaw > 0n
 
   return (
-    <div className={styles.card}>
+    <div
+      className={[styles.card, shaking && incompleteCtaShakeClass].filter(Boolean).join(' ')}
+      onAnimationEnd={onShakeAnimationEnd}
+    >
       <div className={styles.cardTop}>
       {header ? <div className={styles.cardHeader}>{header}</div> : null}
       {title ? <p className={styles.cardTitle}>{title}</p> : null}

--- a/apps/armada-interface/src/components/payments/SendInputStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendInputStep.tsx
@@ -44,6 +44,10 @@ export interface SendInputStepProps {
   inputRef?: Ref<HTMLInputElement>
   /** Called when the disabled "Input amount" CTA is tapped — focuses the amount field alongside the shake. */
   onIncompleteContinue?: () => void
+  /** One-shot shake on the amount card — the incomplete-CTA nudge (owned by the modal). */
+  shaking?: boolean
+  /** Clears the shake once its animation ends; wire to `useNudgeShake().onShakeAnimationEnd`. */
+  onShakeAnimationEnd?: (event: React.AnimationEvent<HTMLDivElement>) => void
 }
 
 export function SendInputStepContent({
@@ -60,6 +64,8 @@ export function SendInputStepContent({
   gasChainId,
   gaslessMode = true,
   inputRef,
+  shaking = false,
+  onShakeAnimationEnd,
 }: Pick<
   SendInputStepProps,
   | 'variant'
@@ -75,6 +81,8 @@ export function SendInputStepContent({
   | 'gasChainId'
   | 'gaslessMode'
   | 'inputRef'
+  | 'shaking'
+  | 'onShakeAnimationEnd'
 >) {
   const allChains = useMemo(
     () => getAllChainIdentities().map((c) => ({ chainId: c.chainId, label: c.name })),
@@ -113,6 +121,8 @@ export function SendInputStepContent({
           error={amountError}
           amountAriaLabel={variant === 'withdraw' ? 'Withdrawal amount' : 'Send amount'}
           inputRef={inputRef}
+          shaking={shaking}
+          onShakeAnimationEnd={onShakeAnimationEnd}
         />
         {showGasNotice ? (
           <GasBalanceNotice
@@ -138,7 +148,6 @@ export function SendInputStepFooter({
   const { value: amount, error: parseError } = parseUsdcInput(amountStr)
   const tooMuch = amount > maxInput
   const canReview = hasActiveAmount(amountStr) && !tooMuch && !parseError
-  const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
 
   return (
     <div className={`${depositOverlayShellStyles.buttonRow} ${modalActionRowEnter}`}>
@@ -156,26 +165,33 @@ export function SendInputStepFooter({
         showIcon={false}
         disabled={!canReview}
         onClick={onContinue}
-        onDisabledClick={() => {
-          nudge()
-          onIncompleteContinue?.()
-        }}
-        shaking={shaking}
-        onShakeAnimationEnd={onShakeAnimationEnd}
+        // Tapping the incomplete CTA nudges (shake the amount card) + focuses the field — the modal
+        // owns useNudgeShake and folds nudge() into onIncompleteContinue.
+        onDisabledClick={() => onIncompleteContinue?.()}
       />
     </div>
   )
 }
 
 export function SendInputStep(props: SendInputStepProps) {
-  // The step is the common parent of the amount card + footer, so it owns the ref shared between them.
+  // The step is the common parent of the amount card + footer, so it owns the ref + nudge shared
+  // between them (the modals render Content/Footer directly and own their own; this covers standalone use).
   const amountInputRef = useRef<HTMLInputElement>(null)
+  const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
   return (
     <>
-      <SendInputStepContent {...props} inputRef={amountInputRef} />
+      <SendInputStepContent
+        {...props}
+        inputRef={amountInputRef}
+        shaking={shaking}
+        onShakeAnimationEnd={onShakeAnimationEnd}
+      />
       <SendInputStepFooter
         {...props}
-        onIncompleteContinue={() => amountInputRef.current?.focus()}
+        onIncompleteContinue={() => {
+          nudge()
+          amountInputRef.current?.focus()
+        }}
       />
     </>
   )

--- a/apps/armada-interface/src/components/payments/SendModal.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.test.tsx
@@ -182,10 +182,10 @@ describe('<SendModal>', () => {
   it('Continue enables only once the recipient is a valid address', () => {
     renderModal({ open: 'payment', shielded: 10_000_000n })
     // Empty + invalid: the CTA is always present but disabled + labeled "Enter address".
-    expect(screen.getByRole('button', { name: /Enter address/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Enter address/ })).toHaveAttribute('aria-disabled', 'true')
     fireEvent.change(screen.getByLabelText('Recipient address'), { target: { value: 'not-an-address' } })
     expect(screen.getByRole('alert')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Enter address/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Enter address/ })).toHaveAttribute('aria-disabled', 'true')
     fireEvent.change(screen.getByLabelText('Recipient address'), { target: { value: VALID_0ZK } })
     expect(screen.getByRole('button', { name: /^Continue$/ })).not.toBeDisabled()
   })

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -40,6 +40,7 @@ import {
 } from '@/components/flow'
 import { FlowShell } from '@/components/flow/FlowShell'
 import { useFlowExit } from '@/components/flow/useFlowExit'
+import { useNudgeShake } from '@/hooks/useNudgeShake'
 import { SendRecipientStep, type SendFlowVariant } from './SendRecipientStep'
 import { SendInputStepContent, SendInputStepFooter } from './SendInputStep'
 import { ForceOutcomeSelect } from '@/components/debug/ForceOutcomeSelect'
@@ -120,6 +121,13 @@ export function SendModal() {
   // Shared across the amount step's card + footer (siblings) so tapping the disabled "Input amount"
   // CTA can focus the amount field alongside the shake.
   const amountInputRef = useRef<HTMLInputElement>(null)
+  // The nudge shakes the amount CARD (mockup), so the hook lives here — the common parent of the
+  // card (Content) + CTA (Footer). Tapping the incomplete CTA fires nudge() + focus.
+  const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
+  const nudgeIncomplete = () => {
+    nudge()
+    amountInputRef.current?.focus()
+  }
 
   // Source data. `max` (and the fee-on-top guard) draws from SPENDABLE only, so a not-yet-final
   // ("pending") note can't be selected; `pendingUsdc` is display-only (0 on local Anvil).
@@ -465,6 +473,8 @@ export function SendModal() {
             // they've toggled Preferences → "Submit transactions from my wallet".
             gaslessMode={!prefs.submitFromWallet}
             inputRef={amountInputRef}
+            shaking={shaking}
+            onShakeAnimationEnd={onShakeAnimationEnd}
           />
           <ForceOutcomeSelect />
           <SendInputStepFooter
@@ -472,7 +482,7 @@ export function SendModal() {
             maxInput={inputMax}
             onBack={() => setStep('recipient')}
             onContinue={() => setStep('review')}
-            onIncompleteContinue={() => amountInputRef.current?.focus()}
+            onIncompleteContinue={nudgeIncomplete}
           />
         </>
       )}

--- a/apps/armada-interface/src/components/payments/SendRecipientStep.test.tsx
+++ b/apps/armada-interface/src/components/payments/SendRecipientStep.test.tsx
@@ -38,14 +38,20 @@ describe('<SendRecipientStep>', () => {
 
   it('shows a disabled "Enter address" CTA while the recipient is empty', () => {
     setup()
-    expect(screen.getByRole('button', { name: /Enter address/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Enter address/ })).toHaveAttribute('aria-disabled', 'true')
     expect(screen.queryByRole('button', { name: /^Continue$/ })).toBeNull()
   })
 
   it('shows an error and keeps the CTA disabled + labeled "Enter address" for a malformed address', () => {
     setup({ recipient: 'nonsense' })
     expect(screen.getByRole('alert')).toHaveTextContent(/valid 0zk or 0x/i)
-    expect(screen.getByRole('button', { name: /Enter address/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Enter address/ })).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('nudge: tapping the disabled CTA focuses the recipient input (incomplete-CTA nudge)', () => {
+    setup()
+    fireEvent.click(screen.getByRole('button', { name: /Enter address/ }))
+    expect(screen.getByLabelText('Recipient address')).toHaveFocus()
   })
 
   it('0zk recipient: private badge, no chain selector, Continue enabled', () => {
@@ -76,7 +82,7 @@ describe('<SendRecipientStep>', () => {
     })
     expect(screen.getByRole('alert')).toHaveTextContent(/no deployment manifest/i)
     // The address is valid so the label reads "Continue", but the deployment error keeps it disabled.
-    expect(screen.getByRole('button', { name: /^Continue$/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^Continue$/ })).toHaveAttribute('aria-disabled', 'true')
   })
 
   it('fires onContinue for a valid recipient', () => {

--- a/apps/armada-interface/src/components/payments/SendRecipientStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendRecipientStep.tsx
@@ -1,12 +1,13 @@
 // ABOUTME: Send/Withdraw recipient step — a frost card (title + address input with Clear + a paste row that
 // ABOUTME: previews a valid 0zk/0x on the clipboard + public-only chain selector + privacy badge once valid) over an always-visible Cancel / Continue action row + a recent-recipients list.
 
-import { useEffect, useId, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 import { XMarkIcon, GlobeAltIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline'
-import { ArmadaLogo, Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
+import { ArmadaLogo, Button, modalStepBodyEnter, modalActionRowEnter, incompleteCtaShakeClass } from '@/design'
 import iconButtonStyles from '@/design/components/IconButton/IconButton.module.css'
 import { ChainSelect } from '@/components/ui'
 import { AmountFieldWarning } from '@/components/ui/AmountFieldWarning'
+import { useNudgeShake } from '@/hooks/useNudgeShake'
 import { isShieldedAddress, validateEvmAddress } from '@/lib/address'
 import { truncateAddress } from '@/lib/format'
 import { useMobileLayout } from '@/hooks/useMobileLayout'
@@ -57,6 +58,10 @@ export function SendRecipientStep({
 }: SendRecipientStepProps) {
   const [inputFocused, setInputFocused] = useState(false)
   const isMobile = useMobileLayout()
+  // Incomplete-CTA nudge: tapping the disabled Continue shakes the recipient card + focuses the input
+  // (mockup SendRecipientScreen). The card is the shake target, not the button.
+  const inputRef = useRef<HTMLInputElement>(null)
+  const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
   // Trimmed clipboard content (null if empty / unreadable), used by the paste row. Probed on open +
   // whenever the tab regains focus (the user may copy then return).
   const [clipboardText, setClipboardText] = useState<string | null>(null)
@@ -121,7 +126,12 @@ export function SendRecipientStep({
 
   return (
     <div className={styles.root}>
-      <div className={`${styles.card} ${modalStepBodyEnter}`}>
+      <div
+        className={[styles.card, modalStepBodyEnter, shaking && incompleteCtaShakeClass]
+          .filter(Boolean)
+          .join(' ')}
+        onAnimationEnd={onShakeAnimationEnd}
+      >
         <h1 className={`armada-text-ui-body-lg ${styles.cardTitle}`}>{title}</h1>
 
         <div className={styles.addressBlock}>
@@ -132,6 +142,7 @@ export function SendRecipientStep({
           >
             <div className={styles.addressField}>
               <input
+                ref={inputRef}
                 className={styles.addressInput}
                 type="text"
                 value={inputDisplayValue}
@@ -246,6 +257,10 @@ export function SendRecipientStep({
           showIcon={false}
           disabled={!canContinue}
           onClick={onContinue}
+          onDisabledClick={() => {
+            nudge()
+            inputRef.current?.focus()
+          }}
         />
       </div>
 

--- a/apps/armada-interface/src/components/request/RequestModal.test.tsx
+++ b/apps/armada-interface/src/components/request/RequestModal.test.tsx
@@ -42,7 +42,13 @@ describe('<RequestModal>', () => {
   it('opens on the compose step with the create-link CTA gated on an amount', () => {
     renderRequest()
     expect(screen.getByRole('heading', { name: 'Request USDC via link' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Input amount' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Input amount' })).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('nudge: tapping the disabled create-link CTA focuses the amount input', () => {
+    renderRequest()
+    fireEvent.click(screen.getByRole('button', { name: 'Input amount' }))
+    expect(screen.getByLabelText('Requested amount in USDC')).toHaveFocus()
   })
 
   it('generates a real pay-via-link on Create and shows the link screen', () => {

--- a/apps/armada-interface/src/components/request/RequestReceiveScreen.tsx
+++ b/apps/armada-interface/src/components/request/RequestReceiveScreen.tsx
@@ -1,9 +1,10 @@
 // ABOUTME: RequestReceiveScreen — compose a payment request (amount + expiry + note) that becomes a shareable link.
 // ABOUTME: The first step of the Request flow; "Create link" advances to RequestLinkScreen. Amount-less requests copy the raw address instead.
 
-import { useId } from 'react'
-import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
+import { useId, useRef } from 'react'
+import { Button, modalStepBodyEnter, modalActionRowEnter, incompleteCtaShakeClass } from '@/design'
 import { SegmentedControl } from '@/components/ui'
+import { useNudgeShake } from '@/hooks/useNudgeShake'
 import { hasActiveAmount, sanitizeAmountInput } from '@/utils/amountInput'
 import {
   REQUEST_LINK_EXPIRY_OPTIONS,
@@ -35,6 +36,10 @@ export function RequestReceiveScreen({
 }: RequestReceiveScreenProps) {
   const amountInputId = useId()
   const noteInputId = useId()
+  // Incomplete-CTA nudge: tapping the disabled "Input amount" shakes the link card + focuses the
+  // amount input (mockup RequestReceiveScreen). The card is the shake target, not the button.
+  const amountInputRef = useRef<HTMLInputElement>(null)
+  const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
 
   const canCreateLink = hasActiveAmount(amount)
   const ctaLabel = canCreateLink ? 'Create link' : 'Input amount'
@@ -47,13 +52,17 @@ export function RequestReceiveScreen({
   return (
     <div className={styles.column}>
       <div className={modalStepBodyEnter}>
-        <div className={styles.linkCard}>
+        <div
+          className={[styles.linkCard, shaking && incompleteCtaShakeClass].filter(Boolean).join(' ')}
+          onAnimationEnd={onShakeAnimationEnd}
+        >
           <h1 className={`armada-text-ui-body-lg ${styles.cardTitle}`}>Request USDC via link</h1>
 
           <div className={styles.amountRow}>
             <div className={styles.amountGroup}>
               <div className={styles.amountField}>
                 <input
+                  ref={amountInputRef}
                   id={amountInputId}
                   className={styles.amountInput}
                   type="text"
@@ -109,6 +118,10 @@ export function RequestReceiveScreen({
           showIcon={false}
           disabled={!canCreateLink}
           onClick={onCreateLink}
+          onDisabledClick={() => {
+            nudge()
+            amountInputRef.current?.focus()
+          }}
         />
       </div>
     </div>

--- a/apps/armada-interface/src/components/shield/ShieldAmountStep.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldAmountStep.test.tsx
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import {
   ShieldAmountStepContent,
   ShieldAmountStepFooter,
@@ -30,7 +31,7 @@ const FLOW_BREAKDOWN: FlowFeeBreakdown = {
 }
 
 function renderContent(tab: ShieldTab, onTabChange = vi.fn()) {
-  render(
+  return render(
     <ShieldAmountStepContent
       tab={tab}
       onTabChange={onTabChange}
@@ -49,7 +50,7 @@ function renderContent(tab: ShieldTab, onTabChange = vi.fn()) {
 }
 
 function renderFooter(amountStr: string, minAmount = 0n, onContinue = vi.fn(), onCancel = vi.fn()) {
-  render(
+  const { container } = render(
     <ShieldAmountStepFooter
       amountStr={amountStr}
       maxInput={100_000_000n}
@@ -58,7 +59,7 @@ function renderFooter(amountStr: string, minAmount = 0n, onContinue = vi.fn(), o
       onCancel={onCancel}
     />,
   )
-  return { onContinue, onCancel }
+  return { onContinue, onCancel, container }
 }
 
 describe('ShieldAmountStepContent (direction)', () => {
@@ -81,6 +82,20 @@ describe('ShieldAmountStepContent (direction)', () => {
     renderContent('shield', onTabChange)
     fireEvent.click(screen.getByRole('tab', { name: 'Unshield' }))
     expect(onTabChange).toHaveBeenCalledWith('unshield')
+  })
+})
+
+describe('ShieldAmountStep step-enter animation (regression)', () => {
+  // The amount step is the only step that once shipped without the FlowShell step-enter classes,
+  // so its main card never transitioned in on open. Guard both the body + footer enter hooks here.
+  it('applies modalStepBodyEnter to the content wrapper', () => {
+    const { container } = renderContent('shield')
+    expect((container.firstChild as HTMLElement).className).toContain(modalStepBodyEnter)
+  })
+
+  it('applies modalActionRowEnter to the footer button row', () => {
+    const { container } = renderFooter('5')
+    expect((container.firstChild as HTMLElement).className).toContain(modalActionRowEnter)
   })
 })
 

--- a/apps/armada-interface/src/components/shield/ShieldAmountStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldAmountStep.tsx
@@ -4,7 +4,6 @@
 import type { Ref } from 'react'
 import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { ChainSelect, GasBalanceNotice, SegmentedControl } from '@/components/ui'
-import { useNudgeShake } from '@/hooks/useNudgeShake'
 import { DepositAmountCard } from '@/components/deposit/DepositAmountCard/DepositAmountCard'
 import { depositOverlayShellStyles } from '@/components/deposit/DepositOverlayShell/DepositOverlayShell'
 import type { FlowFeeBreakdown } from '@/components/ui/FeeBreakdownTooltip'
@@ -46,6 +45,10 @@ interface ShieldAmountStepContentProps {
   gasChainId: number
   /** Ref onto the amount input so the footer's incomplete-CTA nudge can focus the field. */
   inputRef?: Ref<HTMLInputElement>
+  /** One-shot shake on the amount card — the incomplete-CTA nudge (owned by the modal). */
+  shaking?: boolean
+  /** Clears the shake once its animation ends; wire to `useNudgeShake().onShakeAnimationEnd`. */
+  onShakeAnimationEnd?: (event: React.AnimationEvent<HTMLDivElement>) => void
 }
 
 export function ShieldAmountStepContent({
@@ -65,6 +68,8 @@ export function ShieldAmountStepContent({
   gaslessMode = true,
   gasChainId,
   inputRef,
+  shaking = false,
+  onShakeAnimationEnd,
 }: ShieldAmountStepContentProps) {
   const gasWarning = useGasBalanceWarning(gasChainId)
   const showGasNotice = !gaslessMode && gasWarning.show
@@ -116,6 +121,8 @@ export function ShieldAmountStepContent({
         error={errorMessage}
         amountAriaLabel={amountAriaLabel}
         inputRef={inputRef}
+        shaking={shaking}
+        onShakeAnimationEnd={onShakeAnimationEnd}
       />
       {showGasNotice ? (
         <GasBalanceNotice
@@ -150,7 +157,6 @@ export function ShieldAmountStepFooter({
   const tooMuch = amount > maxInput
   const tooSmall = minAmount > 0n && amount > 0n && amount <= minAmount
   const canReview = hasActiveAmount(amountStr) && !tooMuch && !tooSmall && !parseError
-  const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
 
   return (
     <div className={`${depositOverlayShellStyles.buttonRow} ${modalActionRowEnter}`}>
@@ -162,12 +168,9 @@ export function ShieldAmountStepFooter({
         showIcon={false}
         disabled={!canReview}
         onClick={onContinue}
-        onDisabledClick={() => {
-          nudge()
-          onIncompleteContinue?.()
-        }}
-        shaking={shaking}
-        onShakeAnimationEnd={onShakeAnimationEnd}
+        // Tapping the incomplete CTA nudges (shake the amount card) + focuses the field — the modal
+        // owns useNudgeShake and folds nudge() into onIncompleteContinue.
+        onDisabledClick={() => onIncompleteContinue?.()}
       />
     </div>
   )

--- a/apps/armada-interface/src/components/shield/ShieldAmountStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldAmountStep.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Direction-agnostic: the caller (ShieldModal) feeds it the active flow's values; footer gates Review on amount (+ shield's fee floor).
 
 import type { Ref } from 'react'
-import { Button } from '@/design'
+import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { ChainSelect, GasBalanceNotice, SegmentedControl } from '@/components/ui'
 import { useNudgeShake } from '@/hooks/useNudgeShake'
 import { DepositAmountCard } from '@/components/deposit/DepositAmountCard/DepositAmountCard'
@@ -88,7 +88,7 @@ export function ShieldAmountStepContent({
       : undefined)
 
   return (
-    <div className={styles.contentZone}>
+    <div className={`${styles.contentZone} ${modalStepBodyEnter}`}>
       <DepositAmountCard
         chainId={chainId}
         // Match the Send flow's network selector — the shared ChainSelect instead of the card's
@@ -153,7 +153,7 @@ export function ShieldAmountStepFooter({
   const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
 
   return (
-    <div className={depositOverlayShellStyles.buttonRow}>
+    <div className={`${depositOverlayShellStyles.buttonRow} ${modalActionRowEnter}`}>
       <Button variant="secondary" size="lg" label="Cancel" showIcon={false} onClick={onCancel} />
       <Button
         variant="primary"

--- a/apps/armada-interface/src/components/shield/ShieldModal.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/flow'
 import { FlowShell } from '@/components/flow/FlowShell'
 import { useFlowExit } from '@/components/flow/useFlowExit'
+import { useNudgeShake } from '@/hooks/useNudgeShake'
 import { RelayerStatusBanner } from '@/components/RelayerStatusBanner'
 import {
   ShieldAmountStepContent,
@@ -56,6 +57,13 @@ export function ShieldModal() {
   // Shared across the amount step's card + footer (siblings) so tapping the disabled "Input amount"
   // CTA can focus the amount field alongside the shake.
   const amountInputRef = useRef<HTMLInputElement>(null)
+  // The nudge shakes the amount CARD (mockup), so the hook lives here — the common parent of the
+  // card (Content) + CTA (Footer). Tapping the incomplete CTA fires nudge() + focus.
+  const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
+  const nudgeIncomplete = () => {
+    nudge()
+    amountInputRef.current?.focus()
+  }
 
   function handleTabChange(next: ShieldTab) {
     if (next === tab) return
@@ -130,6 +138,8 @@ export function ShieldModal() {
             gaslessMode={isShield ? shieldFlow.useGasless : !prefs.submitFromWallet}
             gasChainId={isShield ? shieldFlow.fromChainId : hubChainId}
             inputRef={amountInputRef}
+            shaking={shaking}
+            onShakeAnimationEnd={onShakeAnimationEnd}
           />
           <ShieldAmountStepFooter
             amountStr={active.amountStr}
@@ -137,7 +147,7 @@ export function ShieldModal() {
             minAmount={isShield ? shieldFlow.minAmount : 0n}
             onCancel={close}
             onContinue={active.onContinueToReview}
-            onIncompleteContinue={() => amountInputRef.current?.focus()}
+            onIncompleteContinue={nudgeIncomplete}
           />
         </>
       )}

--- a/apps/armada-interface/src/components/yield/EarnInputStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.tsx
@@ -64,6 +64,10 @@ export interface EarnInputStepProps {
   inputRef?: Ref<HTMLInputElement>
   /** Called when the disabled "Input amount" CTA is tapped — focuses the amount field alongside the shake. */
   onIncompleteContinue?: () => void
+  /** One-shot shake on the amount card — the incomplete-CTA nudge (owned by the modal). */
+  shaking?: boolean
+  /** Clears the shake once its animation ends; wire to `useNudgeShake().onShakeAnimationEnd`. */
+  onShakeAnimationEnd?: (event: React.AnimationEvent<HTMLDivElement>) => void
 }
 
 function formatApy(rate: YieldRate | null): string {
@@ -97,6 +101,8 @@ export function EarnInputStepContent({
   rate,
   continueBlockedReason,
   inputRef,
+  shaking = false,
+  onShakeAnimationEnd,
 }: Pick<
   EarnInputStepProps,
   | 'tab'
@@ -114,6 +120,8 @@ export function EarnInputStepContent({
   | 'rate'
   | 'continueBlockedReason'
   | 'inputRef'
+  | 'shaking'
+  | 'onShakeAnimationEnd'
 >) {
   const hub = getNetworkConfig().hub
   const chains = useMemo(
@@ -187,6 +195,8 @@ export function EarnInputStepContent({
         error={fieldError}
         amountAriaLabel={tab === 'add' ? 'Shielded vault deposit amount' : 'Shielded vault withdrawal amount'}
         inputRef={inputRef}
+        shaking={shaking}
+        onShakeAnimationEnd={onShakeAnimationEnd}
       />
 
       {showGasNotice ? (
@@ -219,7 +229,6 @@ export function EarnInputStepFooter({
   const tooMuch = amount > maxInput
   const canReview =
     hasActiveAmount(amountStr) && !tooMuch && !parseError && !continueBlockedReason
-  const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
 
   return (
     <div className={`${depositOverlayShellStyles.buttonRow} ${modalActionRowEnter}`}>
@@ -237,26 +246,33 @@ export function EarnInputStepFooter({
         showIcon={false}
         disabled={!canReview}
         onClick={onContinue}
-        onDisabledClick={() => {
-          nudge()
-          onIncompleteContinue?.()
-        }}
-        shaking={shaking}
-        onShakeAnimationEnd={onShakeAnimationEnd}
+        // Tapping the incomplete CTA nudges (shake the amount card) + focuses the field — the modal
+        // owns useNudgeShake and folds nudge() into onIncompleteContinue.
+        onDisabledClick={() => onIncompleteContinue?.()}
       />
     </div>
   )
 }
 
 export function EarnInputStep(props: EarnInputStepProps) {
-  // The step is the common parent of the amount card + footer, so it owns the ref shared between them.
+  // The step is the common parent of the amount card + footer, so it owns the ref + nudge shared
+  // between them (the modal renders Content/Footer directly and owns its own; this covers standalone use).
   const amountInputRef = useRef<HTMLInputElement>(null)
+  const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
   return (
     <>
-      <EarnInputStepContent {...props} inputRef={amountInputRef} />
+      <EarnInputStepContent
+        {...props}
+        inputRef={amountInputRef}
+        shaking={shaking}
+        onShakeAnimationEnd={onShakeAnimationEnd}
+      />
       <EarnInputStepFooter
         {...props}
-        onIncompleteContinue={() => amountInputRef.current?.focus()}
+        onIncompleteContinue={() => {
+          nudge()
+          amountInputRef.current?.focus()
+        }}
       />
     </>
   )

--- a/apps/armada-interface/src/components/yield/EarnModal.tsx
+++ b/apps/armada-interface/src/components/yield/EarnModal.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/components/flow'
 import { FlowShell } from '@/components/flow/FlowShell'
 import { useFlowExit } from '@/components/flow/useFlowExit'
+import { useNudgeShake } from '@/hooks/useNudgeShake'
 import { EarnInputStepContent, EarnInputStepFooter, type EarnTab } from './EarnInputStep'
 import { useDisplayFees } from '@/hooks/useDisplayFees'
 import { EarnReviewStep } from './EarnReviewStep'
@@ -59,6 +60,13 @@ export function EarnModal() {
   // Shared across the amount step's card + footer (siblings) so tapping the disabled "Input amount"
   // CTA can focus the amount field alongside the shake.
   const amountInputRef = useRef<HTMLInputElement>(null)
+  // The nudge shakes the amount CARD (mockup), so the hook lives here — the common parent of the
+  // card (Content) + CTA (Footer). Tapping the incomplete CTA fires nudge() + focus.
+  const { shaking, nudge, onShakeAnimationEnd } = useNudgeShake()
+  const nudgeIncomplete = () => {
+    nudge()
+    amountInputRef.current?.focus()
+  }
 
   // Source data. The USDC leg (deposit amount + the withdraw-fee reserve + the fee-on-top guard) draws
   // from SPENDABLE only, so a not-yet-final ("pending") note can't be used; `pendingUsdc` is
@@ -346,6 +354,8 @@ export function EarnModal() {
             rate={yieldRate}
             continueBlockedReason={withdrawFeeBlockedReason}
             inputRef={amountInputRef}
+            shaking={shaking}
+            onShakeAnimationEnd={onShakeAnimationEnd}
           />
           <EarnInputStepFooter
             amountStr={amountStr}
@@ -353,7 +363,7 @@ export function EarnModal() {
             continueBlockedReason={withdrawFeeBlockedReason}
             onCancel={close}
             onContinue={() => setStep('review')}
-            onIncompleteContinue={() => amountInputRef.current?.focus()}
+            onIncompleteContinue={nudgeIncomplete}
           />
         </>
       )}

--- a/apps/armada-interface/src/design/components/Button/Button.module.css
+++ b/apps/armada-interface/src/design/components/Button/Button.module.css
@@ -74,36 +74,6 @@
   }
 }
 
-/* One-shot nudge shake for an incomplete/disabled CTA (see useNudgeShake). Reduced-motion no-op. */
-.shake {
-  animation: incompleteCtaShake 400ms ease-in-out;
-}
-
-@keyframes incompleteCtaShake {
-  0%,
-  100% {
-    transform: translateX(0);
-  }
-  20% {
-    transform: translateX(calc(var(--primitives-spacing-1) * -1));
-  }
-  40% {
-    transform: translateX(var(--primitives-spacing-1));
-  }
-  60% {
-    transform: translateX(calc(var(--primitives-spacing-1) * -0.5));
-  }
-  80% {
-    transform: translateX(calc(var(--primitives-spacing-1) * 0.5));
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .shake {
-    animation: none;
-  }
-}
-
 /* Sizes — Figma: fixed height, asymmetric horizontal padding, 4px gap */
 .sm {
   height: var(--semantic-component-button-primary-sm-height);

--- a/apps/armada-interface/src/design/components/Button/Button.tsx
+++ b/apps/armada-interface/src/design/components/Button/Button.tsx
@@ -27,10 +27,6 @@ export interface ButtonProps {
    * `disabled`, the click routes here instead of `onClick`.
    */
   onDisabledClick?: () => void
-  /** When true, plays a one-shot horizontal shake (reduced-motion no-op). Pair with `onShakeAnimationEnd`. */
-  shaking?: boolean
-  /** Clears the shake once the animation finishes; wire to `useNudgeShake().onShakeAnimationEnd`. */
-  onShakeAnimationEnd?: (event: React.AnimationEvent<HTMLButtonElement>) => void
   style?: React.CSSProperties
   className?: string
   type?: 'button' | 'submit' | 'reset'
@@ -63,8 +59,6 @@ export function Button({
   loading = false,
   onClick,
   onDisabledClick,
-  shaking = false,
-  onShakeAnimationEnd,
   className,
   type = 'button',
   style,
@@ -86,7 +80,6 @@ export function Button({
     !showTrailing && styles.noIcon,
     loading && styles.loading,
     leadingIcon && styles.leading,
-    shaking && styles.shake,
     className ?? '',
   ]
     .filter(Boolean)
@@ -110,7 +103,6 @@ export function Button({
               onClick?.()
             }
       }
-      onAnimationEnd={onShakeAnimationEnd}
       style={style}
     >
       {leadingIcon ? (

--- a/apps/armada-interface/src/design/index.ts
+++ b/apps/armada-interface/src/design/index.ts
@@ -1,6 +1,11 @@
 // ABOUTME: Public barrel for the app-vendored design system — the primitives this app consumes.
 // ABOUTME: Vendored from @armada/ui so the interface is self-contained; style sheets live in ./styles.
 
+import incompleteCtaNudgeStyles from './styles/incompleteCtaNudge.module.css'
+
+/** One-shot "nudge" shake class for an incomplete/disabled CTA — pair with `useNudgeShake`. */
+export const incompleteCtaShakeClass = incompleteCtaNudgeStyles.shake
+
 export { ArmadaLogo } from './components/ArmadaLogo'
 export type { ArmadaLogoProps } from './components/ArmadaLogo'
 

--- a/apps/armada-interface/src/design/styles/incompleteCtaNudge.module.css
+++ b/apps/armada-interface/src/design/styles/incompleteCtaNudge.module.css
@@ -1,0 +1,30 @@
+/* ABOUTME: Shared one-shot "nudge" shake for an incomplete/disabled CTA — shakes the field card the CTA points at. */
+/* ABOUTME: Ported from the armada-app mockup (incompleteCtaNudge.module.css); paired with useNudgeShake. Reduced-motion no-op. */
+.shake {
+  animation: incompleteCtaShake 400ms ease-in-out;
+}
+
+@keyframes incompleteCtaShake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(calc(var(--primitives-spacing-1) * -1));
+  }
+  40% {
+    transform: translateX(var(--primitives-spacing-1));
+  }
+  60% {
+    transform: translateX(calc(var(--primitives-spacing-1) * -0.5));
+  }
+  80% {
+    transform: translateX(calc(var(--primitives-spacing-1) * 0.5));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shake {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Amount/field-step motion fixes for the shield/send/earn/request flows.

## 1. Shield/unshield amount card didn't transition in
`ShieldAmountStep.tsx` was the only amount step missing the FlowShell step-enter classes — its content wrapper lacked `modalStepBodyEnter` and its footer lacked `modalActionRowEnter` (didn't even import them), so the card just appeared on open while every other step/flow animated. Fix mirrors `SendInputStep`/`EarnInputStep`: add the two classes (+ import). No CSS/logic changes.

## 2. Incomplete-CTA nudge shook the wrong element
Our nudge (mockup ref `d31913c`) applied the `shaking` class to the **Button**; the mockup shakes the **field card** (and mobile keypad block) to point the eye at the empty field — its Button has only `onDisabledClick`, no `shaking`. Result: tapping the disabled CTA jiggled a small button ~4px instead of jolting the card, so it read as broken.

Fix (mirror the mockup, adapted to our split `Content`/`Footer` architecture):
- New shared `src/design/styles/incompleteCtaNudge.module.css` (exported as `incompleteCtaShakeClass` from `@/design`); removed the now-unused `.shake`/keyframes + `shaking`/`onShakeAnimationEnd` from the `Button` primitive.
- `DepositAmountCard` gains `shaking` + `onShakeAnimationEnd` props and applies the shake to its card root.
- `useNudgeShake` lifted from each Footer up to the modal (ShieldModal/SendModal/EarnModal) — the common parent of card + CTA, which already owns `amountInputRef`. Tapping the incomplete CTA fires `nudge()` (shake card) + focus, via the existing `onIncompleteContinue` callback.
- Combined `SendInputStep`/`EarnInputStep` wrappers (test-only) keep their own hook so they stay self-contained.

## 3. Nudge wired on the remaining two screens (mockup `d31913c`)
The same mockup commit also nudges the **Send recipient step** and **Request-compose** screen — now wired:
- `SendRecipientStep` — disabled "Enter address"/"Continue" tap shakes the recipient card + focuses the address input.
- `RequestReceiveScreen` — disabled "Input amount" tap shakes the link card + focuses the amount input.

Both are single self-contained components (card + CTA together), so each owns `useNudgeShake` directly like the mockup screens. Their CTAs are now `aria-disabled` (clickable) instead of natively disabled; the affected test assertions moved from `toBeDisabled()` to `aria-disabled`.

## Verification
`tsc -b` clean; full interface suite green (171 files, 1 skipped; +6 new tests — 2 step-enter guards, 2 card-shake guards, 2 recipient/request focus-on-nudge guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)