### PR TITLE
chore(interface): declare @testing-library/dom devDependency

### DIFF
--- a/apps/armada-interface/package.json
+++ b/apps/armada-interface/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@sentry/vite-plugin": "^5.3.0",
     "@tailwindcss/vite": "^4.1.0",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^22.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
       "devDependencies": {
         "@sentry/vite-plugin": "^5.3.0",
         "@tailwindcss/vite": "^4.1.0",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^22.15.0",


### PR DESCRIPTION
## What

Adds `@testing-library/dom@^10.4.1` to `apps/armada-interface` devDependencies.

## Why

`@testing-library/react` v16 requires `@testing-library/dom` as an **explicit peer** the consumer must install. The interface never declared it — it silently resolves via the copy `crowdfund-ui` declares, which npm hoists to the monorepo root. This is a latent under-declaration: the moment the app is installed outside the monorepo (the interface spin-out), 86 vitest suites fail to load with `Cannot find module '@testing-library/dom'`.

Declaring it explicitly makes the monorepo honest today and lets the app's history carry the fix into its future standalone repo.

## Verification

- Standalone install (outside the monorepo tree) + `vitest`: **1254 passed / 8 skipped** with the dep; 86 suites fail to load without it.
- In-monorepo behavior is unchanged (additive declaration of an already-resolved version — no version churn; 2-line diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)