### PR TITLE
chore: re-pin @armada/sdk to #79 (typed outputs + spend-block history dating)

### DIFF
--- a/apps/armada-interface/package.json
+++ b/apps/armada-interface/package.json
@@ -14,7 +14,7 @@
     "prepare:artifacts": "node scripts/prepare-artifacts.mjs"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#67c1aab47cb9df940db78e46822ec0d82aa5fef8",
+    "@armada/sdk": "github:ship-armada/armada-sdk#555621f40447ff0801912d4fda891f8d2dae97e5",
     "@heroicons/react": "^2.2.0",
     "@noble/ciphers": "^0.4.1",
     "@noble/hashes": "^1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "apps/*"
       ],
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#67c1aab47cb9df940db78e46822ec0d82aa5fef8",
+        "@armada/sdk": "github:ship-armada/armada-sdk#555621f40447ff0801912d4fda891f8d2dae97e5",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
         "@nomicfoundation/hardhat-ethers": "^3.1.3",
@@ -68,7 +68,7 @@
       "name": "@armada/interface",
       "version": "0.1.0",
       "dependencies": {
-        "@armada/sdk": "github:ship-armada/armada-sdk#67c1aab47cb9df940db78e46822ec0d82aa5fef8",
+        "@armada/sdk": "github:ship-armada/armada-sdk#555621f40447ff0801912d4fda891f8d2dae97e5",
         "@heroicons/react": "^2.2.0",
         "@noble/ciphers": "^0.4.1",
         "@noble/hashes": "^1.8.0",
@@ -410,8 +410,8 @@
     },
     "node_modules/@armada/sdk": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#67c1aab47cb9df940db78e46822ec0d82aa5fef8",
-      "integrity": "sha512-0+gFMBWUwFOtz7VlegLvSzSpDT+w94Z3AqlCyLDgk2/yyPNpbFDOnIMAIBeoHjUmzdv+E1M/GbWZvQbUuBxcMg==",
+      "resolved": "git+ssh://git@github.com/ship-armada/armada-sdk.git#555621f40447ff0801912d4fda891f8d2dae97e5",
+      "integrity": "sha512-o8xMPYh+OmB84lgaRP1O98Kbx6ehdp8s1eo30MSWHCNIZAX0u6H+S+Zt3SwYOrV5mMkuyt8LfiLHjqRCEwrFXA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "verify:etherscan:sepolia:clientB": "hardhat run scripts/verify_sepolia.ts --network sepoliaClientB"
   },
   "dependencies": {
-    "@armada/sdk": "github:ship-armada/armada-sdk#67c1aab47cb9df940db78e46822ec0d82aa5fef8",
+    "@armada/sdk": "github:ship-armada/armada-sdk#555621f40447ff0801912d4fda891f8d2dae97e5",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.3",


### PR DESCRIPTION
Adopts armada-sdk 555621f (ship-armada/armada-sdk#79, fixes armada-sdk#78): the transaction builder now tags output notes `BroadcasterFee`/`Transfer`/`Change`, so scan-reconstructed `transfer-sent` history gets a clean `sentOutputs` (recipients only) and a populated `broadcasterFee`; spend entries are dated by the spend block instead of the spent input's origin block (commit fa4b4dc1).

Interface impact: the chain-history-recovery path (`historyEntryToTxRecord`) now recovers correct amount/recipient/fee for sends authored after this SDK version. Pre-fix on-chain sends still reconstruct polluted (outputType is baked into their annotation data); the blockNumber fix applies retroactively.

Blast-radius verified: root `tsc --project tsconfig.ci.json` clean, `test:sdk-backend` 4/4, interface typecheck clean, interface vitest 1251 passed / 3 failed. The 3 failures (`ShieldModal.test.tsx`, `GAS_ESTIMATION_FAILED` before the wallet step) are pre-existing: identical under the old pin (67c1aab) in the same environment — likely needing local Anvil chains, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)