### PR TITLE
feat(interface): chain-picker "more chains soon" notice + remove dead built-in picker

### DIFF
--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.module.css
@@ -70,36 +70,10 @@
   width: 100%;
 }
 
-.chainRoot {
-  position: relative;
-}
-
-.chainTrigger,
-.chainTriggerStatic,
-.chainOption,
 .tokenGroup,
 .balanceGroup {
   display: flex;
   align-items: center;
-}
-
-.chainTrigger,
-.chainTriggerStatic {
-  gap: var(--primitives-spacing-2);
-  padding: 0;
-  border: none;
-  background: transparent;
-  cursor: default;
-}
-
-.chainTrigger {
-  cursor: pointer;
-}
-
-.chainTrigger:focus-visible {
-  outline: 2px solid var(--semantic-color-border-focus);
-  outline-offset: 2px;
-  border-radius: calc(var(--primitives-borderRadius-sm) * 1px);
 }
 
 .tokenGroup {
@@ -159,7 +133,6 @@
   outline-offset: 1px;
 }
 
-.chainIconSlot,
 .tokenIconSlot {
   width: var(--primitives-spacing-8);
   height: var(--primitives-spacing-8);
@@ -171,24 +144,12 @@
   border-radius: calc(var(--primitives-borderRadius-full) * 1px);
 }
 
-.chainIconSlot {
-  border: var(--primitives-borderWidth-default) solid
-    color-mix(in srgb, var(--primitives-color-white-full) 40%, transparent);
-  background: var(--semantic-color-surface-raised);
-  font-family: var(--primitives-fontFamily-ui), sans-serif;
-  font-size: calc(var(--primitives-fontSize-sm) * 1px);
-  font-weight: var(--primitives-fontWeight-medium);
-  color: var(--semantic-color-text-secondary);
-}
-
-.chainIconSlot :global(svg),
 .tokenIconSlot :global(svg) {
   width: 100%;
   height: 100%;
   display: block;
 }
 
-.chainName,
 .tokenName,
 .balanceText,
 .feeGroup {
@@ -213,59 +174,11 @@
   color: var(--semantic-color-status-error);
 }
 
