### PR TITLE
fix(interface): make ShieldModal.test hermetic — stub useFees

### DIFF
--- a/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
+++ b/apps/armada-interface/src/components/shield/ShieldModal.test.tsx
@@ -62,6 +62,36 @@ vi.mock('@/hooks/useDisplayFees', () => ({
   }),
 }))
 
+// useFees hits the relayer's /fees endpoint (React Query); there's no backend in the test env, so
+// the real hook's `refresh()` resolves to null. Since #506, `submit()` calls `resolveFreshQuote`
+// (which awaits `refresh()`) before advancing, and throws → 'error' step when the quote is null —
+// so the wallet-step assertions can't be reached without a deterministic quote. Stub a zero-fee
+// hub quote (matches the mocked useDisplayFees) + a `refresh` that resolves to it, keeping the
+// submit path hermetic and order-independent. (Live fee fetching is covered in useFees.test.ts.)
+const STUB_FEE_QUOTE = {
+  cacheId: 'test-cache-id',
+  expiresAt: Number.MAX_SAFE_INTEGER,
+  chainId: 31337,
+  broadcasterShieldedAddress: '0zk' + '0'.repeat(60),
+  fees: {
+    transfer: '0',
+    unshield: '0',
+    crossContract: '0',
+    crossChainShield: '0',
+    crossChainUnshield: '0',
+    shield: '0',
+    shieldXchain: '0',
+  },
+}
+vi.mock('@/hooks/useFees', () => ({
+  useFees: () => ({
+    quote: STUB_FEE_QUOTE,
+    isStale: false,
+    isUnavailable: false,
+    refresh: async () => STUB_FEE_QUOTE,
+  }),
+}))
+
 // ShieldModal reads the connected EVM address via wagmi's useAccount for the review-step summary;
 // these tests don't mount a WagmiProvider, so stub it with a fixed address.
 vi.mock('wagmi', async (importOriginal) => ({


### PR DESCRIPTION
Fixes 3 pre-existing `ShieldModal.test.tsx` failures on `main` (`…advances to the dedicated wallet step`, double-click P0-7, dismissible S-M2) that fail CI on every PR.

## Root cause (bisected)
Introduced by **#506 (`8cb862fb`, "refetch fee quote at submit")** — bisect: `#505` = 13 passed → `#506` = 3 failed, red ever since.

`#506` added a submit-time fee refetch to `useShieldFlow.submit()`:
```
const { quote } = await resolveFreshQuote({ refresh, ... })   // refresh = useFees().refresh
if (!activeQuote) throw new Error('Could not fetch a current fee quote')
```
`ShieldModal.test` mocked `useDisplayFees` but **not `useFees`**, so in the test env `fetchFees` fails, `refresh()` resolves to `null`, `submit()` throws, and the step goes to `error` instead of `wallet` — the "Wallet confirmations" list never renders. The test was left non-hermetic; it only appeared green when ambient suite state happened to satisfy the fee fetch, and a later merge-order shift stopped masking it. (The `executeTx` no-op from #516 guards a *different*, later race that `submit()` never reaches here.)

## Fix
Stub `@/hooks/useFees` in `ShieldModal.test.tsx` with a zero-fee hub quote + a `refresh` that resolves to it (mirrors the existing `useDisplayFees` mock). `resolveFreshQuote` now returns a quote deterministically → `submit()` reaches `setStep('wallet')`. Test-only; no production code touched.

## Audit
Checked the sibling submit-path tests: `SendModal.test` and `EarnModal.test` already mock `useFees` and pass in isolation — `ShieldModal.test` was the lone gap.

## Verification
`tsc -b` clean. `ShieldModal.test` 13/13 in isolation. Full interface suite pristine again: **171 passed, 1 skipped** (was 170 / 3 failed / 1 skipped on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)