-.feeText,
-.chainOptionLabel {
+.feeText {
   font-family: var(--primitives-fontFamily-ui), sans-serif;
   font-weight: var(--primitives-fontWeight-regular);
   font-size: calc(var(--primitives-fontSize-base) * 1px);
   color: var(--semantic-color-text-secondary);
-}
-
-.chevron {
-  width: var(--primitives-spacing-5);
-  height: var(--primitives-spacing-5);
-  color: var(--semantic-color-text-secondary);
-  flex-shrink: 0;
-}
-
-.chainMenu {
-  position: absolute;
-  top: calc(100% + var(--primitives-spacing-2));
-  left: 0;
-  z-index: 20;
-  min-width: calc(var(--primitives-spacing-8) * 5);
-  margin: 0;
-  padding: var(--primitives-spacing-1);
-  list-style: none;
-  background: var(--semantic-color-surface-tooltip);
-  border: var(--primitives-borderWidth-default) solid var(--semantic-color-border-default);
-  border-radius: calc(var(--semantic-borderRadius-card) * 1px);
-  box-shadow: 0 var(--primitives-spacing-3) var(--primitives-spacing-6)
-    color-mix(in srgb, var(--semantic-color-surface-bg) 55%, transparent);
-}
-
-.chainOption {
-  gap: var(--primitives-spacing-2);
-  width: 100%;
-  padding: var(--primitives-spacing-2) var(--primitives-spacing-3);
-  border: none;
-  border-radius: calc(var(--primitives-borderRadius-sm) * 1px);
-  background: transparent;
-  cursor: pointer;
-  text-align: left;
-}
-
-.chainOption:hover {
-  background: var(--semantic-color-surface-raised-hover);
-}
-
-.chainOption[aria-selected='true'] {
-  background: var(--semantic-color-surface-raised-pressed);
-}
-
-.chainOption:focus-visible {
-  outline: 2px solid var(--semantic-color-border-focus);
-  outline-offset: -2px;
 }
 
 /* Amount + fee caption cluster (mockup `.amountStack`) — the caption sits directly under the

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.test.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.test.tsx
@@ -7,8 +7,6 @@ import { incompleteCtaShakeClass } from '@/design'
 import { formatUsdcPlain } from '@/lib/format'
 import { DepositAmountCard } from './DepositAmountCard'
 
-const CHAINS = [{ chainId: 31337, label: 'Hub' }]
-
 /** Temporarily report non-reduced motion (setup defaults to reduced) for the duration of `fn`. */
 function withMotionEnabled(fn: () => void) {
   const original = window.matchMedia
@@ -33,8 +31,6 @@ function withMotionEnabled(fn: () => void) {
 function renderCard(props: Partial<Parameters<typeof DepositAmountCard>[0]> = {}) {
   return render(
     <DepositAmountCard
-      chains={CHAINS}
-      chainId={31337}
       amount=""
       onAmountChange={() => {}}
       balance="12.00"
@@ -117,8 +113,6 @@ describe('DepositAmountCard — presets + amount roll', () => {
       const onAmountChange = vi.fn()
       const { rerender } = render(
         <DepositAmountCard
-          chains={CHAINS}
-          chainId={31337}
           amount="1"
           onAmountChange={onAmountChange}
           maxInput={12_000000n}
@@ -129,8 +123,6 @@ describe('DepositAmountCard — presets + amount roll', () => {
       // The parent commits the new amount → the roll effect starts on the prop change.
       rerender(
         <DepositAmountCard
-          chains={CHAINS}
-          chainId={31337}
           amount="6"
           onAmountChange={onAmountChange}
           maxInput={12_000000n}
@@ -146,8 +138,6 @@ describe('DepositAmountCard — presets + amount roll', () => {
     const onAmountChange = vi.fn()
     const { rerender } = render(
       <DepositAmountCard
-        chains={CHAINS}
-        chainId={31337}
         amount="1"
         onAmountChange={onAmountChange}
         maxInput={12_000000n}
@@ -157,8 +147,6 @@ describe('DepositAmountCard — presets + amount roll', () => {
     fireEvent.click(screen.getByRole('button', { name: '50%' }))
     rerender(
       <DepositAmountCard
-        chains={CHAINS}
-        chainId={31337}
         amount="6"
         onAmountChange={onAmountChange}
         maxInput={12_000000n}

--- a/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
+++ b/apps/armada-interface/src/components/deposit/DepositAmountCard/DepositAmountCard.tsx
@@ -1,10 +1,9 @@
-// ABOUTME: Deposit amount card — optional in-card title, chain dropdown, left-aligned large mono amount, balance/fee row.
-// ABOUTME: Chain list from parent (network config); icons via @web3icons when mapped, else letter fallback.
+// ABOUTME: Deposit amount card — optional in-card title, chain slot, left-aligned large mono amount, balance/fee row.
+// ABOUTME: The chain UI (when shown) is supplied by the caller via `chainSlot` (e.g. the shared ChainSelect).
 
 import { useEffect, useId, useRef, useState, type ReactNode } from 'react'
-import { ChevronDownIcon, WalletIcon } from '@heroicons/react/24/solid'
+import { WalletIcon } from '@heroicons/react/24/solid'
 import { formatAmountInputDisplay, hasActiveAmount, sanitizeAmountInput } from '@/utils/amountInput'
-import { chainIconForChainId } from '@/components/ui/chainIcons'
 import { AmountFieldWarning } from '@/components/ui/AmountFieldWarning'
 import { FeeBreakdownTooltip, type FlowFeeBreakdown } from '@/components/ui/FeeBreakdownTooltip'
 import { RollingBalanceValue } from '@/components/dashboard/RollingBalanceValue'
@@ -17,8 +16,6 @@ import type { DisplayFees } from '@/lib/fees/displayFees'
 import { incompleteCtaShakeClass } from '@/design'
 import styles from './DepositAmountCard.module.css'
 
-const ICON_SIZE = 32
-
 function prefersReducedMotion(): boolean {
   if (typeof window === 'undefined') return false
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches
@@ -30,21 +27,10 @@ function amountRollMs(formatted: string): number {
   return BALANCE_ROLL_DURATION_MS + Math.max(0, digitCount - 1) * BALANCE_ROLL_DIGIT_STAGGER_MS + 80
 }
 
-export interface DepositChainOption {
-  chainId: number
-  label: string
-}
-
 export interface DepositAmountCardProps {
-  chains?: ReadonlyArray<DepositChainOption>
-  chainId: number
-  onChainIdChange?: (chainId: number) => void
-  /** Hide the chain row entirely (e.g. the Send flow, where the chain is chosen on a prior step). */
-  showChain?: boolean
   /**
-   * Custom chain-row content rendered in place of the built-in picker (e.g. the shared `ChainSelect`
-   * so shield/unshield match the Send flow's network selector). When set, the built-in picker +
-   * `chains`/`showChain` are ignored.
+   * Chain-row content rendered above the title (e.g. the shared `ChainSelect`). Omit for flows with
+   * no in-card chain row (e.g. Send/Earn, where the chain is chosen on a prior step or is fixed).
    */
   chainSlot?: ReactNode
   /**
@@ -97,27 +83,7 @@ export interface DepositAmountCardProps {
   onShakeAnimationEnd?: (event: React.AnimationEvent<HTMLDivElement>) => void
 }
 
-function ChainIcon({ chainId, label }: { chainId: number; label: string }) {
-  const Icon = chainIconForChainId(chainId)
-  if (Icon) {
-    return (
-      <span className={styles.chainIconSlot} aria-hidden>
-        <Icon size={ICON_SIZE} variant="branded" />
-      </span>
-    )
-  }
-  return (
-    <span className={styles.chainIconSlot} aria-hidden>
-      {label.charAt(0).toUpperCase()}
-    </span>
-  )
-}
-
 export function DepositAmountCard({
-  chains = [],
-  chainId,
-  onChainIdChange,
-  showChain = true,
   chainSlot,
   header,
   title,
@@ -137,30 +103,8 @@ export function DepositAmountCard({
   shaking = false,
   onShakeAnimationEnd,
 }: DepositAmountCardProps) {
-  const [menuOpen, setMenuOpen] = useState(false)
-  const chainRootRef = useRef<HTMLDivElement>(null)
-  const listboxId = useId()
   const amountInputId = useId()
   const amountErrorId = useId()
-
-  const selected = chains.find((c) => c.chainId === chainId) ?? chains[0]
-  const chainSelectable = Boolean(onChainIdChange) && chains.length > 1
-
-  useEffect(() => {
-    if (!menuOpen) return
-    function handlePointerDown(event: MouseEvent) {
-      if (!chainRootRef.current?.contains(event.target as Node)) {
-        setMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handlePointerDown)
-    return () => document.removeEventListener('mousedown', handlePointerDown)
-  }, [menuOpen])
-
-  function selectChain(nextId: number) {
-    onChainIdChange?.(nextId)
-    setMenuOpen(false)
-  }
 
   // Odometer roll for preset/Max taps (mockup): the amount digit-spins from the old value to the new
   // one. A preset handler records where we're rolling *from*; the effect below detects the resulting
@@ -273,53 +217,7 @@ export function DepositAmountCard({
       <div className={styles.cardTop}>
       {header ? <div className={styles.cardHeader}>{header}</div> : null}
       {title ? <p className={styles.cardTitle}>{title}</p> : null}
-      {chainSlot ? (
-        <div className={styles.topRow}>{chainSlot}</div>
-      ) : showChain ? (
-      <div className={styles.topRow}>
-        <div className={styles.chainRoot} ref={chainRootRef}>
-          {chainSelectable ? (
-            <button
-              type="button"
-              className={styles.chainTrigger}
-              aria-haspopup="listbox"
-              aria-expanded={menuOpen}
-              aria-controls={listboxId}
-              onClick={() => setMenuOpen((open) => !open)}
-            >
-              <ChainIcon chainId={chainId} label={selected?.label ?? ''} />
-              <span className={styles.chainName}>{selected?.label}</span>
-              <ChevronDownIcon className={styles.chevron} aria-hidden />
-            </button>
-          ) : (
-            <div className={styles.chainTriggerStatic}>
-              <ChainIcon chainId={chainId} label={selected?.label ?? ''} />
-              <span className={styles.chainName}>{selected?.label}</span>
-            </div>
-          )}
-
-          {menuOpen && chainSelectable ? (
-            <ul id={listboxId} className={styles.chainMenu} role="listbox" aria-label="Network">
-              {chains.map((option) => (
-                <li key={option.chainId} role="presentation">
-                  <button
-                    type="button"
-                    role="option"
-                    aria-selected={option.chainId === chainId}
-                    className={styles.chainOption}
-                    onClick={() => selectChain(option.chainId)}
-                  >
-                    <ChainIcon chainId={option.chainId} label={option.label} />
-                    <span className={styles.chainOptionLabel}>{option.label}</span>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          ) : null}
-        </div>
-
-      </div>
-      ) : null}
+      {chainSlot ? <div className={styles.topRow}>{chainSlot}</div> : null}
 
       <div className={styles.amountStack}>
         <label className={styles.amountWrapper} htmlFor={amountInputId}>

--- a/apps/armada-interface/src/components/payments/SendInputStep.tsx
+++ b/apps/armada-interface/src/components/payments/SendInputStep.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Send/Withdraw amount step — DepositAmountCard (no chain row; chosen on the recipient step) + percent pills + gas notice.
 // ABOUTME: Recipient + chain live on the preceding recipient step, so this step gates only on the amount.
 
-import { useMemo, useRef, type Ref } from 'react'
+import { useRef, type Ref } from 'react'
 import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { DepositAmountCard } from '@/components/deposit/DepositAmountCard/DepositAmountCard'
 import { depositOverlayShellStyles } from '@/components/deposit/DepositOverlayShell/DepositOverlayShell'
@@ -10,7 +10,6 @@ import { useNudgeShake } from '@/hooks/useNudgeShake'
 import type { DisplayFees } from '@/lib/fees/displayFees'
 import type { FlowFeeBreakdown } from '@/components/ui/FeeBreakdownTooltip'
 import { useGasBalanceWarning } from '@/hooks/useGasBalanceWarning'
-import { getAllChainIdentities } from '@/config/network'
 import { formatUsdcPlain, parseUsdcInput, usdcInputErrorMessage } from '@/lib/format'
 import { hasActiveAmount } from '@/utils/amountInput'
 import type { SendFlowVariant } from './SendRecipientStep'
@@ -18,8 +17,6 @@ import styles from './SendInputStep.module.css'
 
 export interface SendInputStepProps {
   variant: SendFlowVariant
-  /** Destination chain — chosen on the recipient step; rendered statically here. */
-  destChainId: number
   amountStr: string
   onAmountChange: (next: string) => void
   max: bigint
@@ -52,7 +49,6 @@ export interface SendInputStepProps {
 
 export function SendInputStepContent({
   variant,
-  destChainId,
   amountStr,
   onAmountChange,
   max,
@@ -69,7 +65,6 @@ export function SendInputStepContent({
 }: Pick<
   SendInputStepProps,
   | 'variant'
-  | 'destChainId'
   | 'amountStr'
   | 'onAmountChange'
   | 'max'
@@ -84,11 +79,6 @@ export function SendInputStepContent({
   | 'shaking'
   | 'onShakeAnimationEnd'
 >) {
-  const allChains = useMemo(
-    () => getAllChainIdentities().map((c) => ({ chainId: c.chainId, label: c.name })),
-    [],
-  )
-
   const { value: amount, error: parseError } = parseUsdcInput(amountStr)
   const gasWarning = useGasBalanceWarning(gasChainId)
   // Only surface the gas notice when the user actually pays gas themselves. All three SendModal
@@ -102,11 +92,8 @@ export function SendInputStepContent({
     <div className={`${styles.sendContent} ${modalStepBodyEnter}`}>
       <div className={styles.amountGroup}>
         <DepositAmountCard
-          chains={allChains}
-          chainId={destChainId}
-          // Title now lives inside the card; the chain is chosen on the recipient step (no chain row here).
+          // Title lives inside the card; the chain is chosen on the recipient step (no chain row here).
           title="How much USDC?"
-          showChain={false}
           amount={amountStr}
           onAmountChange={onAmountChange}
           balance={formatUsdcPlain(max)}

--- a/apps/armada-interface/src/components/payments/SendModal.tsx
+++ b/apps/armada-interface/src/components/payments/SendModal.tsx
@@ -456,7 +456,6 @@ export function SendModal() {
         <>
           <SendInputStepContent
             variant={variant}
-            destChainId={destChainId}
             amountStr={amountStr}
             onAmountChange={setAmountStr}
             max={max}

--- a/apps/armada-interface/src/components/shield/ShieldAmountStep.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldAmountStep.tsx
@@ -95,9 +95,7 @@ export function ShieldAmountStepContent({
   return (
     <div className={`${styles.contentZone} ${modalStepBodyEnter}`}>
       <DepositAmountCard
-        chainId={chainId}
-        // Match the Send flow's network selector — the shared ChainSelect instead of the card's
-        // built-in picker (which the mockup lacks; we keep a picker here but style it consistently).
+        // The chain row is the shared ChainSelect (matches the Send flow's network selector).
         chainSlot={<ChainSelect value={chainId} onChange={onChainIdChange} label="Network" />}
         header={
           <SegmentedControl<ShieldTab>

--- a/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.module.css
+++ b/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.module.css
@@ -198,3 +198,15 @@
   font-size: calc(var(--primitives-fontSize-base) * 1px);
   color: var(--semantic-color-text-primary);
 }
+
+/* Non-interactive "more chains soon" hint below the selectable chains — muted, with a hairline
+   divider separating it from the last option. Not an option: no hover/pointer affordance. */
+.notice {
+  margin-top: var(--primitives-spacing-1);
+  padding: var(--primitives-spacing-2) var(--primitives-spacing-3);
+  border-top: calc(var(--primitives-borderWidth-default) * 1px) solid var(--semantic-color-border-default);
+  font-family: var(--primitives-fontFamily-ui), sans-serif;
+  font-size: calc(var(--primitives-fontSize-sm) * 1px);
+  color: var(--semantic-color-text-muted);
+  cursor: default;
+}

--- a/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.test.tsx
+++ b/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.test.tsx
@@ -38,6 +38,24 @@ describe('<ChainSelect>', () => {
     expect(onChange).toHaveBeenCalledWith(31338)
   })
 
+  it('shows a non-interactive "more chains soon" notice below the chains (desktop)', () => {
+    render(<ChainSelect value={31337} onChange={() => {}} label="From chain" />)
+    fireEvent.click(screen.getByLabelText('From chain'))
+    const notice = screen.getByText('More chains supported soon')
+    expect(notice).toBeInTheDocument()
+    // Not part of the selectable set: not an option, not a button.
+    expect(notice).not.toHaveAttribute('role', 'option')
+    expect(notice.closest('button')).toBeNull()
+  })
+
+  it('shows the notice in the mobile bottom sheet too', () => {
+    vi.mocked(useMobileLayout).mockReturnValue(true)
+    render(<ChainSelect value={31337} onChange={() => {}} label="From chain" />)
+    fireEvent.click(screen.getByLabelText('From chain'))
+    expect(screen.getByText('More chains supported soon')).toBeInTheDocument()
+    vi.mocked(useMobileLayout).mockReturnValue(false)
+  })
+
   it('collapses to a static, non-interactive trigger with a single chain', () => {
     render(<ChainSelect value={1} onChange={() => {}} chains={[MAINNET]} label="From chain" />)
     // Only one chain → nothing to pick → no trigger button, just the label shown statically.

--- a/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.tsx
+++ b/apps/armada-interface/src/components/ui/ChainSelect/ChainSelect.tsx
@@ -88,6 +88,14 @@ export function ChainSelect({ value, onChange, chains, label, disabled, classNam
     </li>
   ))
 
+  // Non-interactive "coming soon" hint below the selectable chains. `role="presentation"` keeps it
+  // out of the listbox's option set (not selectable, not arrow-navigable); the text stays perceivable.
+  const moreChainsNotice = (
+    <li role="presentation" className={styles.notice}>
+      More chains supported soon
+    </li>
+  )
+
   return (
     <div className={cls} ref={rootRef}>
       {selectable ? (
@@ -120,6 +128,7 @@ export function ChainSelect({ value, onChange, chains, label, disabled, classNam
       {menuOpen && selectable && !isMobile ? (
         <ul id={listboxId} className={styles.menu} role="listbox" aria-label="Network">
           {optionItems}
+          {moreChainsNotice}
         </ul>
       ) : null}
 
@@ -132,6 +141,7 @@ export function ChainSelect({ value, onChange, chains, label, disabled, classNam
         >
           <ul className={styles.sheetList} role="listbox" aria-label="Network">
             {optionItems}
+            {moreChainsNotice}
           </ul>
         </BottomSheet>
       ) : null}

--- a/apps/armada-interface/src/components/yield/EarnInputStep.tsx
+++ b/apps/armada-interface/src/components/yield/EarnInputStep.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Earn amount step — APY intro banner (DepositTooltip) above a chain-less DepositAmountCard whose in-card header holds the Add/Withdraw SegmentedControl.
 // ABOUTME: The vault has no chain selection; the banner headline is driven by the live vault rate and shows on both tabs (matches the mockup).
 
-import { useMemo, useRef, type Ref } from 'react'
+import { useRef, type Ref } from 'react'
 import { ChartBarIcon } from '@heroicons/react/24/solid'
 import { Button, modalStepBodyEnter, modalActionRowEnter } from '@/design'
 import { DepositAmountCard } from '@/components/deposit/DepositAmountCard/DepositAmountCard'
@@ -12,7 +12,6 @@ import { useNudgeShake } from '@/hooks/useNudgeShake'
 import type { DisplayFees } from '@/lib/fees/displayFees'
 import type { FlowFeeBreakdown } from '@/components/ui/FeeBreakdownTooltip'
 import { useGasBalanceWarning } from '@/hooks/useGasBalanceWarning'
-import { getNetworkConfig } from '@/config/network'
 import { formatUsdcPlain, parseUsdcInput, usdcInputErrorMessage } from '@/lib/format'
 import { rateToApy } from '@/lib/yield'
 import type { YieldRate } from '@/hooks/useYieldRate'
@@ -123,12 +122,6 @@ export function EarnInputStepContent({
   | 'shaking'
   | 'onShakeAnimationEnd'
 >) {
-  const hub = getNetworkConfig().hub
-  const chains = useMemo(
-    () => [{ chainId: hub.chainId, label: hub.name }],
-    [hub.chainId, hub.name],
-  )
-
   const gasWarning = useGasBalanceWarning(gasChainId)
   // Only surface the gas notice when the user actually pays gas themselves. `yield-deposit`
   // defaults to relayer-mediated; `yield-withdraw` is force-routed through the wallet today,
@@ -166,8 +159,6 @@ export function EarnInputStepContent({
       />
 
       <DepositAmountCard
-        chains={chains}
-        chainId={hub.chainId}
         // Add/Withdraw mode tabs live inside the card, above the title (mockup headerSlot).
         header={
           <SegmentedControl<EarnTab>
@@ -178,9 +169,8 @@ export function EarnInputStepContent({
             options={TABS}
           />
         }
-        // Title now lives inside the card; the vault has no chain selection (no chain row here).
+        // Title lives inside the card; the vault has no chain selection (no chain row).
         title={question}
-        showChain={false}
         amount={amountStr}
         onAmountChange={onAmountChange}
         balance={formatUsdcPlain(max)}


### PR DESCRIPTION
Two small, related changes to the chain picker.

## 1. "More chains supported soon" notice
A non-interactive hint rendered below the chains in `ChainSelect`'s dropdown — the single live chain picker, used by both the Shield/Unshield "Network" row and the Send "Destination chain" row, on desktop popover **and** mobile bottom sheet (shared `optionItems`, one insertion point each). It's a `role="presentation"` `<li>` (not an option, not focusable, no click) with a muted style + hairline divider, so it sits outside the selectable set but stays perceivable.

Shows wherever the dropdown can open (multiple configured chains). With a single chain the picker is a static trigger with no menu, so no notice — acceptable.

## 2. Remove the dead built-in `DepositAmountCard` chain picker
`DepositAmountCard` carried its own inline chain dropdown, but it was unreachable — every caller passes `chainSlot` (Shield → `ChainSelect`) or `showChain={false}` (Send/Earn). Removed the dead render + its exclusive machinery (`chains`/`chainId`/`onChainIdChange`/`showChain` props, `DepositChainOption` type, local `ChainIcon`, menu state/effect, and the picker-only CSS), and dropped the now-unused wiring from the three callers (`ChainSelect`-supplied chain rows are unaffected). Net −227 lines. `noUnusedLocals` + `tsc -b` confirm nothing dangling.

## Verification
`tsc -b` clean. My additions pass; +2 new ChainSelect tests (desktop + mobile notice, non-interactive).

## ⚠️ Pre-existing `main` breakage (not from this PR)
`ShieldModal.test.tsx` has **3 failing tests on `main`** (`…advances to the dedicated wallet step`, double-click P0-7, dismissible S-M2) — verified by running the full suite with this branch's changes stashed: clean `main` is 170 passed / **3 failed** / 1 skipped. This branch doesn't touch `ShieldModal.tsx` or the shield wallet path; it inherits the failure. Flagging separately — happy to investigate in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)